### PR TITLE
Pre-release minor refinements

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ $ bundle exec tapioca
 Commands:
   tapioca generate [gem...]  # generate RBIs from gems
   tapioca help [COMMAND]     # Describe available commands or one specific command
+  tapioca init               # initalizes folder structure
   tapioca sync               # sync RBIs to Gemfile
 
 Options:
@@ -33,6 +34,12 @@ Options:
 ```
 
 ## Usage
+
+### Initialize folder structure
+
+Command: `tapioca init`
+
+This will create the `sorbet/config` and `sorbet/tapioca/require.rb` files for you, if they don't exist. If any of the files already exist, they will not be changed.
 
 ### Generate for gems
 

--- a/lib/tapioca/cli.rb
+++ b/lib/tapioca/cli.rb
@@ -5,6 +5,8 @@ require 'thor'
 
 module Tapioca
   class Cli < Thor
+    include(Thor::Actions)
+
     class_option :prerequire,
                   aliases: ["--pre", "-b"],
                   banner: "file",
@@ -29,6 +31,24 @@ module Tapioca
                   default: {},
                   banner: "gem:level",
                   desc: "Overrides for typed sigils for generated gem RBIs"
+
+    desc "init", "initalizes folder structure"
+    def init
+      create_file(Generator::SORBET_CONFIG, skip: true) do
+        <<~CONTENT
+          --dir
+          .
+        CONTENT
+      end
+      create_file(Generator::DEFAULT_POSTREQUIRE, skip: true) do
+        <<~CONTENT
+          # frozen_string_literal: true
+          # typed: false
+
+          # Add your extra requires here
+        CONTENT
+      end
+    end
 
     desc "generate [gem...]", "generate RBIs from gems"
     def generate(*gems)

--- a/lib/tapioca/cli.rb
+++ b/lib/tapioca/cli.rb
@@ -11,6 +11,7 @@ module Tapioca
                   desc: "A file to be required before Bundler.require is called"
     class_option :postrequire,
                   aliases: ["--post", "-a"],
+                  default: Generator::DEFAULT_POSTREQUIRE,
                   banner: "file",
                   desc: "A file to be required after Bundler.require is called"
     class_option :outdir,

--- a/lib/tapioca/generator.rb
+++ b/lib/tapioca/generator.rb
@@ -8,6 +8,7 @@ module Tapioca
   class Generator < ::Thor::Shell::Color
     extend(T::Sig)
 
+    SORBET_CONFIG = "sorbet/config"
     DEFAULT_POSTREQUIRE = "sorbet/tapioca/require.rb"
     DEFAULT_OUTDIR = "sorbet/rbi/gems"
     DEFAULT_OVERRIDES = T.let({

--- a/lib/tapioca/generator.rb
+++ b/lib/tapioca/generator.rb
@@ -8,6 +8,7 @@ module Tapioca
   class Generator < ::Thor::Shell::Color
     extend(T::Sig)
 
+    DEFAULT_POSTREQUIRE = "sorbet/tapioca/require.rb"
     DEFAULT_OUTDIR = "sorbet/rbi/gems"
     DEFAULT_OVERRIDES = T.let({
       # ActiveSupport overrides some core methods with different signatures
@@ -38,7 +39,7 @@ module Tapioca
     def initialize(outdir: nil, prerequire: nil, postrequire: nil, command: nil, typed_overrides: nil)
       @outdir = T.let(Pathname.new(outdir || DEFAULT_OUTDIR), Pathname)
       @prerequire = T.let(prerequire, T.nilable(String))
-      @postrequire = T.let(postrequire, T.nilable(String))
+      @postrequire = T.let(postrequire || DEFAULT_POSTREQUIRE, T.nilable(String))
       @command = T.let(command || default_command, String)
       @typed_overrides = T.let(typed_overrides || {}, T::Hash[String, String])
       @bundle = T.let(nil, T.nilable(Gemfile))

--- a/spec/tapioca/cli_spec.rb
+++ b/spec/tapioca/cli_spec.rb
@@ -79,6 +79,56 @@ RSpec.describe(Tapioca::Cli) do
     end
   end
 
+  describe("#init") do
+    before(:each) do
+      FileUtils.rm_rf(repo_path / "sorbet")
+    end
+
+    after(:each) do
+      FileUtils.rm_rf(repo_path / "sorbet")
+    end
+
+    it 'must create proper files' do
+      output = run("init")
+
+      expect(output).to(eq(<<-OUTPUT))
+      create  sorbet/config
+      create  sorbet/tapioca/require.rb
+      OUTPUT
+
+      expect(File).to(exist(repo_path / "sorbet/config"))
+      expect(File.read(repo_path / "sorbet/config")).to(eq(<<~CONTENTS))
+        --dir
+        .
+      CONTENTS
+      expect(File).to(exist(repo_path / "sorbet/tapioca/require.rb"))
+      expect(File.read(repo_path / "sorbet/tapioca/require.rb")).to(eq(<<~CONTENTS))
+        # frozen_string_literal: true
+        # typed: false
+
+        # Add your extra requires here
+      CONTENTS
+    end
+
+    it 'must not overwrite files' do
+      FileUtils.mkdir_p(repo_path / "sorbet/tapioca")
+      FileUtils.touch([
+        repo_path / "sorbet/config",
+        repo_path / "sorbet/tapioca/require.rb",
+      ])
+
+      output = run("init")
+
+      expect(output).to(eq(<<-OUTPUT))
+        skip  sorbet/config
+        skip  sorbet/tapioca/require.rb
+      OUTPUT
+
+      expect(File.read(repo_path / "sorbet/config")).to(be_empty)
+      expect(File.read(repo_path / "sorbet/tapioca/require.rb")).to(be_empty)
+    end
+  end
+
   describe("#generate") do
     it 'must generate a single gem RBI' do
       output = run("generate", "foo")


### PR DESCRIPTION
- Make the default post-require script `sorbet/tapioca/require.rb`
- Add an `init` command to create a basic `sorbet` folder structure with:
   - `sorbet/config` with contents `--dir=.`
   - `sorbet/tapioca/require.rb` with empty contents
