### PR TITLE
Modify sigil order in the `config/tapioca/require.rb` to comply with our own Ruby styleguide

### DIFF
--- a/lib/tapioca/cli.rb
+++ b/lib/tapioca/cli.rb
@@ -44,8 +44,8 @@ module Tapioca
       end
       create_file(Config::DEFAULT_POSTREQUIRE, skip: true) do
         <<~CONTENT
-          # frozen_string_literal: true
           # typed: false
+          # frozen_string_literal: true          
 
           # Add your extra requires here
         CONTENT

--- a/lib/tapioca/cli.rb
+++ b/lib/tapioca/cli.rb
@@ -45,7 +45,7 @@ module Tapioca
       create_file(Config::DEFAULT_POSTREQUIRE, skip: true) do
         <<~CONTENT
           # typed: false
-          # frozen_string_literal: true          
+          # frozen_string_literal: true
 
           # Add your extra requires here
         CONTENT

--- a/spec/tapioca/cli_spec.rb
+++ b/spec/tapioca/cli_spec.rb
@@ -121,8 +121,8 @@ describe(Tapioca::Cli) do
       CONTENTS
       assert_path_exists(repo_path / "sorbet/tapioca/require.rb")
       assert_equal(<<~CONTENTS, File.read(repo_path / "sorbet/tapioca/require.rb"))
-        # frozen_string_literal: true
         # typed: false
+        # frozen_string_literal: true
 
         # Add your extra requires here
       CONTENTS
@@ -245,8 +245,8 @@ describe(Tapioca::Cli) do
 
       assert_path_exists(repo_path / "sorbet/tapioca/require.rb")
       assert_equal(<<~CONTENTS, File.read(repo_path / "sorbet/tapioca/require.rb"))
-        # frozen_string_literal: true
         # typed: false
+        # frozen_string_literal: true
 
         # Add your extra requires here
       CONTENTS


### PR DESCRIPTION
The sigil order don't comply with our Rubocop rule. Since this project and the Rubocop-sorbet one are both owned by Shopify, I'd like to have some consistency as otherwise running `tapioca generate rbis` would fail ruby lint out of the box.

Ref https://github.com/Shopify/rubocop-sorbet/blob/7cc2c9fbfd1f4fb4f2e052726e5b745e0235cbae/lib/rubocop/cop/sorbet/sigils/enforce_sigil_order.rb