### PR TITLE
Add support for T::Struct default values in gem RBI generation

### DIFF
--- a/lib/tapioca/compilers/symbol_table/symbol_generator.rb
+++ b/lib/tapioca/compilers/symbol_table/symbol_generator.rb
@@ -209,7 +209,11 @@ module Tapioca
             method = "const" if prop.fetch(:immutable, false)
             type = prop.fetch(:type_object, "T.untyped")
 
-            indented("#{method} :#{name}, #{type}")
+            if prop.key?(:default)
+              indented("#{method} :#{name}, #{type}, default: T.unsafe(nil)")
+            else
+              indented("#{method} :#{name}, #{type}")
+            end
           end.join("\n")
         end
 

--- a/spec/tapioca/compilers/symbol_table_compiler_spec.rb
+++ b/spec/tapioca/compilers/symbol_table_compiler_spec.rb
@@ -1902,7 +1902,7 @@ class Tapioca::Compilers::SymbolTableCompilerSpec < Minitest::HooksSpec
           const :foo, Integer
           prop :bar, String
           const :baz, T::Hash[String, T.untyped]
-          prop :quux, T.untyped
+          prop :quux, T.untyped, default: T.unsafe(nil)
 
           class << self
             def inherited(s); end
@@ -1958,6 +1958,53 @@ class Tapioca::Compilers::SymbolTableCompilerSpec < Minitest::HooksSpec
           def foo=(_); end
           sig { override.returns(Integer) }
           def something; end
+        end
+      RUBY
+
+      assert_equal(output, source)
+    end
+
+    it("compiles structs with default values") do
+      source = compile(<<~RUBY)
+        class Foo < T::Struct
+          extend T::Sig
+
+          prop :a, T.nilable(Integer), default: nil
+          prop :b, T::Boolean, default: true
+          prop :c, T::Boolean, default: false
+          prop :d, Symbol, default: :Bar
+          prop :e, String, default: "Foo"
+          prop :f, Integer, default: 42
+          prop :g, Float, default: 4.2
+          prop :h, T::Array[String], default: ["1", "2"]
+          prop :i, T::Hash[String, Integer], default: {"1": 1, "2": 2}
+
+          prop :k, Foo, default: Foo.new(a: 10, h: ["a", "b"])
+          prop :l, T::Array[Foo], default: [Foo.new(a: 10, h: ["a", "b"])]
+          prop :m, T::Hash[Foo, Foo], default: {Foo.new(a: 10, h: ["a", "b"]) => Foo.new(a: 10, h: ["a", "b"])}
+          prop :n, Foo, default: T.unsafe(nil)
+        end
+      RUBY
+
+      output = template(<<~RUBY)
+        class Foo < ::T::Struct
+          prop :a, T.nilable(Integer), default: T.unsafe(nil)
+          prop :b, T::Boolean, default: T.unsafe(nil)
+          prop :c, T::Boolean, default: T.unsafe(nil)
+          prop :d, Symbol, default: T.unsafe(nil)
+          prop :e, String, default: T.unsafe(nil)
+          prop :f, Integer, default: T.unsafe(nil)
+          prop :g, Float, default: T.unsafe(nil)
+          prop :h, T::Array[String], default: T.unsafe(nil)
+          prop :i, T::Hash[String, Integer], default: T.unsafe(nil)
+          prop :k, Foo, default: T.unsafe(nil)
+          prop :l, T::Array[Foo], default: T.unsafe(nil)
+          prop :m, T::Hash[Foo, Foo], default: T.unsafe(nil)
+          prop :n, Foo, default: T.unsafe(nil)
+
+          class << self
+            def inherited(s); end
+          end
         end
       RUBY
 


### PR DESCRIPTION
In its current state, Tapioca does not produce default values for `T::Struct` in gems RBI.

So for the following code in a gem:

```rb
# gem.rb
class Foo < T::Struct
 const :a, String, default: "a"
end
```

Tapioca will generate the following RBI:

```rbi
# gem.rbi
class Foo < T::Struct
 const :a, String
end
```

Which will make valid uses of the `Foo` struct in clients wrongly invalid:

```rb
# client.rb

Foo.new # error: missing parameter `:a`
```

This PR allows Tapioca to produce default values when needed by the original implementation:

```rbi
# gem.rbi
class Foo < T::Struct
 const :a, String, default: T.unsafe(nil)
end
```

We use `T.unsafe(nil)` because the `default` field in the struct can contains anything from a primitive data type to a complex statement but since we explore the gem through meta-programming we only see the interpreted value. This is similar behaviour to how we treat arguments with default values.