### PR TITLE
Push for increased typing strictness

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,3 +10,7 @@ AllCops:
 
 Style/CaseEquality:
   Enabled: false
+
+Style/ClassAndModuleChildren:
+  Exclude:
+  - spec/tapioca/**/*

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,6 +3,9 @@
 inherit_gem:
   rubocop-shopify: rubocop.yml
 
+require:
+ - rubocop-sorbet
+
 AllCops:
   TargetRubyVersion: 2.3
   Exclude:
@@ -14,3 +17,19 @@ Style/CaseEquality:
 Style/ClassAndModuleChildren:
   Exclude:
   - spec/tapioca/**/*
+
+Sorbet:
+  Enabled: true
+
+Sorbet/FalseSigil:
+  Enabled: false
+
+Sorbet/TrueSigil:
+  Enabled: true
+  Include:
+  - "**/*.rb"
+  Exclude:
+  - "spec/support/gems/baz/lib/baz.rb"
+
+Sorbet/ConstantsFromStrings:
+  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -34,3 +34,5 @@ group(:development, :test) do
   gem("activeresource", "~> 5.1", require: false)
   gem("google-protobuf", "~>3.12.0", require: false)
 end
+
+gem "rubocop-sorbet", ">= 0.4.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -172,6 +172,8 @@ GEM
       unicode-display_width (>= 1.4.0, < 1.7)
     rubocop-shopify (1.0.0)
       rubocop (>= 0.78.0)
+    rubocop-sorbet (0.4.1)
+      rubocop
     ruby-progressbar (1.10.1)
     smart_properties (1.15.0)
     sorbet (0.5.5895)
@@ -222,6 +224,7 @@ DEPENDENCIES
   rails (~> 5.2)
   rake
   rubocop-shopify
+  rubocop-sorbet (>= 0.4.1)
   smart_properties (>= 1.15.0)
   sorbet
   sprockets (~> 3.7)

--- a/lib/tapioca/cli.rb
+++ b/lib/tapioca/cli.rb
@@ -1,5 +1,5 @@
-# frozen_string_literal: true
 # typed: true
+# frozen_string_literal: true
 
 require 'thor'
 

--- a/lib/tapioca/compilers/dsl_compiler.rb
+++ b/lib/tapioca/compilers/dsl_compiler.rb
@@ -56,7 +56,7 @@ module Tapioca
 
       sig { params(requested_generators: T::Array[String]).returns(T.proc.params(klass: Class).returns(T::Boolean)) }
       def generator_filter(requested_generators)
-        return ->(klass) { true } if requested_generators.empty?
+        return ->(_klass) { true } if requested_generators.empty?
 
         generators = requested_generators.map(&:downcase)
 

--- a/lib/tapioca/compilers/dsl_compiler.rb
+++ b/lib/tapioca/compilers/dsl_compiler.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-# typed: true
+# typed: strict
 
 require "tapioca/compilers/dsl/base"
 
@@ -30,7 +30,7 @@ module Tapioca
           T::Enumerable[Dsl::Base]
         )
         @requested_constants = requested_constants
-        @error_handler = error_handler || $stderr.method(:puts)
+        @error_handler = T.let(error_handler || $stderr.method(:puts), T.proc.params(error: String).void)
       end
 
       sig { params(blk: T.proc.params(constant: Module, rbi: String).void).void }
@@ -54,9 +54,9 @@ module Tapioca
 
       private
 
-      sig { params(requested_generators: T::Array[String]).returns(Proc) }
+      sig { params(requested_generators: T::Array[String]).returns(T.proc.params(klass: Class).returns(T::Boolean)) }
       def generator_filter(requested_generators)
-        return proc { true } if requested_generators.empty?
+        return ->(klass) { true } if requested_generators.empty?
 
         generators = requested_generators.map(&:downcase)
 
@@ -70,7 +70,7 @@ module Tapioca
       def gather_generators(requested_generators)
         generator_filter = generator_filter(requested_generators)
 
-        Dsl::Base.descendants.select(&generator_filter).map(&:new)
+        T.cast(Dsl::Base.descendants.select(&generator_filter).map(&:new), T::Enumerable[Dsl::Base])
       end
 
       sig { params(requested_constants: T::Array[Module]).returns(T::Set[Module]) }

--- a/lib/tapioca/compilers/dsl_compiler.rb
+++ b/lib/tapioca/compilers/dsl_compiler.rb
@@ -1,5 +1,5 @@
-# frozen_string_literal: true
 # typed: strict
+# frozen_string_literal: true
 
 require "tapioca/compilers/dsl/base"
 

--- a/lib/tapioca/compilers/requires_compiler.rb
+++ b/lib/tapioca/compilers/requires_compiler.rb
@@ -1,5 +1,5 @@
-# frozen_string_literal: true
 # typed: strict
+# frozen_string_literal: true
 
 require 'spoom'
 

--- a/lib/tapioca/compilers/sorbet.rb
+++ b/lib/tapioca/compilers/sorbet.rb
@@ -1,5 +1,5 @@
-# frozen_string_literal: true
 # typed: true
+# frozen_string_literal: true
 
 require 'pathname'
 require 'shellwords'

--- a/lib/tapioca/compilers/symbol_table/symbol_generator.rb
+++ b/lib/tapioca/compilers/symbol_table/symbol_generator.rb
@@ -1,5 +1,5 @@
-# frozen_string_literal: true
 # typed: true
+# frozen_string_literal: true
 
 require 'pathname'
 

--- a/lib/tapioca/compilers/symbol_table/symbol_loader.rb
+++ b/lib/tapioca/compilers/symbol_table/symbol_loader.rb
@@ -1,5 +1,5 @@
-# frozen_string_literal: true
 # typed: true
+# frozen_string_literal: true
 
 require 'json'
 require 'tempfile'

--- a/lib/tapioca/compilers/symbol_table_compiler.rb
+++ b/lib/tapioca/compilers/symbol_table_compiler.rb
@@ -1,5 +1,5 @@
-# frozen_string_literal: true
 # typed: strong
+# frozen_string_literal: true
 
 module Tapioca
   module Compilers

--- a/lib/tapioca/compilers/todos_compiler.rb
+++ b/lib/tapioca/compilers/todos_compiler.rb
@@ -1,5 +1,5 @@
-# frozen_string_literal: true
 # typed: strong
+# frozen_string_literal: true
 
 module Tapioca
   module Compilers

--- a/lib/tapioca/core_ext/class.rb
+++ b/lib/tapioca/core_ext/class.rb
@@ -19,8 +19,10 @@ class Class
   #   C.descendants # => [B, A, D]
   sig { returns(T::Array[Class]) }
   def descendants
-    T.cast(ObjectSpace.each_object(singleton_class).reject do |k|
+    result = ObjectSpace.each_object(singleton_class).reject do |k|
       T.cast(k, Module).singleton_class? || k == self
-    end, T::Array[Class])
+    end
+
+    T.cast(result, T::Array[Class])
   end
 end

--- a/lib/tapioca/core_ext/class.rb
+++ b/lib/tapioca/core_ext/class.rb
@@ -1,7 +1,9 @@
-# typed: false
+# typed: strict
 # frozen_string_literal: true
 
 class Class
+  extend T::Sig
+
   # Returns an array with all classes that are < than its receiver.
   #
   #   class C; end
@@ -15,9 +17,10 @@ class Class
   #
   #   class D < C; end
   #   C.descendants # => [B, A, D]
+  sig { returns(T::Array[Class]) }
   def descendants
-    ObjectSpace.each_object(singleton_class).reject do |k|
-      k.singleton_class? || k == self
-    end
+    T.cast(ObjectSpace.each_object(singleton_class).reject do |k|
+      T.cast(k, Module).singleton_class? || k == self
+    end, T::Array[Class])
   end
 end

--- a/lib/tapioca/gemfile.rb
+++ b/lib/tapioca/gemfile.rb
@@ -1,5 +1,5 @@
-# frozen_string_literal: true
 # typed: strict
+# frozen_string_literal: true
 
 require "bundler"
 

--- a/lib/tapioca/generator.rb
+++ b/lib/tapioca/generator.rb
@@ -1,5 +1,5 @@
-# frozen_string_literal: true
 # typed: strict
+# frozen_string_literal: true
 
 require 'pathname'
 require 'thor'

--- a/lib/tapioca/loader.rb
+++ b/lib/tapioca/loader.rb
@@ -1,5 +1,5 @@
-# frozen_string_literal: true
 # typed: strict
+# frozen_string_literal: true
 
 module Tapioca
   class Loader

--- a/sorbet/config
+++ b/sorbet/config
@@ -1,4 +1,3 @@
 --dir
 .
 --ignore=/vendor
---ignore=/spec

--- a/sorbet/tapioca/require.rb
+++ b/sorbet/tapioca/require.rb
@@ -1,5 +1,5 @@
-# frozen_string_literal: true
 # typed: strict
+# frozen_string_literal: true
 
 # Add your extra requires here
 require "parlour"

--- a/spec/content_helper.rb
+++ b/spec/content_helper.rb
@@ -26,7 +26,7 @@ module ContentHelper
       Tapioca.silence_warnings do
         # Require Ruby files
         contents.keys
-          .select {|k| k.end_with?(".rb") }
+          .select { |k| k.end_with?(".rb") }
           .each do |file|
             Kernel.require(dir.join("lib/#{file}").to_s)
           end

--- a/spec/content_helper.rb
+++ b/spec/content_helper.rb
@@ -1,11 +1,22 @@
+# typed: strict
 # frozen_string_literal: true
 
 module ContentHelper
-  def with_contents(contents, requires: [contents.keys.first], &block)
+  extend T::Sig
+
+  sig do
+    type_parameters(:Result)
+      .params(
+        contents: T::Hash[String, String],
+        block: T.proc.params(dir: Pathname).returns(T.type_parameter(:Result))
+      )
+      .returns(T.type_parameter(:Result))
+  end
+  def with_contents(contents, &block)
     Dir.mktmpdir do |path|
       dir = Pathname.new(path)
       # Create a "lib" folder
-      Dir.mkdir(dir.join("lib"))
+      Dir.mkdir(dir.join("lib").to_s)
 
       contents.each do |file, content|
         # Add our contents into their files in lib folder
@@ -13,17 +24,15 @@ module ContentHelper
       end
 
       Tapioca.silence_warnings do
-        # Require files
-        requires.each do |file|
-          require(dir.join("lib/#{file}"))
-        end
+        # Require Ruby files
+        contents.keys
+          .select {|k| k.end_with?(".rb") }
+          .each do |file|
+            Kernel.require(dir.join("lib/#{file}").to_s)
+          end
 
         block.call(dir)
       end
     end
-  end
-
-  def with_content(content, &block)
-    with_contents({ "file.rb" => content }, &block)
   end
 end

--- a/spec/dsl_spec.rb
+++ b/spec/dsl_spec.rb
@@ -1,0 +1,99 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "sorbet-runtime"
+require "minitest/spec"
+
+class DslSpec < Minitest::Spec
+  extend T::Sig
+
+  before(:all) do
+    # Get an unsafe reference to `self`
+    this = T.unsafe(self)
+    # See if there are any registered "require_before" blocks, and call them
+    extra_require = this.spec_test_class.instance_variable_get(:@require_before)
+    extra_require&.call
+    # Require the file that the target class should be loaded from
+    Kernel.require(this.target_class_file)
+  end
+
+  subject do
+    # Get the class under test and initialize a new instance of it
+    # as the "subject"
+    class_name = T.unsafe(self).target_class_name
+    Object.const_get(class_name).new
+  end
+
+  sig { params(blk: T.proc.void).void }
+  def self.require_before(&blk)
+    @require_before = blk
+  end
+  @require_before = T.let(nil, T.nilable(T.proc.void))
+
+  sig { returns(Class) }
+  def spec_test_class
+    # Find the spec test class
+    klass = T.unsafe(self).class
+    # It should be the one that directly inherits from DslSpec
+    klass = klass.superclass while klass.superclass != DslSpec
+    klass
+  end
+
+  sig { returns(String) }
+  def target_class_name
+    # Get the name of the class under test from the name of the
+    # test class
+    T.must(spec_test_class.name).gsub(/Spec$/, '')
+  end
+
+  sig { returns(String) }
+  def target_class_file
+    underscore(target_class_name)
+  end
+
+  sig { params(camel_cased_word: String).returns(String) }
+  def underscore(camel_cased_word)
+    return camel_cased_word unless /[A-Z-]|::/.match?(camel_cased_word)
+    word = camel_cased_word.to_s.gsub("::", "/")
+    word.gsub!(/([A-Z\d]+)([A-Z][a-z])/, '\1_\2')
+    word.gsub!(/([a-z\d])([A-Z])/, '\1_\2')
+    word.tr!("-", "_")
+    word.downcase!
+    word
+  end
+
+  sig { params(str: String, indent: Integer).returns(String) }
+  def indented(str, indent)
+    str.lines.map! do |line|
+      next line if line.chomp.empty?
+      " " * indent + line
+    end.join
+  end
+
+  sig do
+    params(
+      content: String
+    ).void
+  end
+  def constants_from(content)
+    with_contents({ "file.rb" => content }) do
+      T.unsafe(self).subject.processable_constants.map(&:to_s).sort
+    end
+  end
+
+  sig do
+    params(
+      constant_name: T.any(Symbol, String),
+      contents: T.any(String, T::Hash[String, String])
+    ).returns(String)
+  end
+  def rbi_for(constant_name, contents)
+    contents = { "file.rb" => contents } if String === contents
+
+    with_contents(contents) do
+      parlour = Parlour::RbiGenerator.new(sort_namespaces: true)
+      T.unsafe(self).subject.decorate(parlour.root, Object.const_get(constant_name))
+      parlour.rbi
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,6 +10,7 @@ require "minitest/reporters"
 
 require "content_helper"
 require "template_helper"
+require "dsl_spec"
 
 Minitest::Reporters.use!(Minitest::Reporters::DefaultReporter.new(color: true))
 Minitest.parallel_executor = Minitest::ForkExecutor.new
@@ -21,82 +22,5 @@ module Minitest
     include TemplateHelper
 
     Minitest::Test.make_my_diffs_pretty!
-  end
-end
-
-class DslSpec < Minitest::Spec
-  before(:all) do
-    extra_require = T.unsafe(self).target_class.instance_variable_get(:@require_before)
-    extra_require&.call
-    Kernel.require(T.unsafe(self).underscore(T.unsafe(self).target_class_name))
-  end
-
-  subject do
-    class_name = T.unsafe(self).target_class_name
-    Object.const_get(class_name).new
-  end
-
-  sig { params(blk: T.proc.void).void }
-  def self.require_before(&blk)
-    @require_before = blk
-  end
-  @require_before = T.let(nil, T.nilable(T.proc.void))
-
-  sig { returns(Class) }
-  def target_class
-    klass = T.unsafe(self).class
-    klass = klass.superclass while klass.superclass != DslSpec
-    klass
-  end
-
-  sig { returns(String) }
-  def target_class_name
-    T.must(target_class.name).gsub(/Spec$/, '')
-  end
-
-  sig { params(camel_cased_word: String).returns(String) }
-  def underscore(camel_cased_word)
-    return camel_cased_word unless /[A-Z-]|::/.match?(camel_cased_word)
-    word = camel_cased_word.to_s.gsub("::", "/")
-    word.gsub!(/([A-Z\d]+)([A-Z][a-z])/, '\1_\2')
-    word.gsub!(/([a-z\d])([A-Z])/, '\1_\2')
-    word.tr!("-", "_")
-    word.downcase!
-    word
-  end
-
-  sig { params(str: String, indent: Integer).returns(String) }
-  def indented(str, indent)
-    str.lines.map! do |line|
-      next line if line.chomp.empty?
-      " " * indent + line
-    end.join
-  end
-
-  sig do
-    params(
-      content: String
-    ).void
-  end
-  def constants_from(content)
-    with_contents({ "file.rb" => content }) do
-      T.unsafe(self).subject.processable_constants.map(&:to_s).sort
-    end
-  end
-
-  sig do
-    params(
-      constant_name: T.any(Symbol, String),
-      contents: T.any(String, T::Hash[String, String])
-    ).returns(String)
-  end
-  def rbi_for(constant_name, contents)
-    contents = { "file.rb" => contents } if String === contents
-
-    with_contents(contents) do
-      parlour = Parlour::RbiGenerator.new(sort_namespaces: true)
-      T.unsafe(self).subject.decorate(parlour.root, Object.const_get(constant_name))
-      parlour.rbi
-    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -27,13 +27,13 @@ end
 class DslSpec < Minitest::Spec
   before(:all) do
     extra_require = T.unsafe(self).target_class.instance_variable_get(:@require_before)
