### PR TITLE
These are the changes I needed to make to get it to work on 2.4.6

### DIFF
--- a/lib/tapioca/compilers/symbol_table/symbol_generator.rb
+++ b/lib/tapioca/compilers/symbol_table/symbol_generator.rb
@@ -504,7 +504,8 @@ module Tapioca
         def parent_declares_constant?(name)
           name_parts = name.split("::")
 
-          parent_name = name_parts[0...-1].join("::").delete_prefix("::")
+          parent_name = name_parts[0...-1].join("::")
+          parent_name = parent_name[2..-1] if parent_name.start_with?("::")
           parent_name = 'Object' if parent_name == ""
           parent = T.cast(resolve_constant(parent_name), T.nilable(Module))
 

--- a/lib/tapioca/gemfile.rb
+++ b/lib/tapioca/gemfile.rb
@@ -101,7 +101,7 @@ module Tapioca
       sig { returns(T::Array[Pathname]) }
       def files
         @spec.full_require_paths.flat_map do |path|
-          Pathname.new(path).glob("**/*.rb")
+          Pathname.glob((Pathname.new(path) / "**/*.rb").to_s)
         end
       end
 

--- a/lib/tapioca/generator.rb
+++ b/lib/tapioca/generator.rb
@@ -119,8 +119,8 @@ module Tapioca
 
     sig { returns(T::Hash[String, String]) }
     def existing_rbis
-      @existing_rbis ||= Dir.glob("*@*.rbi", T.unsafe(base: outdir))
-        .map { |f| File.basename(f, ".*").split('@') }
+      @existing_rbis ||= Pathname.glob((Pathname.new(outdir) / "*@*.rbi").to_s)
+        .map { |f| f.basename(".*").to_s.split('@') }
         .to_h
     end
 
@@ -291,7 +291,7 @@ module Tapioca
 
       say("Done", :green)
 
-      outdir.glob("#{gem.name}@*.rbi") do |file|
+      Pathname.glob((outdir / "#{gem.name}@*.rbi").to_s) do |file|
         remove(file) unless file.basename.to_s == gem.rbi_file_name
       end
     end

--- a/spec/tapioca/compilers/symbol_table_compiler_spec.rb
+++ b/spec/tapioca/compilers/symbol_table_compiler_spec.rb
@@ -5,6 +5,19 @@ require "spec_helper"
 require "pathname"
 require "tmpdir"
 
+RSpec.configure do |config|
+  # Some tests are not compatible with different Ruby versions.
+  # You can add `ruby: "X.Y.Z"` on a spec to specify which version should run it.
+  #
+  # For example:
+  #   it("tests something with Ruby 2.5 or greater", ruby: ">= 2.5.0") do
+  #     # ...
+  #   end
+  config.filter_run_excluding(ruby: ->(v) do
+    !Gem::Requirement.new(v).satisfied_by?(Gem::Version.new(RUBY_VERSION))
+  end)
+end
+
 RSpec.describe(Tapioca::Compilers::SymbolTableCompiler) do
   describe("compile") do
     def run_in_child
@@ -608,7 +621,7 @@ RSpec.describe(Tapioca::Compilers::SymbolTableCompiler) do
       )
     end
 
-    it("compiles Structs, Classes, and Modules") do
+    it("compiles Structs, Classes, and Modules for Ruby >= 2.5", ruby: ">= 2.5.0") do
       expect(
         compile(<<~RUBY)
           class S1 < Struct.new(:foo)
@@ -676,6 +689,82 @@ RSpec.describe(Tapioca::Compilers::SymbolTableCompiler) do
 
             def self.[](*_); end
             def self.inspect; end
+            def self.members; end
+            def self.new(*_); end
+          end
+
+          class S4 < ::Struct
+          end
+        RUBY
+      )
+    end
+
+    it("compiles Structs, Classes, and Modules for Ruby < 2.5", ruby: "~> 2.4.0") do
+      expect(
+        compile(<<~RUBY)
+          class S1 < Struct.new(:foo)
+          end
+          S2 = Struct.new(:foo) do
+            def foo
+            end
+          end
+          S3 = Struct.new(:foo)
+          class S4 < Struct.new("Foo", :foo)
+          end
+          class C1 < Class.new
+          end
+          C2 = Class.new do
+            def foo
+            end
+          end
+          C3 = Class.new
+          module M1
+          end
+          M2 = Module.new do
+            def foo
+            end
+          end
+          M3 = Module.new
+        RUBY
+      ).to(
+        eq(<<~RUBY.chomp)
+          class C1
+          end
+
+          class C2
+            def foo; end
+          end
+
+          class C3
+          end
+
+          module M1
+          end
+
+          module M2
+            def foo; end
+          end
+
+          module M3
+          end
+
+          class S1 < ::Struct
+          end
+
+          class S2 < ::Struct
+            def foo; end
+            def foo=(_); end
+
+            def self.[](*_); end
+            def self.members; end
+            def self.new(*_); end
+          end
+
+          class S3 < ::Struct
+            def foo; end
+            def foo=(_); end
+
+            def self.[](*_); end
             def self.members; end
             def self.new(*_); end
           end

--- a/spec/tapioca/compilers/symbol_table_compiler_spec.rb
+++ b/spec/tapioca/compilers/symbol_table_compiler_spec.rb
@@ -964,8 +964,10 @@ RSpec.describe(Tapioca::Compilers::SymbolTableCompiler) do
           obj = Object.new
 
           Dir.glob(File.join('yard', 'core_ext', '*.rb')).each do |file|
-            require file
-          rescue LoadError
+            begin
+              require file
+            rescue LoadError
+            end
           end
 
           def tap; yield(self); self end unless defined?(tap)


### PR DESCRIPTION
This fixes API differences between ruby 2.4 and >= 2.5. I'm not too happy about the hack to remove the self.inspect differences between 2.4 and others but it seemed like a small contained hack.

Let me know what you think.