### PR TITLE
Turn RBI generation test case outputs to templates

### DIFF
--- a/spec/tapioca/compilers/symbol_table_compiler_spec.rb
+++ b/spec/tapioca/compilers/symbol_table_compiler_spec.rb
@@ -5,19 +5,6 @@ require "spec_helper"
 require "pathname"
 require "tmpdir"
 
-RSpec.configure do |config|
-  # Some tests are not compatible with different Ruby versions.
-  # You can add `ruby: "X.Y.Z"` on a spec to specify which version should run it.
-  #
-  # For example:
-  #   it("tests something with Ruby 2.5 or greater", ruby: ">= 2.5.0") do
-  #     # ...
-  #   end
-  config.filter_run_excluding(ruby: ->(v) do
-    !Gem::Requirement.new(v).satisfied_by?(Gem::Version.new(RUBY_VERSION))
-  end)
-end
-
 RSpec.describe(Tapioca::Compilers::SymbolTableCompiler) do
   describe("compile") do
     def run_in_child
@@ -64,6 +51,10 @@ RSpec.describe(Tapioca::Compilers::SymbolTableCompiler) do
       end
     end
 
+    def ruby_version(selector)
+      Gem::Requirement.new(selector).satisfied_by?(Gem::Version.new(RUBY_VERSION))
+    end
+
     def template(src)
       ERB.new(src, nil, ">").result(binding).chomp
     end
@@ -108,6 +99,9 @@ RSpec.describe(Tapioca::Compilers::SymbolTableCompiler) do
           end
 
           class Object < ::BasicObject
+          <% if defined?(PP::ObjectMixin) %>
+            include(::PP::ObjectMixin)
+          <% end %>
             include(::JSON::Ext::Generator::GeneratorMethods::Object)
             include(::Kernel)
 
@@ -682,7 +676,9 @@ RSpec.describe(Tapioca::Compilers::SymbolTableCompiler) do
             def foo=(_); end
 
             def self.[](*_); end
+          <% if ruby_version(">= 2.5.0") %>
             def self.inspect; end
+          <% end %>
             def self.members; end
             def self.new(*_); end
           end
@@ -692,7 +688,9 @@ RSpec.describe(Tapioca::Compilers::SymbolTableCompiler) do
             def foo=(_); end
 
             def self.[](*_); end
+          <% if ruby_version(">= 2.5.0") %>
             def self.inspect; end
+          <% end %>
             def self.members; end
             def self.new(*_); end
           end

--- a/spec/tapioca/compilers/symbol_table_compiler_spec.rb
+++ b/spec/tapioca/compilers/symbol_table_compiler_spec.rb
@@ -64,6 +64,10 @@ RSpec.describe(Tapioca::Compilers::SymbolTableCompiler) do
       end
     end
 
