### PR TITLE
fix rspec failure reporting

### DIFF
--- a/lib/tapioca/compilers/dsl/smart_properties.rb
+++ b/lib/tapioca/compilers/dsl/smart_properties.rb
@@ -140,7 +140,7 @@ module Tapioca
             "T.untyped"
           elsif accepter == Array
             "T::Array[T.untyped]"
-          elsif BOOLEANS.any?(accepter)
+          elsif BOOLEANS.include?(accepter)
             "T::Boolean"
           elsif Array(accepter).all? { |a| a.is_a?(Module) }
             accepters = Array(accepter)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -41,7 +41,7 @@ def run_in_child
 
   write.close
   Process.wait(pid)
-  read.read.chomp
+  read.read
 ensure
   read&.close
 end
@@ -94,7 +94,7 @@ module RSpec
         ::ERB.new(src, nil, ">")
       end
 
-      erb.result(Binding.new.erb_bindings).chomp
+      erb.result(Binding.new.erb_bindings)
     end
   end
 end

--- a/spec/tapioca/cli_spec.rb
+++ b/spec/tapioca/cli_spec.rb
@@ -248,7 +248,6 @@ RSpec.describe(Tapioca::Cli) do
         <% else %>
         Foo::Secret::VALUE = T.let(T.unsafe(nil), Fixnum)
         <% end %>
-
       CONTENTS
 
       expect(File).to_not(exist("#{outdir}/bar@0.3.0.rbi"))

--- a/spec/tapioca/compilers/dsl/frozen_record_spec.rb
+++ b/spec/tapioca/compilers/dsl/frozen_record_spec.rb
@@ -26,10 +26,13 @@ RSpec.describe(Tapioca::Compilers::Dsl::FrozenRecord) do
   end
 
   describe("#decorate") do
-    let(:output) do
-      parlour = Parlour::RbiGenerator.new(sort_namespaces: true)
-      subject.decorate(parlour.root, Student)
-      parlour.rbi
+    def rbi_for(contents)
+      with_contents(contents) do |dir|
+        FrozenRecord::Base.base_path = dir + "lib"
+        parlour = Parlour::RbiGenerator.new(sort_namespaces: true)
+        subject.decorate(parlour.root, Student)
+        parlour.rbi
+      end
     end
 
     it("generates empty RBI file if there are no frozen records") do
@@ -43,15 +46,12 @@ RSpec.describe(Tapioca::Compilers::Dsl::FrozenRecord) do
         YAML
       }
 
-      expected = <<~RUBY
+      expected = <<~RUBY.chomp
         # typed: strong
 
       RUBY
 
-      with_contents(files) do |dir|
-        FrozenRecord::Base.base_path = dir + "lib"
-        expect(output).to(eq(expected))
-      end
+      expect(rbi_for(files)).to(eq(expected))
     end
 
     it("generates an RBI file for frozen records") do
@@ -71,7 +71,7 @@ RSpec.describe(Tapioca::Compilers::Dsl::FrozenRecord) do
         YAML
       }
 
-      expected = <<~RUBY
+      expected = <<~RUBY.chomp
         # typed: strong
         class Student
           include Student::FrozenRecordAttributeMethods
@@ -98,10 +98,7 @@ RSpec.describe(Tapioca::Compilers::Dsl::FrozenRecord) do
         end
       RUBY
 
-      with_contents(files) do |dir|
-        FrozenRecord::Base.base_path = dir + "lib"
-        expect(output).to(eq(expected))
-      end
+      expect(rbi_for(files)).to(eq(expected))
     end
   end
 end

--- a/spec/tapioca/compilers/dsl/frozen_record_spec.rb
+++ b/spec/tapioca/compilers/dsl/frozen_record_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe(Tapioca::Compilers::Dsl::FrozenRecord) do
         YAML
       }
 
-      expected = <<~RUBY.chomp
+      expected = <<~RUBY
         # typed: strong
 
       RUBY
@@ -71,7 +71,7 @@ RSpec.describe(Tapioca::Compilers::Dsl::FrozenRecord) do
         YAML
       }
 
-      expected = <<~RUBY.chomp
+      expected = <<~RUBY
         # typed: strong
         class Student
           include Student::FrozenRecordAttributeMethods

--- a/spec/tapioca/compilers/dsl/smart_properties_spec.rb
+++ b/spec/tapioca/compilers/dsl/smart_properties_spec.rb
@@ -47,10 +47,12 @@ RSpec.describe(Tapioca::Compilers::Dsl::SmartProperties) do
   end
 
   describe("#decorate") do
