### PR TITLE
Make AR association builder non-nilable

### DIFF
--- a/lib/tapioca/compilers/dsl/active_record_associations.rb
+++ b/lib/tapioca/compilers/dsl/active_record_associations.rb
@@ -45,10 +45,10 @@ module Tapioca
       #   sig { params(value: T.nilable(::User)).void }
       #   def author=(value); end
       #
-      #   sig { params(args: T.untyped, blk: T.untyped).returns(T.nilable(::User)) }
+      #   sig { params(args: T.untyped, blk: T.untyped).returns(::User) }
       #   def build_author(*args, &blk); end
       #
-      #   sig { params(args: T.untyped, blk: T.untyped).returns(T.nilable(::Category)) }
+      #   sig { params(args: T.untyped, blk: T.untyped).returns(::Category) }
       #   def build_category(*args, &blk); end
       #
       #   sig { returns(T.nilable(::Category)) }
@@ -69,16 +69,16 @@ module Tapioca
       #   sig { params(value: T::Enumerable[::Comment]).void }
       #   def comments=(value); end
       #
-      #   sig { params(args: T.untyped, blk: T.untyped).returns(T.nilable(::User)) }
+      #   sig { params(args: T.untyped, blk: T.untyped).returns(::User) }
       #   def create_author(*args, &blk); end
       #
-      #   sig { params(args: T.untyped, blk: T.untyped).returns(T.nilable(::User)) }
+      #   sig { params(args: T.untyped, blk: T.untyped).returns(::User) }
       #   def create_author!(*args, &blk); end
       #
-      #   sig { params(args: T.untyped, blk: T.untyped).returns(T.nilable(::Category)) }
+      #   sig { params(args: T.untyped, blk: T.untyped).returns(::Category) }
       #   def create_category(*args, &blk); end
       #
-      #   sig { params(args: T.untyped, blk: T.untyped).returns(T.nilable(::Category)) }
+      #   sig { params(args: T.untyped, blk: T.untyped).returns(::Category) }
       #   def create_category!(*args, &blk); end
       #
       #   sig { returns(T.nilable(::User)) }
@@ -160,7 +160,7 @@ module Tapioca
                 Parlour::RbiGenerator::Parameter.new("*args", type: "T.untyped"),
                 Parlour::RbiGenerator::Parameter.new("&blk", type: "T.untyped"),
               ],
-              return_type: association_type
+              return_type: association_class
             )
             create_method(
               klass,
@@ -169,7 +169,7 @@ module Tapioca
                 Parlour::RbiGenerator::Parameter.new("*args", type: "T.untyped"),
                 Parlour::RbiGenerator::Parameter.new("&blk", type: "T.untyped"),
               ],
-              return_type: association_type
+              return_type: association_class
             )
             create_method(
               klass,
@@ -178,7 +178,7 @@ module Tapioca
                 Parlour::RbiGenerator::Parameter.new("*args", type: "T.untyped"),
                 Parlour::RbiGenerator::Parameter.new("&blk", type: "T.untyped"),
               ],
-              return_type: association_type
+              return_type: association_class
             )
           end
         end

--- a/manual/generator_activerecordassociations.md
+++ b/manual/generator_activerecordassociations.md
@@ -33,10 +33,10 @@ module Post::GeneratedAssociationMethods
   sig { params(value: T.nilable(::User)).void }
   def author=(value); end
 
-  sig { params(args: T.untyped, blk: T.untyped).returns(T.nilable(::User)) }
+  sig { params(args: T.untyped, blk: T.untyped).returns(::User) }
   def build_author(*args, &blk); end
 
-  sig { params(args: T.untyped, blk: T.untyped).returns(T.nilable(::Category)) }
+  sig { params(args: T.untyped, blk: T.untyped).returns(::Category) }
   def build_category(*args, &blk); end
 
   sig { returns(T.nilable(::Category)) }
@@ -57,16 +57,16 @@ module Post::GeneratedAssociationMethods
   sig { params(value: T::Enumerable[::Comment]).void }
   def comments=(value); end
 
-  sig { params(args: T.untyped, blk: T.untyped).returns(T.nilable(::User)) }
+  sig { params(args: T.untyped, blk: T.untyped).returns(::User) }
   def create_author(*args, &blk); end
 
