### PR TITLE
Fix parameter names for attr writers with signature

### DIFF
--- a/spec/tapioca/compilers/symbol_table_compiler_spec.rb
+++ b/spec/tapioca/compilers/symbol_table_compiler_spec.rb
@@ -1879,7 +1879,7 @@ describe("Tapioca::Compilers::SymbolTableCompiler") do
           sig { returns(String) }
           def bar; end
           sig { params(baz: T::Hash[String, Object]).returns(T::Hash[String, Object]) }
-          def baz=(_); end
+          def baz=(baz); end
           sig { returns(T::Array[Integer]) }
           def foo; end
           def foo=(_); end


### PR DESCRIPTION
## Motivation

Normally `attr_writer` generated methods do not have a name for the single parameter that the method accepts. However, if the `attr_writer` has a signature, then the parameter name should be the name of the attribute.

We have been defaulting the parameter name to `_` if the parameter name didn't exist. But, as outlined above, if the writer method has a signature, that ends up meaning that the parameter name in the signature does not match the one in the method definition.

## Implementation

This commit fixes that by trying to detect writer methods with a signature and naming the parameter properly in those cases.

## Tests

I fixed the test we have for signature generation to ensure that we generate the correct thing.