### PR TITLE
Extract ActiveRecordAssociations DSL Generator

### DIFF
--- a/lib/tapioca/compilers/dsl/active_record_associations.rb
+++ b/lib/tapioca/compilers/dsl/active_record_associations.rb
@@ -1,0 +1,284 @@
+# typed: true
+# frozen_string_literal: true
+
+require "parlour"
+
+begin
+  require "active_record"
+rescue LoadError
+  return
+end
+
+module Tapioca
+  module Compilers
+    module Dsl
+      # `Tapioca::Compilers::Dsl::ActiveRecordAssociations` refines RBI files for subclasses of `ActiveRecord::Base`
+      # (see https://api.rubyonrails.org/classes/ActiveRecord/Base.html). This generator is only
+      # responsible for defining the methods that would be created for the association that
+      # are defined in the Active Record model.
+      #
+      # For example, with the following model class:
+      #
+      # ~~~rb
+      # class Post < ActiveRecord::Base
+      #   belongs_to :category
+      #   has_many :comments
+      #   has_one :author, class_name: "User"
+      # end
+      # ~~~
+      #
+      # this generator will produce the following methods in the RBI file
+      # `post.rbi`:
+      #
+      # ~~~rbi
+      # # post.rbi
+      # # typed: true
+      #
+      # class Post
+      #   include Post::GeneratedAssociationMethods
+      # end
+      #
+      # module Post::GeneratedAssociationMethods
+      #   sig { returns(T.nilable(::User)) }
+      #   def author; end
+      #
+      #   sig { params(value: T.nilable(::User)).void }
+      #   def author=(value); end
+      #
+      #   sig { params(args: T.untyped, blk: T.untyped).returns(T.nilable(::User)) }
+      #   def build_author(*args, &blk); end
+      #
+      #   sig { params(args: T.untyped, blk: T.untyped).returns(T.nilable(::Category)) }
+      #   def build_category(*args, &blk); end
+      #
+      #   sig { returns(T.nilable(::Category)) }
+      #   def category; end
+      #
+      #   sig { params(value: T.nilable(::Category)).void }
+      #   def category=(value); end
+      #
+      #   sig { returns(T::Array[T.untyped]) }
+      #   def comment_ids; end
+      #
+      #   sig { params(ids: T::Array[T.untyped]).returns(T::Array[T.untyped]) }
+      #   def comment_ids=(ids); end
+      #
+      #   sig { returns(::ActiveRecord::Associations::CollectionProxy[Comment]) }
+      #   def comments; end
+      #
+      #   sig { params(value: T::Enumerable[::Comment]).void }
+      #   def comments=(value); end
+      #
+      #   sig { params(args: T.untyped, blk: T.untyped).returns(T.nilable(::User)) }
+      #   def create_author(*args, &blk); end
+      #
+      #   sig { params(args: T.untyped, blk: T.untyped).returns(T.nilable(::User)) }
+      #   def create_author!(*args, &blk); end
+      #
+      #   sig { params(args: T.untyped, blk: T.untyped).returns(T.nilable(::Category)) }
+      #   def create_category(*args, &blk); end
+      #
+      #   sig { params(args: T.untyped, blk: T.untyped).returns(T.nilable(::Category)) }
+      #   def create_category!(*args, &blk); end
+      #
+      #   sig { returns(T.nilable(::User)) }
+      #   def reload_author; end
+      #
+      #   sig { returns(T.nilable(::Category)) }
+      #   def reload_category; end
+      # end
+      # ~~~
+      class ActiveRecordAssociations < Base
+        extend T::Sig
+
+        ReflectionType = T.type_alias do
+          T.any(::ActiveRecord::Reflection::ThroughReflection, ::ActiveRecord::Reflection::AssociationReflection)
+        end
+
+        sig { override.params(root: Parlour::RbiGenerator::Namespace, constant: T.class_of(ActiveRecord::Base)).void }
+        def decorate(root, constant)
+          return if constant.reflections.empty?
+
+          module_name = "#{constant}::GeneratedAssociationMethods"
+          root.create_module(module_name) do |mod|
+            constant.reflections.each do |association_name, reflection|
+              if reflection.collection?
+                populate_collection_assoc_getter_setter(mod, constant, association_name, reflection)
+              else
+                populate_single_assoc_getter_setter(mod, constant, association_name, reflection)
+              end
+            end
+          end
+
+          root.path(constant) do |klass|
+            klass.create_include(module_name)
+          end
+        end
+
+        sig { override.returns(T::Enumerable[Module]) }
+        def gather_constants
+          ActiveRecord::Base.descendants.reject(&:abstract_class?)
+        end
+
+        private
+
+        sig do
+          params(
+            klass: Parlour::RbiGenerator::Namespace,
+            constant: T.class_of(ActiveRecord::Base),
+            association_name: T.any(String, Symbol),
+            reflection: ReflectionType
+          ).void
+        end
+        def populate_single_assoc_getter_setter(klass, constant, association_name, reflection)
+          association_class = type_for(constant, reflection)
+          association_type = if belongs_to_and_required?(constant, reflection)
+                               association_class
+                             else
+                               "T.nilable(#{association_class})"
+                             end
+
+          create_method(
+            klass,
+            association_name.to_s,
+            return_type: association_type,
+          )
+          create_method(
+            klass,
+            "#{association_name}=",
+            parameters: [
+              Parlour::RbiGenerator::Parameter.new("value", type: association_type),
+            ],
+            return_type: nil
+          )
+          create_method(
+            klass,
+            "reload_#{association_name}",
+            return_type: association_type,
+          )
+          if reflection.constructable?
+            create_method(
+              klass,
+              "build_#{association_name}",
+              parameters: [
+                Parlour::RbiGenerator::Parameter.new("*args", type: "T.untyped"),
+                Parlour::RbiGenerator::Parameter.new("&blk", type: "T.untyped"),
+              ],
+              return_type: association_type
+            )
+            create_method(
+              klass,
+              "create_#{association_name}",
+              parameters: [
+                Parlour::RbiGenerator::Parameter.new("*args", type: "T.untyped"),
+                Parlour::RbiGenerator::Parameter.new("&blk", type: "T.untyped"),
+              ],
+              return_type: association_type
+            )
+            create_method(
+              klass,
+              "create_#{association_name}!",
+              parameters: [
+                Parlour::RbiGenerator::Parameter.new("*args", type: "T.untyped"),
+                Parlour::RbiGenerator::Parameter.new("&blk", type: "T.untyped"),
+              ],
+              return_type: association_type
+            )
+          end
+        end
+
+        sig do
+          params(
+            klass: Parlour::RbiGenerator::Namespace,
+            constant: T.class_of(ActiveRecord::Base),
+            association_name: T.any(String, Symbol),
+            reflection: ReflectionType
+          ).void
+        end
+        def populate_collection_assoc_getter_setter(klass, constant, association_name, reflection)
+          association_class = type_for(constant, reflection)
+          relation_class = relation_type_for(constant, reflection)
+
+          create_method(
+            klass,
+            association_name.to_s,
+            return_type: relation_class,
+          )
+          create_method(
+            klass,
+            "#{association_name}=",
+            parameters: [
+              Parlour::RbiGenerator::Parameter.new("value", type: "T::Enumerable[#{association_class}]"),
+            ],
+            return_type: nil,
+          )
+          create_method(
+            klass,
+            "#{association_name.to_s.singularize}_ids",
+            return_type: "T::Array[T.untyped]"
+          )
+          create_method(
+            klass,
+            "#{association_name.to_s.singularize}_ids=",
+            parameters: [
+              Parlour::RbiGenerator::Parameter.new("ids", type: "T::Array[T.untyped]"),
+            ],
+            return_type: "T::Array[T.untyped]"
+          )
+        end
+
+        sig do
+          params(
+            constant: T.class_of(ActiveRecord::Base),
+            reflection: ReflectionType
+          ).returns(T::Boolean)
+        end
+        def belongs_to_and_required?(constant, reflection)
+          return false unless constant.table_exists?
+          return false unless reflection.belongs_to?
+          column_definition = constant.columns_hash[reflection.foreign_key.to_s]
+
+          !column_definition.nil? && !column_definition.null
+        end
+
+        sig do
+          params(
+            constant: T.class_of(ActiveRecord::Base),
+            reflection: ReflectionType
+          ).returns(String)
+        end
+        def type_for(constant, reflection)
+          return "T.untyped" if !constant.table_exists? || polymorphic_association?(reflection)
+
+          "::#{reflection.klass.name}"
+        end
+
+        sig do
+          params(
+            constant: T.class_of(ActiveRecord::Base),
+            reflection: ReflectionType
+          ).returns(String)
+        end
+        def relation_type_for(constant, reflection)
+          "ActiveRecord::Associations::CollectionProxy" if !constant.table_exists? || polymorphic_association?(reflection)
+
+          # Change to: "::#{reflection.klass.name}::ActiveRecord_Associations_CollectionProxy"
+          "::ActiveRecord::Associations::CollectionProxy[#{reflection.klass.name}]"
+        end
+
+        sig do
+          params(
+            reflection: ReflectionType
+          ).returns(T::Boolean)
+        end
+        def polymorphic_association?(reflection)
+          if reflection.through_reflection?
+            polymorphic_association?(reflection.source_reflection)
+          else
+            !!reflection.polymorphic?
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/tapioca/compilers/dsl/active_record_associations.rb
+++ b/lib/tapioca/compilers/dsl/active_record_associations.rb
@@ -133,10 +133,10 @@ module Tapioca
         def populate_single_assoc_getter_setter(klass, constant, association_name, reflection)
           association_class = type_for(constant, reflection)
           association_type = if belongs_to_and_required?(constant, reflection)