-  sig { params(args: T.untyped, blk: T.untyped).returns(T.nilable(::User)) }
+  sig { params(args: T.untyped, blk: T.untyped).returns(::User) }
   def create_author!(*args, &blk); end
 
-  sig { params(args: T.untyped, blk: T.untyped).returns(T.nilable(::Category)) }
+  sig { params(args: T.untyped, blk: T.untyped).returns(::Category) }
   def create_category(*args, &blk); end
 
-  sig { params(args: T.untyped, blk: T.untyped).returns(T.nilable(::Category)) }
+  sig { params(args: T.untyped, blk: T.untyped).returns(::Category) }
   def create_category!(*args, &blk); end
 
   sig { returns(T.nilable(::User)) }

--- a/spec/tapioca/compilers/dsl/active_record_associations_spec.rb
+++ b/spec/tapioca/compilers/dsl/active_record_associations_spec.rb
@@ -96,10 +96,10 @@ class Tapioca::Compilers::Dsl::ActiveRecordAssociationsSpec < DslSpec
           sig { params(value: T.nilable(::User)).void }
           def author=(value); end
 
-          sig { params(args: T.untyped, blk: T.untyped).returns(T.nilable(::User)) }
+          sig { params(args: T.untyped, blk: T.untyped).returns(::User) }
           def build_author(*args, &blk); end
 
-          sig { params(args: T.untyped, blk: T.untyped).returns(T.nilable(::Category)) }
+          sig { params(args: T.untyped, blk: T.untyped).returns(::Category) }
           def build_category(*args, &blk); end
 
           sig { returns(T.nilable(::Category)) }
@@ -108,16 +108,16 @@ class Tapioca::Compilers::Dsl::ActiveRecordAssociationsSpec < DslSpec
           sig { params(value: T.nilable(::Category)).void }
           def category=(value); end
 
-          sig { params(args: T.untyped, blk: T.untyped).returns(T.nilable(::User)) }
+          sig { params(args: T.untyped, blk: T.untyped).returns(::User) }
           def create_author(*args, &blk); end
 
-          sig { params(args: T.untyped, blk: T.untyped).returns(T.nilable(::User)) }
+          sig { params(args: T.untyped, blk: T.untyped).returns(::User) }
           def create_author!(*args, &blk); end
 
-          sig { params(args: T.untyped, blk: T.untyped).returns(T.nilable(::Category)) }
+          sig { params(args: T.untyped, blk: T.untyped).returns(::Category) }
           def create_category(*args, &blk); end
 
-          sig { params(args: T.untyped, blk: T.untyped).returns(T.nilable(::Category)) }
+          sig { params(args: T.untyped, blk: T.untyped).returns(::Category) }
           def create_category!(*args, &blk); end
 
           sig { returns(T.nilable(::User)) }
@@ -189,13 +189,13 @@ class Tapioca::Compilers::Dsl::ActiveRecordAssociationsSpec < DslSpec
           sig { params(value: T.nilable(::User)).void }
           def author=(value); end
 
-          sig { params(args: T.untyped, blk: T.untyped).returns(T.nilable(::User)) }
+          sig { params(args: T.untyped, blk: T.untyped).returns(::User) }
           def build_author(*args, &blk); end
 
-          sig { params(args: T.untyped, blk: T.untyped).returns(T.nilable(::User)) }
+          sig { params(args: T.untyped, blk: T.untyped).returns(::User) }
           def create_author(*args, &blk); end
 
-          sig { params(args: T.untyped, blk: T.untyped).returns(T.nilable(::User)) }
+          sig { params(args: T.untyped, blk: T.untyped).returns(::User) }
           def create_author!(*args, &blk); end
 
           sig { returns(T.nilable(::User)) }


### PR DESCRIPTION
The return value of ActiveRecord singular builder methods
(`build_#{name}`, `create_#{name}`, `create_#{name}!`) were incorrectly
considered nilable. Their actual value is always of the association's class,
never nil.

[`ActiveRecord::Associations::ClassMethods`](https://api.rubyonrails.org/classes/ActiveRecord/Associations/ClassMethods.html#method-i-belongs_to)'s documentation never mentions `nil`.
