### PR TITLE
ActiveRecord changes return nilable types

### DIFF
--- a/lib/tapioca/compilers/dsl/active_record_columns.rb
+++ b/lib/tapioca/compilers/dsl/active_record_columns.rb
@@ -196,25 +196,25 @@ module Tapioca
             klass,
             "#{attribute_name}_before_last_save",
             methods_to_add,
-            return_type: getter_type
+            return_type: as_nilable_type(getter_type)
           )
           add_method(
             klass,
             "#{attribute_name}_change_to_be_saved",
             methods_to_add,
-            return_type: "[#{getter_type}, #{getter_type}]"
+            return_type: "T.nilable([#{getter_type}, #{getter_type}])"
           )
           add_method(
             klass,
             "#{attribute_name}_in_database",
             methods_to_add,
-            return_type: getter_type
+            return_type: as_nilable_type(getter_type)
           )
           add_method(
             klass,
             "saved_change_to_#{attribute_name}",
             methods_to_add,
-            return_type: "[#{getter_type}, #{getter_type}]"
+            return_type: "T.nilable([#{getter_type}, #{getter_type}])"
           )
           add_method(
             klass,
@@ -235,7 +235,7 @@ module Tapioca
             klass,
             "#{attribute_name}_change",
             methods_to_add,
-            return_type: "[#{getter_type}, #{getter_type}]"
+            return_type: "T.nilable([#{getter_type}, #{getter_type}])"
           )
           add_method(
             klass,
@@ -252,13 +252,13 @@ module Tapioca
             klass,
             "#{attribute_name}_was",
             methods_to_add,
-            return_type: getter_type
+            return_type: as_nilable_type(getter_type)
           )
           add_method(
             klass,
             "#{attribute_name}_previous_change",
             methods_to_add,
-            return_type: "[#{getter_type}, #{getter_type}]"
+            return_type: "T.nilable([#{getter_type}, #{getter_type}])"
           )
           add_method(
             klass,
@@ -270,7 +270,7 @@ module Tapioca
             klass,
             "#{attribute_name}_previously_was",
             methods_to_add,
-            return_type: getter_type
+            return_type: as_nilable_type(getter_type)
           )
           add_method(
             klass,
@@ -380,6 +380,12 @@ module Tapioca
           return if T::Types::Simple === arg_type && T::Generic === arg_type.raw_type
 
           arg_type.to_s
+        end
+
+        sig { params(type: String).returns(String) }
+        def as_nilable_type(type)
+          return type if type.start_with?("T.nilable(")
+          "T.nilable(#{type})"
         end
       end
     end

--- a/spec/tapioca/compilers/dsl/active_record_columns_spec.rb
+++ b/spec/tapioca/compilers/dsl/active_record_columns_spec.rb
@@ -111,10 +111,10 @@ describe("Tapioca::Compilers::Dsl::ActiveRecordColumns") do
           sig { returns(T::Boolean) }
           def id_came_from_user?; end
 
-          sig { returns([T.nilable(::Integer), T.nilable(::Integer)]) }
+          sig { returns(T.nilable([T.nilable(::Integer), T.nilable(::Integer)])) }
           def id_change; end
 
-          sig { returns([T.nilable(::Integer), T.nilable(::Integer)]) }
+          sig { returns(T.nilable([T.nilable(::Integer), T.nilable(::Integer)])) }
           def id_change_to_be_saved; end
 
           sig { returns(T::Boolean) }
@@ -123,7 +123,7 @@ describe("Tapioca::Compilers::Dsl::ActiveRecordColumns") do
           sig { returns(T.nilable(::Integer)) }
           def id_in_database; end
 
-          sig { returns([T.nilable(::Integer), T.nilable(::Integer)]) }
+          sig { returns(T.nilable([T.nilable(::Integer), T.nilable(::Integer)])) }
           def id_previous_change; end
 
           sig { returns(T::Boolean) }
@@ -141,7 +141,7 @@ describe("Tapioca::Compilers::Dsl::ActiveRecordColumns") do
           sig { void }
           def restore_id!; end
 
-          sig { returns([T.nilable(::Integer), T.nilable(::Integer)]) }
+          sig { returns(T.nilable([T.nilable(::Integer), T.nilable(::Integer)])) }
           def saved_change_to_id; end
 
           sig { returns(T::Boolean) }
@@ -440,10 +440,10 @@ describe("Tapioca::Compilers::Dsl::ActiveRecordColumns") do
           sig { returns(T::Boolean) }
           def author_came_from_user?; end
 
-          sig { returns([T.nilable(::String), T.nilable(::String)]) }
+          sig { returns(T.nilable([T.nilable(::String), T.nilable(::String)])) }
           def author_change; end
 
-          sig { returns([T.nilable(::String), T.nilable(::String)]) }
+          sig { returns(T.nilable([T.nilable(::String), T.nilable(::String)])) }
           def author_change_to_be_saved; end
 
           sig { returns(T::Boolean) }
@@ -452,7 +452,7 @@ describe("Tapioca::Compilers::Dsl::ActiveRecordColumns") do
           sig { returns(T.nilable(::String)) }
           def author_in_database; end
 
-          sig { returns([T.nilable(::String), T.nilable(::String)]) }
+          sig { returns(T.nilable([T.nilable(::String), T.nilable(::String)])) }
           def author_previous_change; end
 
           sig { returns(T::Boolean) }
@@ -475,7 +475,7 @@ describe("Tapioca::Compilers::Dsl::ActiveRecordColumns") do
       assert_includes(output, expected)
 
       expected = indented(<<~RUBY, 2)
-        sig { returns([T.nilable(::String), T.nilable(::String)]) }
+        sig { returns(T.nilable([T.nilable(::String), T.nilable(::String)])) }
         def saved_change_to_author; end
 
         sig { returns(T::Boolean) }
@@ -533,10 +533,10 @@ describe("Tapioca::Compilers::Dsl::ActiveRecordColumns") do
           sig { returns(T::Boolean) }
           def body_came_from_user?; end
 
-          sig { returns([T.nilable(::String), T.nilable(::String)]) }
+          sig { returns(T.nilable([T.nilable(::String), T.nilable(::String)])) }
           def body_change; end
 
-          sig { returns([T.nilable(::String), T.nilable(::String)]) }
+          sig { returns(T.nilable([T.nilable(::String), T.nilable(::String)])) }
           def body_change_to_be_saved; end
 
           sig { returns(T::Boolean) }
@@ -545,7 +545,7 @@ describe("Tapioca::Compilers::Dsl::ActiveRecordColumns") do
           sig { returns(T.nilable(::String)) }
           def body_in_database; end
 
-          sig { returns([T.nilable(::String), T.nilable(::String)]) }
+          sig { returns(T.nilable([T.nilable(::String), T.nilable(::String)])) }
           def body_previous_change; end
 
           sig { returns(T::Boolean) }
@@ -571,7 +571,7 @@ describe("Tapioca::Compilers::Dsl::ActiveRecordColumns") do
       assert_includes(output, expected)
 
       expected = indented(<<~RUBY, 2)
-        sig { returns([T.nilable(::String), T.nilable(::String)]) }
+        sig { returns(T.nilable([T.nilable(::String), T.nilable(::String)])) }
         def saved_change_to_body; end
 
         sig { returns(T::Boolean) }


### PR DESCRIPTION
All the ActiveRecord methods used to access the previous change state of a column can actually return `nil`.

For example:

```ruby
class Foo < ApplicationRecord; end

foo = Foo.new(name: "foo")
foo.name_previous_change # => nil
```

This pull-request uses `T.nilable` as return type for all the impacted methods.