### PR TITLE
Make file matching more accepting

### DIFF
--- a/lib/tapioca/compilers/symbol_table/symbol_generator.rb
+++ b/lib/tapioca/compilers/symbol_table/symbol_generator.rb
@@ -454,8 +454,8 @@ module Tapioca
 
         sig { params(constant: Module, strict: T::Boolean).returns(T::Boolean) }
         def defined_in_gem?(constant, strict: true)
-          files = get_file_candidates(constant)
-          files = Tapioca::ConstantLocator.files_for(constant) if files.empty?
+          files = Set.new(get_file_candidates(constant))
+            .merge(Tapioca::ConstantLocator.files_for(constant))
 
           return !strict if files.empty?
 


### PR DESCRIPTION
It is sometimes the case that `pry` returns a match that does not live in the gem folder, but our `ConstantLocator` can locate it to the correct file. A case in point is `ActiveStorage::Current`, which, as far as `pry` is concerned is defined in the file `activesupport/lib/active_support/current_attributes.rb` but is actually defined in `activestorage/app/models/active_storage/current.rb`, which is properly located by our `ConstantLocator` (thanks to `TracePoint`).

Thus, instead of falling back from one to the other, we need to consider the whole set of results as one and see if any of them match a file under the current gem folder.