### PR TITLE
Report test failures correctly

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -57,14 +57,16 @@ def with_contents(contents, requires: [contents.keys.first], &block)
       File.write(dir.join("lib/#{file}"), content)
     end
 
-    run_in_child do
+    result = run_in_child do
       # Require files
       requires.each do |file|
         require(dir.join("lib/#{file}"))
       end
 
-      block.call(dir)
+      block.call(dir).to_yaml
     end
+
+    YAML.load(result)
   end
 end
 

--- a/spec/tapioca/compilers/dsl/action_controller_helpers_spec.rb
+++ b/spec/tapioca/compilers/dsl/action_controller_helpers_spec.rb
@@ -6,6 +6,12 @@ require "tapioca/compilers/dsl/action_controller_helpers"
 
 RSpec.describe(Tapioca::Compilers::Dsl::ActionControllerHelpers) do
   describe("#initialize") do
+    def rbi_for(content)
+      with_content(content) do
+        subject.processable_constants.to_a.map(&:to_s)
+      end
+    end
+
     it("gathers no constants if there are no  classes") do
       expect(subject.processable_constants).to(be_empty)
     end
@@ -19,9 +25,7 @@ RSpec.describe(Tapioca::Compilers::Dsl::ActionControllerHelpers) do
         end
       RUBY
 
-      with_content(content) do
-        expect(subject.processable_constants).to(eq(Set.new([UserController])))
-      end
+      expect(rbi_for(content).to_a).to(eq(["UserController"]))
     end
 
     it("does not gather included modules as their own processable constant") do
@@ -34,9 +38,7 @@ RSpec.describe(Tapioca::Compilers::Dsl::ActionControllerHelpers) do
         end
       RUBY
 
-      with_content(content) do
-        expect(subject.processable_constants).to(eq(Set.new([UserController])))
-      end
+      expect(rbi_for(content).to_a).to(eq(["UserController"]))
     end
 
     it("gathers subclasses of ActionController subclasses") do
@@ -48,9 +50,7 @@ RSpec.describe(Tapioca::Compilers::Dsl::ActionControllerHelpers) do
         end
       RUBY
 
-      with_content(content) do
-        expect(subject.processable_constants).to(eq(Set.new([UserController, HandController])))
-      end
+      expect(rbi_for(content).to_a).to(eq(["UserController", "HandController"]))
     end
 
     it("ignores abstract subclasses of ActionController") do
@@ -63,9 +63,7 @@ RSpec.describe(Tapioca::Compilers::Dsl::ActionControllerHelpers) do
         end
       RUBY
 
-      with_content(content) do
-        expect(subject.processable_constants).to(eq(Set.new([UserController])))
-      end
+      expect(rbi_for(content).to_a).to(eq(["UserController"]))
     end
   end
 

--- a/spec/tapioca/compilers/dsl/action_controller_helpers_spec.rb
+++ b/spec/tapioca/compilers/dsl/action_controller_helpers_spec.rb
@@ -6,9 +6,9 @@ require "tapioca/compilers/dsl/action_controller_helpers"
 
 RSpec.describe(Tapioca::Compilers::Dsl::ActionControllerHelpers) do
   describe("#initialize") do
-    def rbi_for(content)
+    def constants_from(content)
       with_content(content) do
-        subject.processable_constants.to_a.map(&:to_s)
+        subject.processable_constants.map(&:to_s).sort
       end
     end
 
@@ -25,7 +25,7 @@ RSpec.describe(Tapioca::Compilers::Dsl::ActionControllerHelpers) do
         end
       RUBY
 
-      expect(rbi_for(content).to_a).to(eq(["UserController"]))
+      expect(constants_from(content)).to(eq(["UserController"]))
     end
 
     it("does not gather included modules as their own processable constant") do
@@ -38,7 +38,7 @@ RSpec.describe(Tapioca::Compilers::Dsl::ActionControllerHelpers) do
         end
       RUBY
 
-      expect(rbi_for(content).to_a).to(eq(["UserController"]))
+      expect(constants_from(content)).to(eq(["UserController"]))
     end
 
     it("gathers subclasses of ActionController subclasses") do
@@ -50,7 +50,7 @@ RSpec.describe(Tapioca::Compilers::Dsl::ActionControllerHelpers) do
         end
       RUBY
 
-      expect(rbi_for(content).to_a).to(eq(["UserController", "HandController"]))
+      expect(constants_from(content)).to(eq(["HandController", "UserController"]))
     end
 
     it("ignores abstract subclasses of ActionController") do
@@ -63,7 +63,7 @@ RSpec.describe(Tapioca::Compilers::Dsl::ActionControllerHelpers) do
         end
       RUBY
 
-      expect(rbi_for(content).to_a).to(eq(["UserController"]))
+      expect(constants_from(content)).to(eq(["UserController"]))
     end
   end
 