-                               association_class
-                             else
-                               "T.nilable(#{association_class})"
-                             end
+            association_class
+          else
+            "T.nilable(#{association_class})"
+          end
 
           create_method(
             klass,

--- a/lib/tapioca/compilers/dsl/active_record_associations.rb
+++ b/lib/tapioca/compilers/dsl/active_record_associations.rb
@@ -260,7 +260,8 @@ module Tapioca
           ).returns(String)
         end
         def relation_type_for(constant, reflection)
-          "ActiveRecord::Associations::CollectionProxy" if !constant.table_exists? || polymorphic_association?(reflection)
+          "ActiveRecord::Associations::CollectionProxy" if !constant.table_exists? ||
+                                                            polymorphic_association?(reflection)
 
           # Change to: "::#{reflection.klass.name}::ActiveRecord_Associations_CollectionProxy"
           "::ActiveRecord::Associations::CollectionProxy[#{reflection.klass.name}]"

--- a/spec/tapioca/compilers/dsl/active_record_associations_spec.rb
+++ b/spec/tapioca/compilers/dsl/active_record_associations_spec.rb
@@ -50,19 +50,41 @@ describe("Tapioca::Compilers::Dsl::ActiveRecordAssociations") do
   end
 
   describe("#decorate") do
-    before(:each) do
-      ActiveRecord::Base.establish_connection(
-        adapter: 'sqlite3',
-        database: ':memory:'
-      )
-    end
-
-    def rbi_for(contents)
-      with_contents(contents, requires: contents.keys) do
+    def rbi_for(content)
+      with_content(content) do
         parlour = Parlour::RbiGenerator.new(sort_namespaces: true)
         subject.decorate(parlour.root, Post)
         parlour.rbi
       end
