### PR TITLE
Make all `belongs_to` associations return nilable types

### DIFF
--- a/lib/tapioca/compilers/dsl/active_record_associations.rb
+++ b/lib/tapioca/compilers/dsl/active_record_associations.rb
@@ -132,11 +132,7 @@ module Tapioca
         end
         def populate_single_assoc_getter_setter(klass, constant, association_name, reflection)
           association_class = type_for(constant, reflection)
-          association_type = if belongs_to_and_required?(constant, reflection)
-            association_class
-          else
-            "T.nilable(#{association_class})"
-          end
+          association_type = "T.nilable(#{association_class})"
 
           create_method(
             klass,
@@ -225,20 +221,6 @@ module Tapioca
             ],
             return_type: "T::Array[T.untyped]"
           )
-        end
-
-        sig do
-          params(
-            constant: T.class_of(ActiveRecord::Base),
-            reflection: ReflectionType
-          ).returns(T::Boolean)
-        end
-        def belongs_to_and_required?(constant, reflection)
-          return false unless constant.table_exists?
-          return false unless reflection.belongs_to?
-          column_definition = constant.columns_hash[reflection.foreign_key.to_s]
-
-          !column_definition.nil? && !column_definition.null
         end
 
         sig do

--- a/spec/tapioca/compilers/dsl/active_record_associations_spec.rb
+++ b/spec/tapioca/compilers/dsl/active_record_associations_spec.rb
@@ -84,8 +84,24 @@ describe("Tapioca::Compilers::Dsl::ActiveRecordAssociations") do
 
     it("generates RBI file for belongs_to single association") do
       content = <<~RUBY
+        ActiveRecord::Migration.suppress_messages do
+          ActiveRecord::Schema.define do
+            create_table :posts do |t|
+              t.references(:category, null: true)
+              t.references(:author, null: false)
+            end
+          end
+        end
+
+        class Category < ActiveRecord::Base
+        end
+
+        class User < ActiveRecord::Base
+        end
+
         class Post < ActiveRecord::Base
           belongs_to :category
+          belongs_to :author, class_name: "User"
         end
       RUBY
 
@@ -96,22 +112,40 @@ describe("Tapioca::Compilers::Dsl::ActiveRecordAssociations") do
         end
 
         module Post::GeneratedAssociationMethods
-          sig { params(args: T.untyped, blk: T.untyped).returns(T.nilable(T.untyped)) }
+          sig { returns(T.nilable(::User)) }
+          def author; end
+
+          sig { params(value: T.nilable(::User)).void }
+          def author=(value); end
+
+          sig { params(args: T.untyped, blk: T.untyped).returns(T.nilable(::User)) }
+          def build_author(*args, &blk); end
+
+          sig { params(args: T.untyped, blk: T.untyped).returns(T.nilable(::Category)) }
           def build_category(*args, &blk); end
 
-          sig { returns(T.nilable(T.untyped)) }
+          sig { returns(T.nilable(::Category)) }
           def category; end
 
-          sig { params(value: T.nilable(T.untyped)).void }
+          sig { params(value: T.nilable(::Category)).void }
           def category=(value); end
 
-          sig { params(args: T.untyped, blk: T.untyped).returns(T.nilable(T.untyped)) }
+          sig { params(args: T.untyped, blk: T.untyped).returns(T.nilable(::User)) }
+          def create_author(*args, &blk); end
+
+          sig { params(args: T.untyped, blk: T.untyped).returns(T.nilable(::User)) }
+          def create_author!(*args, &blk); end
+
+          sig { params(args: T.untyped, blk: T.untyped).returns(T.nilable(::Category)) }
           def create_category(*args, &blk); end
 
-          sig { params(args: T.untyped, blk: T.untyped).returns(T.nilable(T.untyped)) }
+          sig { params(args: T.untyped, blk: T.untyped).returns(T.nilable(::Category)) }
           def create_category!(*args, &blk); end
 
-          sig { returns(T.nilable(T.untyped)) }
+          sig { returns(T.nilable(::User)) }
+          def reload_author; end
+
+          sig { returns(T.nilable(::Category)) }
           def reload_category; end
         end
       RUBY


### PR DESCRIPTION
Active Record model objects exhibit different type behaviour in different contexts. For an Active Record model that is created in memory, the attributes and associations can all be `nil`. The strict typing on the object properties are only applied when a model is read from the database.

The signature generation code was looking at the database column nilability to understand if the association property returns a nilable type or not. It turns out that that is not the correct way to represent the association method return types, since this is totally valid Ruby on Rails code:

```ruby
class Model < ActiveRecord::Base
  belongs_to :foo
end

model = Model.new
model.foo #=> nil
```

even when the database column that the `foo` association maps to is strictly not nilable.

Thus, the solution is to make all associations to return a nilable type by default.