### PR TITLE
Move templating features to `RSpec::Matchers` so it can be used from any test file

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -27,3 +27,21 @@ RSpec.configure do |config|
     config.default_formatter = "doc"
   end
 end
+
+module RSpec
+  module Matchers
+    class Binding
+      def ruby_version(selector)
+        Gem::Requirement.new(selector).satisfied_by?(Gem::Version.new(RUBY_VERSION))
+      end
+
+      def erb_bindings
+        binding
+      end
+    end
+
+    def template(src)
+      ERB.new(src, nil, ">").result(Binding.new.erb_bindings).chomp
+    end
+  end
+end

--- a/spec/tapioca/compilers/symbol_table_compiler_spec.rb
+++ b/spec/tapioca/compilers/symbol_table_compiler_spec.rb
@@ -52,14 +52,6 @@ RSpec.describe(Tapioca::Compilers::SymbolTableCompiler) do
       end
     end
 
-    def ruby_version(selector)
-      Gem::Requirement.new(selector).satisfied_by?(Gem::Version.new(RUBY_VERSION))
-    end
-
-    def template(src)
-      ERB.new(src, nil, ">").result(binding).chomp
-    end
-
     it("compiles DelegateClass") do
       expect(
         compile(<<~RUBY)


### PR DESCRIPTION
We also need it from `cli_spec.rb` for variations with Ruby 2.3.

Signed-off-by: Alexandre Terrasa <alexandre.terrasa@shopify.com>