### PR TITLE
Bump spoom to v1.0.6

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -180,7 +180,7 @@ GEM
       sorbet-static (= 0.5.6064)
     sorbet-runtime (0.5.6064)
     sorbet-static (0.5.6064-universal-darwin-14)
-    spoom (1.0.4)
+    spoom (1.0.6)
       colorize
       sorbet (~> 0.5.5)
       sorbet-runtime

--- a/spec/tapioca/compilers/symbol_table_compiler_spec.rb
+++ b/spec/tapioca/compilers/symbol_table_compiler_spec.rb
@@ -231,10 +231,10 @@ class Tapioca::Compilers::SymbolTableCompilerSpec < Minitest::HooksSpec
 
         class String
           include(::Comparable)
-          include(::Colorize::InstanceMethods)
           include(::JSON::Ext::Generator::GeneratorMethods::String)
-          extend(::Colorize::ClassMethods)
+          include(::Colorize::InstanceMethods)
           extend(::JSON::Ext::Generator::GeneratorMethods::String::Extend)
+          extend(::Colorize::ClassMethods)
 
           def to_foo(base = T.unsafe(nil)); end
         end


### PR DESCRIPTION
Bump spoom to https://rubygems.org/gems/spoom/versions/1.0.6