--- a/spec/tapioca/compilers/dsl/action_mailer_spec.rb
+++ b/spec/tapioca/compilers/dsl/action_mailer_spec.rb
@@ -5,9 +5,9 @@ require "spec_helper"
 
 RSpec.describe(Tapioca::Compilers::Dsl::ActionMailer) do
   describe("#initialize") do
-    def rbi_for(content)
+    def constants_from(content)
       with_content(content) do
-        subject.processable_constants.to_a.map(&:to_s)
+        subject.processable_constants.map(&:to_s).sort
       end
     end
 
@@ -24,7 +24,7 @@ RSpec.describe(Tapioca::Compilers::Dsl::ActionMailer) do
         end
       RUBY
 
-      expect(rbi_for(content).to_a).to(eq(["NotifierMailer"]))
+      expect(constants_from(content)).to(eq(["NotifierMailer"]))
     end
 
     it("gathers subclasses of ActionMailer subclasses") do
@@ -36,7 +36,7 @@ RSpec.describe(Tapioca::Compilers::Dsl::ActionMailer) do
         end
       RUBY
 
-      expect(rbi_for(content).to_a).to(eq(["NotifierMailer", "SecondaryMailer"]))
+      expect(constants_from(content)).to(eq(["NotifierMailer", "SecondaryMailer"]))
     end
 
     it("ignores abstract subclasses") do
@@ -49,7 +49,7 @@ RSpec.describe(Tapioca::Compilers::Dsl::ActionMailer) do
         end
       RUBY
 
-      expect(rbi_for(content).to_a).to(eq(["NotifierMailer"]))
+      expect(constants_from(content)).to(eq(["NotifierMailer"]))
     end
   end
 

--- a/spec/tapioca/compilers/dsl/action_mailer_spec.rb
+++ b/spec/tapioca/compilers/dsl/action_mailer_spec.rb
@@ -5,6 +5,12 @@ require "spec_helper"
 
 RSpec.describe(Tapioca::Compilers::Dsl::ActionMailer) do
   describe("#initialize") do
+    def rbi_for(content)
+      with_content(content) do
+        subject.processable_constants.to_a.map(&:to_s)
+      end
+    end
+
     it("gathers no constants if there are no ActionMailer subclasses") do
       expect(subject.processable_constants).to(be_empty)
     end
@@ -18,9 +24,7 @@ RSpec.describe(Tapioca::Compilers::Dsl::ActionMailer) do
         end
       RUBY
 
-      with_content(content) do
-        expect(subject.processable_constants).to(eq(Set.new([NotifierMailer])))
-      end
+      expect(rbi_for(content).to_a).to(eq(["NotifierMailer"]))
     end
 
     it("gathers subclasses of ActionMailer subclasses") do
@@ -32,9 +36,7 @@ RSpec.describe(Tapioca::Compilers::Dsl::ActionMailer) do
         end
       RUBY
 
-      with_content(content) do
-        expect(subject.processable_constants).to(eq(Set.new([NotifierMailer, SecondaryMailer])))
-      end
+      expect(rbi_for(content).to_a).to(eq(["NotifierMailer", "SecondaryMailer"]))
     end
 
     it("ignores abstract subclasses") do
@@ -47,9 +49,7 @@ RSpec.describe(Tapioca::Compilers::Dsl::ActionMailer) do
         end
       RUBY
 
-      with_content(content) do
-        expect(subject.processable_constants).to(eq(Set.new([NotifierMailer])))
-      end
+      expect(rbi_for(content).to_a).to(eq(["NotifierMailer"]))
     end
   end
 

--- a/spec/tapioca/compilers/dsl/frozen_record_spec.rb
+++ b/spec/tapioca/compilers/dsl/frozen_record_spec.rb
@@ -6,6 +6,12 @@ require "tapioca/compilers/dsl/frozen_record"
 
 RSpec.describe(Tapioca::Compilers::Dsl::FrozenRecord) do
   describe("#initialize") do
+    def rbi_for(content)
+      with_content(content) do
+        subject.processable_constants.to_a.map(&:to_s)
+      end
+    end
+
     it("gathers no constants if there are no FrozenRecord classes") do
       expect(subject.processable_constants).to(be_empty)
     end
@@ -19,9 +25,7 @@ RSpec.describe(Tapioca::Compilers::Dsl::FrozenRecord) do
         end
       RUBY
 
-      with_content(content) do
-        expect(subject.processable_constants).to(eq(Set.new([Student])))
-      end
+      expect(rbi_for(content).to_a).to(eq(["Student"]))
     end
   end
 

--- a/spec/tapioca/compilers/dsl/frozen_record_spec.rb
+++ b/spec/tapioca/compilers/dsl/frozen_record_spec.rb
@@ -6,9 +6,9 @@ require "tapioca/compilers/dsl/frozen_record"
 
 RSpec.describe(Tapioca::Compilers::Dsl::FrozenRecord) do
   describe("#initialize") do
-    def rbi_for(content)
+    def constants_from(content)
       with_content(content) do
