### PR TITLE
Fix IdentityCache `fetch_X` method return to be nilable

### DIFF
--- a/lib/tapioca/compilers/dsl/active_record_identity_cache.rb
+++ b/lib/tapioca/compilers/dsl/active_record_identity_cache.rb
@@ -126,7 +126,7 @@ module Tapioca
           if returns_collection
             COLLECTION_TYPE.call(cache_type)
           else
-            "::#{cache_type}"
+            "T.nilable(::#{cache_type})"
           end
         rescue ArgumentError
           "T.untyped"

--- a/spec/tapioca/compilers/dsl/active_record_identity_cache_spec.rb
+++ b/spec/tapioca/compilers/dsl/active_record_identity_cache_spec.rb
@@ -183,7 +183,7 @@ describe("Tapioca::Compilers::Dsl::ActiveRecordIdentityCache") do
       expected = <<~RUBY
         # typed: strong
         class Post
-          sig { returns(::User) }
+          sig { returns(T.nilable(::User)) }
           def fetch_user; end
 
           sig { returns(T.untyped) }
@@ -232,7 +232,7 @@ describe("Tapioca::Compilers::Dsl::ActiveRecordIdentityCache") do
       expected = <<~RUBY
         # typed: strong
         class Post
-          sig { returns(::User) }
+          sig { returns(T.nilable(::User)) }
           def fetch_user; end
         end
       RUBY


### PR DESCRIPTION
This is a leftover from #112.

As we can see [here](https://github.com/Shopify/tapioca/blob/master/lib/tapioca/compilers/dsl/active_record_identity_cache.rb#L146) this will create a method for each field `def fetch_X` that [still returns a non-nilable value](https://github.com/Shopify/tapioca/blob/master/lib/tapioca/compilers/dsl/active_record_identity_cache.rb#L129).

This PR fixes this problem and updates the tests.
