### PR TITLE
Better `mixes_in_class_methods` detection

### DIFF
--- a/spec/tapioca/compilers/symbol_table_compiler_spec.rb
+++ b/spec/tapioca/compilers/symbol_table_compiler_spec.rb
@@ -1346,6 +1346,17 @@ RSpec.describe(Tapioca::Compilers::SymbolTableCompiler) do
               end
             end
           end
+
+          module SomeOtherConcern
+            def included(base)
+              base.include(FooConcern)
+              base.include(BarConcern)
+            end
+          end
+
+          module Baz
+            extend SomeOtherConcern
+          end
         RUBY
       ).to(
         eq(template(<<~RUBY))
@@ -1355,6 +1366,13 @@ RSpec.describe(Tapioca::Compilers::SymbolTableCompiler) do
 
           module BarConcern::Something
             def another_class_method; end
+          end
+
+          module Baz
+            extend(::SomeOtherConcern)
+
+            include(::FooConcern)
+            include(::BarConcern)
           end
 
           module Concern
@@ -1371,6 +1389,10 @@ RSpec.describe(Tapioca::Compilers::SymbolTableCompiler) do
 
           module FooConcern::ClassMethods
             def wow_a_class_method; end
+          end
+
+          module SomeOtherConcern
+            def included(base); end
           end
         RUBY
       )

--- a/spec/tapioca/compilers/symbol_table_compiler_spec.rb
+++ b/spec/tapioca/compilers/symbol_table_compiler_spec.rb
@@ -1308,16 +1308,17 @@ RSpec.describe(Tapioca::Compilers::SymbolTableCompiler) do
       )
     end
 
-    it("adds mixes_in_class_methods to modules extending ActiveSupport::Concern") do
+    it("adds mixes_in_class_methods to modules that extend base classes") do
       expect(
         compile(<<~RUBY)
-          module ActiveSupport
-            module Concern
+          module Concern
+            def included(base)
+              base.extend(const_get(:ClassMethods)) if const_defined?(:ClassMethods)
             end
           end
 
           module FooConcern
-            extend(ActiveSupport::Concern)
+            extend(Concern)
 
             module ClassMethods
               def wow_a_class_method
@@ -1331,33 +1332,39 @@ RSpec.describe(Tapioca::Compilers::SymbolTableCompiler) do
           end
 
           module BarConcern
-            extend(ActiveSupport::Concern)
+            module Something
+              def another_class_method
+                "super awesome"
+              end
+            end
 
-            ClassMethods = 1
+            class << self
+              private
+
+              def included(base)
+                base.extend(Something)
+              end
+            end
           end
         RUBY
       ).to(
         eq(template(<<~RUBY))
-          module ActiveSupport
-          end
-
-          module ActiveSupport::Concern
-          end
-
           module BarConcern
-            extend(::ActiveSupport::Concern)
+            mixes_in_class_methods(::BarConcern::Something)
           end
 
-          <% if ruby_version(">= 2.4.0") %>
-          BarConcern::ClassMethods = T.let(T.unsafe(nil), Integer)
-          <% else %>
-          BarConcern::ClassMethods = T.let(T.unsafe(nil), Fixnum)
-          <% end %>
+          module BarConcern::Something
+            def another_class_method; end
+          end
+
+          module Concern
+            def included(base); end
+          end
 
           module FooConcern
-            extend(::ActiveSupport::Concern)
+            extend(::Concern)
 
-            mixes_in_class_methods(ClassMethods)
+            mixes_in_class_methods(::FooConcern::ClassMethods)
 
             def a_normal_method; end
           end


### PR DESCRIPTION
The current state of `mixes_in_class_methods` discovery is subpar and can only detect ones coming from the usage of `ActiveSupport::Concern`. However, there is a chance to do better and this PR is an attempt to implement that.

The basic idea is to have a temporary empty class template that we include any `module` we find. The empty class template does two things:

1. It defines `method_missing` both on the instance and class level so that we can ignore calls to some expected methods on the including class coming from some modules as they are being includes/extended. For example, `IdentityCache` just plain assumes that it will be able to call some AR methods in the `self.included` block. Implementing an empty `method_missing` allows those calls to happen in a no-op manner.
2. It hooks the singleton `include` method to keep track of what modules are being included to the test class and what `extends` are they pulling into the class as they are being included. This is for the cases where a single top-level include pulls in more includes each of which does an `extend` on the base class. Again, `IdentityCache` is a case-in-point, where `include IdentityCache` ends up including about 5-6 other modules each of which is an `ActiveSupport::Concern` and end up mixing their own class methods. The singleton hook is able to tell us exactly which extra includes are being done and which class methods those are bringing along with them.

This _does_ add extra complexity for the `tapioca` runtime and slows RBI generation down by about 10%-15% (based on my tests on Core, where the total gem RBI generation went from ~5m30s to ~6m10s) which I think is acceptable in return for better type generation.