### PR TITLE
Remove unnecessary dependency from dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,6 @@ updates:
       interval: "daily"
     allow:
       - dependency-name: "sorbet"
-      - dependency-name: "sorbet-static"
       - dependency-name: "sorbet-runtime"
     reviewers:
       - "Shopify/sorbet"


### PR DESCRIPTION
Specifying `sorbet` already pulls in changes for `sorbet-static` therefore it's unnecessary to specify both