+    end
+
+    it("generates empty RBI file if there are no associations") do
+      content = <<~RUBY
+        class Post < ActiveRecord::Base
+        end
+      RUBY
+
+      expected = <<~RUBY
+        # typed: strong
+
+      RUBY
+
+      assert_equal(rbi_for(content), expected)
+    end
+
+    it("generates RBI file for belongs_to association") do
+      content = <<~RUBY
+        class Post < ActiveRecord::Base
+          belongs_to :category
+        end
+      RUBY
+
+      expected = <<~RUBY
+        # typed: strong
+
+      RUBY
+
+      assert_equal(rbi_for(content), expected)
     end
   end
 end

--- a/spec/tapioca/compilers/dsl/active_record_associations_spec.rb
+++ b/spec/tapioca/compilers/dsl/active_record_associations_spec.rb
@@ -116,6 +116,34 @@ describe("Tapioca::Compilers::Dsl::ActiveRecordAssociations") do
       assert_equal(rbi_for(content), expected)
     end
 
+    it("generates RBI file for polymorphic belongs_to association") do
+      content = <<~RUBY
+        class Post < ActiveRecord::Base
+          belongs_to :category, polymorphic: true
+        end
+      RUBY
+
+      expected = <<~RUBY
+        # typed: strong
+        class Post
+          include Post::GeneratedAssociationMethods
+        end
+
+        module Post::GeneratedAssociationMethods
+          sig { returns(T.nilable(T.untyped)) }
+          def category; end
+
+          sig { params(value: T.nilable(T.untyped)).void }
+          def category=(value); end
+
+          sig { returns(T.nilable(T.untyped)) }
+          def reload_category; end
+        end
+      RUBY
+
+      assert_equal(rbi_for(content), expected)
+    end
+
     it("generates RBI file for has_one association") do
       content = <<~RUBY
         ActiveRecord::Migration.suppress_messages do