-    extra_require.call if extra_require
+    extra_require&.call
     Kernel.require(T.unsafe(self).underscore(T.unsafe(self).target_class_name))
   end
 
   subject do
     class_name = T.unsafe(self).target_class_name
-    Object.const_get(class_name).new # rubocop:disable Sorbet/ConstantsFromStrings
+    Object.const_get(class_name).new
   end
 
   sig { params(blk: T.proc.void).void }
@@ -45,9 +45,7 @@ class DslSpec < Minitest::Spec
   sig { returns(Class) }
   def target_class
     klass = T.unsafe(self).class
-    while klass.superclass != DslSpec
-      klass = klass.superclass
-    end
+    klass = klass.superclass while klass.superclass != DslSpec
     klass
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,15 +16,89 @@ Minitest.parallel_executor = Minitest::ForkExecutor.new
 
 module Minitest
   class Test
+    extend T::Sig
     include ContentHelper
     include TemplateHelper
 
     Minitest::Test.make_my_diffs_pretty!
-    def indented(str, indent)
-      str.lines.map! do |line|
-        next line if line.chomp.empty?
-        " " * indent + line
-      end.join
+  end
+end
+
+class DslSpec < Minitest::Spec
+  before(:all) do
+    extra_require = T.unsafe(self).target_class.instance_variable_get(:@require_before)
+    extra_require.call if extra_require
+    Kernel.require(T.unsafe(self).underscore(T.unsafe(self).target_class_name))
+  end
+
+  subject do
+    class_name = T.unsafe(self).target_class_name
+    Object.const_get(class_name).new # rubocop:disable Sorbet/ConstantsFromStrings
+  end
+
+  sig { params(blk: T.proc.void).void }
+  def self.require_before(&blk)
+    @require_before = blk
+  end
+  @require_before = T.let(nil, T.nilable(T.proc.void))
+
+  sig { returns(Class) }
+  def target_class
+    klass = T.unsafe(self).class
+    while klass.superclass != DslSpec
+      klass = klass.superclass
+    end
+    klass
+  end
+
+  sig { returns(String) }
+  def target_class_name
+    T.must(target_class.name).gsub(/Spec$/, '')
+  end
+
+  sig { params(camel_cased_word: String).returns(String) }
+  def underscore(camel_cased_word)
+    return camel_cased_word unless /[A-Z-]|::/.match?(camel_cased_word)
+    word = camel_cased_word.to_s.gsub("::", "/")
+    word.gsub!(/([A-Z\d]+)([A-Z][a-z])/, '\1_\2')
+    word.gsub!(/([a-z\d])([A-Z])/, '\1_\2')
+    word.tr!("-", "_")
+    word.downcase!
+    word
+  end
+
+  sig { params(str: String, indent: Integer).returns(String) }
+  def indented(str, indent)
+    str.lines.map! do |line|
+      next line if line.chomp.empty?
+      " " * indent + line
+    end.join
+  end
+
+  sig do
+    params(
+      content: String
+    ).void
+  end
+  def constants_from(content)
+    with_contents({ "file.rb" => content }) do
+      T.unsafe(self).subject.processable_constants.map(&:to_s).sort
+    end
+  end
+
+  sig do
+    params(
+      constant_name: T.any(Symbol, String),
+      contents: T.any(String, T::Hash[String, String])
+    ).returns(String)
+  end
+  def rbi_for(constant_name, contents)
+    contents = { "file.rb" => contents } if String === contents
+
+    with_contents(contents) do
+      parlour = Parlour::RbiGenerator.new(sort_namespaces: true)
+      T.unsafe(self).subject.decorate(parlour.root, Object.const_get(constant_name))
+      parlour.rbi
     end
   end
 end

--- a/spec/support/gems/bar/lib/bar.rb
+++ b/spec/support/gems/bar/lib/bar.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 module Bar

--- a/spec/support/gems/baz/lib/baz.rb
+++ b/spec/support/gems/baz/lib/baz.rb
@@ -1,3 +1,4 @@
+# typed: ignore
 # frozen_string_literal: true
 
 require "zeitwerk"

--- a/spec/support/gems/baz/lib/baz/role.rb
+++ b/spec/support/gems/baz/lib/baz/role.rb
@@ -1,3 +1,4 @@
+# typed: strict
 # frozen_string_literal: true
 
 module Baz

--- a/spec/support/gems/foo/lib/foo.rb
+++ b/spec/support/gems/foo/lib/foo.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 module Foo

--- a/spec/support/gems/foo/lib/foo/secret.rb
+++ b/spec/support/gems/foo/lib/foo/secret.rb
@@ -1,3 +1,4 @@
+# typed: strict
 # frozen_string_literal: true
 
 module Foo

--- a/spec/support/gems/qux/lib/qux.rb
+++ b/spec/support/gems/qux/lib/qux.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 module Qux

--- a/spec/support/repo/config/application.rb
+++ b/spec/support/repo/config/application.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require 'smart_properties'
@@ -6,7 +6,7 @@ require 'active_support/all'
 require 'baz'
 
 # Fake as much of Rails as we can
-class Rails
+module Rails
   def self.autoloaders
     []
   end

--- a/spec/support/repo/config/environment.rb
+++ b/spec/support/repo/config/environment.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: strict
 # frozen_string_literal: true
 
 require_relative "application.rb"

--- a/spec/support/repo/config/shim.rbi
+++ b/spec/support/repo/config/shim.rbi
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 
 module SmartProperties
 end

--- a/spec/support/repo/postrequire.rb
+++ b/spec/support/repo/postrequire.rb
@@ -1,3 +1,4 @@
+# typed: strict
 # frozen_string_literal: true
 
 require 'foo/secret'

--- a/spec/support/repo/postrequire_faulty.rb
+++ b/spec/support/repo/postrequire_faulty.rb
@@ -1,3 +1,4 @@
+# typed: strict
 # frozen_string_literal: true
 
 require 'foo/will_fail'

--- a/spec/support/require/multi/file1.rb
+++ b/spec/support/require/multi/file1.rb
@@ -1,2 +1,3 @@
+# typed: strict
 # frozen_string_literal: true
 require 'c'

--- a/spec/support/require/multi/file2.rb
+++ b/spec/support/require/multi/file2.rb
@@ -1,2 +1,3 @@
+# typed: strict
 # frozen_string_literal: true
 require 'd'

--- a/spec/support/require/multi/file3.rb
+++ b/spec/support/require/multi/file3.rb
@@ -1,2 +1,3 @@
+# typed: strict
 # frozen_string_literal: true
 require 'e'

--- a/spec/support/require/multi/lib/file1.rb
+++ b/spec/support/require/multi/lib/file1.rb
@@ -1,2 +1,3 @@
+# typed: strict
 # frozen_string_literal: true
 require 'a'

--- a/spec/support/require/multi/lib/file2.rb
+++ b/spec/support/require/multi/lib/file2.rb
@@ -1,2 +1,3 @@
+# typed: strict
 # frozen_string_literal: true
 require 'b'

--- a/spec/support/require/project_ignore/file1.rb
+++ b/spec/support/require/project_ignore/file1.rb
@@ -1,3 +1,4 @@
+# typed: strict
 # frozen_string_literal: true
 require 'a'
 require 'libc'

--- a/spec/support/require/project_ignore/file2.rb
+++ b/spec/support/require/project_ignore/file2.rb
@@ -1,3 +1,4 @@
+# typed: strict
 # frozen_string_literal: true
 require 'b'
 require 'libd'

--- a/spec/support/require/project_ignore/lib/a.rb
+++ b/spec/support/require/project_ignore/lib/a.rb
@@ -1,2 +1,3 @@
+# typed: strict
 # frozen_string_literal: true
 require 'liba'

--- a/spec/support/require/project_ignore/lib/b.rb
+++ b/spec/support/require/project_ignore/lib/b.rb
@@ -1,2 +1,3 @@
+# typed: strict
 # frozen_string_literal: true
 require 'libb'

--- a/spec/support/require/simple/simple.rb
+++ b/spec/support/require/simple/simple.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 #
 # rubocop:disable Layout/ExtraSpacing
@@ -13,7 +14,7 @@ require"e"
 require("f")
 require_relative 'z'
 
-if true
+if Random.rand > 0.5
   require 'g'
   require_relative "z"
 else

--- a/spec/support/require/simple/simple.rb
+++ b/spec/support/require/simple/simple.rb
@@ -3,7 +3,6 @@
 #
 # rubocop:disable Layout/ExtraSpacing
 # rubocop:disable Layout/SpaceBeforeFirstArg
-# rubocop:disable Lint/LiteralAsCondition
 # rubocop:disable Lint/ParenthesesAsGroupedExpression
 # rubocop:disable Style/RedundantParentheses/
 require 'a'

--- a/spec/support/require/sorbet_ignore/file1.rb
+++ b/spec/support/require/sorbet_ignore/file1.rb
@@ -1,2 +1,3 @@
+# typed: strict
 # frozen_string_literal: true
 require 'c'

--- a/spec/support/require/sorbet_ignore/file2.rb
+++ b/spec/support/require/sorbet_ignore/file2.rb
@@ -1,2 +1,3 @@
+# typed: strict
 # frozen_string_literal: true
 require 'd'

--- a/spec/support/require/sorbet_ignore/file3.rb
+++ b/spec/support/require/sorbet_ignore/file3.rb
@@ -1,2 +1,3 @@
+# typed: strict
 # frozen_string_literal: true
 require 'e'

--- a/spec/support/require/sorbet_ignore/lib/file1.rb
+++ b/spec/support/require/sorbet_ignore/lib/file1.rb
@@ -1,2 +1,3 @@
+# typed: strict
 # frozen_string_literal: true
 require 'a'

--- a/spec/support/require/sorbet_ignore/lib/file2.rb
+++ b/spec/support/require/sorbet_ignore/lib/file2.rb
@@ -1,2 +1,3 @@
+# typed: strict
 # frozen_string_literal: true
 require 'b'

--- a/spec/tapioca/cli_spec.rb
+++ b/spec/tapioca/cli_spec.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 require "spec_helper"
@@ -58,7 +59,7 @@ module Contents
   CONTENTS
 end
 
-describe(Tapioca::Cli) do
+class Tapioca::CliSpec < Minitest::HooksSpec
   attr_reader :outdir
   attr_reader :repo_path
 
@@ -97,12 +98,12 @@ describe(Tapioca::Cli) do
   end
 
   around(:each) do |&blk|
-    FileUtils.rm_rf(repo_path / "sorbet")
+    FileUtils.rm_rf(T.unsafe(self).repo_path / "sorbet")
     Dir.mktmpdir do |outdir|
       @outdir = outdir
       super(&blk)
     end
-    FileUtils.rm_rf(repo_path / "sorbet")
+    FileUtils.rm_rf(T.unsafe(self).repo_path / "sorbet")
   end
 
   describe("#init") do
@@ -148,7 +149,7 @@ describe(Tapioca::Cli) do
   end
 
   describe("#todo") do
-    before(:each) do
+    before do
       execute("init")
     end
 
@@ -225,7 +226,7 @@ describe(Tapioca::Cli) do
   end
 
   describe("#require") do
-    before(:each) do
+    before do
       execute("init")
     end
 
@@ -451,7 +452,7 @@ describe(Tapioca::Cli) do
   end
 
   describe("#generate") do
-    before(:each) do
+    before do
       execute("init")
     end
 
@@ -595,7 +596,7 @@ describe(Tapioca::Cli) do
     end
 
     it 'does not crash when the extras gem is loaded' do
-      File.write(repo_path / "sorbet/tapioca/require.rb", 'require "extras/all"')
+      File.write(repo_path / "sorbet/tapioca/require.rb", 'require "extras/shell"')
       output = execute("generate", "foo")
 
       assert_includes(output, <<~OUTPUT)
@@ -611,7 +612,7 @@ describe(Tapioca::Cli) do
   end
 
   describe("#sync") do
-    before(:each) do
+    before do
       execute("init")
     end
 

--- a/spec/tapioca/compilers/dsl/action_controller_helpers_spec.rb
+++ b/spec/tapioca/compilers/dsl/action_controller_helpers_spec.rb
@@ -1,26 +1,12 @@
-# typed: false
 # frozen_string_literal: true
+# typed: strict
 
 require "spec_helper"
 
-describe("Tapioca::Compilers::Dsl::ActionControllerHelpers") do
-  before(:each) do
-    require "tapioca/compilers/dsl/action_controller_helpers"
-  end
-
-  subject do
-    Tapioca::Compilers::Dsl::ActionControllerHelpers.new
-  end
-
+class Tapioca::Compilers::Dsl::ActionControllerHelpersSpec < DslSpec
   describe("#initialize") do
-    def constants_from(content)
-      with_content(content) do
-        subject.processable_constants.map(&:to_s).sort
-      end
-    end
-
     it("gathers no constants if there are no  classes") do
-      assert_empty(subject.processable_constants)
+      assert_empty(constants_from(""))
     end
 
     it("gathers only ActionController subclasses") do
@@ -75,14 +61,6 @@ describe("Tapioca::Compilers::Dsl::ActionControllerHelpers") do
   end
 
   describe("#decorate") do
-    def rbi_for(contents)
-      with_contents(contents, requires: contents.keys) do
-        parlour = Parlour::RbiGenerator.new(sort_namespaces: true)
-        subject.decorate(parlour.root, UserController)
-        parlour.rbi
-      end
-    end
-
     it("generates empty helper module when there are no helper methods specified") do
       files = {
         "controller.rb" => <<~RUBY,
@@ -109,7 +87,7 @@ describe("Tapioca::Compilers::Dsl::ActionControllerHelpers") do
         end
       RUBY
 
-      assert_equal(expected, rbi_for(files))
+      assert_equal(expected, rbi_for(:UserController, files))
     end
 
     it("generates helper module and helper proxy class when defining helper using helper_method") do
@@ -153,7 +131,7 @@ describe("Tapioca::Compilers::Dsl::ActionControllerHelpers") do
         end
       RUBY
 
-      assert_equal(expected, rbi_for(files))
+      assert_equal(expected, rbi_for(:UserController, files))
     end
 
     it("generates helper module and helper proxy class when defining helper using block") do
@@ -197,7 +175,7 @@ describe("Tapioca::Compilers::Dsl::ActionControllerHelpers") do
         end
       RUBY
 
-      assert_equal(expected, rbi_for(files))
+      assert_equal(expected, rbi_for(:UserController, files))
     end
 
     it("generates helper module and helper proxy class for defining external helper") do
@@ -237,7 +215,7 @@ describe("Tapioca::Compilers::Dsl::ActionControllerHelpers") do
         end
       RUBY
 
-      assert_equal(expected, rbi_for(files))
+      assert_equal(expected, rbi_for(:UserController, files))
     end
   end
 end

--- a/spec/tapioca/compilers/dsl/action_controller_helpers_spec.rb
+++ b/spec/tapioca/compilers/dsl/action_controller_helpers_spec.rb
@@ -1,5 +1,5 @@
-# frozen_string_literal: true
 # typed: strict
+# frozen_string_literal: true
 
 require "spec_helper"
 

--- a/spec/tapioca/compilers/dsl/action_mailer_spec.rb
+++ b/spec/tapioca/compilers/dsl/action_mailer_spec.rb
@@ -1,26 +1,12 @@
-# typed: false
+# typed: strict
 # frozen_string_literal: true
 
 require "spec_helper"
 
-describe("Tapioca::Compilers::Dsl::ActionMailer") do
-  before(:each) do
-    require "tapioca/compilers/dsl/action_mailer"
-  end
-
-  subject do
-    Tapioca::Compilers::Dsl::ActionMailer.new
-  end
-
+class Tapioca::Compilers::Dsl::ActionMailerSpec < DslSpec
   describe("#initialize") do
-    def constants_from(content)
-      with_content(content) do
-        subject.processable_constants.map(&:to_s).sort
-      end
-    end
-
     it("gathers no constants if there are no ActionMailer subclasses") do
-      assert_empty(subject.processable_constants)
+      assert_empty(constants_from(""))
     end
 
     it("gathers only ActionMailer subclasses") do
@@ -62,14 +48,6 @@ describe("Tapioca::Compilers::Dsl::ActionMailer") do
   end
 
   describe("#decorate") do
-    def rbi_for(content)
-      with_content(content) do
-        parlour = Parlour::RbiGenerator.new(sort_namespaces: true)
-        subject.decorate(parlour.root, NotifierMailer)
-        parlour.rbi
-      end
-    end
-
     it("generates empty RBI file if there are no methods") do
       content = <<~RUBY
         class NotifierMailer < ActionMailer::Base
@@ -82,7 +60,7 @@ describe("Tapioca::Compilers::Dsl::ActionMailer") do
         end
       RUBY
 
-      assert_equal(expected, rbi_for(content))
+      assert_equal(expected, rbi_for(:NotifierMailer, content))
     end
 
     it("generates correct RBI file for subclass with methods") do
@@ -102,7 +80,7 @@ describe("Tapioca::Compilers::Dsl::ActionMailer") do
         end
       RUBY
 
-      assert_equal(expected, rbi_for(content))
+      assert_equal(expected, rbi_for(:NotifierMailer, content))
     end
 
     it("generates correct RBI file for subclass with method signatures") do
@@ -124,7 +102,7 @@ describe("Tapioca::Compilers::Dsl::ActionMailer") do
         end
       RUBY
 
-      assert_equal(expected, rbi_for(content))
+      assert_equal(expected, rbi_for(:NotifierMailer, content))
     end
 
     it("does not generate RBI for methods defined in abstract classes") do
@@ -152,7 +130,7 @@ describe("Tapioca::Compilers::Dsl::ActionMailer") do
         end
       RUBY
 
-      assert_equal(expected, rbi_for(content))
+      assert_equal(expected, rbi_for(:NotifierMailer, content))
     end
   end
 end

--- a/spec/tapioca/compilers/dsl/active_record_associations_spec.rb
+++ b/spec/tapioca/compilers/dsl/active_record_associations_spec.rb
@@ -1,26 +1,12 @@
-# typed: false
+# typed: strict
 # frozen_string_literal: true
 
 require "spec_helper"
 
-describe("Tapioca::Compilers::Dsl::ActiveRecordAssociations") do
-  before(:each) do
-    require "tapioca/compilers/dsl/active_record_associations"
-  end
-
-  subject do
-    Tapioca::Compilers::Dsl::ActiveRecordAssociations.new
-  end
-
+class Tapioca::Compilers::Dsl::ActiveRecordAssociationsSpec < DslSpec
   describe("#initialize") do
-    def constants_from(content)
-      with_content(content) do
-        subject.processable_constants.map(&:to_s).sort
-      end
-    end
-
     it("gathers no constants if there are no ActiveRecord subclasses") do
-      assert_empty(subject.processable_constants)
+      assert_empty(constants_from(""))
     end
 
     it("gathers only ActiveRecord subclasses") do
@@ -60,14 +46,6 @@ describe("Tapioca::Compilers::Dsl::ActiveRecordAssociations") do
       )
     end
 