-    let(:output) do
-      parlour = Parlour::RbiGenerator.new(sort_namespaces: true)
-      subject.decorate(parlour.root, Post)
-      parlour.rbi
+    def rbi_for(content)
+      with_content(content) do
+        parlour = Parlour::RbiGenerator.new(sort_namespaces: true)
+        subject.decorate(parlour.root, Post)
+        parlour.rbi
+      end
     end
 
     it("generates empty RBI file if there are no smart properties") do
@@ -60,14 +62,12 @@ RSpec.describe(Tapioca::Compilers::Dsl::SmartProperties) do
         end
       RUBY
 
-      expected = <<~RUBY
+      expected = <<~RUBY.chomp
         # typed: strong
 
       RUBY
 
-      with_content(content) do
-        expect(output).to(eq(expected))
-      end
+      expect(rbi_for(content)).to(eq(expected))
     end
 
     it("generates RBI file for simple smart property") do
@@ -78,7 +78,7 @@ RSpec.describe(Tapioca::Compilers::Dsl::SmartProperties) do
         end
       RUBY
 
-      expected = <<~RUBY
+      expected = <<~RUBY.chomp
         # typed: strong
         class Post
           sig { returns(T.nilable(::String)) }
@@ -89,9 +89,7 @@ RSpec.describe(Tapioca::Compilers::Dsl::SmartProperties) do
         end
       RUBY
 
-      with_content(content) do
-        expect(output).to(eq(expected))
-      end
+      expect(rbi_for(content)).to(eq(expected))
     end
 
     it("generates RBI file for required smart property") do
@@ -102,7 +100,7 @@ RSpec.describe(Tapioca::Compilers::Dsl::SmartProperties) do
         end
       RUBY
 
-      expected = <<~RUBY
+      expected = <<~RUBY.chomp
         # typed: strong
         class Post
           sig { returns(::String) }
@@ -113,9 +111,7 @@ RSpec.describe(Tapioca::Compilers::Dsl::SmartProperties) do
         end
       RUBY
 
-      with_content(content) do
-        expect(output).to(eq(expected))
-      end
+      expect(rbi_for(content)).to(eq(expected))
     end
 
     it("defaults to T.untyped for smart property that does not have an accepter") do
@@ -126,7 +122,7 @@ RSpec.describe(Tapioca::Compilers::Dsl::SmartProperties) do
         end
       RUBY
 
-      expected = <<~RUBY
+      expected = <<~RUBY.chomp
         # typed: strong
         class Post
           sig { returns(T.untyped) }
@@ -137,9 +133,7 @@ RSpec.describe(Tapioca::Compilers::Dsl::SmartProperties) do
         end
       RUBY
 
-      with_content(content) do
-        expect(output).to(eq(expected))
-      end
+      expect(rbi_for(content)).to(eq(expected))
     end
 
     it("defaults to T::Array for smart property that accepts Arrays") do
@@ -150,7 +144,7 @@ RSpec.describe(Tapioca::Compilers::Dsl::SmartProperties) do
         end
       RUBY
 
-      expected = <<~RUBY
+      expected = <<~RUBY.chomp
         # typed: strong
         class Post
           sig { returns(T.nilable(T::Array[T.untyped])) }
@@ -161,9 +155,7 @@ RSpec.describe(Tapioca::Compilers::Dsl::SmartProperties) do
         end
       RUBY
 
-      with_content(content) do
-        expect(output).to(eq(expected))
-      end
+      expect(rbi_for(content)).to(eq(expected))
     end
 
     it("generates RBI file for smart property that accepts booleans") do
@@ -174,7 +166,7 @@ RSpec.describe(Tapioca::Compilers::Dsl::SmartProperties) do
         end
       RUBY
 
-      expected = <<~RUBY
+      expected = <<~RUBY.chomp
         # typed: strong
         class Post
           sig { returns(T.nilable(T::Boolean)) }
@@ -185,9 +177,7 @@ RSpec.describe(Tapioca::Compilers::Dsl::SmartProperties) do
         end
       RUBY
 
-      with_content(content) do
-        expect(output).to(eq(expected))
-      end
+      expect(rbi_for(content)).to(eq(expected))
     end
 
     it("generates RBI file for smart property that accepts an array of values") do
@@ -198,7 +188,7 @@ RSpec.describe(Tapioca::Compilers::Dsl::SmartProperties) do
         end
       RUBY
 
-      expected = <<~RUBY
+      expected = <<~RUBY.chomp
         # typed: strong
         class Post
           sig { returns(T.nilable(T.any(::String, ::Integer))) }
@@ -209,9 +199,7 @@ RSpec.describe(Tapioca::Compilers::Dsl::SmartProperties) do
         end
       RUBY
 