-        subject.processable_constants.to_a.map(&:to_s)
+        subject.processable_constants.map(&:to_s).sort
       end
     end
 
@@ -25,7 +25,7 @@ RSpec.describe(Tapioca::Compilers::Dsl::FrozenRecord) do
         end
       RUBY
 
-      expect(rbi_for(content).to_a).to(eq(["Student"]))
+      expect(constants_from(content)).to(eq(["Student"]))
     end
   end
 

--- a/spec/tapioca/compilers/dsl/smart_properties_spec.rb
+++ b/spec/tapioca/compilers/dsl/smart_properties_spec.rb
@@ -6,6 +6,12 @@ require "tapioca/compilers/dsl/smart_properties"
 
 RSpec.describe(Tapioca::Compilers::Dsl::SmartProperties) do
   describe("#initialize") do
+    def rbi_for(content)
+      with_content(content) do
+        subject.processable_constants.to_a.map(&:to_s)
+      end
+    end
+
     it("gathers no constants if there are no SmartProperty classes") do
       expect(subject.processable_constants).to(be_empty)
     end
@@ -24,9 +30,7 @@ RSpec.describe(Tapioca::Compilers::Dsl::SmartProperties) do
         end
       RUBY
 
-      with_content(content) do
-        expect(subject.processable_constants).to(eq(Set.new([Post, User])))
-      end
+      expect(rbi_for(content).to_a).to(eq(["User", "Post"]))
     end
 
     it("ignores SmartProperty classes without a name") do

--- a/spec/tapioca/compilers/dsl/smart_properties_spec.rb
+++ b/spec/tapioca/compilers/dsl/smart_properties_spec.rb
@@ -6,9 +6,9 @@ require "tapioca/compilers/dsl/smart_properties"
 
 RSpec.describe(Tapioca::Compilers::Dsl::SmartProperties) do
   describe("#initialize") do
-    def rbi_for(content)
+    def constants_from(content)
       with_content(content) do
-        subject.processable_constants.to_a.map(&:to_s)
+        subject.processable_constants.map(&:to_s).sort
       end
     end
 
@@ -30,7 +30,7 @@ RSpec.describe(Tapioca::Compilers::Dsl::SmartProperties) do
         end
       RUBY
 
-      expect(rbi_for(content).to_a).to(eq(["User", "Post"]))
+      expect(constants_from(content)).to(eq(["Post", "User"]))
     end
 
     it("ignores SmartProperty classes without a name") do
@@ -44,9 +44,7 @@ RSpec.describe(Tapioca::Compilers::Dsl::SmartProperties) do
         end
       RUBY
 
-      with_content(content) do
-        expect(subject.processable_constants).to(be_empty)
-      end
+      expect(constants_from(content)).to(be_empty)
     end
   end
 

--- a/spec/tapioca/compilers/dsl/state_machines_spec.rb
+++ b/spec/tapioca/compilers/dsl/state_machines_spec.rb
@@ -6,6 +6,12 @@ require "tapioca/compilers/dsl/smart_properties"
 
 RSpec.describe(Tapioca::Compilers::Dsl::StateMachines) do
   describe("#initialize") do
+    def rbi_for(content)
+      with_content(content) do
+        subject.processable_constants.to_a.map(&:to_s)
+      end
+    end
+
     it("gathers no constants if there are no StateMachines classes") do
       expect(subject.processable_constants).to(be_empty)
     end
@@ -24,9 +30,7 @@ RSpec.describe(Tapioca::Compilers::Dsl::StateMachines) do
         end
       RUBY
 
-      with_content(content) do
-        expect(subject.processable_constants).to(eq(Set.new([Vehicle, User])))
-      end
+      expect(rbi_for(content).to_a).to(eq(["Vehicle", "User"]))
     end
   end
 

--- a/spec/tapioca/compilers/dsl/state_machines_spec.rb
+++ b/spec/tapioca/compilers/dsl/state_machines_spec.rb
@@ -6,9 +6,9 @@ require "tapioca/compilers/dsl/smart_properties"
 
 RSpec.describe(Tapioca::Compilers::Dsl::StateMachines) do
   describe("#initialize") do
-    def rbi_for(content)
+    def constants_from(content)
       with_content(content) do
-        subject.processable_constants.to_a.map(&:to_s)
+        subject.processable_constants.map(&:to_s).sort
       end
     end
 
@@ -30,7 +30,7 @@ RSpec.describe(Tapioca::Compilers::Dsl::StateMachines) do
         end
       RUBY
 
-      expect(rbi_for(content).to_a).to(eq(["Vehicle", "User"]))
+      expect(constants_from(content)).to(eq(["User", "Vehicle"]))
     end
   end
 


### PR DESCRIPTION
continuation of https://github.com/Shopify/tapioca/pull/59 where we were having problems with rspec reporting the test failures. This PR removes the `expect` call out of the child process.

In order to more easily extract output from the child processes they are parsed as YAML and then outputted as an array of strings using `YAML#load`