-    def rbi_for(content)
-      with_content(content) do
-        parlour = Parlour::RbiGenerator.new(sort_namespaces: true)
-        subject.decorate(parlour.root, Post)
-        parlour.rbi
-      end
-    end
-
     it("generates empty RBI file if there are no associations") do
       content = <<~RUBY
         class Post < ActiveRecord::Base
@@ -79,7 +57,7 @@ describe("Tapioca::Compilers::Dsl::ActiveRecordAssociations") do
 
       RUBY
 
-      assert_equal(expected, rbi_for(content))
+      assert_equal(expected, rbi_for(:Post, content))
     end
 
     it("generates RBI file for belongs_to single association") do
@@ -150,7 +128,7 @@ describe("Tapioca::Compilers::Dsl::ActiveRecordAssociations") do
         end
       RUBY
 
-      assert_equal(expected, rbi_for(content))
+      assert_equal(expected, rbi_for(:Post, content))
     end
 
     it("generates RBI file for polymorphic belongs_to single association") do
@@ -178,7 +156,7 @@ describe("Tapioca::Compilers::Dsl::ActiveRecordAssociations") do
         end
       RUBY
 
-      assert_equal(expected, rbi_for(content))
+      assert_equal(expected, rbi_for(:Post, content))
     end
 
     it("generates RBI file for has_one single association") do
@@ -225,7 +203,7 @@ describe("Tapioca::Compilers::Dsl::ActiveRecordAssociations") do
         end
       RUBY
 
-      assert_equal(expected, rbi_for(content))
+      assert_equal(expected, rbi_for(:Post, content))
     end
 
     it("generates RBI file for has_many collection association") do
@@ -259,7 +237,7 @@ describe("Tapioca::Compilers::Dsl::ActiveRecordAssociations") do
         end
       RUBY
 
-      assert_equal(expected, rbi_for(content))
+      assert_equal(expected, rbi_for(:Post, content))
     end
 
     it("generates RBI file for has_many :through collection association") do
@@ -320,7 +298,7 @@ describe("Tapioca::Compilers::Dsl::ActiveRecordAssociations") do
         end
       RUBY
 
-      assert_equal(expected, rbi_for(content))
+      assert_equal(expected, rbi_for(:Post, content))
     end
 
     it("generates RBI file for has_and_belongs_to_many collection association") do
@@ -355,7 +333,7 @@ describe("Tapioca::Compilers::Dsl::ActiveRecordAssociations") do
         end
       RUBY
 
-      assert_equal(expected, rbi_for(content))
+      assert_equal(expected, rbi_for(:Post, content))
     end
   end
 end

--- a/spec/tapioca/compilers/dsl/active_record_columns_spec.rb
+++ b/spec/tapioca/compilers/dsl/active_record_columns_spec.rb
@@ -1,184 +1,239 @@
-# typed: false
+# typed: strict
 # frozen_string_literal: true
 
 require "spec_helper"
 
-describe("Tapioca::Compilers::Dsl::ActiveRecordColumns") do
-  before(:each) do
-    require "tapioca/compilers/dsl/active_record_columns"
-  end
+class Tapioca::Compilers::Dsl::ActiveRecordColumnsSpec < DslSpec
+  describe("Tapioca::Compilers::Dsl::ActiveRecordColumns") do
+    describe("#initialize") do
+      it("gathers no constants if there are no ActiveRecord subclasses") do
+        assert_empty(constants_from(""))
+      end
 
-  subject do
-    Tapioca::Compilers::Dsl::ActiveRecordColumns.new
-  end
+      it("gathers only ActiveRecord subclasses") do
+        content = <<~RUBY
+          class Post < ActiveRecord::Base
+          end
 
-  describe("#initialize") do
-    def constants_from(content)
-      with_content(content) do
-        subject.processable_constants.map(&:to_s).sort
+          class Current
+          end
+        RUBY
+
+        assert_equal(["Post"], constants_from(content))
+      end
+
+      it("rejects abstract ActiveRecord subclasses") do
+        content = <<~RUBY
+          class Post < ActiveRecord::Base
+          end
+
+          class Current < ActiveRecord::Base
+            self.abstract_class = true
+          end
+        RUBY
+
+        assert_equal(["Post"], constants_from(content))
       end
     end
 
-    it("gathers no constants if there are no ActiveRecord subclasses") do
-      assert_empty(subject.processable_constants)
-    end
-
-    it("gathers only ActiveRecord subclasses") do
-      content = <<~RUBY
-        class Post < ActiveRecord::Base
-        end
-
-        class Current
-        end
-      RUBY
-
-      assert_equal(["Post"], constants_from(content))
-    end
-
-    it("rejects abstract ActiveRecord subclasses") do
-      content = <<~RUBY
-        class Post < ActiveRecord::Base
-        end
-
-        class Current < ActiveRecord::Base
-          self.abstract_class = true
-        end
-      RUBY
-
-      assert_equal(["Post"], constants_from(content))
-    end
-  end
-
-  describe("#decorate") do
-    before(:each) do
-      ActiveRecord::Base.establish_connection(
-        adapter: 'sqlite3',
-        database: ':memory:'
-      )
-    end
-
-    def rbi_for(contents)
-      with_contents(contents, requires: contents.keys) do
-        parlour = Parlour::RbiGenerator.new(sort_namespaces: true)
-        subject.decorate(parlour.root, Post)
-        parlour.rbi
+    describe("#decorate") do
+      before(:each) do
+        ActiveRecord::Base.establish_connection(
+          adapter: 'sqlite3',
+          database: ':memory:'
+        )
       end
-    end
 
-    it("generates RBI file for class without custom attributes with StrongTypeGeneration") do
-      files = {
-        "file.rb" => <<~RUBY,
-          module StrongTypeGeneration
-          end
+      it("generates RBI file for class without custom attributes with StrongTypeGeneration") do
+        files = {
+          "file.rb" => <<~RUBY,
+            module StrongTypeGeneration
+            end
 
-          class Post < ActiveRecord::Base
-            extend StrongTypeGeneration
-          end
-        RUBY
+            class Post < ActiveRecord::Base
+              extend StrongTypeGeneration
+            end
+          RUBY
 
-        "schema.rb" => <<~RUBY,
-          ActiveRecord::Migration.suppress_messages do
-            ActiveRecord::Schema.define do
-              create_table :posts do |t|
+          "schema.rb" => <<~RUBY,
+            ActiveRecord::Migration.suppress_messages do
+              ActiveRecord::Schema.define do
+                create_table :posts do |t|
+                end
               end
             end
-          end
-        RUBY
-      }
+          RUBY
+        }
 
-      expected = <<~RUBY
-        # typed: strong
-        class Post
-          include Post::GeneratedAttributeMethods
-        end
-
-        module Post::GeneratedAttributeMethods
-          sig { returns(T.nilable(::Integer)) }
-          def id; end
-
-          sig { params(value: ::Integer).returns(::Integer) }
-          def id=(value); end
-
-          sig { returns(T::Boolean) }
-          def id?; end
-
-          sig { returns(T.nilable(::Integer)) }
-          def id_before_last_save; end
-
-          sig { returns(T.untyped) }
-          def id_before_type_cast; end
-
-          sig { returns(T::Boolean) }
-          def id_came_from_user?; end
-
-          sig { returns(T.nilable([T.nilable(::Integer), T.nilable(::Integer)])) }
-          def id_change; end
-
-          sig { returns(T.nilable([T.nilable(::Integer), T.nilable(::Integer)])) }
-          def id_change_to_be_saved; end
-
-          sig { returns(T::Boolean) }
-          def id_changed?; end
-
-          sig { returns(T.nilable(::Integer)) }
-          def id_in_database; end
-
-          sig { returns(T.nilable([T.nilable(::Integer), T.nilable(::Integer)])) }
-          def id_previous_change; end
-
-          sig { returns(T::Boolean) }
-          def id_previously_changed?; end
-
-          sig { returns(T.nilable(::Integer)) }
-          def id_previously_was; end
-
-          sig { returns(T.nilable(::Integer)) }
-          def id_was; end
-
-          sig { void }
-          def id_will_change!; end
-
-          sig { void }
-          def restore_id!; end
-
-          sig { returns(T.nilable([T.nilable(::Integer), T.nilable(::Integer)])) }
-          def saved_change_to_id; end
-
-          sig { returns(T::Boolean) }
-          def saved_change_to_id?; end
-
-          sig { returns(T::Boolean) }
-          def will_save_change_to_id?; end
-        end
-      RUBY
-
-      assert_equal(expected, rbi_for(files))
-    end
-
-    it("generates RBI file for custom attributes with strong type generation") do
-      files = {
-        "file.rb" => <<~RUBY,
-          module StrongTypeGeneration
+        expected = <<~RUBY
+          # typed: strong
+          class Post
+            include Post::GeneratedAttributeMethods
           end
 
-          class Post < ActiveRecord::Base
-            extend StrongTypeGeneration
+          module Post::GeneratedAttributeMethods
+            sig { returns(T.nilable(::Integer)) }
+            def id; end
+
+            sig { params(value: ::Integer).returns(::Integer) }
+            def id=(value); end
+
+            sig { returns(T::Boolean) }
+            def id?; end
+
+            sig { returns(T.nilable(::Integer)) }
+            def id_before_last_save; end
+
+            sig { returns(T.untyped) }
+            def id_before_type_cast; end
+
+            sig { returns(T::Boolean) }
+            def id_came_from_user?; end
+
+            sig { returns(T.nilable([T.nilable(::Integer), T.nilable(::Integer)])) }
+            def id_change; end
+
+            sig { returns(T.nilable([T.nilable(::Integer), T.nilable(::Integer)])) }
+            def id_change_to_be_saved; end
+
+            sig { returns(T::Boolean) }
+            def id_changed?; end
+
+            sig { returns(T.nilable(::Integer)) }
+            def id_in_database; end
+
+            sig { returns(T.nilable([T.nilable(::Integer), T.nilable(::Integer)])) }
+            def id_previous_change; end
+
+            sig { returns(T::Boolean) }
+            def id_previously_changed?; end
+
+            sig { returns(T.nilable(::Integer)) }
+            def id_previously_was; end
+
+            sig { returns(T.nilable(::Integer)) }
+            def id_was; end
+
+            sig { void }
+            def id_will_change!; end
+
+            sig { void }
+            def restore_id!; end
+
+            sig { returns(T.nilable([T.nilable(::Integer), T.nilable(::Integer)])) }
+            def saved_change_to_id; end
+
+            sig { returns(T::Boolean) }
+            def saved_change_to_id?; end
+
+            sig { returns(T::Boolean) }
+            def will_save_change_to_id?; end
           end
         RUBY
 
-        "schema.rb" => <<~RUBY,
-          ActiveRecord::Migration.suppress_messages do
-            ActiveRecord::Schema.define do
-              create_table :posts do |t|
-                t.string :body
+        assert_equal(expected, rbi_for(:Post, files))
+      end
+
+      it("generates RBI file for custom attributes with strong type generation") do
+        files = {
+          "file.rb" => <<~RUBY,
+            module StrongTypeGeneration
+            end
+
+            class Post < ActiveRecord::Base
+              extend StrongTypeGeneration
+            end
+          RUBY
+
+          "schema.rb" => <<~RUBY,
+            ActiveRecord::Migration.suppress_messages do
+              ActiveRecord::Schema.define do
+                create_table :posts do |t|
+                  t.string :body
+                end
               end
             end
-          end
-        RUBY
-      }
+          RUBY
+        }
 
-      expected = <<~RUBY
-        module Post::GeneratedAttributeMethods
+        expected = <<~RUBY
+          module Post::GeneratedAttributeMethods
+            sig { returns(T.nilable(::String)) }
+            def body; end
+
+            sig { params(value: T.nilable(::String)).returns(T.nilable(::String)) }
+            def body=(value); end
+
+            sig { returns(T::Boolean) }
+            def body?; end
+        RUBY
+        assert_includes(rbi_for(:Post, files), expected)
+      end
+
+      it("generates RBI file for custom attributes without strong type generation") do
+        files = {
+          "file.rb" => <<~RUBY,
+            module StrongTypeGeneration
+            end
+
+            class Post < ActiveRecord::Base
+              # StrongTypeGeneration is not extended
+            end
+          RUBY
+
+          "schema.rb" => <<~RUBY,
+            ActiveRecord::Migration.suppress_messages do
+              ActiveRecord::Schema.define do
+                create_table :posts do |t|
+                  t.string :body
+                end
+              end
+            end
+          RUBY
+        }
+
+        expected = <<~RUBY
+          module Post::GeneratedAttributeMethods
+            sig { returns(T.untyped) }
+            def body; end
+
+            sig { params(value: T.untyped).returns(T.untyped) }
+            def body=(value); end
+
+            sig { returns(T::Boolean) }
+            def body?; end
+        RUBY
+
+        assert_includes(rbi_for(:Post, files), expected)
+      end
+
+      it("generates RBI file given nullability of an attribute") do
+        files = {
+          "file.rb" => <<~RUBY,
+            module StrongTypeGeneration
+            end
+
+            class Post < ActiveRecord::Base
+              extend StrongTypeGeneration
+            end
+          RUBY
+
+          "schema.rb" => <<~RUBY,
+            ActiveRecord::Migration.suppress_messages do
+              ActiveRecord::Schema.define do
+                create_table :posts do |t|
+                  t.string :title, null: false
+                  t.string :body, null: true
+                  t.timestamps
+                end
+              end
+            end
+          RUBY
+        }
+
+        output = rbi_for(:Post, files)
+
+        expected = indented(<<~RUBY, 2)
           sig { returns(T.nilable(::String)) }
           def body; end
 
@@ -187,663 +242,589 @@ describe("Tapioca::Compilers::Dsl::ActiveRecordColumns") do
 
           sig { returns(T::Boolean) }
           def body?; end
-      RUBY
-      assert_includes(rbi_for(files), expected)
-    end
-
-    it("generates RBI file for custom attributes without strong type generation") do
-      files = {
-        "file.rb" => <<~RUBY,
-          module StrongTypeGeneration
-          end
-
-          class Post < ActiveRecord::Base
-            # StrongTypeGeneration is not extended
-          end
         RUBY
+        assert_includes(output, expected)
 
-        "schema.rb" => <<~RUBY,
-          ActiveRecord::Migration.suppress_messages do
-            ActiveRecord::Schema.define do
-              create_table :posts do |t|
-                t.string :body
-              end
-            end
-          end
-        RUBY
-      }
+        expected = indented(<<~RUBY, 2)
+          sig { returns(::String) }
+          def title; end
 
