### PR TITLE
Remove thor dependency requirement upperbound:

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,7 @@ PATH
       pry (>= 0.12.2)
       sorbet-runtime
       sorbet-static (~> 0.4.4471)
-      thor (~> 0.20.3)
+      thor (>= 0.20.3)
 
 GEM
   remote: https://rubygems.org/

--- a/tapioca.gemspec
+++ b/tapioca.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency("pry", ">= 0.12.2")
   spec.add_dependency("sorbet-static", "~> 0.4.4471")
   spec.add_dependency("sorbet-runtime")
-  spec.add_dependency("thor", "~> 0.20.3")
+  spec.add_dependency("thor", ">= 0.20.3")
 
   spec.add_development_dependency("bundler", "~> 1.17")
   spec.add_development_dependency("pry-byebug")


### PR DESCRIPTION
Remove thor dependency requirement upperbound:

- ### Problem

  Rails made thor 1.0 a dependency requirement. Application
  using Rails HEAD and taopica can't have their dependencies resolved
  since there is a version conflict.

  ### Solution

  I couldn't find a reason in the history on why we added a upperbound
  requirement on thor so I'm just removing it. It will make things
  easier for applications next time thor release a new version.