### PR TITLE
Add dependabot to trigger CI run against new versions of Sorbet

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "bundler"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    allow:
+      - dependency-name: "sorbet"
+      - dependency-name: "sorbet-static"
+      - dependency-name: "sorbet-runtime"
+    reviewers:
+      - "Shopify/sorbet"


### PR DESCRIPTION
This uses Dependabot version 2. Which seems to slightly differ from version 1 in terms of the config. I also didn't have to enable Shopify's dependabot in this repo since it's acquired by Github it's available to everyone for free. I assume this is an acceptable way of enabling Dependabot within Shopify.

Validated the config with https://dependabot.com/docs/config-file-beta/validator/ 
I'll keep an eye out and modify the config if it's not working as intended in the next week.

resolves https://github.com/Shopify/sorbet-issues/issues/72