-      expected = <<~RUBY
-        module Post::GeneratedAttributeMethods
-          sig { returns(T.untyped) }
-          def body; end
-
-          sig { params(value: T.untyped).returns(T.untyped) }
-          def body=(value); end
+          sig { params(value: ::String).returns(::String) }
+          def title=(value); end
 
           sig { returns(T::Boolean) }
-          def body?; end
-      RUBY
-
-      assert_includes(rbi_for(files), expected)
-    end
-
-    it("generates RBI file given nullability of an attribute") do
-      files = {
-        "file.rb" => <<~RUBY,
-          module StrongTypeGeneration
-          end
-
-          class Post < ActiveRecord::Base
-            extend StrongTypeGeneration
-          end
+          def title?; end
         RUBY
+        assert_includes(output, expected)
+      end
 
-        "schema.rb" => <<~RUBY,
-          ActiveRecord::Migration.suppress_messages do
-            ActiveRecord::Schema.define do
-              create_table :posts do |t|
-                t.string :title, null: false
-                t.string :body, null: true
-                t.timestamps
+      it("generates RBI file containing every ActiveRecord column type") do
+        files = {
+          "file.rb" => <<~RUBY,
+            module StrongTypeGeneration
+            end
+
+            class Post < ActiveRecord::Base
+              extend StrongTypeGeneration
+            end
+          RUBY
+
+          "schema.rb" => <<~RUBY,
+            ActiveRecord::Migration.suppress_messages do
+              ActiveRecord::Schema.define do
+                create_table :posts do |t|
+                  t.integer :integer_column
+                  t.string :string_column
+                  t.date :date_column
+                  t.decimal :decimal_column
+                  t.float :float_column
+                  t.boolean :boolean_column
+                  t.datetime :datetime_column
+                end
               end
             end
-          end
+          RUBY
+        }
+
+        output = rbi_for(:Post, files)
+
+        expected = indented(<<~RUBY, 2)
+          sig { params(value: T.nilable(::Integer)).returns(T.nilable(::Integer)) }
+          def integer_column=(value); end
         RUBY
-      }
+        assert_includes(output, expected)
 
-      expected = indented(<<~RUBY, 2)
-        sig { returns(T.nilable(::String)) }
-        def body; end
-
-        sig { params(value: T.nilable(::String)).returns(T.nilable(::String)) }
-        def body=(value); end
-
-        sig { returns(T::Boolean) }
-        def body?; end
-      RUBY
-      output = rbi_for(files)
-      assert_includes(output, expected)
-
-      expected = indented(<<~RUBY, 2)
-        sig { returns(::String) }
-        def title; end
-
-        sig { params(value: ::String).returns(::String) }
-        def title=(value); end
-
-        sig { returns(T::Boolean) }
-        def title?; end
-      RUBY
-      assert_includes(output, expected)
-    end
-
-    it("generates RBI file containing every ActiveRecord column type") do
-      files = {
-        "file.rb" => <<~RUBY,
-          module StrongTypeGeneration
-          end
-
-          class Post < ActiveRecord::Base
-            extend StrongTypeGeneration
-          end
-        RUBY
-
-        "schema.rb" => <<~RUBY,
-          ActiveRecord::Migration.suppress_messages do
-            ActiveRecord::Schema.define do
-              create_table :posts do |t|
-                t.integer :integer_column
-                t.string :string_column
-                t.date :date_column
-                t.decimal :decimal_column
-                t.float :float_column
-                t.boolean :boolean_column
-                t.datetime :datetime_column
-              end
-            end
-          end
-        RUBY
-      }
-
-      expected = indented(<<~RUBY, 2)
-        sig { params(value: T.nilable(::Integer)).returns(T.nilable(::Integer)) }
-        def integer_column=(value); end
-      RUBY
-
-      output = rbi_for(files)
-      assert_includes(output, expected)
-
-      expected = indented(<<~RUBY, 2)
-        sig { params(value: T.nilable(::String)).returns(T.nilable(::String)) }
-        def string_column=(value); end
-      RUBY
-      assert_includes(output, expected)
-
-      expected = indented(<<~RUBY, 2)
-        sig { params(value: T.nilable(::Date)).returns(T.nilable(::Date)) }
-        def date_column=(value); end
-      RUBY
-      assert_includes(output, expected)
-
-      expected = indented(<<~RUBY, 2)
-        sig { params(value: T.nilable(::BigDecimal)).returns(T.nilable(::BigDecimal)) }
-        def decimal_column=(value); end
-      RUBY
-      assert_includes(output, expected)
-
-      expected = indented(<<~RUBY, 2)
-        sig { params(value: T.nilable(::Float)).returns(T.nilable(::Float)) }
-        def float_column=(value); end
-      RUBY
-      assert_includes(output, expected)
-
-      expected = indented(<<~RUBY, 2)
-        sig { params(value: T.nilable(T::Boolean)).returns(T.nilable(T::Boolean)) }
-        def boolean_column=(value); end
-      RUBY
-      assert_includes(output, expected)
-
-      expected = indented(<<~RUBY, 2)
-        sig { params(value: T.nilable(::DateTime)).returns(T.nilable(::DateTime)) }
-        def datetime_column=(value); end
-      RUBY
-      assert_includes(output, expected)
-    end
-
-    it("generates RBI file for time_zone_aware_attributes") do
-      files = {
-        "file.rb" => <<~RUBY,
-          module StrongTypeGeneration
-          end
-
-          class Post < ActiveRecord::Base
-            extend StrongTypeGeneration
-          end
-        RUBY
-
-        "schema.rb" => <<~RUBY,
-          ActiveRecord::Base.time_zone_aware_attributes = true
-          ActiveRecord::Migration.suppress_messages do
-            ActiveRecord::Schema.define do
-              create_table :posts do |t|
-                t.timestamp :timestamp_column
-                t.datetime :datetime_column
-                t.time :time_column
-              end
-            end
-          end
-        RUBY
-      }
-
-      expected = indented(<<~RUBY, 2)
-        sig { params(value: T.nilable(::ActiveSupport::TimeWithZone)).returns(T.nilable(::ActiveSupport::TimeWithZone)) }
-        def timestamp_column=(value); end
-      RUBY
-
-      output = rbi_for(files)
-      assert_includes(output, expected)
-
-      expected = indented(<<~RUBY, 2)
-        sig { params(value: T.nilable(::ActiveSupport::TimeWithZone)).returns(T.nilable(::ActiveSupport::TimeWithZone)) }
-        def datetime_column=(value); end
-      RUBY
-      assert_includes(output, expected)
-
-      expected = indented(<<~RUBY, 2)
-        sig { params(value: T.nilable(::ActiveSupport::TimeWithZone)).returns(T.nilable(::ActiveSupport::TimeWithZone)) }
-        def time_column=(value); end
-      RUBY
-      assert_includes(output, expected)
-    end
-
-    it("generates RBI file for alias_attributes") do
-      files = {
-        "file.rb" => <<~RUBY,
-          module StrongTypeGeneration
-          end
-
-          class Post < ActiveRecord::Base
-            extend StrongTypeGeneration
-            alias_attribute :author, :name
-          end
-        RUBY
-
-        "schema.rb" => <<~RUBY,
-          ActiveRecord::Migration.suppress_messages do
-            ActiveRecord::Schema.define do
-              create_table :posts do |t|
-                t.string :name
-              end
-            end
-          end
-        RUBY
-      }
-
-      expected = <<~RUBY
-        module Post::GeneratedAttributeMethods
-          sig { returns(T.nilable(::String)) }
-          def author; end
-
+        expected = indented(<<~RUBY, 2)
           sig { params(value: T.nilable(::String)).returns(T.nilable(::String)) }
-          def author=(value); end
+          def string_column=(value); end
+        RUBY
+        assert_includes(output, expected)
 
-          sig { returns(T::Boolean) }
-          def author?; end
+        expected = indented(<<~RUBY, 2)
+          sig { params(value: T.nilable(::Date)).returns(T.nilable(::Date)) }
+          def date_column=(value); end
+        RUBY
+        assert_includes(output, expected)
 
-          sig { returns(T.nilable(::String)) }
-          def author_before_last_save; end
+        expected = indented(<<~RUBY, 2)
+          sig { params(value: T.nilable(::BigDecimal)).returns(T.nilable(::BigDecimal)) }
+          def decimal_column=(value); end
+        RUBY
+        assert_includes(output, expected)
 
-          sig { returns(T.untyped) }
-          def author_before_type_cast; end
+        expected = indented(<<~RUBY, 2)
+          sig { params(value: T.nilable(::Float)).returns(T.nilable(::Float)) }
+          def float_column=(value); end
+        RUBY
+        assert_includes(output, expected)
 
-          sig { returns(T::Boolean) }
-          def author_came_from_user?; end
+        expected = indented(<<~RUBY, 2)
+          sig { params(value: T.nilable(T::Boolean)).returns(T.nilable(T::Boolean)) }
+          def boolean_column=(value); end
+        RUBY
+        assert_includes(output, expected)
 
-          sig { returns(T.nilable([T.nilable(::String), T.nilable(::String)])) }
-          def author_change; end
+        expected = indented(<<~RUBY, 2)
+          sig { params(value: T.nilable(::DateTime)).returns(T.nilable(::DateTime)) }
+          def datetime_column=(value); end
+        RUBY
+        assert_includes(output, expected)
+      end
 
-          sig { returns(T.nilable([T.nilable(::String), T.nilable(::String)])) }
-          def author_change_to_be_saved; end
+      it("generates RBI file for time_zone_aware_attributes") do
+        files = {
+          "file.rb" => <<~RUBY,
+            module StrongTypeGeneration
+            end
 
-          sig { returns(T::Boolean) }
-          def author_changed?; end
+            class Post < ActiveRecord::Base
+              extend StrongTypeGeneration
+            end
+          RUBY
 
-          sig { returns(T.nilable(::String)) }
-          def author_in_database; end
+          "schema.rb" => <<~RUBY,
+            ActiveRecord::Base.time_zone_aware_attributes = true
+            ActiveRecord::Migration.suppress_messages do
+              ActiveRecord::Schema.define do
+                create_table :posts do |t|
+                  t.timestamp :timestamp_column
+                  t.datetime :datetime_column
+                  t.time :time_column
+                end
+              end
+            end
+          RUBY
+        }
 
-          sig { returns(T.nilable([T.nilable(::String), T.nilable(::String)])) }
-          def author_previous_change; end
+        output = rbi_for(:Post, files)
 
-          sig { returns(T::Boolean) }
-          def author_previously_changed?; end
+        expected = indented(<<~RUBY, 2)
+          sig { params(value: T.nilable(::ActiveSupport::TimeWithZone)).returns(T.nilable(::ActiveSupport::TimeWithZone)) }
+          def timestamp_column=(value); end
+        RUBY
+        assert_includes(output, expected)
 
-          sig { returns(T.nilable(::String)) }
-          def author_was; end
+        expected = indented(<<~RUBY, 2)
+          sig { params(value: T.nilable(::ActiveSupport::TimeWithZone)).returns(T.nilable(::ActiveSupport::TimeWithZone)) }
+          def datetime_column=(value); end
+        RUBY
+        assert_includes(output, expected)
 
+        expected = indented(<<~RUBY, 2)
+          sig { params(value: T.nilable(::ActiveSupport::TimeWithZone)).returns(T.nilable(::ActiveSupport::TimeWithZone)) }
+          def time_column=(value); end
+        RUBY
+        assert_includes(output, expected)
+      end
+
+      it("generates RBI file for alias_attributes") do
+        files = {
+          "file.rb" => <<~RUBY,
+            module StrongTypeGeneration
+            end
+
+            class Post < ActiveRecord::Base
+              extend StrongTypeGeneration
+              alias_attribute :author, :name
+            end
+          RUBY
+
+          "schema.rb" => <<~RUBY,
+            ActiveRecord::Migration.suppress_messages do
+              ActiveRecord::Schema.define do
+                create_table :posts do |t|
+                  t.string :name
+                end
+              end
+            end
+          RUBY
+        }
+
+        output = rbi_for(:Post, files)
+
+        expected = <<~RUBY
+          module Post::GeneratedAttributeMethods
+            sig { returns(T.nilable(::String)) }
+            def author; end
+
+            sig { params(value: T.nilable(::String)).returns(T.nilable(::String)) }
+            def author=(value); end
+
+            sig { returns(T::Boolean) }
+            def author?; end
+
+            sig { returns(T.nilable(::String)) }
+            def author_before_last_save; end
+
+            sig { returns(T.untyped) }
+            def author_before_type_cast; end
+
+            sig { returns(T::Boolean) }
+            def author_came_from_user?; end
+
+            sig { returns(T.nilable([T.nilable(::String), T.nilable(::String)])) }
+            def author_change; end
+
+            sig { returns(T.nilable([T.nilable(::String), T.nilable(::String)])) }
+            def author_change_to_be_saved; end
+
+            sig { returns(T::Boolean) }
+            def author_changed?; end
+
+            sig { returns(T.nilable(::String)) }
+            def author_in_database; end
+
+            sig { returns(T.nilable([T.nilable(::String), T.nilable(::String)])) }
+            def author_previous_change; end
+
+            sig { returns(T::Boolean) }
+            def author_previously_changed?; end
+
+            sig { returns(T.nilable(::String)) }
+            def author_was; end
+
+            sig { void }
+            def author_will_change!; end
+        RUBY
+        assert_includes(output, expected)
+
+        expected = indented(<<~RUBY, 2)
           sig { void }
-          def author_will_change!; end
-      RUBY
-
-      output = rbi_for(files)
-      assert_includes(output, expected)
-
-      expected = indented(<<~RUBY, 2)
-        sig { void }
-        def restore_author!; end
-      RUBY
-      assert_includes(output, expected)
-
-      expected = indented(<<~RUBY, 2)
-        sig { returns(T.nilable([T.nilable(::String), T.nilable(::String)])) }
-        def saved_change_to_author; end
-
-        sig { returns(T::Boolean) }
-        def saved_change_to_author?; end
-      RUBY
-      assert_includes(output, expected)
-
-      expected = indented(<<~RUBY, 2)
-        sig { returns(T::Boolean) }
-        def will_save_change_to_author?; end
-      RUBY
-      assert_includes(output, expected)
-    end
-
-    it("generated RBI file ignores conflicting alias_attributes") do
-      files = {
-        "file.rb" => <<~RUBY,
-          module StrongTypeGeneration
-          end
-
-          class Post < ActiveRecord::Base
-            extend StrongTypeGeneration
-            alias_attribute :body?, :body
-          end
+          def restore_author!; end
         RUBY
+        assert_includes(output, expected)
 
-        "schema.rb" => <<~RUBY,
-          ActiveRecord::Migration.suppress_messages do
-            ActiveRecord::Schema.define do
-              create_table :posts do |t|
-                t.string :body
+        expected = indented(<<~RUBY, 2)
+          sig { returns(T.nilable([T.nilable(::String), T.nilable(::String)])) }
+          def saved_change_to_author; end
+
+          sig { returns(T::Boolean) }
+          def saved_change_to_author?; end
+        RUBY
+        assert_includes(output, expected)
+
+        expected = indented(<<~RUBY, 2)
+          sig { returns(T::Boolean) }
+          def will_save_change_to_author?; end
+        RUBY
+        assert_includes(output, expected)
+      end
+
+      it("generated RBI file ignores conflicting alias_attributes") do
+        files = {
+          "file.rb" => <<~RUBY,
+            module StrongTypeGeneration
+            end
+
+            class Post < ActiveRecord::Base
+              extend StrongTypeGeneration
+              alias_attribute :body?, :body
+            end
+          RUBY
+
+          "schema.rb" => <<~RUBY,
+            ActiveRecord::Migration.suppress_messages do
+              ActiveRecord::Schema.define do
+                create_table :posts do |t|
+                  t.string :body
+                end
               end
             end
-          end
+          RUBY
+        }
+
+        output = rbi_for(:Post, files)
+
+        expected = <<~RUBY
+          module Post::GeneratedAttributeMethods
+            sig { returns(T.nilable(::String)) }
+            def body; end
+
+            sig { params(value: T.nilable(::String)).returns(T.nilable(::String)) }
+            def body=(value); end
+
+            sig { returns(T::Boolean) }
+            def body?; end
+
+            sig { returns(T.nilable(::String)) }
+            def body_before_last_save; end
+
+            sig { returns(T.untyped) }
+            def body_before_type_cast; end
+
+            sig { returns(T::Boolean) }
+            def body_came_from_user?; end
+
+            sig { returns(T.nilable([T.nilable(::String), T.nilable(::String)])) }
+            def body_change; end
+
+            sig { returns(T.nilable([T.nilable(::String), T.nilable(::String)])) }
+            def body_change_to_be_saved; end
+
+            sig { returns(T::Boolean) }
+            def body_changed?; end
+
+            sig { returns(T.nilable(::String)) }
+            def body_in_database; end
+
+            sig { returns(T.nilable([T.nilable(::String), T.nilable(::String)])) }
+            def body_previous_change; end
+
+            sig { returns(T::Boolean) }
+            def body_previously_changed?; end
+
+            sig { returns(T.nilable(::String)) }
+            def body_previously_was; end
+
+            sig { returns(T.nilable(::String)) }
+            def body_was; end
+
+            sig { void }
+            def body_will_change!; end
         RUBY
-      }
+        assert_includes(output, expected)
 
