### PR TITLE
Add `--exclude` option

### DIFF
--- a/lib/tapioca/cli.rb
+++ b/lib/tapioca/cli.rb
@@ -23,10 +23,15 @@ module Tapioca
                   aliases: ["--cmd", "-c"],
                   banner: "command",
                   desc: "The command to run to regenerate RBI files"
+    class_option :exclude,
+                  aliases: ["-x"],
+                  type: :array,
+                  banner: "gem [gem ...]",
+                  desc: "Excludes the given gem(s) from RBI generation"
     class_option :typed_overrides,
                   aliases: ["--typed", "-t"],
                   type: :hash,
-                  banner: "gem:level",
+                  banner: "gem:level [gem:level ...]",
                   desc: "Overrides for typed sigils for generated gem RBIs"
 
     desc "init", "initializes folder structure"

--- a/lib/tapioca/config.rb
+++ b/lib/tapioca/config.rb
@@ -9,6 +9,7 @@ module Tapioca
     const(:prerequire, T.nilable(String))
     const(:postrequire, String)
     const(:generate_command, String)
+    const(:exclude, T::Array[String])
     const(:typed_overrides, T::Hash[String, String])
 
     sig { returns(Pathname) }

--- a/lib/tapioca/config_builder.rb
+++ b/lib/tapioca/config_builder.rb
@@ -55,6 +55,7 @@ module Tapioca
       "postrequire" => Config::DEFAULT_POSTREQUIRE,
       "outdir" => Config::DEFAULT_OUTDIR,
       "generate_command" => default_command,
+      "exclude" => [],
       "typed_overrides" => Config::DEFAULT_OVERRIDES,
     }.freeze, T::Hash[String, T.untyped])
   end

--- a/lib/tapioca/generator.rb
+++ b/lib/tapioca/generator.rb
@@ -30,13 +30,15 @@ module Tapioca
     def build_gem_rbis(gem_names)
       require_gem_file
 
-      gems_to_generate(gem_names).map do |gem|
-        say("Processing '#{gem.name}' gem:", :green)
-        indent do
-          compile_rbi(gem)
-          puts
+      gems_to_generate(gem_names)
+        .reject { |gem| config.exclude.include?(gem.name) }
+        .each do |gem|
+          say("Processing '#{gem.name}' gem:", :green)
+          indent do
+            compile_rbi(gem)
+            puts
+          end
         end
-      end
 
       say("All operations performed in working directory.", [:green, :bold])
       say("Please review changes and commit them.", [:green, :bold])
@@ -94,6 +96,7 @@ module Tapioca
     sig { returns(T::Hash[String, String]) }
     def expected_rbis
       @expected_rbis ||= bundle.dependencies
+        .reject { |gem| config.exclude.include?(gem.name) }
         .map { |gem| [gem.name, gem.version.to_s] }
         .to_h
     end

--- a/spec/tapioca/cli_spec.rb
+++ b/spec/tapioca/cli_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe(Tapioca::Cli) do
   def run(command, args = [], flags = {})
     flags = {
       outdir: outdir,
-      generate_command: "generate command",
+      generate_command: "'generate command'",
     }.merge(flags).flat_map { |k, v| ["--#{k}", v.to_s] }
 
     exec_command = [
@@ -67,7 +67,7 @@ RSpec.describe(Tapioca::Cli) do
       {
         "BUNDLE_GEMFILE" => (repo_path / "Gemfile").to_s,
       },
-      exec_command,
+      exec_command.join(' '),
       chdir: repo_path
     ).read
   end


### PR DESCRIPTION
It is sometimes desirable to exclude certain gems from the RBI generation process. This PR adds the `--exclude` flag to both `generate` and `sync` commands to cater for this use case.