### PR TITLE
Start filtering empty params calls

### DIFF
--- a/lib/tapioca/compilers/symbol_table/symbol_generator.rb
+++ b/lib/tapioca/compilers/symbol_table/symbol_generator.rb
@@ -616,6 +616,7 @@ module Tapioca
           signature_body = signature_body
             .gsub(".returns(<VOID>)", ".void")
             .gsub("<NOT-TYPED>", "T.untyped")
+            .gsub(".params()", "")
             .gsub(TYPE_PARAMETER_MATCHER, "T.type_parameter(:\\1)")[1..-1]
 
           "sig { #{signature_body} }"

--- a/spec/tapioca/compilers/symbol_table_compiler_spec.rb
+++ b/spec/tapioca/compilers/symbol_table_compiler_spec.rb
@@ -1930,7 +1930,7 @@ class Tapioca::Compilers::SymbolTableCompilerSpec < Minitest::HooksSpec
           def baz(a); end
           sig { params(a: Integer, b: String).void }
           def foo(a, b:); end
-          sig { params(a: Integer, b: Integer, c: Integer, d: Integer, e: Integer, f: Integer, blk: T.proc.params().void).void }
+          sig { params(a: Integer, b: Integer, c: Integer, d: Integer, e: Integer, f: Integer, blk: T.proc.void).void }
           def many_kinds_of_args(*a, b, c, d:, e: T.unsafe(nil), **f, &blk); end
 
           class << self


### PR DESCRIPTION
These empty `.params()` calls are now causing type-checking errors in more recent versions of Sorbet. For `sig` blocks, we never generate empty params calls, but since `T.proc` calls end up serializing
themselves, we need to remove all such empty params calls.