### PR TITLE
Gather IdentityCache::WithoutPrimaryIndex classes

### DIFF
--- a/lib/tapioca/compilers/dsl/active_record_identity_cache.rb
+++ b/lib/tapioca/compilers/dsl/active_record_identity_cache.rb
@@ -108,7 +108,7 @@ module Tapioca
         sig { override.returns(T::Enumerable[Module]) }
         def gather_constants
           ::ActiveRecord::Base.descendants.select do |klass|
-            klass < IdentityCache || klass < IdentityCache::WithoutPrimaryIndex
+            klass < IdentityCache::WithoutPrimaryIndex
           end
         end
 

--- a/lib/tapioca/compilers/dsl/active_record_identity_cache.rb
+++ b/lib/tapioca/compilers/dsl/active_record_identity_cache.rb
@@ -108,7 +108,7 @@ module Tapioca
         sig { override.returns(T::Enumerable[Module]) }
         def gather_constants
           ::ActiveRecord::Base.descendants.select do |klass|
-            klass < IdentityCache
+            klass < IdentityCache || klass < IdentityCache::WithoutPrimaryIndex
           end
         end
 

--- a/spec/tapioca/compilers/dsl/active_record_identity_cache_spec.rb
+++ b/spec/tapioca/compilers/dsl/active_record_identity_cache_spec.rb
@@ -27,6 +27,16 @@ class Tapioca::Compilers::Dsl::ActiveRecordIdentityCacheSpec < DslSpec
 
       assert_equal(["CustomPost", "Post"], constants_from(content))
     end
+
+    it("gathers IdentityCache::WithoutPrimaryIndex classes") do
+      content = <<~RUBY
+        class Post < ActiveRecord::Base
+          include IdentityCache::WithoutPrimaryIndex
+        end
+      RUBY
+
+      assert_equal(["Post"], constants_from(content))
+    end
   end
 
   describe("#decorate") do


### PR DESCRIPTION
IdentityCache has a valid use case where classes only include `IdentityCache::WithoutPrimaryIndex` https://github.com/Shopify/identity_cache/blob/master/lib/identity_cache/without_primary_index.rb

We should support this in the generator as well