### PR TITLE
Add activesupport as a dependency since Class#descendants is used

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     tapioca (0.1.3)
+      activesupport
       pry (>= 0.12.2)
       sorbet-static (~> 0.4.4371)
       thor (~> 0.20.3)
@@ -10,15 +11,24 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    activesupport (5.2.3)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
     ast (2.4.0)
     byebug (11.0.1)
     coderay (1.1.2)
+    concurrent-ruby (1.1.5)
     diff-lcs (1.3)
     highline (1.6.20)
+    i18n (1.6.0)
+      concurrent-ruby (~> 1.0)
     jaro_winkler (1.5.2)
     json_pure (1.8.1)
     method_source (0.9.2)
     mime-types (2.99.3)
+    minitest (5.11.3)
     netrc (0.11.0)
     package_cloud (0.2.45)
       highline (= 1.6.20)
@@ -66,6 +76,9 @@ GEM
       sorbet-static (= 0.4.4371)
     sorbet-static (0.4.4371-universal-darwin-18)
     thor (0.20.3)
+    thread_safe (0.3.6)
+    tzinfo (1.2.5)
+      thread_safe (~> 0.1)
     unicode-display_width (1.6.0)
     zeitwerk (2.1.8)
 

--- a/lib/tapioca/compilers/symbol_table/symbol_generator.rb
+++ b/lib/tapioca/compilers/symbol_table/symbol_generator.rb
@@ -2,6 +2,7 @@
 # typed: true
 
 require 'pathname'
+require "active_support/core_ext/class/subclasses"
 
 module Tapioca
   module Compilers

--- a/lib/tapioca/gemfile.rb
+++ b/lib/tapioca/gemfile.rb
@@ -2,6 +2,7 @@
 # typed: strict
 
 require "bundler"
+require "active_support/core_ext/class/subclasses"
 
 module Tapioca
   class Gemfile

--- a/tapioca.gemspec
+++ b/tapioca.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency("sorbet-static", "~> 0.4.4371")
   spec.add_dependency("thor", "~> 0.20.3")
   spec.add_dependency("zeitwerk", "~> 2.1")
+  spec.add_dependency("activesupport")
 
   spec.add_development_dependency("bundler", "~> 1.17")
   spec.add_development_dependency("pry-byebug")


### PR DESCRIPTION
On a fresh Rails project I noticed that when running `bundle exec tapioca bundle` and `bundle exec tapioca generate activejob`, both commands would fail with the following error:

```ruby
bundler: failed to load command: tapioca (/Users/jonsimpson/.gem/ruby/2.6.3/bin/tapioca)
RuntimeError: Rails::Engine is abstract, you cannot instantiate it directly.
  /Users/jonsimpson/.gem/ruby/2.6.3/gems/railties-6.0.0.rc1/lib/rails/railtie.rb:211:in `initialize'
  /Users/jonsimpson/.gem/ruby/2.6.3/gems/railties-6.0.0.rc1/lib/rails/engine.rb:436:in `initialize'
  /Users/jonsimpson/.gem/ruby/2.6.3/gems/railties-6.0.0.rc1/lib/rails/railtie.rb:167:in `new'
  /Users/jonsimpson/.gem/ruby/2.6.3/gems/railties-6.0.0.rc1/lib/rails/railtie.rb:167:in `instance'
  /Users/jonsimpson/.gem/ruby/2.6.3/gems/railties-6.0.0.rc1/lib/rails/railtie.rb:189:in `method_missing'
  /Users/jonsimpson/.gem/ruby/2.6.3/gems/tapioca-0.1.3/lib/tapioca/gemfile.rb:77:in `load_rails_engines'
  /Users/jonsimpson/.gem/ruby/2.6.3/gems/tapioca-0.1.3/lib/tapioca/gemfile.rb:50:in `require_bundle'
  /Users/jonsimpson/.gem/ruby/2.6.3/gems/tapioca-0.1.3/lib/tapioca/generator.rb:102:in `require_gem_file'
  /Users/jonsimpson/.gem/ruby/2.6.3/gems/tapioca-0.1.3/lib/tapioca/generator.rb:210:in `block in perform_additions'
  /Users/jonsimpson/.gem/ruby/2.6.3/gems/thor-0.20.3/lib/thor/shell/basic.rb:44:in `indent'
  /Users/jonsimpson/.gem/ruby/2.6.3/gems/tapioca-0.1.3/lib/tapioca/generator.rb:206:in `perform_additions'
  /Users/jonsimpson/.gem/ruby/2.6.3/gems/tapioca-0.1.3/lib/tapioca/generator.rb:66:in `sync_rbis_with_gemfile'
  /Users/jonsimpson/.gem/ruby/2.6.3/gems/tapioca-0.1.3/lib/tapioca/cli.rb:42:in `block in bundle'
  /Users/jonsimpson/.gem/ruby/2.6.3/gems/tapioca-0.1.3/lib/tapioca.rb:14:in `silence_warnings'
  /Users/jonsimpson/.gem/ruby/2.6.3/gems/tapioca-0.1.3/lib/tapioca/cli.rb:41:in `bundle'
  /Users/jonsimpson/.gem/ruby/2.6.3/gems/thor-0.20.3/lib/thor/command.rb:27:in `run'
  /Users/jonsimpson/.gem/ruby/2.6.3/gems/thor-0.20.3/lib/thor/invocation.rb:126:in `invoke_command'
  /Users/jonsimpson/.gem/ruby/2.6.3/gems/thor-0.20.3/lib/thor.rb:387:in `dispatch'
  /Users/jonsimpson/.gem/ruby/2.6.3/gems/thor-0.20.3/lib/thor/base.rb:466:in `start'
  /Users/jonsimpson/.gem/ruby/2.6.3/gems/tapioca-0.1.3/exe/tapioca:6:in `<top (required)>'
  /Users/jonsimpson/.gem/ruby/2.6.3/bin/tapioca:23:in `load'
  /Users/jonsimpson/.gem/ruby/2.6.3/bin/tapioca:23:in `<top (required)>'
```

This led me to discover that `Class#descendants` from the `activesupport` gem is missing from this gem. [activesupport docs](https://guides.rubyonrails.org/active_support_core_extensions.html#subclasses-descendants).

This PR makes Tapioca depend on `activesupport`, and adds the necessary `require`s where `Class#descendants` is used.


## Note for reviewers

- is there a version that `activesupport` should be pinned or scoped to in `tapioca.gemspec`?
- is there a test that we can write that will prevent this and other similar missing dependency problems from occurring?

## 🎩 

Run `bundle exec tapioca bundle` on a Ruby project with tapioca as a dependency that is using this branch. Observe that the command finishes successfully and does not print out the error included above.