### PR TITLE
Make inclusion order deterministic

### DIFF
--- a/lib/tapioca/compilers/symbol_table/symbol_generator.rb
+++ b/lib/tapioca/compilers/symbol_table/symbol_generator.rb
@@ -329,7 +329,7 @@ module Tapioca
               # properly for method resolution, so we generate an
               # include statement instead
               indented("include(#{qualified_name_of(mod)})")
-            end
+            end.sort
 
           includes = include
             .reverse
@@ -337,7 +337,7 @@ module Tapioca
             .select(&method(:public_module?))
             .map do |mod|
               indented("include(#{qualified_name_of(mod)})")
-            end
+            end.sort
 
           extends = extend
             .reverse
@@ -345,7 +345,7 @@ module Tapioca
             .select(&method(:public_module?))
             .map do |mod|
               indented("extend(#{qualified_name_of(mod)})")
-            end
+            end.sort
 
           (prepends + includes + extends).join("\n")
         end

--- a/spec/tapioca/compilers/symbol_table_compiler_spec.rb
+++ b/spec/tapioca/compilers/symbol_table_compiler_spec.rb
@@ -98,11 +98,11 @@ class Tapioca::Compilers::SymbolTableCompilerSpec < Minitest::HooksSpec
         end
 
         class Object < ::BasicObject
+          include(::JSON::Ext::Generator::GeneratorMethods::Object)
           include(::Kernel)
         <% if defined?(Minitest::Expectations) %>
           include(::Minitest::Expectations)
         <% end %>
-          include(::JSON::Ext::Generator::GeneratorMethods::Object)
         <% if defined?(PP::ObjectMixin) %>
           include(::PP::ObjectMixin)
         <% end %>
@@ -130,9 +130,9 @@ class Tapioca::Compilers::SymbolTableCompilerSpec < Minitest::HooksSpec
           include ModuleB
           include ModuleC
 
-          extend ModuleC
-          extend ModuleB
           extend ModuleA
+          extend ModuleB
+          extend ModuleC
         end
       RUBY
 
@@ -141,9 +141,9 @@ class Tapioca::Compilers::SymbolTableCompilerSpec < Minitest::HooksSpec
           include(::ModuleA)
           include(::ModuleB)
           include(::ModuleC)
-          extend(::ModuleC)
-          extend(::ModuleB)
           extend(::ModuleA)
+          extend(::ModuleB)
+          extend(::ModuleC)
         end
 
         module ModuleA
@@ -230,8 +230,8 @@ class Tapioca::Compilers::SymbolTableCompilerSpec < Minitest::HooksSpec
         end
 
         class String
-          include(::Comparable)
           include(::Colorize::InstanceMethods)
+          include(::Comparable)
           include(::JSON::Ext::Generator::GeneratorMethods::String)
           extend(::Colorize::ClassMethods)
           extend(::JSON::Ext::Generator::GeneratorMethods::String::Extend)
@@ -751,8 +751,8 @@ class Tapioca::Compilers::SymbolTableCompilerSpec < Minitest::HooksSpec
 
       output = template(<<~RUBY)
         class Bar
-          include(::Foo)
           include(::Baz)
+          include(::Foo)
 
           class << self
             def abc; end


### PR DESCRIPTION
While bumping `spoom` the test suite returned errors because of differences in the inclusion order: https://github.com/Shopify/tapioca/runs/1424355030.

This PR makes the order of include/prepend/append deterministic sorting them by their qualified name so it doesn't happen again.

While the order may have an importance regarding behaviour, since the RBIs are only read by `sorbet-static`, this has no impact on the runtime execution.