-      expected = <<~RUBY
-        module Post::GeneratedAttributeMethods
-          sig { returns(T.nilable(::String)) }
-          def body; end
-
-          sig { params(value: T.nilable(::String)).returns(T.nilable(::String)) }
-          def body=(value); end
-
-          sig { returns(T::Boolean) }
-          def body?; end
-
-          sig { returns(T.nilable(::String)) }
-          def body_before_last_save; end
-
-          sig { returns(T.untyped) }
-          def body_before_type_cast; end
-
-          sig { returns(T::Boolean) }
-          def body_came_from_user?; end
-
-          sig { returns(T.nilable([T.nilable(::String), T.nilable(::String)])) }
-          def body_change; end
-
-          sig { returns(T.nilable([T.nilable(::String), T.nilable(::String)])) }
-          def body_change_to_be_saved; end
-
-          sig { returns(T::Boolean) }
-          def body_changed?; end
-
-          sig { returns(T.nilable(::String)) }
-          def body_in_database; end
-
-          sig { returns(T.nilable([T.nilable(::String), T.nilable(::String)])) }
-          def body_previous_change; end
-
-          sig { returns(T::Boolean) }
-          def body_previously_changed?; end
-
-          sig { returns(T.nilable(::String)) }
-          def body_previously_was; end
-
-          sig { returns(T.nilable(::String)) }
-          def body_was; end
-
+        expected = indented(<<~RUBY, 2)
           sig { void }
-          def body_will_change!; end
-      RUBY
+          def restore_body!; end
+        RUBY
+        assert_includes(output, expected)
 
-      output = rbi_for(files)
-      assert_includes(output, expected)
+        expected = indented(<<~RUBY, 2)
+          sig { returns(T.nilable([T.nilable(::String), T.nilable(::String)])) }
+          def saved_change_to_body; end
 
-      expected = indented(<<~RUBY, 2)
-        sig { void }
-        def restore_body!; end
-      RUBY
-      assert_includes(output, expected)
+          sig { returns(T::Boolean) }
+          def saved_change_to_body?; end
+        RUBY
+        assert_includes(output, expected)
 
-      expected = indented(<<~RUBY, 2)
-        sig { returns(T.nilable([T.nilable(::String), T.nilable(::String)])) }
-        def saved_change_to_body; end
+        expected = indented(<<~RUBY, 2)
+          sig { returns(T::Boolean) }
+          def will_save_change_to_body?; end
+        RUBY
+        assert_includes(output, expected)
+      end
 
-        sig { returns(T::Boolean) }
-        def saved_change_to_body?; end
-      RUBY
-      assert_includes(output, expected)
-
-      expected = indented(<<~RUBY, 2)
-        sig { returns(T::Boolean) }
-        def will_save_change_to_body?; end
-      RUBY
-      assert_includes(output, expected)
-    end
-
-    it("generates RBI file for custom type with signature on deserialize method") do
-      files = {
-        "file.rb" => <<~RUBY,
-          module StrongTypeGeneration
-          end
-
-          class Money
-            attr_accessor :value
-
-            def initialize(number = 0.0)
-              @value = number
+      it("generates RBI file for custom type with signature on deserialize method") do
+        files = {
+          "file.rb" => <<~RUBY,
+            module StrongTypeGeneration
             end
 
-            class Type < ActiveRecord::Type::Value
+            class Money
+              attr_accessor :value
+
+              def initialize(number = 0.0)
+                @value = number
+              end
+
+              class Type < ActiveRecord::Type::Value
+                extend(T::Sig)
+
+                sig { params(value: Numeric).returns(::Money)}
+                def deserialize(value)
+                  Money.new(value)
+                end
+              end
+            end
+
+            class Post < ActiveRecord::Base
+              extend StrongTypeGeneration
+
+              attribute :cost, Money::Type.new
+            end
+          RUBY
+
+          "schema.rb" => <<~RUBY,
+            ActiveRecord::Migration.suppress_messages do
+              ActiveRecord::Schema.define do
+                create_table :posts do |t|
+                  t.decimal :cost
+                end
+              end
+            end
+          RUBY
+        }
+
+        expected = indented(<<~RUBY, 2)
+          sig { returns(T.nilable(Money)) }
+          def cost; end
+
+          sig { params(value: T.nilable(Money)).returns(T.nilable(Money)) }
+          def cost=(value); end
+        RUBY
+
+        assert_includes(rbi_for(:Post, files), expected)
+      end
+
+      it("generates RBI file for custom type with signature on cast method") do
+        files = {
+          "file.rb" => <<~RUBY,
+            module StrongTypeGeneration
+            end
+
+            class Money
+              attr_accessor :value
+
+              def initialize(number = 0.0)
+                @value = number
+              end
+
+              class Type < ActiveRecord::Type::Value
+                extend(T::Sig)
+
+                sig { params(value: ::Numeric).returns(T.any(::Money, Numeric)) }
+                def cast(value)
+                  decimal = super
+                  return Money.new(decimal) if decimal
+                  decimal
+                end
+              end
+            end
+
+            class Post < ActiveRecord::Base
+              extend StrongTypeGeneration
+
+              attribute :cost, Money::Type.new
+            end
+          RUBY
+
+          "schema.rb" => <<~RUBY,
+            ActiveRecord::Migration.suppress_messages do
+              ActiveRecord::Schema.define do
+                create_table :posts do |t|
+                  t.decimal :cost
+                end
+              end
+            end
+          RUBY
+        }
+
+        expected = indented(<<~RUBY, 2)
+          sig { returns(T.nilable(T.any(Money, Numeric))) }
+          def cost; end
+
+          sig { params(value: T.nilable(T.any(Money, Numeric))).returns(T.nilable(T.any(Money, Numeric))) }
+          def cost=(value); end
+        RUBY
+
+        assert_includes(rbi_for(:Post, files), expected)
+      end
+
+      it("generates RBI file for custom type with signature on serialize method") do
+        files = {
+          "file.rb" => <<~RUBY,
+            module StrongTypeGeneration
+            end
+
+            class Money
+              attr_accessor :value
+
+              def initialize(number = 0.0)
+                @value = number
+              end
+
+              class Type < ActiveRecord::Type::Value
+                extend(T::Sig)
+
+                sig { params(money: ::Money).returns(Numeric) }
+                def serialize(money)
+                  money = super unless money.is_a?(::Money)
+                  money.value unless money.nil?
+                end
+              end
+            end
+
+            class Post < ActiveRecord::Base
+              extend StrongTypeGeneration
+
+              attribute :cost, Money::Type.new
+            end
+          RUBY
+
+          "schema.rb" => <<~RUBY,
+            ActiveRecord::Migration.suppress_messages do
+              ActiveRecord::Schema.define do
+                create_table :posts do |t|
+                  t.decimal :cost
+                end
+              end
+            end
+          RUBY
+        }
+
+        expected = indented(<<~RUBY, 2)
+          sig { returns(T.nilable(Money)) }
+          def cost; end
+
+          sig { params(value: T.nilable(Money)).returns(T.nilable(Money)) }
+          def cost=(value); end
+        RUBY
+
+        assert_includes(rbi_for(:Post, files), expected)
+      end
+
+      it("generates RBI file for custom type that returns a generic type") do
+        files = {
+          "file.rb" => <<~RUBY,
+            module StrongTypeGeneration
+            end
+
+            class ValueType
+              extend T::Generic
+
+              Elem = type_member
+            end
+
+            class ColumnType < ActiveRecord::Type::Value
               extend(T::Sig)
 
-              sig { params(value: Numeric).returns(::Money)}
-              def deserialize(value)
-                Money.new(value)
+              sig { params(value: ::ValueType[Integer]).returns(Numeric) }
+              def serialize(value)
+                super
               end
             end
-          end
 
-          class Post < ActiveRecord::Base
-            extend StrongTypeGeneration
+            class Post < ActiveRecord::Base
+              extend StrongTypeGeneration
 
-            attribute :cost, Money::Type.new
-          end
-        RUBY
+              attribute :cost, ColumnType.new
+            end
+          RUBY
 
-        "schema.rb" => <<~RUBY,
-          ActiveRecord::Migration.suppress_messages do
-            ActiveRecord::Schema.define do
-              create_table :posts do |t|
-                t.decimal :cost
+          "schema.rb" => <<~RUBY,
+            ActiveRecord::Migration.suppress_messages do
+              ActiveRecord::Schema.define do
+                create_table :posts do |t|
+                  t.decimal :cost
+                end
               end
             end
-          end
+          RUBY
+        }
+
+        expected = indented(<<~RUBY, 2)
+          sig { returns(T.nilable(T.untyped)) }
+          def cost; end
+
+          sig { params(value: T.nilable(T.untyped)).returns(T.nilable(T.untyped)) }
+          def cost=(value); end
         RUBY
-      }
 
-      expected = indented(<<~RUBY, 2)
-        sig { returns(T.nilable(Money)) }
-        def cost; end
+        assert_includes(rbi_for(:Post, files), expected)
+      end
 
-        sig { params(value: T.nilable(Money)).returns(T.nilable(Money)) }
-        def cost=(value); end
-      RUBY
-
-      assert_includes(rbi_for(files), expected)
-    end
-
-    it("generates RBI file for custom type with signature on cast method") do
-      files = {
-        "file.rb" => <<~RUBY,
-          module StrongTypeGeneration
-          end
-
-          class Money
-            attr_accessor :value
-
-            def initialize(number = 0.0)
-              @value = number
+      it("generates RBI file for custom type without signatures") do
+        files = {
+          "file.rb" => <<~RUBY,
+            module StrongTypeGeneration
             end
 
-            class Type < ActiveRecord::Type::Value
-              extend(T::Sig)
+            class Money
+              attr_accessor :value
 
-              sig { params(value: ::Numeric).returns(T.any(::Money, Numeric)) }
-              def cast(value)
-                decimal = super
-                return Money.new(decimal) if decimal
-                decimal
+              def initialize(number = 0.0)
+                @value = number
+              end
+
+              class Type < ActiveRecord::Type::Value
+                extend(T::Sig)
+
+                def deserialize(value)
+                  Money.new(value)
+                end
               end
             end
-          end
 
-          class Post < ActiveRecord::Base
-            extend StrongTypeGeneration
+            class Post < ActiveRecord::Base
+              extend StrongTypeGeneration
 
-            attribute :cost, Money::Type.new
-          end
-        RUBY
+              attribute :cost, Money::Type.new
+            end
+          RUBY
 
-        "schema.rb" => <<~RUBY,
-          ActiveRecord::Migration.suppress_messages do
-            ActiveRecord::Schema.define do
-              create_table :posts do |t|
-                t.decimal :cost
+          "schema.rb" => <<~RUBY,
+            ActiveRecord::Migration.suppress_messages do
+              ActiveRecord::Schema.define do
+                create_table :posts do |t|
+                  t.decimal :cost
+                end
               end
             end
-          end
-        RUBY
-      }
+          RUBY
+        }
 
-      expected = indented(<<~RUBY, 2)
-        sig { returns(T.nilable(T.any(Money, Numeric))) }
-        def cost; end
+        expected = indented(<<~RUBY, 2)
+          sig { returns(T.nilable(T.untyped)) }
+          def cost; end
 
-        sig { params(value: T.nilable(T.any(Money, Numeric))).returns(T.nilable(T.any(Money, Numeric))) }
-        def cost=(value); end
-      RUBY
-
-      assert_includes(rbi_for(files), expected)
-    end
-
-    it("generates RBI file for custom type with signature on serialize method") do
-      files = {
-        "file.rb" => <<~RUBY,
-          module StrongTypeGeneration
-          end
-
-          class Money
-            attr_accessor :value
-
-            def initialize(number = 0.0)
-              @value = number
-            end
-
-            class Type < ActiveRecord::Type::Value
-              extend(T::Sig)
-
-              sig { params(money: ::Money).returns(Numeric) }
-              def serialize(money)
-                money = super unless money.is_a?(::Money)
-                money.value unless money.nil?
-              end
-            end
-          end
-
-          class Post < ActiveRecord::Base
-            extend StrongTypeGeneration
-
-            attribute :cost, Money::Type.new
-          end
+          sig { params(value: T.nilable(T.untyped)).returns(T.nilable(T.untyped)) }
+          def cost=(value); end
         RUBY
 
-        "schema.rb" => <<~RUBY,
-          ActiveRecord::Migration.suppress_messages do
-            ActiveRecord::Schema.define do
-              create_table :posts do |t|
-                t.decimal :cost
-              end
-            end
-          end
-        RUBY
-      }
-
-      expected = indented(<<~RUBY, 2)
-        sig { returns(T.nilable(Money)) }
-        def cost; end
-
-        sig { params(value: T.nilable(Money)).returns(T.nilable(Money)) }
-        def cost=(value); end
-      RUBY
-
-      assert_includes(rbi_for(files), expected)
-    end
-
-    it("generates RBI file for custom type that returns a generic type") do
-      files = {
-        "file.rb" => <<~RUBY,
-          module StrongTypeGeneration
-          end
-
-          class ValueType
-            extend T::Generic
-
-            Elem = type_member
-          end
-
-          class ColumnType < ActiveRecord::Type::Value
-            extend(T::Sig)
-
-            sig { params(value: ::ValueType[Integer]).returns(Numeric) }
-            def serialize(value)
-              super
-            end
-          end
-
-          class Post < ActiveRecord::Base
-            extend StrongTypeGeneration
-
-            attribute :cost, ColumnType.new
-          end
-        RUBY
-
-        "schema.rb" => <<~RUBY,
-          ActiveRecord::Migration.suppress_messages do
-            ActiveRecord::Schema.define do
-              create_table :posts do |t|
-                t.decimal :cost
-              end
-            end
-          end
-        RUBY
-      }
-
-      expected = indented(<<~RUBY, 2)
-        sig { returns(T.nilable(T.untyped)) }
-        def cost; end
-
-        sig { params(value: T.nilable(T.untyped)).returns(T.nilable(T.untyped)) }
-        def cost=(value); end
-      RUBY
-
-      assert_includes(rbi_for(files), expected)
-    end
-
-    it("generates RBI file for custom type without signatures") do
-      files = {
-        "file.rb" => <<~RUBY,
-          module StrongTypeGeneration
-          end
-
-          class Money
-            attr_accessor :value
-
-            def initialize(number = 0.0)
-              @value = number
-            end
-
-            class Type < ActiveRecord::Type::Value
-              extend(T::Sig)
-
-              def deserialize(value)
-                Money.new(value)
-              end
-            end
-          end
-
-          class Post < ActiveRecord::Base
-            extend StrongTypeGeneration
-
-            attribute :cost, Money::Type.new
-          end
-        RUBY
-
-        "schema.rb" => <<~RUBY,
-          ActiveRecord::Migration.suppress_messages do
-            ActiveRecord::Schema.define do
-              create_table :posts do |t|
-                t.decimal :cost
-              end
-            end
-          end
-        RUBY
-      }
-
-      expected = indented(<<~RUBY, 2)
-        sig { returns(T.nilable(T.untyped)) }
-        def cost; end
-
-        sig { params(value: T.nilable(T.untyped)).returns(T.nilable(T.untyped)) }
-        def cost=(value); end
-      RUBY
-
-      assert_includes(rbi_for(files), expected)
+        assert_includes(rbi_for(:Post, files), expected)
+      end
     end
   end
 end

--- a/spec/tapioca/compilers/dsl/active_record_enum_spec.rb
+++ b/spec/tapioca/compilers/dsl/active_record_enum_spec.rb
@@ -1,26 +1,12 @@
-# typed: false
+# typed: strict
 # frozen_string_literal: true
 
 require "spec_helper"
 
