### PR TITLE
Fix parameter handling in signatures

### DIFF
--- a/spec/tapioca/compilers/symbol_table_compiler_spec.rb
+++ b/spec/tapioca/compilers/symbol_table_compiler_spec.rb
@@ -1761,6 +1761,10 @@ describe("Tapioca::Compilers::SymbolTableCompiler") do
             a
           end
 
+          sig { params(a: Integer, b: Integer, c: Integer, d: Integer, e: Integer, f: Integer, blk: T.proc.void).void }
+          def many_kinds_of_args(*a, b, c, d:, e: 42, **f, &blk)
+          end
+
           class << self
             extend(T::Sig)
 
@@ -1859,6 +1863,8 @@ describe("Tapioca::Compilers::SymbolTableCompiler") do
           def baz(a); end
           sig { params(a: Integer, b: String).void }
           def foo(a, b:); end
+          sig { params(a: Integer, b: Integer, c: Integer, d: Integer, e: Integer, f: Integer, blk: T.proc.params().void).void }
+          def many_kinds_of_args(*a, b, c, d:, e: T.unsafe(nil), **f, &blk); end
 
           class << self
             sig { void }


### PR DESCRIPTION
## Motivation

Fixes #116

There were a couple of problems with parameter handling in signatures:

1. We were messing up the parameter ordering in the signature which sometimes ended up not matching with the order in which parameters were declared in the method parameter list. 
2. We were skipping `keyrest` arguments completely. :facepalm:

## Implementation

The main problem is fixed by iterating over the actual method parameters and only using signature parameter mapping as a lookup table to get the relevant type for the parameter. I had to keep a sanitized version of the parameter list to pass to the signature compile step, since we end up modifying the parameter names while generating the method definition. The parameter name in the signature should match that changed name, so the sanitized parameter list should be used when processing the signatures.