### PR TITLE
Fix realpath problems with some gems

### DIFF
--- a/lib/tapioca/compilers/symbol_table/symbol_generator.rb
+++ b/lib/tapioca/compilers/symbol_table/symbol_generator.rb
@@ -424,11 +424,6 @@ module Tapioca
           SymbolLoader.ignore_symbol?(symbol_name)
         end
 
-        sig { params(path: String).returns(T::Boolean) }
-        def path_in_gem?(path)
-          File.realpath(path).start_with?(gem.full_gem_path)
-        end
-
         SPECIAL_METHOD_NAMES = %w[! ~ +@ ** -@ * / % + - << >> & | ^ < <= => > >= == === != =~ !~ <=> [] []= `]
 
         sig { params(name: String).returns(T::Boolean) }
@@ -462,7 +457,7 @@ module Tapioca
           source_location = method.source_location&.first
           return false if source_location.nil?
 
-          path_in_gem?(source_location)
+          gem.contains_path?(source_location)
         end
 
         sig { params(constant: Module, strict: T::Boolean).returns(T::Boolean) }
@@ -473,7 +468,7 @@ module Tapioca
           return !strict if files.empty?
 
           files.any? do |file|
-            path_in_gem?(file)
+            gem.contains_path?(file)
           end
         end
 

--- a/lib/tapioca/gemfile.rb
+++ b/lib/tapioca/gemfile.rb
@@ -88,7 +88,7 @@ module Tapioca
       sig { params(spec: Spec).void }
       def initialize(spec)
         @spec = T.let(spec, Tapioca::Gemfile::Spec)
-        real_gem_path = File.realpath(@spec.full_gem_path.to_s)
+        real_gem_path = to_realpath(@spec.full_gem_path)
         @full_gem_path = T.let(real_gem_path, String)
       end
 
@@ -119,7 +119,19 @@ module Tapioca
         "#{name}@#{version}.rbi"
       end
 
+      sig { params(path: String).returns(T::Boolean) }
+      def contains_path?(path)
+        to_realpath(path).start_with?(full_gem_path)
+      end
+
       private
+
+      sig { params(path: T.any(String, Pathname)).returns(String) }
+      def to_realpath(path)
+        path_string = path.to_s
+        path_string = File.realpath(path_string) if File.exist?(path_string)
+        path_string
+      end
 
       sig { returns(T::Boolean) }
       def gem_ignored?

--- a/spec/support/repo/Gemfile
+++ b/spec/support/repo/Gemfile
@@ -6,3 +6,5 @@ gem("foo", path: "../gems/foo")
 gem("bar", path: "../gems/bar")
 gem("baz", path: "../gems/baz")
 gem("tapioca", path: "../../../")
+
+gem("psych")


### PR DESCRIPTION
@rafaelfranca observed a case with a non-Nixified repo where the path to the `psych` gem as it was supplied by `Bundler`, was a non-existent path. This obviously breaks the `File.realpath` lookup and fails the run.

The fix is to check for path existence before attempting to convert the path to a realpath. If the path does not exist, we fallback to the old flow.

### Testing
- This change was tested and verified by @rafaelfranca on the repo he ran into problems
- I've also added `psych` to the test repo `Gemfile` to make sure that we run into the same problem and verified that this change fixes tests.