### PR TITLE
Improve fallback parameter names

### DIFF
--- a/lib/tapioca/compilers/dsl/base.rb
+++ b/lib/tapioca/compilers/dsl/base.rb
@@ -92,24 +92,28 @@ module Tapioca
           method_def = signature.nil? ? method_def : signature.method
           method_types = parameters_types_from_signature(method_def, signature)
 
-          method_def.parameters.each_with_index.map do |(type, name), i|
-            name ||= :_
-            name = name.to_s.gsub(/&|\*/, "_#{i}") # avoid incorrect names from `delegate`
+          method_def.parameters.each_with_index.map do |(type, name), index|
+            fallback_arg_name = "_arg#{index}"
+
+            name ||= fallback_arg_name
+            name = name.to_s.gsub(/&|\*/, fallback_arg_name) # avoid incorrect names from `delegate`
+            method_type = method_types[index]
+
             case type
             when :req
-              ::Parlour::RbiGenerator::Parameter.new(name, type: method_types[i])
+              ::Parlour::RbiGenerator::Parameter.new(name, type: method_type)
             when :opt
-              ::Parlour::RbiGenerator::Parameter.new(name, type: method_types[i], default: 'T.unsafe(nil)')
+              ::Parlour::RbiGenerator::Parameter.new(name, type: method_type, default: 'T.unsafe(nil)')
             when :rest
-              ::Parlour::RbiGenerator::Parameter.new("*#{name}", type: method_types[i])
+              ::Parlour::RbiGenerator::Parameter.new("*#{name}", type: method_type)
             when :keyreq
-              ::Parlour::RbiGenerator::Parameter.new("#{name}:", type: method_types[i])
+              ::Parlour::RbiGenerator::Parameter.new("#{name}:", type: method_type)
             when :key
-              ::Parlour::RbiGenerator::Parameter.new("#{name}:", type: method_types[i], default: 'T.unsafe(nil)')
+              ::Parlour::RbiGenerator::Parameter.new("#{name}:", type: method_type, default: 'T.unsafe(nil)')
             when :keyrest
-              ::Parlour::RbiGenerator::Parameter.new("**#{name}", type: method_types[i])
+              ::Parlour::RbiGenerator::Parameter.new("**#{name}", type: method_type)
             when :block
-              ::Parlour::RbiGenerator::Parameter.new("&#{name}", type: method_types[i])
+              ::Parlour::RbiGenerator::Parameter.new("&#{name}", type: method_type)
             else
               raise "Unknown type `#{type}`."
             end

--- a/lib/tapioca/compilers/symbol_table/symbol_generator.rb
+++ b/lib/tapioca/compilers/symbol_table/symbol_generator.rb
@@ -517,7 +517,9 @@ module Tapioca
 
           parameters = T.let(method.parameters, T::Array[[Symbol, T.nilable(Symbol)]])
 
-          sanitized_parameters = parameters.map do |type, name|
+          sanitized_parameters = parameters.each_with_index.map do |(type, name), index|
+            fallback_arg_name = "_arg#{index}"
+
             unless name
               # For attr_writer methods, Sorbet signatures have the name
               # of the method (without the trailing = sign) as the name of
@@ -537,12 +539,12 @@ module Tapioca
               name = if writer_method_with_sig
                 T.must(method_name[0...-1]).to_sym
               else
-                :_
+                fallback_arg_name
               end
             end
 
             # Sanitize param names
-            name = name.to_s.gsub(/[^a-zA-Z0-9_]/, '_')
+            name = name.to_s.gsub(/[^a-zA-Z0-9_]/, fallback_arg_name)
 
             [type, name]
           end

--- a/spec/tapioca/compilers/symbol_table_compiler_spec.rb
+++ b/spec/tapioca/compilers/symbol_table_compiler_spec.rb
@@ -701,12 +701,12 @@ class Tapioca::Compilers::SymbolTableCompilerSpec < Minitest::HooksSpec
           def foo=(_); end
 
           class << self
-            def [](*_); end
+            def [](*_arg0); end
         <% if ruby_version(">= 2.5.0") %>
             def inspect; end
         <% end %>
             def members; end
-            def new(*_); end
+            def new(*_arg0); end
           end
         end
 
@@ -715,12 +715,12 @@ class Tapioca::Compilers::SymbolTableCompilerSpec < Minitest::HooksSpec
           def foo=(_); end
 
           class << self
-            def [](*_); end
+            def [](*_arg0); end
         <% if ruby_version(">= 2.5.0") %>
             def inspect; end
         <% end %>
             def members; end
-            def new(*_); end
+            def new(*_arg0); end
           end
         end
 
@@ -886,8 +886,8 @@ class Tapioca::Compilers::SymbolTableCompilerSpec < Minitest::HooksSpec
           def a; end
           def b; end
           def bar; end
-          def bar=(_); end
-          def baz=(_); end
+          def bar=(_arg0); end
+          def baz=(_arg0); end
           def foo; end
         end
       RUBY
@@ -975,7 +975,7 @@ class Tapioca::Compilers::SymbolTableCompilerSpec < Minitest::HooksSpec
 
       output = template(<<~RUBY)
         class Toto
-          def toto(a, *_, **_); end
+          def toto(a, *_arg1, **_arg2); end
         end
       RUBY
 
@@ -1790,7 +1790,7 @@ class Tapioca::Compilers::SymbolTableCompilerSpec < Minitest::HooksSpec
       assert_equal(output, source)
     end
 
-    it("sanitize parameter names creating through meta-programming") do
+    it("sanitize parameter names created through meta-programming") do
       source = compile(template(<<~RUBY))
         class Foo
         <% if ruby_version(">= 2.7.0") %>
@@ -1802,7 +1802,7 @@ class Tapioca::Compilers::SymbolTableCompilerSpec < Minitest::HooksSpec
       output = template(<<~RUBY)
         class Foo
         <% if ruby_version(">= 2.7.0") %>
-          def foo(*_, &_); end
+          def foo(*_arg0, &_arg1); end
         <% end %>
         end
       RUBY
@@ -1955,7 +1955,7 @@ class Tapioca::Compilers::SymbolTableCompilerSpec < Minitest::HooksSpec
           def baz=(baz); end
           sig { returns(T::Array[Integer]) }
           def foo; end
-          def foo=(_); end
+          def foo=(_arg0); end
           sig { override.returns(Integer) }
           def something; end
         end


### PR DESCRIPTION
### Motivation

The previous PR has changed the parameter names to `_0`, `_1`, etc but there is a risk that these will conflict with numbered parameters introduced in Ruby 2.7. Instead, naming them `_arg0`, `_arg1`, etc seems more explicit and more readable.

We also need to do the same fallback mechanism in the symbol table generator code as well, so this PR adds that too.

### Tests

I have added explicit delegation tests (both the Rails kind and Ruby 2.7 kind) in Action Mailer generator to make sure we don't regress. I have also updated the relevant tests in symbol table compiler.