-describe("Tapioca::Compilers::Dsl::ActiveRecordEnum") do
-  before(:each) do
-    require "tapioca/compilers/dsl/active_record_enum"
-  end
-
-  subject do
-    Tapioca::Compilers::Dsl::ActiveRecordEnum.new
-  end
-
+class Tapioca::Compilers::Dsl::ActiveRecordEnumSpec < DslSpec
   describe("#initialize") do
-    def constants_from(content)
-      with_content(content) do
-        subject.processable_constants.map(&:to_s).sort
-      end
-    end
-
     it("gathers no constants if there are no ActiveRecord classes") do
-      assert_empty(subject.processable_constants)
+      assert_empty(constants_from(""))
     end
 
     it("gathers only ActiveRecord constants with no abstract classes") do
@@ -41,14 +27,6 @@ describe("Tapioca::Compilers::Dsl::ActiveRecordEnum") do
   end
 
   describe("#decorate") do
-    def rbi_for(content)
-      with_content(content) do
-        parlour = Parlour::RbiGenerator.new(sort_namespaces: true)
-        subject.decorate(parlour.root, Conversation)
-        parlour.rbi
-      end
-    end
-
     it("generates RBI file for classes with an enum attribute") do
       content = <<~RUBY
         class Conversation < ActiveRecord::Base
@@ -81,7 +59,7 @@ describe("Tapioca::Compilers::Dsl::ActiveRecordEnum") do
         end
       RUBY
 
-      assert_equal(expected, rbi_for(content))
+      assert_equal(expected, rbi_for(:Conversation, content))
     end
 
     it("generates RBI file for classes with an enum attribute with string values") do
@@ -116,7 +94,7 @@ describe("Tapioca::Compilers::Dsl::ActiveRecordEnum") do
         end
       RUBY
 
-      assert_equal(expected, rbi_for(content))
+      assert_equal(expected, rbi_for(:Conversation, content))
     end
 
     it("generates RBI file for classes with an enum attribute with mix value types") do
@@ -157,7 +135,7 @@ describe("Tapioca::Compilers::Dsl::ActiveRecordEnum") do
         end
       RUBY
 
-      assert_equal(expected, rbi_for(content))
+      assert_equal(expected, rbi_for(:Conversation, content))
     end
 
     it("generates RBI file for classes with multiple enum attributes") do
@@ -208,7 +186,7 @@ describe("Tapioca::Compilers::Dsl::ActiveRecordEnum") do
         end
       RUBY
 
-      assert_equal(expected, rbi_for(content))
+      assert_equal(expected, rbi_for(:Conversation, content))
     end
 
     it("generates RBI file for classes with multiple enum attributes with mix value types") do
@@ -277,7 +255,7 @@ describe("Tapioca::Compilers::Dsl::ActiveRecordEnum") do
         end
       RUBY
 
-      assert_equal(expected, rbi_for(content))
+      assert_equal(expected, rbi_for(:Conversation, content))
     end
 
     it("generates RBI file for classes with enum attribute with suffix specified") do
@@ -312,7 +290,7 @@ describe("Tapioca::Compilers::Dsl::ActiveRecordEnum") do
         end
       RUBY
 
-      assert_equal(expected, rbi_for(content))
+      assert_equal(expected, rbi_for(:Conversation, content))
     end
 
     it("generates RBI file for classes with enum attribute with prefix specified") do
@@ -347,7 +325,7 @@ describe("Tapioca::Compilers::Dsl::ActiveRecordEnum") do
         end
       RUBY
 
-      assert_equal(expected, rbi_for(content))
+      assert_equal(expected, rbi_for(:Conversation, content))
     end
   end
 end

--- a/spec/tapioca/compilers/dsl/active_record_identity_cache_spec.rb
+++ b/spec/tapioca/compilers/dsl/active_record_identity_cache_spec.rb
@@ -1,26 +1,12 @@
-# typed: false
+# typed: strict
 # frozen_string_literal: true
 
 require "spec_helper"
 
-describe("Tapioca::Compilers::Dsl::ActiveRecordIdentityCache") do
-  before(:each) do
-    require "tapioca/compilers/dsl/active_record_identity_cache"
-  end
-
-  subject do
-    Tapioca::Compilers::Dsl::ActiveRecordIdentityCache.new
-  end
-
+class Tapioca::Compilers::Dsl::ActiveRecordIdentityCacheSpec < DslSpec
   describe("#initialize") do
-    def constants_from(content)
-      with_content(content) do
-        subject.processable_constants.map(&:to_s).sort
-      end
-    end
-
     it("gathers no constants if there are no ActiveRecordIdentityCache classes") do
-      assert_empty(subject.processable_constants)
+      assert_empty(constants_from(""))
     end
 
     it("gather only IdentityCache classes") do
@@ -44,14 +30,6 @@ describe("Tapioca::Compilers::Dsl::ActiveRecordIdentityCache") do
   end
 
   describe("#decorate") do
-    def rbi_for(content)
-      with_content(content) do
-        parlour = Parlour::RbiGenerator.new(sort_namespaces: true)
-        subject.decorate(parlour.root, Post)
-        parlour.rbi
-      end
-    end
-
     it("generates RBI file for classes with multiple cache_indexes") do
       content = <<~RUBY
         class Post < ActiveRecord::Base
@@ -78,7 +56,7 @@ describe("Tapioca::Compilers::Dsl::ActiveRecordIdentityCache") do
         end
       RUBY
 
-      assert_equal(expected, rbi_for(content))
+      assert_equal(expected, rbi_for(:Post, content))
     end
 
     it("generates multiple methods for singled cache_index with unique field") do
@@ -110,7 +88,7 @@ describe("Tapioca::Compilers::Dsl::ActiveRecordIdentityCache") do
         end
       RUBY
 
-      assert_equal(expected, rbi_for(content))
+      assert_equal(expected, rbi_for(:Post, content))
     end
 
     it("generates methods for combined cache_indexes") do
@@ -139,7 +117,7 @@ describe("Tapioca::Compilers::Dsl::ActiveRecordIdentityCache") do
         end
       RUBY
 
-      assert_equal(expected, rbi_for(content))
+      assert_equal(expected, rbi_for(:Post, content))
     end
 
     it("generates methods for classes with cache_has_manys index") do
@@ -165,7 +143,7 @@ describe("Tapioca::Compilers::Dsl::ActiveRecordIdentityCache") do
         end
       RUBY
 
-      assert_equal(expected, rbi_for(content))
+      assert_equal(expected, rbi_for(:Post, content))
     end
 
     it("generates methods for classes with cache_has_one index") do
@@ -191,7 +169,7 @@ describe("Tapioca::Compilers::Dsl::ActiveRecordIdentityCache") do
         end
       RUBY
 
-      assert_equal(expected, rbi_for(content))
+      assert_equal(expected, rbi_for(:Post, content))
     end
 
     it("generates methods for classes with cache_belongs_to index on a polymorphic relation") do
@@ -214,7 +192,7 @@ describe("Tapioca::Compilers::Dsl::ActiveRecordIdentityCache") do
         end
       RUBY
 
-      assert_equal(expected, rbi_for(content))
+      assert_equal(expected, rbi_for(:Post, content))
     end
 
     it("generates methods for classes with cache_belongs_to index and a simple belong_to") do
@@ -237,7 +215,7 @@ describe("Tapioca::Compilers::Dsl::ActiveRecordIdentityCache") do
         end
       RUBY
 
-      assert_equal(expected, rbi_for(content))
+      assert_equal(expected, rbi_for(:Post, content))
     end
   end
 end

--- a/spec/tapioca/compilers/dsl/active_record_scope_spec.rb
+++ b/spec/tapioca/compilers/dsl/active_record_scope_spec.rb
@@ -1,26 +1,12 @@
-# typed: false
+# typed: strict
 # frozen_string_literal: true
 
 require "spec_helper"
 
-describe("Tapioca::Compilers::Dsl::ActiveRecordScope") do
-  before(:each) do
-    require "tapioca/compilers/dsl/active_record_scope"
-  end
-
-  subject do
-    Tapioca::Compilers::Dsl::ActiveRecordScope.new
-  end
-
+class Tapioca::Compilers::Dsl::ActiveRecordScopeSpec < DslSpec
   describe("#initialize") do
-    def constants_from(content)
-      with_content(content) do
-        subject.processable_constants.map(&:to_s).sort
-      end
-    end
-
     it("gathers no constants if there are no ActiveRecord classes") do
-      assert_empty(subject.processable_constants)
+      assert_empty(constants_from(""))
     end
 
     it("gathers only ActiveRecord constants with no abstract classes") do
@@ -41,14 +27,6 @@ describe("Tapioca::Compilers::Dsl::ActiveRecordScope") do
   end
 
   describe("#decorate") do
-    def rbi_for(content)
-      with_content(content) do
-        parlour = Parlour::RbiGenerator.new(sort_namespaces: true)
-        subject.decorate(parlour.root, Post)
-        parlour.rbi
-      end
-    end
-
     it("generates an empty RBI file for ActiveRecord classes with no scope field") do
       content = <<~RUBY
         class Post < ActiveRecord::Base
@@ -61,7 +39,7 @@ describe("Tapioca::Compilers::Dsl::ActiveRecordScope") do
 
       RUBY
 
-      assert_equal(expected, rbi_for(content))
+      assert_equal(expected, rbi_for(:Post, content))
     end
 
     it("generates RBI file for ActiveRecord classes with a scope field") do
@@ -84,7 +62,7 @@ describe("Tapioca::Compilers::Dsl::ActiveRecordScope") do
         end
       RUBY
 
-      assert_equal(expected, rbi_for(content))
+      assert_equal(expected, rbi_for(:Post, content))
     end
 
     it("generates RBI file for ActiveRecord classes with multiple scope fields") do
@@ -111,7 +89,7 @@ describe("Tapioca::Compilers::Dsl::ActiveRecordScope") do
         end
       RUBY
 
-      assert_equal(expected, rbi_for(content))
+      assert_equal(expected, rbi_for(:Post, content))
     end
   end
 end

--- a/spec/tapioca/compilers/dsl/active_record_typed_store_spec.rb
+++ b/spec/tapioca/compilers/dsl/active_record_typed_store_spec.rb
@@ -1,27 +1,16 @@
-# typed: false
+# typed: strict
 # frozen_string_literal: true
 
 require "spec_helper"
 
-describe("Tapioca::Compilers::Dsl::ActiveRecordTypedStore") do
-  before(:each) do
+class Tapioca::Compilers::Dsl::ActiveRecordTypedStoreSpec < DslSpec
+  require_before do
     require "active_record"
-    require "tapioca/compilers/dsl/active_record_typed_store"
-  end
-
-  subject do
-    Tapioca::Compilers::Dsl::ActiveRecordTypedStore.new
   end
 
   describe("#initialize") do
-    def constants_from(content)
-      with_content(content) do
-        subject.processable_constants.map(&:to_s).sort
-      end
-    end
-
     it("gathers no constants if there are no ActiveRecordTypedStore classes") do
-      assert_empty(subject.processable_constants)
+      assert_empty(constants_from(""))
     end
 
     it("gather only TypedStore classes") do
@@ -47,14 +36,6 @@ describe("Tapioca::Compilers::Dsl::ActiveRecordTypedStore") do
   end
 
   describe("#decorate") do
-    def rbi_for(content)
-      with_content(content) do
-        parlour = Parlour::RbiGenerator.new(sort_namespaces: true)
-        subject.decorate(parlour.root, Post)
-        parlour.rbi
-      end
-    end
-
     it("generates no definitions if there are no accessors to define") do
       content = <<~RUBY
         class Post < ActiveRecord::Base
@@ -74,7 +55,7 @@ describe("Tapioca::Compilers::Dsl::ActiveRecordTypedStore") do
 
       RUBY
 
-      assert_equal(rbi_for(content), expected)
+      assert_equal(rbi_for(:Post, content), expected)
     end
 
     it("generates RBI for TypedStore classes with string type") do
@@ -149,7 +130,7 @@ describe("Tapioca::Compilers::Dsl::ActiveRecordTypedStore") do
         end
       RUBY
 
-      assert_equal(rbi_for(content), expected)
+      assert_equal(rbi_for(:Post, content), expected)
     end
 
     it("generates methods with non-nilable types for accessors marked as not null") do
@@ -193,7 +174,7 @@ describe("Tapioca::Compilers::Dsl::ActiveRecordTypedStore") do
         end
       RUBY
 
-      assert_equal(rbi_for(content), expected)
+      assert_equal(rbi_for(:Post, content), expected)
     end
 
     it("generates methods with Date type for attributes with date type") do
@@ -268,7 +249,7 @@ describe("Tapioca::Compilers::Dsl::ActiveRecordTypedStore") do
         end
       RUBY
 
-      assert_equal(rbi_for(content), expected)
+      assert_equal(rbi_for(:Post, content), expected)
     end
 
     it("generates methods with DteTime type for attributes with datetime type") do
@@ -291,7 +272,7 @@ describe("Tapioca::Compilers::Dsl::ActiveRecordTypedStore") do
           def review_date=(review_date); end
       RUBY
 
-      assert_includes(rbi_for(content), expected)
+      assert_includes(rbi_for(:Post, content), expected)
     end
 
     it("generates methods with Time type for attributes with time type") do
@@ -312,7 +293,7 @@ describe("Tapioca::Compilers::Dsl::ActiveRecordTypedStore") do
           sig { params(review_time: T.nilable(Time)).returns(T.nilable(Time)) }
           def review_time=(review_time); end
         RUBY
-      assert_includes(rbi_for(content), expected)
+      assert_includes(rbi_for(:Post, content), expected)
     end
 
     it("generates methods with Decimal type for attributes with decimal type") do
@@ -334,7 +315,7 @@ describe("Tapioca::Compilers::Dsl::ActiveRecordTypedStore") do
           def rate=(rate); end
       RUBY
 
-      assert_includes(rbi_for(content), expected)
+      assert_includes(rbi_for(:Post, content), expected)
     end
 
     it("generates methods with T.untyped type for attributes with any type") do
@@ -356,7 +337,7 @@ describe("Tapioca::Compilers::Dsl::ActiveRecordTypedStore") do
           def kind=(kind); end
       RUBY
 
-      assert_includes(rbi_for(content), expected)
+      assert_includes(rbi_for(:Post, content), expected)
     end
 
     it("generates methods with Integer type for attributes with integer type") do
@@ -378,7 +359,7 @@ describe("Tapioca::Compilers::Dsl::ActiveRecordTypedStore") do
           def rate=(rate); end
       RUBY
 
-      assert_includes(rbi_for(content), expected)
+      assert_includes(rbi_for(:Post, content), expected)
     end
 
     it("generates methods with Float type for attributes with float type") do
@@ -400,7 +381,7 @@ describe("Tapioca::Compilers::Dsl::ActiveRecordTypedStore") do
           def rate=(rate); end
       RUBY
 
-      assert_includes(rbi_for(content), expected)
+      assert_includes(rbi_for(:Post, content), expected)
     end
   end
 end

--- a/spec/tapioca/compilers/dsl/active_resource_spec.rb
+++ b/spec/tapioca/compilers/dsl/active_resource_spec.rb
@@ -1,26 +1,12 @@
-# typed: false
+# typed: strict
 # frozen_string_literal: true
 
 require "spec_helper"
 
-describe("Tapioca::Compilers::Dsl::ActiveResource") do
-  before(:each) do
-    require "tapioca/compilers/dsl/active_resource"
-  end
-
-  subject do
-    Tapioca::Compilers::Dsl::ActiveResource.new
-  end
-
+class Tapioca::Compilers::Dsl::ActiveResourceSpec < DslSpec
   describe("#initialize") do
-    def constants_from(content)
-      with_content(content) do
-        subject.processable_constants.map(&:to_s).sort
-      end
-    end
-
     it("gathers no constants if there are no ActiveResource classes") do
-      assert_empty(subject.processable_constants)
+      assert_empty(constants_from(""))
     end
 
     it("gathers only ActiveResource constants ") do
@@ -40,14 +26,6 @@ describe("Tapioca::Compilers::Dsl::ActiveResource") do
   end
 
   describe("#decorate") do
-    def rbi_for(content)
-      with_content(content) do
-        parlour = Parlour::RbiGenerator.new(sort_namespaces: true)
-        subject.decorate(parlour.root, Post)
-        parlour.rbi
-      end
-    end
-
     it("generates RBI file for ActiveResource classes with an integer schema field") do
       content = <<~RUBY
         class Post < ActiveResource::Base
@@ -72,7 +50,7 @@ describe("Tapioca::Compilers::Dsl::ActiveResource") do
         end
       RUBY
 
