### PR TITLE
Remove dependency to Zeitwerk so we can support Ruby 2.3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,7 +6,6 @@ PATH
       sorbet-runtime
       sorbet-static (~> 0.4.4471)
       thor (~> 0.20.3)
-      zeitwerk (~> 2.1)
 
 GEM
   remote: https://rubygems.org/
@@ -69,7 +68,6 @@ GEM
     sorbet-static (0.4.4476-universal-darwin-14)
     thor (0.20.3)
     unicode-display_width (1.6.0)
-    zeitwerk (2.1.8)
 
 PLATFORMS
   ruby
@@ -83,7 +81,6 @@ DEPENDENCIES
   rubocop (~> 0.70.0)
   sorbet
   tapioca!
-  zeitwerk (~> 2.1)
 
 BUNDLED WITH
    1.17.3

--- a/lib/tapioca.rb
+++ b/lib/tapioca.rb
@@ -1,10 +1,7 @@
 # typed: true
 # frozen_string_literal: true
-require "sorbet-runtime"
-require "zeitwerk"
 
-loader = Zeitwerk::Loader.for_gem
-loader.setup
+require "sorbet-runtime"
 
 module Tapioca
   def self.silence_warnings
@@ -31,4 +28,12 @@ rescue
   nil
 end
 
-loader.eager_load
+require_relative "tapioca/loader"
+require_relative "tapioca/constant_locator"
+require_relative "tapioca/generator"
+require_relative "tapioca/cli"
+require_relative "tapioca/gemfile"
+require_relative "tapioca/compilers/symbol_table_compiler"
+require_relative "tapioca/compilers/symbol_table/symbol_generator"
+require_relative "tapioca/compilers/symbol_table/symbol_loader"
+require_relative "tapioca/version"

--- a/spec/tapioca/compilers/symbol_table_compiler_spec.rb
+++ b/spec/tapioca/compilers/symbol_table_compiler_spec.rb
@@ -4,6 +4,7 @@
 require "spec_helper"
 require "pathname"
 require "tmpdir"
+require "bundler"
 
 RSpec.configure do |config|
   # Some tests are not compatible with different Ruby versions.

--- a/tapioca.gemspec
+++ b/tapioca.gemspec
@@ -29,14 +29,12 @@ Gem::Specification.new do |spec|
   spec.add_dependency("sorbet-static", "~> 0.4.4471")
   spec.add_dependency("sorbet-runtime")
   spec.add_dependency("thor", "~> 0.20.3")
-  spec.add_dependency("zeitwerk", "~> 2.1")
 
   spec.add_development_dependency("bundler", "~> 1.17")
   spec.add_development_dependency("pry-byebug")
   spec.add_development_dependency("rspec", "~> 3.7")
   spec.add_development_dependency("rubocop", "~> 0.70.0")
   spec.add_development_dependency("sorbet")
-  spec.add_development_dependency("zeitwerk", "~> 2.1")
 
   spec.required_ruby_version = ">= 2.4.4"
 end


### PR DESCRIPTION
From [Zeitwerk documentation:](https://github.com/fxn/zeitwerk#supported-ruby-versions)

> Zeitwerk works with MRI 2.4.4 and above.

This make it difficult to use `tapioca` on Ruby 2.3.

After discussing with @paracycle, seems like Zeitwerk is not absolutely mandatory for this project and we can do manual requires since there are only a few files. This is the goal of this PR.