--- a/spec/tapioca/compilers/dsl/active_record_associations_spec.rb
+++ b/spec/tapioca/compilers/dsl/active_record_associations_spec.rb
@@ -1,0 +1,68 @@
+# typed: false
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe("Tapioca::Compilers::Dsl::ActiveRecordAssociations") do
+  before(:each) do
+    require "tapioca/compilers/dsl/active_record_associations"
+  end
+
+  subject do
+    Tapioca::Compilers::Dsl::ActiveRecordAssociations.new
+  end
+
+  describe("#initialize") do
+    def constants_from(content)
+      with_content(content) do
+        subject.processable_constants.map(&:to_s).sort
+      end
+    end
+
+    it("gathers no constants if there are no ActiveRecord subclasses") do
+      assert_empty(subject.processable_constants)
+    end
+
+    it("gathers only ActiveRecord subclasses") do
+      content = <<~RUBY
+        class Post < ActiveRecord::Base
+        end
+
+        class Current
+        end
+      RUBY
+
+      assert_equal(constants_from(content), ["Post"])
+    end
+
+    it("rejects abstract ActiveRecord subclasses") do
+      content = <<~RUBY
+        class Post < ActiveRecord::Base
+        end
+
+        class Current < ActiveRecord::Base
+          self.abstract_class = true
+        end
+      RUBY
+
+      assert_equal(constants_from(content), ["Post"])
+    end
+  end
+
+  describe("#decorate") do
+    before(:each) do
+      ActiveRecord::Base.establish_connection(
+        adapter: 'sqlite3',
+        database: ':memory:'
+      )
+    end
+
+    def rbi_for(contents)
+      with_contents(contents, requires: contents.keys) do
+        parlour = Parlour::RbiGenerator.new(sort_namespaces: true)
+        subject.decorate(parlour.root, Post)
+        parlour.rbi
+      end
+    end
+  end
+end

--- a/spec/tapioca/compilers/dsl/active_record_associations_spec.rb
+++ b/spec/tapioca/compilers/dsl/active_record_associations_spec.rb
@@ -79,7 +79,7 @@ describe("Tapioca::Compilers::Dsl::ActiveRecordAssociations") do
       assert_equal(rbi_for(content), expected)
     end
 
-    it("generates RBI file for belongs_to association") do
+    it("generates RBI file for belongs_to single association") do
       content = <<~RUBY
         class Post < ActiveRecord::Base
           belongs_to :category
@@ -116,7 +116,7 @@ describe("Tapioca::Compilers::Dsl::ActiveRecordAssociations") do
       assert_equal(rbi_for(content), expected)
     end
 
-    it("generates RBI file for polymorphic belongs_to association") do
+    it("generates RBI file for polymorphic belongs_to single association") do
       content = <<~RUBY
         class Post < ActiveRecord::Base
           belongs_to :category, polymorphic: true