-      with_content(content) do
-        expect(output).to(eq(expected))
-      end
+      expect(rbi_for(content)).to(eq(expected))
     end
 
     it("defaults to T.untyped if a converter is defined") do
@@ -222,7 +210,7 @@ RSpec.describe(Tapioca::Compilers::Dsl::SmartProperties) do
         end
       RUBY
 
-      expected = <<~RUBY
+      expected = <<~RUBY.chomp
         # typed: strong
         class Post
           sig { returns(T.untyped) }
@@ -233,9 +221,7 @@ RSpec.describe(Tapioca::Compilers::Dsl::SmartProperties) do
         end
       RUBY
 
-      with_content(content) do
-        expect(output).to(eq(expected))
-      end
+      expect(rbi_for(content)).to(eq(expected))
     end
 
     it("ignores required if it is a lambda") do
@@ -246,7 +232,7 @@ RSpec.describe(Tapioca::Compilers::Dsl::SmartProperties) do
         end
       RUBY
 
-      expected = <<~RUBY
+      expected = <<~RUBY.chomp
         # typed: strong
         class Post
           sig { returns(T.nilable(::Integer)) }
@@ -257,9 +243,7 @@ RSpec.describe(Tapioca::Compilers::Dsl::SmartProperties) do
         end
       RUBY
 
-      with_content(content) do
-        expect(output).to(eq(expected))
-      end
+      expect(rbi_for(content)).to(eq(expected))
     end
 
     it("ignores required if property is not typed") do
@@ -270,7 +254,7 @@ RSpec.describe(Tapioca::Compilers::Dsl::SmartProperties) do
         end
       RUBY
 
-      expected = <<~RUBY
+      expected = <<~RUBY.chomp
         # typed: strong
         class Post
           sig { returns(T.untyped) }
@@ -281,9 +265,7 @@ RSpec.describe(Tapioca::Compilers::Dsl::SmartProperties) do
         end
       RUBY
 
-      with_content(content) do
-        expect(output).to(eq(expected))
-      end
+      expect(rbi_for(content)).to(eq(expected))
     end
 
     it("generates a reader that has been renamed correctly") do
@@ -294,7 +276,7 @@ RSpec.describe(Tapioca::Compilers::Dsl::SmartProperties) do
         end
       RUBY
 
-      expected = <<~RUBY
+      expected = <<~RUBY.chomp
         # typed: strong
         class Post
           sig { returns(T.nilable(::Integer)) }
@@ -305,9 +287,7 @@ RSpec.describe(Tapioca::Compilers::Dsl::SmartProperties) do
         end
       RUBY
 
-      with_content(content) do
-        expect(output).to(eq(expected))
-      end
+      expect(rbi_for(content)).to(eq(expected))
     end
 
     it("generates RBI file for smart property that accepts boolean and has a default") do
@@ -318,7 +298,7 @@ RSpec.describe(Tapioca::Compilers::Dsl::SmartProperties) do
         end
       RUBY
 
-      expected = <<~RUBY
+      expected = <<~RUBY.chomp
         # typed: strong
         class Post
           sig { returns(T.nilable(T::Boolean)) }
@@ -329,9 +309,7 @@ RSpec.describe(Tapioca::Compilers::Dsl::SmartProperties) do
         end
       RUBY
 
-      with_content(content) do
-        expect(output).to(eq(expected))
-      end
+      expect(rbi_for(content)).to(eq(expected))
     end
 
     it("generates RBI file for smart property that accepts a lambda") do
@@ -342,7 +320,7 @@ RSpec.describe(Tapioca::Compilers::Dsl::SmartProperties) do
         end
       RUBY
 
-      expected = <<~RUBY
+      expected = <<~RUBY.chomp
         # typed: strong
         class Post
           sig { returns(T.untyped) }
@@ -353,9 +331,7 @@ RSpec.describe(Tapioca::Compilers::Dsl::SmartProperties) do
         end
       RUBY
 
-      with_content(content) do
-        expect(output).to(eq(expected))
-      end
+      expect(rbi_for(content)).to(eq(expected))
     end
 
     it("generates RBI file for smart property that accepts another ObjectClass") do
@@ -373,7 +349,7 @@ RSpec.describe(Tapioca::Compilers::Dsl::SmartProperties) do
         end
       RUBY
 
-      expected = <<~RUBY
+      expected = <<~RUBY.chomp
         # typed: strong
         class Post
           sig { returns(T.nilable(::Post::TrackingInfoInput)) }
@@ -384,9 +360,7 @@ RSpec.describe(Tapioca::Compilers::Dsl::SmartProperties) do
         end
       RUBY
 
