### PR TITLE
Convert pre/post-require paths to absolute paths

### DIFF
--- a/lib/tapioca/loader.rb
+++ b/lib/tapioca/loader.rb
@@ -12,14 +12,14 @@ module Tapioca
 
     sig { params(initialize_file: T.nilable(String), require_file: T.nilable(String)).void }
     def load_bundle(initialize_file, require_file)
-      require(initialize_file) if initialize_file && File.exist?(initialize_file)
+      require_helper(initialize_file)
 
       load_rails
       load_rake
 
       require_bundle
 
-      require(require_file) if require_file && File.exist?(require_file)
+      require_helper(require_file)
 
       load_rails_engines
     end
@@ -28,6 +28,15 @@ module Tapioca
 
     sig { returns(Tapioca::Gemfile) }
     attr_reader :gemfile
+
+    sig { params(file: T.nilable(String)).void }
+    def require_helper(file)
+      return unless file
+      file = File.absolute_path(file)
+      return unless File.exist?(file)
+
+      require(file)
+    end
 
     sig { void }
     def require_bundle

--- a/spec/tapioca/cli_spec.rb
+++ b/spec/tapioca/cli_spec.rb
@@ -130,6 +130,10 @@ RSpec.describe(Tapioca::Cli) do
   end
 
   describe("#generate") do
+    before(:each) do
+      run("init")
+    end
+
     it 'must generate a single gem RBI' do
       output = run("generate", "foo")
 
@@ -217,6 +221,10 @@ RSpec.describe(Tapioca::Cli) do
   end
 
   describe("#sync") do
+    before(:each) do
+      run("init")
+    end
+
     it 'must perform no operations if everything is up-to-date' do
       run("generate")
 


### PR DESCRIPTION
We had a problem where the default post-require script `sorbet/tapioca/require.rb` was creating a problem with `require` since `require("sorbet/tapioca/require.rb")` was searching for a file in the include path. Converting the require path to an absolute path fixes this problem.

The tests have been updated to perform a `tapioca init` before each run to ensure a `sorbet/tapioca/require.rb` file exists so that we actually do test this case and catch the error.