@@ -144,7 +144,7 @@ describe("Tapioca::Compilers::Dsl::ActiveRecordAssociations") do
       assert_equal(rbi_for(content), expected)
     end
 
-    it("generates RBI file for has_one association") do
+    it("generates RBI file for has_one single association") do
       content = <<~RUBY
         ActiveRecord::Migration.suppress_messages do
           ActiveRecord::Schema.define do
@@ -191,7 +191,7 @@ describe("Tapioca::Compilers::Dsl::ActiveRecordAssociations") do
       assert_equal(rbi_for(content), expected)
     end
 
-    it("generates RBI file for has_many association") do
+    it("generates RBI file for has_many collection association") do
       content = <<~RUBY
         class Comment
         end
@@ -225,7 +225,7 @@ describe("Tapioca::Compilers::Dsl::ActiveRecordAssociations") do
       assert_equal(rbi_for(content), expected)
     end
 
-    it("generates RBI file for has_many :through association") do
+    it("generates RBI file for has_many :through collection association") do
       content = <<~RUBY
         class Commenter < ActiveRecord::Base
           has_many :comments
@@ -279,7 +279,7 @@ describe("Tapioca::Compilers::Dsl::ActiveRecordAssociations") do
       assert_equal(rbi_for(content), expected)
     end
 
-    it("generates RBI file for has_and_belongs_to_many association") do
+    it("generates RBI file for has_and_belongs_to_many collection association") do
       content = <<~RUBY
         class Commenter < ActiveRecord::Base
           has_and_belongs_to_many :posts

--- a/spec/tapioca/compilers/dsl/active_record_associations_spec.rb
+++ b/spec/tapioca/compilers/dsl/active_record_associations_spec.rb
@@ -116,7 +116,7 @@ describe("Tapioca::Compilers::Dsl::ActiveRecordAssociations") do
       assert_equal(rbi_for(content), expected)
     end
 
-    it ("generates RBI file for has_one association") do
+    it("generates RBI file for has_one association") do
       content = <<~RUBY
         ActiveRecord::Migration.suppress_messages do
           ActiveRecord::Schema.define do
@@ -157,6 +157,129 @@ describe("Tapioca::Compilers::Dsl::ActiveRecordAssociations") do
 
           sig { returns(T.nilable(::User)) }
           def reload_author; end