-      with_content(content) do
-        expect(output).to(eq(expected))
-      end
+      expect(rbi_for(content)).to(eq(expected))
     end
   end
 end

--- a/spec/tapioca/compilers/dsl/smart_properties_spec.rb
+++ b/spec/tapioca/compilers/dsl/smart_properties_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe(Tapioca::Compilers::Dsl::SmartProperties) do
         end
       RUBY
 
-      expected = <<~RUBY.chomp
+      expected = <<~RUBY
         # typed: strong
 
       RUBY
@@ -78,7 +78,7 @@ RSpec.describe(Tapioca::Compilers::Dsl::SmartProperties) do
         end
       RUBY
 
-      expected = <<~RUBY.chomp
+      expected = <<~RUBY
         # typed: strong
         class Post
           sig { returns(T.nilable(::String)) }
@@ -100,7 +100,7 @@ RSpec.describe(Tapioca::Compilers::Dsl::SmartProperties) do
         end
       RUBY
 
-      expected = <<~RUBY.chomp
+      expected = <<~RUBY
         # typed: strong
         class Post
           sig { returns(::String) }
@@ -122,7 +122,7 @@ RSpec.describe(Tapioca::Compilers::Dsl::SmartProperties) do
         end
       RUBY
 
-      expected = <<~RUBY.chomp
+      expected = <<~RUBY
         # typed: strong
         class Post
           sig { returns(T.untyped) }
@@ -144,7 +144,7 @@ RSpec.describe(Tapioca::Compilers::Dsl::SmartProperties) do
         end
       RUBY
 
-      expected = <<~RUBY.chomp
+      expected = <<~RUBY
         # typed: strong
         class Post
           sig { returns(T.nilable(T::Array[T.untyped])) }
@@ -166,7 +166,7 @@ RSpec.describe(Tapioca::Compilers::Dsl::SmartProperties) do
         end
       RUBY
 
-      expected = <<~RUBY.chomp
+      expected = <<~RUBY
         # typed: strong
         class Post
           sig { returns(T.nilable(T::Boolean)) }
@@ -188,7 +188,7 @@ RSpec.describe(Tapioca::Compilers::Dsl::SmartProperties) do
         end
       RUBY
 
-      expected = <<~RUBY.chomp
+      expected = <<~RUBY
         # typed: strong
         class Post
           sig { returns(T.nilable(T.any(::String, ::Integer))) }
@@ -210,7 +210,7 @@ RSpec.describe(Tapioca::Compilers::Dsl::SmartProperties) do
         end
       RUBY
 
-      expected = <<~RUBY.chomp
+      expected = <<~RUBY
         # typed: strong
         class Post
           sig { returns(T.untyped) }
@@ -232,7 +232,7 @@ RSpec.describe(Tapioca::Compilers::Dsl::SmartProperties) do
         end
       RUBY
 
-      expected = <<~RUBY.chomp
+      expected = <<~RUBY
         # typed: strong
         class Post
           sig { returns(T.nilable(::Integer)) }
@@ -254,7 +254,7 @@ RSpec.describe(Tapioca::Compilers::Dsl::SmartProperties) do
         end
       RUBY
 
-      expected = <<~RUBY.chomp
+      expected = <<~RUBY
         # typed: strong
         class Post
           sig { returns(T.untyped) }
@@ -276,7 +276,7 @@ RSpec.describe(Tapioca::Compilers::Dsl::SmartProperties) do
         end
       RUBY
 
-      expected = <<~RUBY.chomp
+      expected = <<~RUBY
         # typed: strong
         class Post
           sig { returns(T.nilable(::Integer)) }
@@ -298,7 +298,7 @@ RSpec.describe(Tapioca::Compilers::Dsl::SmartProperties) do
         end
       RUBY
 
-      expected = <<~RUBY.chomp
+      expected = <<~RUBY
         # typed: strong
         class Post
           sig { returns(T.nilable(T::Boolean)) }
@@ -320,7 +320,7 @@ RSpec.describe(Tapioca::Compilers::Dsl::SmartProperties) do
         end
       RUBY
 
-      expected = <<~RUBY.chomp
+      expected = <<~RUBY
         # typed: strong
         class Post
           sig { returns(T.untyped) }
@@ -349,7 +349,7 @@ RSpec.describe(Tapioca::Compilers::Dsl::SmartProperties) do
         end
       RUBY
 
-      expected = <<~RUBY.chomp
+      expected = <<~RUBY
         # typed: strong
         class Post
           sig { returns(T.nilable(::Post::TrackingInfoInput)) }


### PR DESCRIPTION
calling `expect` inside a child process prevents rspec from reporting any failures