### PR TITLE
Remove support artefacts before and after all tests

### DIFF
--- a/spec/tapioca/cli_spec.rb
+++ b/spec/tapioca/cli_spec.rb
@@ -73,21 +73,15 @@ RSpec.describe(Tapioca::Cli) do
   end
 
   around(:each) do |example|
+    FileUtils.rm_rf(repo_path / "sorbet")
     Dir.mktmpdir do |outdir|
       @outdir = outdir
       example.run
     end
+    FileUtils.rm_rf(repo_path / "sorbet")
   end
 
   describe("#init") do
-    before(:each) do
-      FileUtils.rm_rf(repo_path / "sorbet")
-    end
-
-    after(:each) do
-      FileUtils.rm_rf(repo_path / "sorbet")
-    end
-
     it 'must create proper files' do
       output = run("init")
 


### PR DESCRIPTION
While testing locally with the `rake` command, I noticed that some artefacts were not cleaned after the tests:

* `spec/support/repo/sorbet/config`
* `spec/support/repo/sorbet/tapioca/require.rb`

This PR removes them after each test.

Signed-off-by: Alexandre Terrasa <alexandre.terrasa@shopify.com>