### PR TITLE
Append index to splat and block parameters

### DIFF
--- a/lib/tapioca/compilers/dsl/base.rb
+++ b/lib/tapioca/compilers/dsl/base.rb
@@ -94,7 +94,7 @@ module Tapioca
 
           method_def.parameters.each_with_index.map do |(type, name), i|
             name ||= :_
-            name = name.to_s.gsub(/&|\*/, '_') # avoid incorrect names from `delegate`
+            name = name.to_s.gsub(/&|\*/, "_#{i}") # avoid incorrect names from `delegate`
             case type
             when :req
               ::Parlour::RbiGenerator::Parameter.new(name, type: method_types[i])


### PR DESCRIPTION
To prevent duplicate hash key parameters such as this: https://buildkite.com/shopify/shopify-sorbet/builds/196718#9ec135db-8b8d-4d8c-94f2-4ccdb6279f10/28-29

I tested the change in core:
```
sig { params(_0: T.untyped, _1: T.untyped).returns(::ActionMailer::MessageDelivery) }
def self.method(*_0, &_1); end
```

I contemplated between keeping an extra counter: 
```
pattern = /&|\*/
if pattern.match?(name)
    name = name.to_s.gsub(pattern, "_#{i}") # avoid incorrect names from `delegate`
end
```
So that we don't end up in situations such as `def foo(a, b, *_2, &_3)`. I don't have a preference I can do this one too if it's better.