-      assert_equal(expected, rbi_for(content))
+      assert_equal(expected, rbi_for(:Post, content))
     end
 
     it("generates RBI file for ActiveResource classes with multiple integer schema fields") do
@@ -117,7 +95,7 @@ describe("Tapioca::Compilers::Dsl::ActiveResource") do
         end
       RUBY
 
-      assert_equal(expected, rbi_for(content))
+      assert_equal(expected, rbi_for(:Post, content))
     end
 
     it("generates RBI file for ActiveResource classes with schema with different types") do
@@ -154,7 +132,7 @@ describe("Tapioca::Compilers::Dsl::ActiveResource") do
         end
       RUBY
 
-      assert_equal(expected, rbi_for(content))
+      assert_equal(expected, rbi_for(:Post, content))
     end
 
     it("generates methods for ActiveResource classes with an unsupported schema type") do
@@ -181,7 +159,7 @@ describe("Tapioca::Compilers::Dsl::ActiveResource") do
         end
       RUBY
 
-      assert_equal(expected, rbi_for(content))
+      assert_equal(expected, rbi_for(:Post, content))
     end
     it("generates methods for ActiveResource classes including all types in schema field") do
       content = <<~RUBY
@@ -202,7 +180,7 @@ describe("Tapioca::Compilers::Dsl::ActiveResource") do
 
       RUBY
 
-      rbi_output = rbi_for(content)
+      rbi_output = rbi_for(:Post, content)
 
       assert_includes(rbi_output, indented(<<~RUBY, 2))
         sig { params(value: T::Boolean).returns(T::Boolean) }

--- a/spec/tapioca/compilers/dsl/active_support_current_attributes_spec.rb
+++ b/spec/tapioca/compilers/dsl/active_support_current_attributes_spec.rb
@@ -1,26 +1,12 @@
-# typed: false
+# typed: strict
 # frozen_string_literal: true
 
 require "spec_helper"
 
-describe("Tapioca::Compilers::Dsl::ActiveSupportCurrentAttributes") do
-  before(:each) do
-    require "tapioca/compilers/dsl/active_support_current_attributes"
-  end
-
-  subject do
-    Tapioca::Compilers::Dsl::ActiveSupportCurrentAttributes.new
-  end
-
+class Tapioca::Compilers::Dsl::ActiveSupportCurrentAttributesSpec < DslSpec
   describe("#initialize") do
-    def constants_from(content)
-      with_content(content) do
-        subject.processable_constants.map(&:to_s).sort
-      end
-    end
-
     it("gathers no constants if there are no ActiveSupport::CurrentAttributes subclasses") do
-      assert_empty(subject.processable_constants)
+      assert_empty(constants_from(""))
     end
 
     it("gathers only ActiveSupport::CurrentAttributes subclasses") do
@@ -37,14 +23,6 @@ describe("Tapioca::Compilers::Dsl::ActiveSupportCurrentAttributes") do
   end
 
   describe("#decorate") do
-    def rbi_for(content)
-      with_content(content) do
-        parlour = Parlour::RbiGenerator.new(sort_namespaces: true)
-        subject.decorate(parlour.root, Current)
-        parlour.rbi
-      end
-    end
-
     it("generates empty RBI file if there are no current attributes") do
       content = <<~RUBY
         class Current < ActiveSupport::CurrentAttributes
@@ -56,7 +34,7 @@ describe("Tapioca::Compilers::Dsl::ActiveSupportCurrentAttributes") do
 
       RUBY
 
-      assert_equal(expected, rbi_for(content))
+      assert_equal(expected, rbi_for(:Current, content))
     end
 
     it("generates method sigs for every current attribute") do
@@ -96,7 +74,7 @@ describe("Tapioca::Compilers::Dsl::ActiveSupportCurrentAttributes") do
         end
       RUBY
 
-      assert_equal(expected, rbi_for(content))
+      assert_equal(expected, rbi_for(:Current, content))
     end
 
     it("only generates a class method definition for non current attribute methods") do
@@ -140,7 +118,7 @@ describe("Tapioca::Compilers::Dsl::ActiveSupportCurrentAttributes") do
         end
       RUBY
 
-      assert_equal(expected, rbi_for(content))
+      assert_equal(expected, rbi_for(:Current, content))
     end
   end
 end

--- a/spec/tapioca/compilers/dsl/frozen_record_spec.rb
+++ b/spec/tapioca/compilers/dsl/frozen_record_spec.rb
@@ -1,27 +1,16 @@
-# typed: false
+# typed: strict
 # frozen_string_literal: true
 
 require 'spec_helper'
 
-describe("Tapioca::Compilers::Dsl::FrozenRecord") do
-  before(:each) do
+class Tapioca::Compilers::Dsl::FrozenRecordSpec < DslSpec
+  require_before do
     require "rails/railtie"
-    require "tapioca/compilers/dsl/frozen_record"
-  end
-
-  subject do
-    Tapioca::Compilers::Dsl::FrozenRecord.new
   end
 
   describe("#initialize") do
-    def constants_from(content)
-      with_content(content) do
-        subject.processable_constants.map(&:to_s).sort
-      end
-    end
-
     it("gathers no constants if there are no FrozenRecord classes") do
-      assert_empty(subject.processable_constants)
+      assert_empty(constants_from(""))
     end
 
     it("gathers only FrozenRecord classes") do
@@ -38,19 +27,11 @@ describe("Tapioca::Compilers::Dsl::FrozenRecord") do
   end
 
   describe("#decorate") do
