### PR TITLE
Call `singleton_class` on Object explicitly

### DIFF
--- a/lib/tapioca/compilers/symbol_table/symbol_generator.rb
+++ b/lib/tapioca/compilers/symbol_table/symbol_generator.rb
@@ -257,7 +257,7 @@ module Tapioca
 
           inherited_singleton_class_ancestors =
             if constant.is_a?(Class)
-              Set.new(constant.superclass.singleton_class.ancestors)
+              Set.new(singleton_class_of(constant.superclass).ancestors)
             else
               Module.ancestors
             end
@@ -267,9 +267,9 @@ module Tapioca
 
           prepend = interesting_ancestors.take_while { |c| !are_equal?(constant, c) }
           include = interesting_ancestors.drop(prepend.size + 1)
-          extend  = constant.singleton_class.ancestors
+          extend  = singleton_class_of(constant).ancestors
             .reject do |mod|
-              mod == constant.singleton_class ||
+              mod == singleton_class_of(constant) ||
                 inherited_singleton_class_ancestors.include?(mod) ||
                 !public_module?(mod) ||
                 Module != class_of(mod)
@@ -321,9 +321,7 @@ module Tapioca
           )
 
           instance_methods = compile_directly_owned_methods(name, constant)
-
-          constant_singleton = Object.instance_method(:singleton_class).bind(constant).call
-          singleton_methods = compile_directly_owned_methods(name, constant_singleton, [:public])
+          singleton_methods = compile_directly_owned_methods(name, singleton_class_of(constant), [:public])
 
           return if symbol_ignored?(name) && instance_methods.empty? && singleton_methods.empty?
 
@@ -543,6 +541,11 @@ module Tapioca
         sig { params(constant: Module).returns(T.nilable(String)) }
         def raw_name_of(constant)
           Module.instance_method(:name).bind(constant).call
+        end
+
+        sig { params(constant: BasicObject).returns(Class) }
+        def singleton_class_of(constant)
+          Object.instance_method(:singleton_class).bind(constant).call
         end
 
         sig { params(constant: Module).returns(T.nilable(String)) }

--- a/lib/tapioca/compilers/symbol_table/symbol_generator.rb
+++ b/lib/tapioca/compilers/symbol_table/symbol_generator.rb
@@ -321,7 +321,9 @@ module Tapioca
           )
 
           instance_methods = compile_directly_owned_methods(name, constant)
-          singleton_methods = compile_directly_owned_methods(name, constant.singleton_class, [:public])
+
+          constant_singleton = Object.instance_method(:singleton_class).bind(constant).call
+          singleton_methods = compile_directly_owned_methods(name, constant_singleton, [:public])
 
           return if symbol_ignored?(name) && instance_methods.empty? && singleton_methods.empty?
 

--- a/spec/tapioca/compilers/symbol_table_compiler_spec.rb
+++ b/spec/tapioca/compilers/symbol_table_compiler_spec.rb
@@ -1584,5 +1584,39 @@ RSpec.describe(Tapioca::Compilers::SymbolTableCompiler) do
         RUBY
       )
     end
+
+    it("doesn't crash when `singleton_class` is overloaded") do
+      expect(
+        compile(<<~RUBY)
+          class Foo
+            module Bar
+
+              private
+
+              def singleton_class(klass)
+                class << klass; self; end
+              end
+            end
+
+            class << self
+              include Bar
+            end
+          end
+        RUBY
+      ).to(
+        eq(template(<<~RUBY))
+          class Foo
+            extend(::Foo::Bar)
+          end
+
+          module Foo::Bar
+
+            private
+
+            def singleton_class(klass); end
+          end
+        RUBY
+      )
+    end
   end
 end


### PR DESCRIPTION
This addresses https://github.com/Shopify/tapioca/issues/23

This works around the case where a gem has defined a `singleton_class`
method with a different method signature (and potenitally different visibility) to the one that's defined on `Object`

This is an approach that is sometimes used to allow access to the singleton class of an object in Rubies pre 2.1.0

When generating `rbi` files we always want to use the result of `Object#singleton_class`