### PR TITLE
Filter Sorbet related types from constants and mixins

### DIFF
--- a/spec/tapioca/compilers/symbol_table_compiler_spec.rb
+++ b/spec/tapioca/compilers/symbol_table_compiler_spec.rb
@@ -72,6 +72,32 @@ RSpec.describe(Tapioca::Compilers::SymbolTableCompiler) do
       )
     end
 
+    it("does not compile Sorbet related constants") do
+      expect(
+        compile(<<~RUBY)
+          module Bar
+            extend(T::Sig)
+            extend(T::Helpers)
+            extend(T::Generic)
+
+            Elem = type_member(fixed: Integer)
+
+            interface!
+
+            Arr = T.let([1,2,3], T::Array[Integer])
+            Foo = T.type_alias { T.any(String, Symbol) }
+          end
+        RUBY
+      ).to(
+        eq(template(<<~RUBY))
+          module Bar
+          end
+
+          Bar::Arr = T.let(T.unsafe(nil), Array)
+        RUBY
+      )
+    end
+
     it("compiles extensions to BasicObject and Object") do
       expect(
         compile(<<~RUBY)


### PR DESCRIPTION
Fixes: #33 

We should not be generating constants of types or mixins exported by `sorbet-runtime` in RBI files. First of all, those constants and mixins have no additional signal value in the generated RBI file (since RBI files are only processed by the static checker) and they create conflicts with the actual definitions of the types, like in #33.