+    def template(src)
+      ERB.new(src, nil, ">").result(binding).chomp
+    end
+
     it("compiles DelegateClass") do
       expect(
         compile(<<~RUBY)
@@ -74,7 +78,7 @@ RSpec.describe(Tapioca::Compilers::SymbolTableCompiler) do
           end
         RUBY
       ).to(
-        eq(<<~RUBY.chomp)
+        eq(template(<<~RUBY))
           class Bar
           end
 
@@ -98,7 +102,7 @@ RSpec.describe(Tapioca::Compilers::SymbolTableCompiler) do
           end
         RUBY
       ).to(
-        eq(<<~RUBY.chomp)
+        eq(template(<<~RUBY))
           class BasicObject
             def hello; end
           end
@@ -157,7 +161,7 @@ RSpec.describe(Tapioca::Compilers::SymbolTableCompiler) do
           end
         RUBY
       ).to(
-        eq(<<~RUBY.chomp)
+        eq(template(<<~RUBY))
           class Foo
             def self.==(other); end
           end
@@ -171,7 +175,7 @@ RSpec.describe(Tapioca::Compilers::SymbolTableCompiler) do
           SymbolTableCompilerTest = Class.new
         RUBY
       ).to(
-        eq(<<~RUBY.chomp)
+        eq(template(<<~RUBY))
           class SymbolTableCompilerTest
           end
         RUBY
@@ -203,7 +207,7 @@ RSpec.describe(Tapioca::Compilers::SymbolTableCompiler) do
           end
         RUBY
       ).to(
-        eq(<<~RUBY.chomp)
+        eq(template(<<~RUBY))
           class Foo
             def bar; end
             def to_s; end
@@ -235,7 +239,7 @@ RSpec.describe(Tapioca::Compilers::SymbolTableCompiler) do
           end
         RUBY
       ).to(
-        eq(<<~RUBY.chomp)
+        eq(template(<<~RUBY))
           class Bar
             def num(a); end
           end
@@ -255,7 +259,7 @@ RSpec.describe(Tapioca::Compilers::SymbolTableCompiler) do
           end
         RUBY
       ).to(
-        eq(<<~RUBY.chomp)
+        eq(template(<<~RUBY))
           class Bar
             def bar; end
             def num; end
@@ -273,7 +277,7 @@ RSpec.describe(Tapioca::Compilers::SymbolTableCompiler) do
           end
         RUBY
       ).to(
-        eq(<<~RUBY.chomp)
+        eq(template(<<~RUBY))
           module A
           end
 
@@ -293,7 +297,7 @@ RSpec.describe(Tapioca::Compilers::SymbolTableCompiler) do
           end
         RUBY
       ).to(
-        eq(<<~RUBY.chomp)
+        eq(template(<<~RUBY))
           class Foo
             def add(a, b:); end
           end
@@ -310,7 +314,7 @@ RSpec.describe(Tapioca::Compilers::SymbolTableCompiler) do
           end
         RUBY
       ).to(
-        eq(<<~RUBY.chomp)
+        eq(template(<<~RUBY))
           class Foo
             def add(a = _, b: _); end
           end
@@ -328,7 +332,7 @@ RSpec.describe(Tapioca::Compilers::SymbolTableCompiler) do
           end
         RUBY
       ).to(
-        eq(<<~RUBY.chomp)
+        eq(template(<<~RUBY))
           module Foo
             def num(a); end
           end
@@ -348,7 +352,7 @@ RSpec.describe(Tapioca::Compilers::SymbolTableCompiler) do
           end
         RUBY
       ).to(
-        eq(<<~RUBY.chomp)
+        eq(template(<<~RUBY))
           module Foo
           end
 
@@ -370,7 +374,7 @@ RSpec.describe(Tapioca::Compilers::SymbolTableCompiler) do
           end
         RUBY
       ).to(
-        eq(<<~RUBY.chomp)
+        eq(template(<<~RUBY))
           module Foo
           end
 
@@ -394,7 +398,7 @@ RSpec.describe(Tapioca::Compilers::SymbolTableCompiler) do
           end
         RUBY
       ).to(
-        eq(<<~RUBY.chomp)
+        eq(template(<<~RUBY))
           module Foo
           end
 
@@ -421,7 +425,7 @@ RSpec.describe(Tapioca::Compilers::SymbolTableCompiler) do
           end
         RUBY
       ).to(
-        eq(<<~RUBY.chomp)
+        eq(template(<<~RUBY))
           module Foo
           end
 
@@ -447,7 +451,7 @@ RSpec.describe(Tapioca::Compilers::SymbolTableCompiler) do
           end
         RUBY
       ).to(
-        eq(<<~RUBY.chomp)
+        eq(template(<<~RUBY))
           class Bar < ::Baz
           end
 
@@ -469,7 +473,7 @@ RSpec.describe(Tapioca::Compilers::SymbolTableCompiler) do
           end
         RUBY
       ).to(
-        eq(<<~RUBY.chomp)
+        eq(template(<<~RUBY))
           module Foo
           end
 
@@ -494,7 +498,7 @@ RSpec.describe(Tapioca::Compilers::SymbolTableCompiler) do
           end
         RUBY
       ).to(
-        eq(<<~RUBY.chomp)
+        eq(template(<<~RUBY))
           class Baz
           end
 
@@ -523,7 +527,7 @@ RSpec.describe(Tapioca::Compilers::SymbolTableCompiler) do
           end
         RUBY
       ).to(
-        eq(<<~RUBY.chomp)
+        eq(template(<<~RUBY))
           module Toto
           end
 
@@ -554,7 +558,7 @@ RSpec.describe(Tapioca::Compilers::SymbolTableCompiler) do
           end
         RUBY
       ).to(
-        eq(<<~RUBY.chomp)
+        eq(template(<<~RUBY))
           module Foo
             def self.const_missing(name); end
           end
@@ -595,7 +599,7 @@ RSpec.describe(Tapioca::Compilers::SymbolTableCompiler) do
           end
         RUBY
       ).to(
-        eq(<<~RUBY.chomp)
+        eq(template(<<~RUBY))
           class Bar < ::Baz
             include(::Tutu)
             include(::Foo)
@@ -621,7 +625,7 @@ RSpec.describe(Tapioca::Compilers::SymbolTableCompiler) do
       )
     end
 