+        end
+      RUBY
+
+      assert_equal(rbi_for(content), expected)
+    end
+
+    it("generates RBI file for has_many association") do
+      content = <<~RUBY
+        class Comment
+        end
+
+        class Post < ActiveRecord::Base
+          has_many :comments
+        end
+      RUBY
+
+      expected = <<~RUBY
+        # typed: strong
+        class Post
+          include Post::GeneratedAssociationMethods
+        end
+
+        module Post::GeneratedAssociationMethods
+          sig { returns(T::Array[T.untyped]) }
+          def comment_ids; end
+
+          sig { params(ids: T::Array[T.untyped]).returns(T::Array[T.untyped]) }
+          def comment_ids=(ids); end
+
+          sig { returns(::ActiveRecord::Associations::CollectionProxy[Comment]) }
+          def comments; end
+
+          sig { params(value: T::Enumerable[T.untyped]).void }
+          def comments=(value); end
+        end
+      RUBY
+
+      assert_equal(rbi_for(content), expected)
+    end
+
+    it("generates RBI file for has_many :through association") do
+      content = <<~RUBY
+        class Commenter < ActiveRecord::Base
+          has_many :comments
+          has_many :posts, through: :comments
+        end
+
+        class Comment < ActiveRecord::Base
+          belongs_to :commenter
+          belongs_to :post
+        end
+
+        class Post < ActiveRecord::Base
+          has_many :comments
+          has_many :commenters, through: :comments
+        end
+      RUBY
+
+      expected = <<~RUBY
+        # typed: strong
+        class Post
+          include Post::GeneratedAssociationMethods
+        end
+
+        module Post::GeneratedAssociationMethods
+          sig { returns(T::Array[T.untyped]) }
+          def comment_ids; end
+
+          sig { params(ids: T::Array[T.untyped]).returns(T::Array[T.untyped]) }
+          def comment_ids=(ids); end
+
+          sig { returns(T::Array[T.untyped]) }
+          def commenter_ids; end
+
+          sig { params(ids: T::Array[T.untyped]).returns(T::Array[T.untyped]) }
+          def commenter_ids=(ids); end
+
+          sig { returns(::ActiveRecord::Associations::CollectionProxy[Commenter]) }
+          def commenters; end
+
+          sig { params(value: T::Enumerable[T.untyped]).void }
+          def commenters=(value); end
+
+          sig { returns(::ActiveRecord::Associations::CollectionProxy[Comment]) }
+          def comments; end
+
+          sig { params(value: T::Enumerable[T.untyped]).void }
+          def comments=(value); end
+        end
+      RUBY
+
+      assert_equal(rbi_for(content), expected)
+    end
+
+    it("generates RBI file for has_and_belongs_to_many association") do
+      content = <<~RUBY
+        class Commenter < ActiveRecord::Base
+          has_and_belongs_to_many :posts
+        end
+
+        class Post < ActiveRecord::Base
+          has_and_belongs_to_many :commenters
+        end
+      RUBY
+
+      expected = <<~RUBY
+        # typed: strong
+        class Post
+          include Post::GeneratedAssociationMethods
+        end
+
+        module Post::GeneratedAssociationMethods
+          sig { returns(T::Array[T.untyped]) }
+          def commenter_ids; end
+
+          sig { params(ids: T::Array[T.untyped]).returns(T::Array[T.untyped]) }
+          def commenter_ids=(ids); end
+
+          sig { returns(::ActiveRecord::Associations::CollectionProxy[Commenter]) }
+          def commenters; end
+
+          sig { params(value: T::Enumerable[T.untyped]).void }
+          def commenters=(value); end
         end
       RUBY
 

--- a/spec/tapioca/compilers/dsl/active_record_associations_spec.rb
+++ b/spec/tapioca/compilers/dsl/active_record_associations_spec.rb
@@ -37,7 +37,10 @@ describe("Tapioca::Compilers::Dsl::ActiveRecordAssociations") do
 
     it("rejects abstract ActiveRecord subclasses") do
       content = <<~RUBY
-        class Post < ActiveRecord::Base
+        class Comment < ActiveRecord::Base
+        end
+
+        class Post < Comment
         end
 
         class Current < ActiveRecord::Base
@@ -45,7 +48,7 @@ describe("Tapioca::Compilers::Dsl::ActiveRecordAssociations") do
         end
       RUBY
 
-      assert_equal(constants_from(content), ["Post"])
+      assert_equal(constants_from(content), ["Comment", "Post"])
     end
   end
 
@@ -227,6 +230,13 @@ describe("Tapioca::Compilers::Dsl::ActiveRecordAssociations") do
 
     it("generates RBI file for has_many :through collection association") do
       content = <<~RUBY
+        ActiveRecord::Migration.suppress_messages do
+          ActiveRecord::Schema.define do
+            create_table :posts do |t|
+            end
+          end
+        end
+
         class Commenter < ActiveRecord::Base
           has_many :comments
           has_many :posts, through: :comments
@@ -265,13 +275,13 @@ describe("Tapioca::Compilers::Dsl::ActiveRecordAssociations") do
           sig { returns(::ActiveRecord::Associations::CollectionProxy[Commenter]) }
           def commenters; end
 
-          sig { params(value: T::Enumerable[T.untyped]).void }
+          sig { params(value: T::Enumerable[::Commenter]).void }
           def commenters=(value); end
 
           sig { returns(::ActiveRecord::Associations::CollectionProxy[Comment]) }
           def comments; end
 
-          sig { params(value: T::Enumerable[T.untyped]).void }
+          sig { params(value: T::Enumerable[::Comment]).void }
           def comments=(value); end
         end
       RUBY


### PR DESCRIPTION
This PR aims to extract our RBI generator for ActiveRecord DSL's from shopify core into tapioca. Specifically the DSL for associations.

Added tests to the existing generator
resolves Shopify/sorbet-issues#189