### PR TITLE
Generate proper url helper RBIs for non-discoverable modules

### DIFF
--- a/spec/tapioca/compilers/dsl/url_helpers_spec.rb
+++ b/spec/tapioca/compilers/dsl/url_helpers_spec.rb
@@ -32,6 +32,7 @@ describe("Tapioca::Compilers::Dsl::UrlHelpers") do
 
       assert_equal([
         "ActionDispatch::IntegrationTest",
+        "ActionView::Helpers",
         "GeneratedPathHelpersModule",
         "GeneratedUrlHelpersModule",
       ], constants_from(content))
@@ -46,6 +47,7 @@ describe("Tapioca::Compilers::Dsl::UrlHelpers") do
 
       assert_equal([
         "ActionDispatch::IntegrationTest",
+        "ActionView::Helpers",
         "GeneratedPathHelpersModule",
         "GeneratedUrlHelpersModule",
         "MyClass",
@@ -61,6 +63,7 @@ describe("Tapioca::Compilers::Dsl::UrlHelpers") do
 
       assert_equal([
         "ActionDispatch::IntegrationTest",
+        "ActionView::Helpers",
         "GeneratedPathHelpersModule",
         "GeneratedUrlHelpersModule",
         "MyClass",
@@ -78,6 +81,7 @@ describe("Tapioca::Compilers::Dsl::UrlHelpers") do
 
       assert_equal([
         "ActionDispatch::IntegrationTest",
+        "ActionView::Helpers",
         "GeneratedPathHelpersModule",
         "GeneratedUrlHelpersModule",
         "MyClass",
@@ -96,6 +100,7 @@ describe("Tapioca::Compilers::Dsl::UrlHelpers") do
 
       assert_equal([
         "ActionDispatch::IntegrationTest",
+        "ActionView::Helpers",
         "GeneratedPathHelpersModule",
         "GeneratedUrlHelpersModule",
         "SuperClass",
@@ -114,6 +119,7 @@ describe("Tapioca::Compilers::Dsl::UrlHelpers") do
 
       assert_equal([
         "ActionDispatch::IntegrationTest",
+        "ActionView::Helpers",
         "GeneratedPathHelpersModule",
         "GeneratedUrlHelpersModule",
         "SuperClass",
@@ -133,6 +139,7 @@ describe("Tapioca::Compilers::Dsl::UrlHelpers") do
 
       assert_equal([
         "ActionDispatch::IntegrationTest",
+        "ActionView::Helpers",
         "GeneratedPathHelpersModule",
         "GeneratedUrlHelpersModule",
         "SuperClass",
@@ -222,6 +229,40 @@ describe("Tapioca::Compilers::Dsl::UrlHelpers") do
       RUBY
 
       assert_equal(expected, rbi_for(content, :GeneratedUrlHelpersModule))
+    end
+
+    it("generates RBI for ActionDispatch::IntegrationTest") do
+      content += <<~RUBY
+      RUBY
+
+      expected = <<~RUBY
+        # typed: strong
+        module ActionDispatch
+          class IntegrationTest
+            include GeneratedPathHelpersModule
+            include GeneratedUrlHelpersModule
+          end
+        end
+      RUBY
+
+      assert_equal(expected, rbi_for(content, "ActionDispatch::IntegrationTest"))
+    end
+
+    it("generates RBI for ActionView::Helpers") do
+      content += <<~RUBY
+      RUBY
+
+      expected = <<~RUBY
+        # typed: strong
+        module ActionView
+          module Helpers
+            include GeneratedPathHelpersModule
+            include GeneratedUrlHelpersModule
+          end
+        end
+      RUBY
+
+      assert_equal(expected, rbi_for(content, "ActionView::Helpers"))
     end
 
     it("generates RBI for constant that includes url_helpers") do


### PR DESCRIPTION
`ActionDispatch::IntegrationTest` and `ActionView::Helpers` bring url helpers with them but don't necessarily include the url helper modules themselves (they either delegate to the actual modules or mix them into includers dynamically). Thus, we cannot discover that these modules include any url helpers.

However, we do want these modules to act like they include url helper modules, so we have to add them to the gathered constants list manually and also make sure that we generate the module includes for them unconditionally.

So far, we had been adding `ActionDispatch::IntegrationTest` to the gathered constants list manually, but we hadn't been checking if the appropriate module includes were being generated for it (surprise: they weren't). So, this commit adds tests to make sure that we generate includes for those modules specifically.