-    it("compiles Structs, Classes, and Modules for Ruby >= 2.5", ruby: ">= 2.5.0") do
+    it("compiles Structs, Classes, and Modules") do
       expect(
         compile(<<~RUBY)
           class S1 < Struct.new(:foo)
@@ -649,7 +653,7 @@ RSpec.describe(Tapioca::Compilers::SymbolTableCompiler) do
           M3 = Module.new
         RUBY
       ).to(
-        eq(<<~RUBY.chomp)
+        eq(template(<<~RUBY))
           class C1
           end
 
@@ -689,82 +693,6 @@ RSpec.describe(Tapioca::Compilers::SymbolTableCompiler) do
 
             def self.[](*_); end
             def self.inspect; end
-            def self.members; end
-            def self.new(*_); end
-          end
-
-          class S4 < ::Struct
-          end
-        RUBY
-      )
-    end
-
-    it("compiles Structs, Classes, and Modules for Ruby < 2.5", ruby: "~> 2.4.0") do
-      expect(
-        compile(<<~RUBY)
-          class S1 < Struct.new(:foo)
-          end
-          S2 = Struct.new(:foo) do
-            def foo
-            end
-          end
-          S3 = Struct.new(:foo)
-          class S4 < Struct.new("Foo", :foo)
-          end
-          class C1 < Class.new
-          end
-          C2 = Class.new do
-            def foo
-            end
-          end
-          C3 = Class.new
-          module M1
-          end
-          M2 = Module.new do
-            def foo
-            end
-          end
-          M3 = Module.new
-        RUBY
-      ).to(
-        eq(<<~RUBY.chomp)
-          class C1
-          end
-
-          class C2
-            def foo; end
-          end
-
-          class C3
-          end
-
-          module M1
-          end
-
-          module M2
-            def foo; end
-          end
-
-          module M3
-          end
-
-          class S1 < ::Struct
-          end
-
-          class S2 < ::Struct
-            def foo; end
-            def foo=(_); end
-
-            def self.[](*_); end
-            def self.members; end
-            def self.new(*_); end
-          end
-
-          class S3 < ::Struct
-            def foo; end
-            def foo=(_); end
-
-            def self.[](*_); end
             def self.members; end
             def self.new(*_); end
           end
@@ -794,7 +722,7 @@ RSpec.describe(Tapioca::Compilers::SymbolTableCompiler) do
           end
         RUBY
       ).to(
-        eq(<<~RUBY.chomp)
+        eq(template(<<~RUBY))
           class Bar
             include(::Baz)
             include(::Foo)
@@ -821,7 +749,7 @@ RSpec.describe(Tapioca::Compilers::SymbolTableCompiler) do
           end
         RUBY
       ).to(
-        eq(<<~RUBY.chomp)
+        eq(template(<<~RUBY))
           class Bar
             def self.num(a); end
           end
@@ -841,7 +769,7 @@ RSpec.describe(Tapioca::Compilers::SymbolTableCompiler) do
           end
         RUBY
       ).to(
-        eq(<<~RUBY.chomp)
+        eq(template(<<~RUBY))
           class Bar
           end
         RUBY
@@ -859,7 +787,7 @@ RSpec.describe(Tapioca::Compilers::SymbolTableCompiler) do
           end
         RUBY
       ).to(
-        eq(<<~RUBY.chomp)
+        eq(template(<<~RUBY))
           class Bar
           end
         RUBY
@@ -877,7 +805,7 @@ RSpec.describe(Tapioca::Compilers::SymbolTableCompiler) do
           end
         RUBY
       ).to(
-        eq(<<~RUBY.chomp)
+        eq(template(<<~RUBY))
           class Bar
             def self.num(a); end
           end
@@ -897,7 +825,7 @@ RSpec.describe(Tapioca::Compilers::SymbolTableCompiler) do
           end
         RUBY
       ).to(
-        eq(<<~RUBY.chomp)
+        eq(template(<<~RUBY))
           class Bar
             def size(&block); end
             def unwrap(&block); end
@@ -920,7 +848,7 @@ RSpec.describe(Tapioca::Compilers::SymbolTableCompiler) do
           end
         RUBY
       ).to(
-        eq(<<~RUBY.chomp)
+        eq(template(<<~RUBY))
           class Bar
             def a; end
             def b; end
@@ -947,7 +875,7 @@ RSpec.describe(Tapioca::Compilers::SymbolTableCompiler) do
           end
         RUBY
       ).to(
-        eq(<<~RUBY.chomp)
+        eq(template(<<~RUBY))
           class Bar
             def foo; end
           end
@@ -969,7 +897,7 @@ RSpec.describe(Tapioca::Compilers::SymbolTableCompiler) do
           end
         RUBY
       ).to(
-        eq(<<~RUBY.chomp)
+        eq(template(<<~RUBY))
           class Bar
             def self.a; end
           end
@@ -994,7 +922,7 @@ RSpec.describe(Tapioca::Compilers::SymbolTableCompiler) do
           end
         RUBY
       ).to(
-        eq(<<~RUBY.chomp)
+        eq(template(<<~RUBY))
           class Toto
           end
         RUBY
@@ -1010,7 +938,7 @@ RSpec.describe(Tapioca::Compilers::SymbolTableCompiler) do
           end
         RUBY
       ).to(
-        eq(<<~RUBY.chomp)
+        eq(template(<<~RUBY))
           class Toto
             def toto(a, *_, **_); end
           end
@@ -1028,7 +956,7 @@ RSpec.describe(Tapioca::Compilers::SymbolTableCompiler) do
           end
         RUBY
       ).to(
-        eq(<<~RUBY.chomp)
+        eq(template(<<~RUBY))
           module Foo
           end
         RUBY
@@ -1071,7 +999,7 @@ RSpec.describe(Tapioca::Compilers::SymbolTableCompiler) do
           end
         RUBY
       ).to(
-        eq(<<~RUBY.chomp)
+        eq(template(<<~RUBY))
           module Foo
           end
         RUBY
@@ -1103,7 +1031,7 @@ RSpec.describe(Tapioca::Compilers::SymbolTableCompiler) do
           end
         RUBY
       ).to(
-        eq(<<~RUBY.chomp)
+        eq(template(<<~RUBY))
           class Bar
             def tutu; end
 
@@ -1146,7 +1074,7 @@ RSpec.describe(Tapioca::Compilers::SymbolTableCompiler) do
           end
         RUBY
       ).to(
-        eq(<<~RUBY.chomp)
+        eq(template(<<~RUBY))
           module Foo
             def tutu; end
 
@@ -1175,7 +1103,7 @@ RSpec.describe(Tapioca::Compilers::SymbolTableCompiler) do
           end
         RUBY
       ).to(
-        eq(<<~RUBY.chomp)
+        eq(template(<<~RUBY))
           class Bar
           end
         RUBY
@@ -1191,7 +1119,7 @@ RSpec.describe(Tapioca::Compilers::SymbolTableCompiler) do
           end
         RUBY
       ).to(
-        eq(<<~RUBY.chomp)
+        eq(template(<<~RUBY))
           class Bar
             def initialize; end
           end
@@ -1218,7 +1146,7 @@ RSpec.describe(Tapioca::Compilers::SymbolTableCompiler) do
           end
         RUBY
       ).to(
-        eq(<<~RUBY.chomp)
+        eq(template(<<~RUBY))
           class Toto
             def foo; end
             def foo=(the_foo); end
@@ -1242,7 +1170,7 @@ RSpec.describe(Tapioca::Compilers::SymbolTableCompiler) do
           end
         RUBY
       ).to(
-        eq(<<~RUBY.chomp)
+        eq(template(<<~RUBY))
           module Baz
             def self.foo(x); end
           end
@@ -1265,7 +1193,7 @@ RSpec.describe(Tapioca::Compilers::SymbolTableCompiler) do
           end
         RUBY
       ).to(
-        eq(<<~RUBY.chomp)
+        eq(template(<<~RUBY))
           module Toto
           end
 
@@ -1294,7 +1222,7 @@ RSpec.describe(Tapioca::Compilers::SymbolTableCompiler) do
           end
         RUBY
       ).to(
-        eq(<<~RUBY.chomp)
+        eq(template(<<~RUBY))
           class Hostile
             def self.!; end
           end
@@ -1310,7 +1238,7 @@ RSpec.describe(Tapioca::Compilers::SymbolTableCompiler) do
           end
         RUBY
       ).to(
-        eq(<<~RUBY.chomp)
+        eq(template(<<~RUBY))
           module Toto
           end
 
@@ -1335,7 +1263,7 @@ RSpec.describe(Tapioca::Compilers::SymbolTableCompiler) do
           end
         RUBY
       ).to(
-        eq(<<~RUBY.chomp)
+        eq(template(<<~RUBY))
           module Foo
           end
         RUBY
@@ -1358,7 +1286,7 @@ RSpec.describe(Tapioca::Compilers::SymbolTableCompiler) do
           end
         RUBY
       ).to(
-        eq(<<~RUBY.chomp)
+        eq(template(<<~RUBY))
           module Foo
           end
         RUBY
@@ -1377,7 +1305,7 @@ RSpec.describe(Tapioca::Compilers::SymbolTableCompiler) do
           end
         RUBY
       ).to(
-        eq(<<~RUBY.chomp)
+        eq(template(<<~RUBY))
           module BasicObjectTest
           end
 
@@ -1420,7 +1348,7 @@ RSpec.describe(Tapioca::Compilers::SymbolTableCompiler) do
           end
         RUBY
       ).to(
-        eq(<<~RUBY.chomp)
+        eq(template(<<~RUBY))
           module ActiveSupport
           end
 
@@ -1504,7 +1432,7 @@ RSpec.describe(Tapioca::Compilers::SymbolTableCompiler) do
           Bar = ActiveSupport::Deprecation::DeprecatedConstantProxy.new("Bar", "Foo")
         RUBY
       ).to(
-        eq(<<~RUBY.chomp)
+        eq(template(<<~RUBY))
           module ActiveSupport
           end
 
@@ -1594,7 +1522,7 @@ RSpec.describe(Tapioca::Compilers::SymbolTableCompiler) do
           Bar = ActiveSupport::Deprecation::DeprecatedConstantProxy.new("Bar", "Foo")
         RUBY
       ).to(
-        eq(<<~RUBY.chomp)
+        eq(template(<<~RUBY))
           module ActiveSupport
           end
 
@@ -1640,7 +1568,7 @@ RSpec.describe(Tapioca::Compilers::SymbolTableCompiler) do
           end
         RUBY
       ).to(
-        eq(<<~RUBY.chomp)
+        eq(template(<<~RUBY))
           class Foo
             def self.name; end
           end


### PR DESCRIPTION
Using ERB templates when matching RBI generation output allows us to change the output matching depending on some external conditions  like Ruby version, if a constant is defined in a certain type or if a certain module is included in a certain class, etc.

This PR adds this functionality.