### PR TITLE
Be *extras* careful

### DIFF
--- a/lib/tapioca/compilers/symbol_table/symbol_loader.rb
+++ b/lib/tapioca/compilers/symbol_table/symbol_loader.rb
@@ -33,7 +33,7 @@ module Tapioca
               file.write(Array(paths).join("\n"))
               file.flush
 
-              symbol_table_json_from("@#{file.path}")
+              symbol_table_json_from("@#{file.path.shellescape}")
             end, T.nilable(String))
 
             return Set.new if output.nil? || output.empty?
@@ -44,7 +44,7 @@ module Tapioca
 
           def ignored_symbols
             unless @ignored_symbols
-              output = symbol_table_json_from("''", table_type: "symbol-table-full-json")
+              output = symbol_table_json_from("-e ''", table_type: "symbol-table-full-json")
               json = JSON.parse(output)
               @ignored_symbols = SymbolTableParser.parse(json)
             end
@@ -61,7 +61,7 @@ module Tapioca
                 "--print=#{table_type}",
                 "--quiet",
                 input,
-              ].shelljoin,
+              ].join(' '),
               err: "/dev/null"
             ).read
           end

--- a/lib/tapioca/compilers/symbol_table/symbol_loader.rb
+++ b/lib/tapioca/compilers/symbol_table/symbol_loader.rb
@@ -55,7 +55,7 @@ module Tapioca
           def symbol_table_json_from(input, table_type: "symbol-table-json")
             IO.popen(
               [
-                SORBET,
+                sorbet_path,
                 # We don't want to pick up any sorbet/config files in cwd
                 "--no-config",
                 "--print=#{table_type}",
@@ -64,6 +64,11 @@ module Tapioca
               ].join(' '),
               err: "/dev/null"
             ).read
+          end
+
+          sig { returns(String) }
+          def sorbet_path
+            SORBET.to_s.shellescape
           end
         end
 

--- a/spec/support/repo/Gemfile
+++ b/spec/support/repo/Gemfile
@@ -8,3 +8,4 @@ gem("baz", path: "../gems/baz")
 gem("tapioca", path: "../../../")
 
 gem("psych")
+gem("extras")

--- a/spec/tapioca/cli_spec.rb
+++ b/spec/tapioca/cli_spec.rb
@@ -57,29 +57,30 @@ RSpec.describe(Tapioca::Cli) do
     }.merge(flags).flat_map { |k, v| ["--#{k}", v.to_s] }
 
     exec_command = [
+      "bundle",
+      "exec",
       "bin/tapioca",
       command,
       *flags,
       *args,
     ]
 
-    IO.popen(
-      {
-        "BUNDLE_GEMFILE" => (repo_path / "Gemfile").to_s,
-      },
-      exec_command.join(' '),
-      chdir: repo_path
-    ).read
+    Bundler.with_clean_env do
+      IO.popen(
+        exec_command.join(' '),
+        chdir: repo_path
+      ).read
+    end
   end
 
   before(:all) do
     @repo_path = (Pathname.new(__dir__) / ".." / "support" / "repo").expand_path
-    IO.popen(
-      {
-        "BUNDLE_GEMFILE" => (@repo_path / "Gemfile").to_s,
-      },
-      ["bundle", "install", "--quiet"]
-    ).read
+    Bundler.with_clean_env do
+      IO.popen(
+        ["bundle", "install", "--quiet"],
+        chdir: @repo_path
+      ).read
+    end
   end
 
   around(:each) do |example|

--- a/spec/tapioca/cli_spec.rb
+++ b/spec/tapioca/cli_spec.rb
@@ -253,6 +253,21 @@ RSpec.describe(Tapioca::Cli) do
 
       expect(File.read("#{outdir}/baz@0.0.2.rbi")).to(eq(Contents::BAZ_RBI))
     end
+
+    it 'does not crash when the extras gem is loaded' do
+      File.write(repo_path / "sorbet/tapioca/require.rb", 'require "extras/all"')
+      output = run("generate", "foo")
+
+      expect(output).to(include(<<~OUTPUT))
+        Processing 'foo' gem:
+          Compiling foo, this may take a few seconds...   Done
+      OUTPUT
+
+      expect(File).to(exist("#{outdir}/foo@0.0.1.rbi"))
+      expect(File.read("#{outdir}/foo@0.0.1.rbi")).to(eq(Contents::FOO_RBI))
+
+      File.delete(repo_path / "sorbet/tapioca/require.rb")
+    end
   end
 
   describe("#sync") do


### PR DESCRIPTION
When used with the [extras](https://rubygems.org/gems/extras/versions/0.3.0) gem, `tapioca` crashes with:

```
/gems/extras-0.3.0/lib/extras/shell.rb:43:in `escape': undefined method `gsub' for #<Pathname:0x00007fb523a32840> (NoMethodError)
```

This actually hides two problems.

1. What happens is that `extras` aliases the `shellescape` method for [its own](https://github.com/envygeeks/extras/blob/master/lib/extras/shell.rb#L49) that doesn't support `Pathname`.

   This is fixed by this PR by only escaping the filename only and not all the other arguments we control.

2. Extras also [redefines the escaped value for the empty string](https://github.com/envygeeks/extras/blob/master/lib/extras/shell.rb#L27) which ends up running sorbet with no argument at all and produce an error.

   This PR fixes it by prepending the `-e` option to ensure Sorbet reads the empty string as a Ruby input.

See the included test for more details.