### PR TITLE
Add revision for git gems

### DIFF
--- a/spec/support/repo/Gemfile
+++ b/spec/support/repo/Gemfile
@@ -17,3 +17,5 @@ gem("extras")
 # gem that we have a DSL generator for.
 gem("smart_properties")
 gem("activesupport")
+# Needed to test Git gems
+gem("ast", git: "https://github.com/whitequark/ast", ref: "e07a4f66e05ac7972643a8841e336d327ea78ae1")

--- a/spec/tapioca/cli_spec.rb
+++ b/spec/tapioca/cli_spec.rb
@@ -531,6 +531,17 @@ describe(Tapioca::Cli) do
       assert_equal(Contents::BAZ_RBI, File.read("#{outdir}/baz@0.0.2.rbi"))
     end
 
+    it 'must generate git gem RBIs with source revision numbers' do
+      output = execute("generate", "ast")
+
+      assert_includes(output, <<~OUTPUT)
+        Processing 'ast' gem:
+          Compiling ast, this may take a few seconds...   Done
+      OUTPUT
+
+      assert_path_exists("#{outdir}/ast@2.4.1-e07a4f66e05ac7972643a8841e336d327ea78ae1.rbi")
+    end
+
     it 'must respect exclude option' do
       output = execute("generate", "", exclude: "foo bar")
 


### PR DESCRIPTION
Git gems usually do not change version numbers but they might still have changes if not fixed to a specific SHA. Thus, it makes more sense to track those gems' versions as the gem version plus the git revision they are at as installed on the system.