### PR TITLE
Fix RBI generation for T.attached_class

### DIFF
--- a/lib/tapioca/compilers/symbol_table/symbol_generator.rb
+++ b/lib/tapioca/compilers/symbol_table/symbol_generator.rb
@@ -565,7 +565,7 @@ module Tapioca
           params << [signature.block_name, signature.block_type] if signature.block_name
 
           params = params.compact.map { |name, type| "#{name}: #{type}" }.join(", ")
-          returns = signature.return_type.to_s
+          returns = type_of(signature.return_type)
 
           type_parameters = (params + returns).scan(TYPE_PARAMETER_MATCHER).flatten.uniq.map { |p| ":#{p}" }.join(", ")
           type_parameters = ".type_parameters(#{type_parameters})" unless type_parameters.empty?
@@ -782,6 +782,11 @@ module Tapioca
           T::Private::Methods.signature_for_method(method)
         rescue LoadError, StandardError
           nil
+        end
+
+        sig { params(constant: Module).returns(String) }
+        def type_of(constant)
+          constant.to_s.gsub(/\bAttachedClass\b/, "T.attached_class")
         end
 
         sig { params(constant: Module, other: BasicObject).returns(T::Boolean).checked(:never) }


### PR DESCRIPTION
As reported by @Edouard-chin, `tapioca` produces incorrect RBIs for methods using `T.attached_class` in their signatures: https://buildkite.com/shopify/shopify-rails-canary-app/builds/314#440cc1e8-c24f-4164-876c-344b3b462c9b

For example, with the following code:

```ruby
class Foo
  class << self
    extend(T::Sig)

    sig { returns(T.attached_class) }
    def a
      Foo.new
    end
  end
end      
```

Tapioca will produce the following RBI:

```ruby
sig { returns(AttachedClass) } # should be T.attached_class
def a; end
```

This is actually the value returned by sorbet-runtime itself:

```ruby
require 'sorbet-runtime'

class Foo
  class << self
    extend T::Sig

    sig { returns(T.attached_class) }
    def foo
      Foo.new
    end
  end
end

m = Foo.method(:foo)
puts T::Private::Methods.signature_for_method(m).return_type # AttachedClass
```

And it's directly coming from here: https://github.com/sorbet/sorbet/blob/master/gems/sorbet-runtime/lib/types/types/attached_class.rb#L15.

This PR fixes that behavior by replacing the `AttachedClass` in the return type string by `T.attached_class`:
* I think it's the only place we need to do it as `T.attached_class` can only be used in the `returns` clause (not in `params`, not in `type_alias`).
* I went with a string search&replace to easily handle nested types like `T::Hash[T.attached_class, T::Array[T.attached_class]]`.