-    def rbi_for(contents)
-      with_contents(contents) do |dir|
-        FrozenRecord::Base.base_path = dir + "lib"
-        parlour = Parlour::RbiGenerator.new(sort_namespaces: true)
-        subject.decorate(parlour.root, Student)
-        parlour.rbi
-      end
-    end
-
     it("generates empty RBI file if there are no frozen records") do
       files = {
         "file.rb" => <<~RUBY,
           class Student < FrozenRecord::Base
+            self.base_path = __dir__
           end
         RUBY
 
@@ -63,13 +44,14 @@ describe("Tapioca::Compilers::Dsl::FrozenRecord") do
 
       RUBY
 
-      assert_equal(expected, rbi_for(files))
+      assert_equal(expected, rbi_for(:Student, files))
     end
 
     it("generates an RBI file for frozen records") do
       files = {
         "file.rb" => <<~RUBY,
           class Student < FrozenRecord::Base
+            self.base_path = __dir__
           end
         RUBY
 
@@ -110,7 +92,7 @@ describe("Tapioca::Compilers::Dsl::FrozenRecord") do
         end
       RUBY
 
-      assert_equal(expected, rbi_for(files))
+      assert_equal(expected, rbi_for(:Student, files))
     end
   end
 end

--- a/spec/tapioca/compilers/dsl/protobuf_spec.rb
+++ b/spec/tapioca/compilers/dsl/protobuf_spec.rb
@@ -1,24 +1,10 @@
-# typed: false
+# typed: strict
 # frozen_string_literal: true
 
 require "spec_helper"
 
-describe("Tapioca::Compilers::Dsl::Protobuf") do
-  before(:each) do
-    require "tapioca/compilers/dsl/protobuf"
-  end
-
-  subject do
-    Tapioca::Compilers::Dsl::Protobuf.new
-  end
-
+class Tapioca::Compilers::Dsl::ProtobufSpec < DslSpec
   describe("#gather_constants") do
-    def constants_from(content)
-      with_content(content) do
-        subject.processable_constants.map(&:to_s).sort
-      end
-    end
-
     it("gathers no constants if there are no Google::Protobuf classes") do
       content = <<~RUBY
         Google::Protobuf::DescriptorPool.generated_pool.build do
@@ -47,14 +33,6 @@ describe("Tapioca::Compilers::Dsl::Protobuf") do
   end
 
   describe("#decorate") do
-    def rbi_for(content)
-      with_content(content) do
-        parlour = Parlour::RbiGenerator.new(sort_namespaces: true)
-        subject.decorate(parlour.root, Cart)
-        parlour.rbi
-      end
-    end
-
     it("generates methods in RBI files for classes with Protobuf with integer field type") do
       content = <<~RUBY
         Google::Protobuf::DescriptorPool.generated_pool.build do
@@ -86,7 +64,7 @@ describe("Tapioca::Compilers::Dsl::Protobuf") do
         end
       RUBY
 
-      assert_equal(expected, rbi_for(content))
+      assert_equal(expected, rbi_for(:Cart, content))
     end
 
     it("generates methods in RBI files for classes with Protobuf with string field type") do
@@ -113,7 +91,7 @@ describe("Tapioca::Compilers::Dsl::Protobuf") do
         end
       RUBY
 
-      assert_equal(expected, rbi_for(content))
+      assert_equal(expected, rbi_for(:Cart, content))
     end
 
     it("generates methods in RBI files for classes with Protobuf with message field type") do
@@ -142,7 +120,7 @@ describe("Tapioca::Compilers::Dsl::Protobuf") do
         end
       RUBY
 
-      assert_equal(expected, rbi_for(content))
+      assert_equal(expected, rbi_for(:Cart, content))
     end
 
     it("generates methods in RBI files for classes with Protobuf with enum field") do
@@ -176,7 +154,7 @@ describe("Tapioca::Compilers::Dsl::Protobuf") do
         end
       RUBY
 
-      assert_equal(expected, rbi_for(content))
+      assert_equal(expected, rbi_for(:Cart, content))
     end
 
     it("generates methods in RBI files for classes with Protobuf with enum field with defined type") do
@@ -210,7 +188,7 @@ describe("Tapioca::Compilers::Dsl::Protobuf") do
         end
       RUBY
 
-      assert_equal(expected, rbi_for(content))
+      assert_equal(expected, rbi_for(:Cart, content))
     end
 
     it("generates methods in RBI files for classes with Protobuf with all types") do
@@ -235,7 +213,7 @@ describe("Tapioca::Compilers::Dsl::Protobuf") do
         Cart = Google::Protobuf::DescriptorPool.generated_pool.lookup("MyCart").msgclass
       RUBY
 
-      rbi_output = rbi_for(content)
+      rbi_output = rbi_for(:Cart, content)
 
       assert_includes(rbi_output, indented(<<~RUBY, 2))
         sig { params(value: T::Boolean).returns(T::Boolean) }

--- a/spec/tapioca/compilers/dsl/smart_properties_spec.rb
+++ b/spec/tapioca/compilers/dsl/smart_properties_spec.rb
@@ -1,26 +1,12 @@
-# typed: false
+# typed: strict
 # frozen_string_literal: true
 
 require "spec_helper"
 
-describe("Tapioca::Compilers::Dsl::SmartProperties") do
-  before(:each) do
-    require "tapioca/compilers/dsl/smart_properties"
-  end
-
-  subject do
-    Tapioca::Compilers::Dsl::SmartProperties.new
-  end
-
+class Tapioca::Compilers::Dsl::SmartPropertiesSpec < DslSpec
   describe("#initialize") do
-    def constants_from(content)
-      with_content(content) do
-        subject.processable_constants.map(&:to_s).sort
-      end
-    end
-
     it("gathers no constants if there are no SmartProperty classes") do
-      assert_empty(subject.processable_constants)
+      assert_empty(constants_from(""))
     end
 
     it("gathers only SmartProperty classes") do
@@ -56,14 +42,6 @@ describe("Tapioca::Compilers::Dsl::SmartProperties") do
   end
 
   describe("#decorate") do
-    def rbi_for(content)
-      with_content(content) do
-        parlour = Parlour::RbiGenerator.new(sort_namespaces: true)
-        subject.decorate(parlour.root, Post)
-        parlour.rbi
-      end
-    end
-
     it("generates empty RBI file if there are no smart properties") do
       content = <<~RUBY
         class Post
@@ -76,7 +54,7 @@ describe("Tapioca::Compilers::Dsl::SmartProperties") do
 
       RUBY
 
-      assert_equal(expected, rbi_for(content))
+      assert_equal(expected, rbi_for(:Post, content))
     end
 
     it("generates RBI file for simple smart property") do
@@ -98,7 +76,7 @@ describe("Tapioca::Compilers::Dsl::SmartProperties") do
         end
       RUBY
 
-      assert_equal(expected, rbi_for(content))
+      assert_equal(expected, rbi_for(:Post, content))
     end
 
     it("generates RBI file for required smart property") do
@@ -120,7 +98,7 @@ describe("Tapioca::Compilers::Dsl::SmartProperties") do
         end
       RUBY
 
-      assert_equal(expected, rbi_for(content))
+      assert_equal(expected, rbi_for(:Post, content))
     end
 
     it("defaults to T.untyped for smart property that does not have an accepter") do
@@ -142,7 +120,7 @@ describe("Tapioca::Compilers::Dsl::SmartProperties") do
         end
       RUBY
 
-      assert_equal(expected, rbi_for(content))
+      assert_equal(expected, rbi_for(:Post, content))
     end
 
     it("defaults to T::Array for smart property that accepts Arrays") do
@@ -164,7 +142,7 @@ describe("Tapioca::Compilers::Dsl::SmartProperties") do
         end
       RUBY
 
-      assert_equal(expected, rbi_for(content))
+      assert_equal(expected, rbi_for(:Post, content))
     end
 
     it("generates RBI file for smart property that accepts booleans") do
@@ -186,7 +164,7 @@ describe("Tapioca::Compilers::Dsl::SmartProperties") do
         end
       RUBY
 
-      assert_equal(expected, rbi_for(content))
+      assert_equal(expected, rbi_for(:Post, content))
     end
 
     it("generates RBI file for smart property that accepts an array of values") do
@@ -208,7 +186,7 @@ describe("Tapioca::Compilers::Dsl::SmartProperties") do
         end
       RUBY
 
-      assert_equal(expected, rbi_for(content))
+      assert_equal(expected, rbi_for(:Post, content))
     end
 
     it("defaults to T.untyped if a converter is defined") do
@@ -230,7 +208,7 @@ describe("Tapioca::Compilers::Dsl::SmartProperties") do
         end
       RUBY
 
-      assert_equal(expected, rbi_for(content))
+      assert_equal(expected, rbi_for(:Post, content))
     end
 
     it("ignores required if it is a lambda") do
@@ -252,7 +230,7 @@ describe("Tapioca::Compilers::Dsl::SmartProperties") do
         end
       RUBY
 
-      assert_equal(expected, rbi_for(content))
+      assert_equal(expected, rbi_for(:Post, content))
     end
 
     it("ignores required if property is not typed") do
@@ -274,7 +252,7 @@ describe("Tapioca::Compilers::Dsl::SmartProperties") do
         end
       RUBY
 
-      assert_equal(expected, rbi_for(content))
+      assert_equal(expected, rbi_for(:Post, content))
     end
 
     it("generates a reader that has been renamed correctly") do
@@ -296,7 +274,7 @@ describe("Tapioca::Compilers::Dsl::SmartProperties") do
         end
       RUBY
 
-      assert_equal(expected, rbi_for(content))
+      assert_equal(expected, rbi_for(:Post, content))
     end
 
     it("generates RBI file for smart property that accepts boolean and has a default") do
@@ -318,7 +296,7 @@ describe("Tapioca::Compilers::Dsl::SmartProperties") do
         end
       RUBY
 
-      assert_equal(expected, rbi_for(content))
+      assert_equal(expected, rbi_for(:Post, content))
     end
 
     it("generates RBI file for smart property that accepts a lambda") do
@@ -340,7 +318,7 @@ describe("Tapioca::Compilers::Dsl::SmartProperties") do
         end
       RUBY
 
-      assert_equal(expected, rbi_for(content))
+      assert_equal(expected, rbi_for(:Post, content))
     end
 
     it("generates RBI file for smart property that accepts another ObjectClass") do
@@ -369,7 +347,7 @@ describe("Tapioca::Compilers::Dsl::SmartProperties") do
         end
       RUBY
 
-      assert_equal(expected, rbi_for(content))
+      assert_equal(expected, rbi_for(:Post, content))
     end
   end
 end

--- a/spec/tapioca/compilers/dsl/state_machines_spec.rb
+++ b/spec/tapioca/compilers/dsl/state_machines_spec.rb
@@ -1,26 +1,12 @@
-# typed: false
+# typed: strict
 # frozen_string_literal: true
 
 require "spec_helper"
 
-describe("Tapioca::Compilers::Dsl::StateMachines") do
-  before(:each) do
-    require "tapioca/compilers/dsl/state_machines"
-  end
-
-  subject do
-    Tapioca::Compilers::Dsl::StateMachines.new
-  end
-
+class Tapioca::Compilers::Dsl::StateMachinesSpec < DslSpec
   describe("#initialize") do
-    def constants_from(content)
-      with_content(content) do
-        subject.processable_constants.map(&:to_s).sort
-      end
-    end
-
     it("gathers no constants if there are no StateMachines classes") do
-      assert_empty(subject.processable_constants)
+      assert_empty(constants_from(""))
     end
 
     it("gathers only StateMachines classes") do
@@ -42,14 +28,6 @@ describe("Tapioca::Compilers::Dsl::StateMachines") do
   end
 
   describe("#decorate") do
-    def rbi_for(content)
-      with_content(content) do
-        parlour = Parlour::RbiGenerator.new(sort_namespaces: true)
-        subject.decorate(parlour.root, Vehicle)
-        parlour.rbi
-      end
-    end
-
     it(" generates an RBI that includes state accessor methods") do
       content = <<~RUBY
         class Vehicle
@@ -143,7 +121,7 @@ describe("Tapioca::Compilers::Dsl::StateMachines") do
         end
       RUBY
 
-      assert_equal(expected, rbi_for(content))
+      assert_equal(expected, rbi_for(:Vehicle, content))
     end
 
     it("generates an RBI that includes name helpers methods") do
@@ -176,7 +154,7 @@ describe("Tapioca::Compilers::Dsl::StateMachines") do
         end
       RUBY
 
-      assert_includes(rbi_for(content), expected)
+      assert_includes(rbi_for(:Vehicle, content), expected)
     end
 
     it("generates an RBI with path, event and state helper methods") do
@@ -226,7 +204,7 @@ describe("Tapioca::Compilers::Dsl::StateMachines") do
         end
       RUBY
 
-      assert_includes(rbi_for(content), expected)
+      assert_includes(rbi_for(:Vehicle, content), expected)
     end
 
     it("generates an RBI with path helper methods only") do
@@ -245,7 +223,7 @@ describe("Tapioca::Compilers::Dsl::StateMachines") do
           def state_paths(*args); end
       RUBY
 
-      assert_includes(rbi_for(content), expected)
+      assert_includes(rbi_for(:Vehicle, content), expected)
     end
 
     it("generates an RBI with scope methods when state machine defines scopes") do
@@ -285,7 +263,7 @@ describe("Tapioca::Compilers::Dsl::StateMachines") do
         def without_states(*states); end
       RUBY
 
-      assert_includes(rbi_for(content), expected)
+      assert_includes(rbi_for(:Vehicle, content), expected)
     end
 
     it("generates an RBI with action methods when state machine defines an action") do
@@ -319,7 +297,7 @@ describe("Tapioca::Compilers::Dsl::StateMachines") do
         def state_event_transition=(value); end
       RUBY
 
-      assert_includes(rbi_for(content), expected)
+      assert_includes(rbi_for(:Vehicle, content), expected)
     end
   end
 end

--- a/spec/tapioca/compilers/dsl/url_helpers_spec.rb
+++ b/spec/tapioca/compilers/dsl/url_helpers_spec.rb
@@ -1,31 +1,15 @@
-# typed: false
+# typed: strict
 # frozen_string_literal: true
 
 require "spec_helper"
 
-describe("Tapioca::Compilers::Dsl::UrlHelpers") do
-  before(:each) do
-    require "tapioca/compilers/dsl/url_helpers"
-  end
-
-  subject do
-    Tapioca::Compilers::Dsl::UrlHelpers.new
-  end
-
+class Tapioca::Compilers::Dsl::UrlHelpersSpec < DslSpec
   describe("#initialize") do
-    def constants_from(content)
-      with_content(content) do
-        subject.processable_constants.map(&:to_s).sort
-      end
-    end
-
-    content = <<~RUBY
-      class Application < Rails::Application
-      end
-    RUBY
-
     it("does not gather constants when url_helpers is not included") do
-      content += <<~RUBY
+      content = <<~RUBY
+        class Application < Rails::Application
+        end
+
         class MyClass
         end
       RUBY
@@ -39,7 +23,10 @@ describe("Tapioca::Compilers::Dsl::UrlHelpers") do
     end
 
     it("gathers constants that include url_helpers") do
-      content += <<~RUBY
+      content = <<~RUBY
+        class Application < Rails::Application
+        end
+
         class MyClass
           include Rails.application.routes.url_helpers
         end
@@ -55,7 +42,10 @@ describe("Tapioca::Compilers::Dsl::UrlHelpers") do
     end
 
     it("gathers constants that extend url_helpers") do
-      content += <<~RUBY
+      content = <<~RUBY
+        class Application < Rails::Application
+        end
+
         class MyClass
           extend Rails.application.routes.url_helpers
         end
@@ -71,7 +61,10 @@ describe("Tapioca::Compilers::Dsl::UrlHelpers") do
     end
 
     it("gathers constants that have a singleton class that includes url_helpers") do
-      content += <<~RUBY
+      content = <<~RUBY
+        class Application < Rails::Application
+        end
+
         class MyClass
           class << self
             include Rails.application.routes.url_helpers
@@ -89,7 +82,10 @@ describe("Tapioca::Compilers::Dsl::UrlHelpers") do
     end
 
     it("does not gather constants when its superclass includes url_helpers") do
-      content += <<~RUBY
+      content = <<~RUBY
+        class Application < Rails::Application
+        end
+
         class SuperClass
           include Rails.application.routes.url_helpers
         end
@@ -108,7 +104,10 @@ describe("Tapioca::Compilers::Dsl::UrlHelpers") do
     end
 
     it("gathers constants when its superclass extends url_helpers") do
-      content += <<~RUBY
+      content = <<~RUBY
+        class Application < Rails::Application
+        end
+
         class SuperClass
           extend Rails.application.routes.url_helpers
         end
@@ -127,7 +126,10 @@ describe("Tapioca::Compilers::Dsl::UrlHelpers") do
     end
 
     it("does not gather constants when the constant and its superclass includes url_helpers") do
-      content += <<~RUBY
+      content = <<~RUBY
+        class Application < Rails::Application
+        end
+
         class SuperClass
           include Rails.application.routes.url_helpers
         end
@@ -148,20 +150,12 @@ describe("Tapioca::Compilers::Dsl::UrlHelpers") do
   end
 
   describe("#decorate") do
-    def rbi_for(content, constant)
-      with_content(content) do
-        parlour = Parlour::RbiGenerator.new(sort_namespaces: true)
-        subject.decorate(parlour.root, Object.const_get(constant))
-        parlour.rbi
-      end
-    end
-
-    content = <<~RUBY
-      class Application < Rails::Application
-      end
-    RUBY
-
     it("generates RBI when there are no helper methods") do
+      content = <<~RUBY
+        class Application < Rails::Application
+        end
+      RUBY
+
       expected = <<~RUBY
         # typed: strong
         module GeneratedUrlHelpersModule
@@ -170,7 +164,7 @@ describe("Tapioca::Compilers::Dsl::UrlHelpers") do
         end
       RUBY
 
-      assert_equal(expected, rbi_for(content, :GeneratedUrlHelpersModule))
+      assert_equal(expected, rbi_for(:GeneratedUrlHelpersModule, content))
     end
 
     it("generates RBI for GeneratedPathHelpersModule with helper methods") do
@@ -199,7 +193,7 @@ describe("Tapioca::Compilers::Dsl::UrlHelpers") do
         end
       RUBY
 
-      assert_equal(expected, rbi_for(content, :GeneratedPathHelpersModule))
+      assert_equal(expected, rbi_for(:GeneratedPathHelpersModule, content))
     end
 
     it("generates RBI for GeneratedUrlHelpersModule with helper methods") do
@@ -228,11 +222,13 @@ describe("Tapioca::Compilers::Dsl::UrlHelpers") do
         end
       RUBY
 
-      assert_equal(expected, rbi_for(content, :GeneratedUrlHelpersModule))
+      assert_equal(expected, rbi_for(:GeneratedUrlHelpersModule, content))
     end
 
     it("generates RBI for ActionDispatch::IntegrationTest") do
-      content += <<~RUBY
+      content = <<~RUBY
+        class Application < Rails::Application
+        end
       RUBY
 
       expected = <<~RUBY
@@ -245,11 +241,13 @@ describe("Tapioca::Compilers::Dsl::UrlHelpers") do
         end
       RUBY
 
-      assert_equal(expected, rbi_for(content, "ActionDispatch::IntegrationTest"))
+      assert_equal(expected, rbi_for("ActionDispatch::IntegrationTest", content))
     end
 
     it("generates RBI for ActionView::Helpers") do
-      content += <<~RUBY
+      content = <<~RUBY
+        class Application < Rails::Application
+        end
       RUBY
 
       expected = <<~RUBY
@@ -262,11 +260,14 @@ describe("Tapioca::Compilers::Dsl::UrlHelpers") do
         end
       RUBY
 
-      assert_equal(expected, rbi_for(content, "ActionView::Helpers"))
+      assert_equal(expected, rbi_for("ActionView::Helpers", content))
     end
 
     it("generates RBI for constant that includes url_helpers") do
-      content += <<~RUBY
+      content = <<~RUBY
+        class Application < Rails::Application
+        end
+
         class MyClass
           include Rails.application.routes.url_helpers
         end
@@ -280,11 +281,14 @@ describe("Tapioca::Compilers::Dsl::UrlHelpers") do
         end
       RUBY
 
-      assert_equal(expected, rbi_for(content, :MyClass))
+      assert_equal(expected, rbi_for(:MyClass, content))
     end
 
     it("generates RBI for constant that extends url_helpers") do
-      content += <<~RUBY
+      content = <<~RUBY
+        class Application < Rails::Application
+        end
+
         class MyClass
           extend Rails.application.routes.url_helpers
         end
@@ -298,11 +302,14 @@ describe("Tapioca::Compilers::Dsl::UrlHelpers") do
         end
       RUBY
 
-      assert_equal(expected, rbi_for(content, :MyClass))
+      assert_equal(expected, rbi_for(:MyClass, content))
     end
 
     it("generates RBI for constant that includes and extends url_helpers") do
-      content += <<~RUBY
+      content = <<~RUBY
+        class Application < Rails::Application
+        end
+
         class MyClass
           include Rails.application.routes.url_helpers
           extend Rails.application.routes.url_helpers
@@ -319,11 +326,14 @@ describe("Tapioca::Compilers::Dsl::UrlHelpers") do
         end
       RUBY
 
-      assert_equal(expected, rbi_for(content, :MyClass))
+      assert_equal(expected, rbi_for(:MyClass, content))
     end
 
     it("generates RBI for constant that has a singleton class which includes url_helpers") do
-      content += <<~RUBY
+      content = <<~RUBY
+        class Application < Rails::Application
+        end
+
         class MyClass
           class << self
             include Rails.application.routes.url_helpers
@@ -339,11 +349,14 @@ describe("Tapioca::Compilers::Dsl::UrlHelpers") do
         end
       RUBY
 
-      assert_equal(expected, rbi_for(content, :MyClass))
+      assert_equal(expected, rbi_for(:MyClass, content))
     end
 
     it("generates RBI when constant itself and its singleton class includes url_helpers") do
-      content += <<~RUBY
+      content = <<~RUBY
+        class Application < Rails::Application
+        end
+
         class MyClass
           include Rails.application.routes.url_helpers
           class << self
@@ -362,7 +375,7 @@ describe("Tapioca::Compilers::Dsl::UrlHelpers") do
         end
       RUBY
 
-      assert_equal(expected, rbi_for(content, :MyClass))
+      assert_equal(expected, rbi_for(:MyClass, content))
     end
   end
 end

--- a/spec/tapioca/compilers/requires_compiler_spec.rb
+++ b/spec/tapioca/compilers/requires_compiler_spec.rb
@@ -1,10 +1,9 @@
-# typed: false
+# typed: strict
 # frozen_string_literal: true
 
 require "spec_helper"
-require_relative "../../../lib/tapioca/compilers/requires_compiler"
 
-describe(Tapioca::Compilers::RequiresCompiler) do
+class Tapioca::Compilers::RequiresCompilerSpec < Minitest::HooksSpec
   it("it does nothing on an empty project") do
     compiler = Tapioca::Compilers::RequiresCompiler.new('spec/support/require/empty/sorbet/config')
     assert_equal('', compiler.compile)

--- a/spec/tapioca/compilers/symbol_table_compiler_spec.rb
+++ b/spec/tapioca/compilers/symbol_table_compiler_spec.rb
@@ -7,7 +7,7 @@ require "tmpdir"
 require "bundler"
 
 class Tapioca::Compilers::SymbolTableCompilerSpec < Minitest::HooksSpec
-  sig {returns(Tapioca::Compilers::SymbolTableCompiler)}
+  sig { returns(Tapioca::Compilers::SymbolTableCompiler) }
   def subject
     Tapioca::Compilers::SymbolTableCompiler.new
   end

--- a/spec/tapioca/compilers/symbol_table_compiler_spec.rb
+++ b/spec/tapioca/compilers/symbol_table_compiler_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: strict
 # frozen_string_literal: true
 
 require "spec_helper"
@@ -6,12 +6,14 @@ require "pathname"
 require "tmpdir"
 require "bundler"
 
-describe("Tapioca::Compilers::SymbolTableCompiler") do
-  subject do
+class Tapioca::Compilers::SymbolTableCompilerSpec < Minitest::HooksSpec
+  sig {returns(Tapioca::Compilers::SymbolTableCompiler)}
+  def subject
     Tapioca::Compilers::SymbolTableCompiler.new
   end
 
   describe("compile") do
+    sig { params(contents: String).returns(String) }
     def compile(contents)
       files = {
         "file.rb" => contents,

--- a/spec/tapioca/compilers/symbol_table_compiler_spec.rb
+++ b/spec/tapioca/compilers/symbol_table_compiler_spec.rb
@@ -99,10 +99,10 @@ class Tapioca::Compilers::SymbolTableCompilerSpec < Minitest::HooksSpec
 
         class Object < ::BasicObject
           include(::Kernel)
-          include(::JSON::Ext::Generator::GeneratorMethods::Object)
         <% if defined?(Minitest::Expectations) %>
           include(::Minitest::Expectations)
         <% end %>
+          include(::JSON::Ext::Generator::GeneratorMethods::Object)
         <% if defined?(PP::ObjectMixin) %>
           include(::PP::ObjectMixin)
         <% end %>

--- a/spec/template_helper.rb
+++ b/spec/template_helper.rb
@@ -1,18 +1,26 @@
+# typed: strict
 # frozen_string_literal: true
 
 module TemplateHelper
-  class ErbBinding
-    ERB_SUPPORTS_KVARGS = ::ERB.instance_method(:initialize).parameters.assoc(:key)
+  extend T::Sig
 
+  class ErbBinding
+    extend T::Sig
+
+    ERB_SUPPORTS_KVARGS = T.let(::ERB.instance_method(:initialize).parameters.assoc(:key), T.nilable([Symbol, Symbol]))
+
+    sig { params(selector: String).returns(T::Boolean) }
     def ruby_version(selector)
       Gem::Requirement.new(selector).satisfied_by?(Gem::Version.new(RUBY_VERSION))
     end
 
+    sig { returns(Binding) }
     def erb_bindings
       binding
     end
   end
 
+  sig { params(src: String).returns(String) }
   def template(src)
     erb = if ErbBinding::ERB_SUPPORTS_KVARGS
       ::ERB.new(src, trim_mode: ">")


### PR DESCRIPTION
## Motivation

The tests and a few other things were ignored from typing for a few reasons. However, there is value in pushing for increased typing, even in tests, since it prevents us from making silly errors. Thus, this PR makes a few changes to push for `typed: true` as a baseline (with a few exceptions).

```
$ bundle exec spoom tc metrics
No errors! Great job.
Sigils:
  files: 161
  ignore: 1 (0%)
  false: 1 (0%)
  true: 86 (53%)
  strict: 70 (43%)
  strong: 3 (1%)

Methods:
  methods: 33269
  signatures: 923 (2%)

Sends:
  sends: 7275
  typed: 5748 (79%)
```

## Implementation

- The implementation heavily relies on the built-in `Minitest` rewriter in Sorbet, which rewrites `describe` and `it` blocks into method definitions for proper testing. However, that requires the test definitions to be wrapped inside a test class, which is added for all tests.
- Now that we were adding a test class for each test, it also made it possible to extract some common functionality into a test superclass. This has allowed us to get rid of some repetitiveness in tests and centralize the late `require` for the class under test and declaring the `subject` block.
- The `rbi_for` method is refactored to accept a constant _name_ to be passed in instead of it expecting a hard-coded constant, which is only found inside the test snippets and fails type-checking.
- Add `rubocop-sorbet` and enforce `typed: true` as the baseline sigil. Plus, fix a couple of rubocop-sorbet cop errors.

## Tests

No extra tests added.