### PR TITLE
Avoid modifying the frozen string `method_name`.

### DIFF
--- a/lib/tapioca/compilers/symbol_table/symbol_generator.rb
+++ b/lib/tapioca/compilers/symbol_table/symbol_generator.rb
@@ -400,7 +400,7 @@ module Tapioca
             end
           end.join(', ')
 
-          method_name = "#{constant.singleton_class? ? 'self.' : ''}#{method_name}"
+          method_name = "#{'self.' if constant.singleton_class?}#{method_name}"
           parameters = "(#{parameters})" if parameters != ""
 
           indented("def #{method_name}#{parameters}; end")

--- a/lib/tapioca/compilers/symbol_table/symbol_generator.rb
+++ b/lib/tapioca/compilers/symbol_table/symbol_generator.rb
@@ -400,7 +400,7 @@ module Tapioca
             end
           end.join(', ')
 
-          method_name.prepend(constant.singleton_class? ? 'self.' : '')
+          method_name = "#{constant.singleton_class? ? 'self.' : ''}#{method_name}"
           parameters = "(#{parameters})" if parameters != ""
 
           indented("def #{method_name}#{parameters}; end")


### PR DESCRIPTION
Avoid crash caused by frozen string modification.

For example while trying to update the `graphql-metrics` gem RBI to 3.0.0 in this branch https://github.com/Shopify/shopify/pull/226539.

The error is:

```
  -> Moving: sorbet/rbi/gems/activemerchant@1.99.0.rbi to sorbet/rbi/gems/activemerchant@1.103.0.rbi
  Compiling activemerchant, this may take a few seconds... bundler: failed to load command: tapioca (/Users/chris/.gem/ruby/2.6.5/bin/tapioca)
FrozenError: can't modify frozen String
  /Users/chris/.gem/ruby/2.6.5/gems/tapioca-0.2.3/lib/tapioca/compilers/symbol_table/symbol_generator.rb:403:in `prepend'
  /Users/chris/.gem/ruby/2.6.5/gems/tapioca-0.2.3/lib/tapioca/compilers/symbol_table/symbol_generator.rb:403:in `compile_method'
  /Users/chris/.gem/ruby/2.6.5/gems/tapioca-0.2.3/lib/tapioca/compilers/symbol_table/symbol_generator.rb:342:in `block (2 levels) in compile_directly_owned_methods'
```

cc. @chrisbutcher 

Signed-off-by: Alexandre Terrasa <alexandre.terrasa@shopify.com>