### PR TITLE
A few fixes for custom column type mapping

### DIFF
--- a/lib/tapioca/compilers/dsl/active_record_columns.rb
+++ b/lib/tapioca/compilers/dsl/active_record_columns.rb
@@ -349,9 +349,9 @@ module Tapioca
               !(constant.singleton_class < Object.const_get(:StrongTypeGeneration))
         end
 
-        sig { params(column_type: Module).returns(String) }
+        sig { params(column_type: Object).returns(String) }
         def handle_unknown_type(column_type)
-          return "T.untyped" unless column_type < ActiveModel::Type::Value
+          return "T.untyped" unless ActiveModel::Type::Value === column_type
 
           lookup_return_type_of_method(column_type, :deserialize) ||
             lookup_return_type_of_method(column_type, :cast) ||
@@ -359,18 +359,18 @@ module Tapioca
             "T.untyped"
         end
 
-        sig { params(column_type: Module, method: Symbol).returns(T.nilable(String)) }
+        sig { params(column_type: ActiveModel::Type::Value, method: Symbol).returns(T.nilable(String)) }
         def lookup_return_type_of_method(column_type, method)
-          signature = T::Private::Methods.signature_for_method(column_type.instance_method(method))
+          signature = T::Private::Methods.signature_for_method(column_type.method(method))
           return unless signature
 
           return_type = signature.return_type.to_s
           return_type if return_type != "<VOID>" && return_type != "<NOT-TYPED>"
         end
 
-        sig { params(column_type: Module, method: Symbol).returns(T.nilable(String)) }
+        sig { params(column_type: ActiveModel::Type::Value, method: Symbol).returns(T.nilable(String)) }
         def lookup_arg_type_of_method(column_type, method)
-          signature = T::Private::Methods.signature_for_method(column_type.instance_method(method))
+          signature = T::Private::Methods.signature_for_method(column_type.method(method))
           signature.arg_types.first.last.to_s if signature
         end
       end

--- a/lib/tapioca/compilers/dsl/active_record_columns.rb
+++ b/lib/tapioca/compilers/dsl/active_record_columns.rb
@@ -364,14 +364,22 @@ module Tapioca
           signature = T::Private::Methods.signature_for_method(column_type.method(method))
           return unless signature
 
-          return_type = signature.return_type.to_s
-          return_type if return_type != "<VOID>" && return_type != "<NOT-TYPED>"
+          return_type = signature.return_type
+          return if T::Types::Simple === return_type && T::Generic === return_type.raw_type
+          return if return_type == T::Private::Types::Void || return_type == T::Private::Types::NotTyped
+
+          return_type.to_s
         end
 
         sig { params(column_type: ActiveModel::Type::Value, method: Symbol).returns(T.nilable(String)) }
         def lookup_arg_type_of_method(column_type, method)
           signature = T::Private::Methods.signature_for_method(column_type.method(method))
-          signature.arg_types.first.last.to_s if signature
+          return unless signature
+
+          arg_type = signature.arg_types.first.last
+          return if T::Types::Simple === arg_type && T::Generic === arg_type.raw_type
+
+          arg_type.to_s
         end
       end
     end

--- a/sorbet/rbi/shims/sorbet.rbi
+++ b/sorbet/rbi/shims/sorbet.rbi
@@ -14,4 +14,9 @@ module T::Private
   class Sealed
     def self.sealed_module?(mod); end
   end
+
+  module Types
+    class NotTyped < T::Types::Base
+    end
+  end
 end

--- a/spec/tapioca/compilers/dsl/active_record_columns_spec.rb
+++ b/spec/tapioca/compilers/dsl/active_record_columns_spec.rb
@@ -599,7 +599,7 @@ describe("Tapioca::Compilers::Dsl::ActiveRecordColumns") do
               @value = number
             end
 
-            class Type < ActiveRecord::Type::Decimal
+            class Type < ActiveRecord::Type::Value
               extend(T::Sig)
 
               sig { params(value: Numeric).returns(::Money)}
@@ -612,7 +612,7 @@ describe("Tapioca::Compilers::Dsl::ActiveRecordColumns") do
           class Post < ActiveRecord::Base
             extend StrongTypeGeneration
 
-            attribute :cost, Money::Type
+            attribute :cost, Money::Type.new
           end
         RUBY
 
@@ -651,7 +651,7 @@ describe("Tapioca::Compilers::Dsl::ActiveRecordColumns") do
               @value = number
             end
 
-            class Type < ActiveRecord::Type::Decimal
+            class Type < ActiveRecord::Type::Value
               extend(T::Sig)
 
               sig { params(value: ::Numeric).returns(T.any(::Money, Numeric)) }
@@ -666,7 +666,7 @@ describe("Tapioca::Compilers::Dsl::ActiveRecordColumns") do
           class Post < ActiveRecord::Base
             extend StrongTypeGeneration
 
-            attribute :cost, Money::Type
+            attribute :cost, Money::Type.new
           end
         RUBY
 
@@ -705,7 +705,7 @@ describe("Tapioca::Compilers::Dsl::ActiveRecordColumns") do
               @value = number
             end
 
-            class Type < ActiveRecord::Type::Decimal
+            class Type < ActiveRecord::Type::Value
               extend(T::Sig)
 
               sig { params(money: ::Money).returns(Numeric) }
@@ -719,7 +719,7 @@ describe("Tapioca::Compilers::Dsl::ActiveRecordColumns") do
           class Post < ActiveRecord::Base
             extend StrongTypeGeneration
 
-            attribute :cost, Money::Type
+            attribute :cost, Money::Type.new
           end
         RUBY
 
@@ -758,7 +758,7 @@ describe("Tapioca::Compilers::Dsl::ActiveRecordColumns") do
               @value = number
             end
 
-            class Type < ActiveRecord::Type::Decimal
+            class Type < ActiveRecord::Type::Value
               extend(T::Sig)
 
               def deserialize(value)
@@ -770,7 +770,7 @@ describe("Tapioca::Compilers::Dsl::ActiveRecordColumns") do
           class Post < ActiveRecord::Base
             extend StrongTypeGeneration
 
-            attribute :cost, Money::Type
+            attribute :cost, Money::Type.new
           end
         RUBY
 


### PR DESCRIPTION
As I was testing the generators on Core, I ran into two problems with the custom column type mapping:

1. The column type definitions are passed as object instances and not classes. We were not handling them correctly.
2. If columns are mapped to generic types, we can't do the mapping correctly since type parameter information is lost.

This PR fixes these problems.