### PR TITLE
Sanitize parameter names

### DIFF
--- a/lib/tapioca/compilers/symbol_table/symbol_generator.rb
+++ b/lib/tapioca/compilers/symbol_table/symbol_generator.rb
@@ -437,9 +437,12 @@ module Tapioca
           parameters = params.map do |(type, name)|
             name ||= :_
 
+            # Sanitize param names
+            name = name.to_s.gsub(/[^a-zA-Z0-9_]/, '_')
+
             case type
             when :req
-              name.to_s
+              name
             when :opt
               "#{name} = _"
             when :rest

--- a/spec/tapioca/compilers/symbol_table_compiler_spec.rb
+++ b/spec/tapioca/compilers/symbol_table_compiler_spec.rb
@@ -1631,5 +1631,25 @@ RSpec.describe(Tapioca::Compilers::SymbolTableCompiler) do
         RUBY
       )
     end
+
+    it("sanitize parameter names creating through meta-programming") do
+      expect(
+        compile(template(<<~RUBY))
+          class Foo
+          <% if ruby_version(">= 2.7.0") %>
+            module_eval("def foo(...); end")
+          <% end %>
+          end
+        RUBY
+      ).to(
+        eq(template(<<~RUBY))
+          class Foo
+          <% if ruby_version(">= 2.7.0") %>
+            def foo(*_, &_); end
+          <% end %>
+          end
+        RUBY
+      )
+    end
   end
 end


### PR DESCRIPTION
Since Rails 6.1, the `delegate` [implementation](https://github.com/rails/rails/blob/master/activesupport/lib/active_support/core_ext/module/delegation.rb#L204-L205) uses the Ruby 2.7 `...` passthrough syntax to define the delegation method.

The method using the `...` is then eval'ed in the module context which end up being represented as:

```ruby
def delegator(*, &); end
```

Which in turn produces the following RBI with `tapioca`:

```ruby
def delegator(**, &&); end
```

This PR fixes the generated RBI by sanitizing the parameter names.

Note: I didn't add any test for the non-metaprogrammed following code

```ruby
class Foo
  def foo(...); end
end
```

as Sorbet doesn't support it yet and it's never loaded in the symbol table thus generating an empty RBI. This will be handled later.