### PR TITLE
Add support for Ruby 2.3(.7)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ sudo: false
 language: ruby
 cache: bundler
 rvm:
+  - 2.3
   - 2.4
   - 2.5
   - 2.6.2

--- a/spec/tapioca/cli_spec.rb
+++ b/spec/tapioca/cli_spec.rb
@@ -152,12 +152,17 @@ RSpec.describe(Tapioca::Cli) do
       OUTPUT
 
       expect(File).to(exist("#{outdir}/foo@0.0.1.rbi"))
-      expect(File.read("#{outdir}/foo@0.0.1.rbi")).to(eq(<<~CONTENTS))
+      expect(File.read("#{outdir}/foo@0.0.1.rbi")).to(eq(template(<<~CONTENTS)))
         #{Contents::FOO_RBI}
         class Foo::Secret
         end
 
+        <% if ruby_version(">= 2.4.0") %>
         Foo::Secret::VALUE = T.let(T.unsafe(nil), Integer)
+        <% else %>
+        Foo::Secret::VALUE = T.let(T.unsafe(nil), Fixnum)
+        <% end %>
+
       CONTENTS
 
       expect(File).to_not(exist("#{outdir}/bar@0.3.0.rbi"))

--- a/spec/tapioca/compilers/symbol_table_compiler_spec.rb
+++ b/spec/tapioca/compilers/symbol_table_compiler_spec.rb
@@ -115,13 +115,21 @@ RSpec.describe(Tapioca::Compilers::SymbolTableCompiler) do
 
           ::RUBY_ENGINE_VERSION = T.let(T.unsafe(nil), String)
 
+          <% if ruby_version(">= 2.4.0") %>
           ::RUBY_PATCHLEVEL = T.let(T.unsafe(nil), Integer)
+          <% else %>
+          ::RUBY_PATCHLEVEL = T.let(T.unsafe(nil), Fixnum)
+          <% end %>
 
           ::RUBY_PLATFORM = T.let(T.unsafe(nil), String)
 
           ::RUBY_RELEASE_DATE = T.let(T.unsafe(nil), String)
 
+          <% if ruby_version(">= 2.4.0") %>
           ::RUBY_REVISION = T.let(T.unsafe(nil), Integer)
+          <% else %>
+          ::RUBY_REVISION = T.let(T.unsafe(nil), Fixnum)
+          <% end %>
 
           ::RUBY_VERSION = T.let(T.unsafe(nil), String)
 
@@ -270,7 +278,11 @@ RSpec.describe(Tapioca::Compilers::SymbolTableCompiler) do
           module A
           end
 
+          <% if ruby_version(">= 2.4.0") %>
           A::ABC = T.let(T.unsafe(nil), Integer)
+          <% else %>
+          A::ABC = T.let(T.unsafe(nil), Fixnum)
+          <% end %>
 
           A::DEF = T.let(T.unsafe(nil), String)
       RUBY
@@ -1352,7 +1364,11 @@ RSpec.describe(Tapioca::Compilers::SymbolTableCompiler) do
             extend(::ActiveSupport::Concern)
           end
 
+          <% if ruby_version(">= 2.4.0") %>
           BarConcern::ClassMethods = T.let(T.unsafe(nil), Integer)
+          <% else %>
+          BarConcern::ClassMethods = T.let(T.unsafe(nil), Fixnum)
+          <% end %>
 
           module FooConcern
             extend(::ActiveSupport::Concern)
@@ -1382,7 +1398,7 @@ RSpec.describe(Tapioca::Compilers::SymbolTableCompiler) do
                   super
                 end
 
-                instance_methods.each { |m| undef_method m unless /^__|^object_id$/.match(m) != nil }
+                instance_methods.each { |m| undef_method m unless /^__|^object_id$/.match(m) }
 
                 def inspect
                   target.inspect
@@ -1480,7 +1496,7 @@ RSpec.describe(Tapioca::Compilers::SymbolTableCompiler) do
                   @new_const = new_const
                 end
 
-                instance_methods.each { |m| undef_method m unless /^__|^object_id$/.match(m) != nil }
+                instance_methods.each { |m| undef_method m unless /^__|^object_id$/.match(m) }
 
                 def inspect
                   target.inspect

--- a/spec/tapioca/compilers/symbol_table_compiler_spec.rb
+++ b/spec/tapioca/compilers/symbol_table_compiler_spec.rb
@@ -1382,7 +1382,7 @@ RSpec.describe(Tapioca::Compilers::SymbolTableCompiler) do
                   super
                 end
 
-                instance_methods.each { |m| undef_method m unless /^__|^object_id$/.match?(m) }
+                instance_methods.each { |m| undef_method m unless /^__|^object_id$/.match(m) != nil }
 
                 def inspect
                   target.inspect
@@ -1480,7 +1480,7 @@ RSpec.describe(Tapioca::Compilers::SymbolTableCompiler) do
                   @new_const = new_const
                 end
 
-                instance_methods.each { |m| undef_method m unless /^__|^object_id$/.match?(m) }
+                instance_methods.each { |m| undef_method m unless /^__|^object_id$/.match(m) != nil }
 
                 def inspect
                   target.inspect

--- a/tapioca.gemspec
+++ b/tapioca.gemspec
@@ -36,5 +36,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency("rubocop", "~> 0.70.0")
   spec.add_development_dependency("sorbet")
 
-  spec.required_ruby_version = ">= 2.4.4"
+  spec.required_ruby_version = ">= 2.3.7"
 end


### PR DESCRIPTION
This PR contains the few tweaks needed to support Ruby 2.3.x.

Please disregard the first commit as it's coming from #19.