### PR TITLE
Bump sorbet to 0.4.4813

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,7 @@ PATH
     tapioca (0.2.2)
       pry (>= 0.12.2)
       sorbet-runtime
-      sorbet-static (~> 0.4.4471)
+      sorbet-static
       thor (~> 0.20.3)
       zeitwerk (~> 2.1)
 
@@ -63,10 +63,10 @@ GEM
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 1.7)
     ruby-progressbar (1.10.1)
-    sorbet (0.4.4476)
-      sorbet-static (= 0.4.4476)
-    sorbet-runtime (0.4.4770)
-    sorbet-static (0.4.4476-universal-darwin-14)
+    sorbet (0.4.4813)
+      sorbet-static (= 0.4.4813)
+    sorbet-runtime (0.4.4813)
+    sorbet-static (0.4.4813-universal-darwin-14)
     thor (0.20.3)
     unicode-display_width (1.6.0)
     zeitwerk (2.1.8)
@@ -81,7 +81,7 @@ DEPENDENCIES
   rake (~> 12.3)
   rspec (~> 3.7)
   rubocop (~> 0.70.0)
-  sorbet
+  sorbet (~> 0.4.4813)
   tapioca!
   zeitwerk (~> 2.1)
 

--- a/tapioca.gemspec
+++ b/tapioca.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   )
 
   spec.add_dependency("pry", ">= 0.12.2")
-  spec.add_dependency("sorbet-static", "~> 0.4.4471")
+  spec.add_dependency("sorbet-static")
   spec.add_dependency("sorbet-runtime")
   spec.add_dependency("thor", "~> 0.20.3")
   spec.add_dependency("zeitwerk", "~> 2.1")
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency("pry-byebug")
   spec.add_development_dependency("rspec", "~> 3.7")
   spec.add_development_dependency("rubocop", "~> 0.70.0")
-  spec.add_development_dependency("sorbet")
+  spec.add_development_dependency("sorbet", "~> 0.4.4813")
   spec.add_development_dependency("zeitwerk", "~> 2.1")
 
   spec.required_ruby_version = ">= 2.4.4"


### PR DESCRIPTION
All is in the title.

I fixed the version on `sorbet` instead of fixing it independently for `static` and `runtime`. Was this intentional? If so, why?

Signed-off-by: Alexandre Terrasa <alexandre.terrasa@shopify.com>