### PR TITLE
Start checking for props using `T::Props::ClassMethods`

### DIFF
--- a/lib/tapioca/compilers/symbol_table/symbol_generator.rb
+++ b/lib/tapioca/compilers/symbol_table/symbol_generator.rb
@@ -473,9 +473,9 @@ module Tapioca
 
         sig { params(constant: Module, method_name: String).returns(T::Boolean) }
         def struct_method?(constant, method_name)
-          return false unless constant < T::Struct
+          return false unless T::Props::ClassMethods === constant
 
-          T.cast(constant, T.class_of(T::Struct))
+          constant
             .props
             .keys
             .include?(method_name.gsub(/=$/, '').to_sym)

--- a/spec/tapioca/compilers/symbol_table_compiler_spec.rb
+++ b/spec/tapioca/compilers/symbol_table_compiler_spec.rb
@@ -1777,6 +1777,14 @@ describe("Tapioca::Compilers::SymbolTableCompiler") do
           prop :quux, T.untyped, default: [1, 2, 3]
         end
 
+        class Buzz
+          include T::Props::Constructor
+          extend T::Props::ClassMethods
+
+          const :foo, Integer
+          prop :bar, String
+        end
+
         class Baz
           extend(T::Sig)
           extend(T::Helpers)
@@ -1837,6 +1845,11 @@ describe("Tapioca::Compilers::SymbolTableCompiler") do
 
           sig { abstract.void }
           def do_it; end
+        end
+
+        class Buzz
+          const :foo, Integer
+          prop :bar, String
         end
 
         class Foo


### PR DESCRIPTION
Fixes: https://github.com/Shopify/tapioca/issues/91

We were checking that the `constant` under examination was subclassing from `T::Struct`. However, other use cases where classes `extend T::Props::ClassMethods` are also possible, like the usage in https://github.com/Shopify/maestro/blob/master/lib/maestro/base.rb#L15

The fix is to explicitly check that the class extends from `T::Props::ClassMethods` and that the method is one of the `const` or `prop` methods.