### PR TITLE
Generate nested definitions for synthetic modules

### DIFF
--- a/lib/tapioca/compilers/dsl/action_controller_helpers.rb
+++ b/lib/tapioca/compilers/dsl/action_controller_helpers.rb
@@ -120,7 +120,7 @@ module Tapioca
         def gather_includes(mod)
           mod.ancestors
             .reject { |ancestor| ancestor.is_a?(Class) || ancestor == mod || ancestor.name.nil? }
-            .map { |ancestor| T.must(ancestor.name) }
+            .map { |ancestor| "::#{ancestor.name}" }
             .reverse
         end
       end

--- a/lib/tapioca/compilers/dsl/action_mailer.rb
+++ b/lib/tapioca/compilers/dsl/action_mailer.rb
@@ -40,12 +40,12 @@ module Tapioca
 
         sig { override.params(root: Parlour::RbiGenerator::Namespace, constant: T.class_of(::ActionMailer::Base)).void }
         def decorate(root, constant)
-          root.path(constant) do |k|
+          root.path(constant) do |mailer|
             constant.action_methods.to_a.each do |mailer_method|
               method_def = constant.instance_method(mailer_method)
               parameters = compile_method_parameters_to_parlour(method_def)
               create_method(
-                k,
+                mailer,
                 mailer_method,
                 parameters: parameters,
                 return_type: '::ActionMailer::MessageDelivery',

--- a/lib/tapioca/compilers/dsl/active_record_associations.rb
+++ b/lib/tapioca/compilers/dsl/active_record_associations.rb
@@ -36,56 +36,56 @@ module Tapioca
       #
       # class Post
       #   include Post::GeneratedAssociationMethods
-      # end
       #
-      # module Post::GeneratedAssociationMethods
-      #   sig { returns(T.nilable(::User)) }
-      #   def author; end
+      #   module Post::GeneratedAssociationMethods
+      #     sig { returns(T.nilable(::User)) }
+      #     def author; end
       #
-      #   sig { params(value: T.nilable(::User)).void }
-      #   def author=(value); end
+      #     sig { params(value: T.nilable(::User)).void }
+      #     def author=(value); end
       #
-      #   sig { params(args: T.untyped, blk: T.untyped).returns(::User) }
-      #   def build_author(*args, &blk); end
+      #     sig { params(args: T.untyped, blk: T.untyped).returns(::User) }
+      #     def build_author(*args, &blk); end
       #
-      #   sig { params(args: T.untyped, blk: T.untyped).returns(::Category) }
-      #   def build_category(*args, &blk); end
+      #     sig { params(args: T.untyped, blk: T.untyped).returns(::Category) }
+      #     def build_category(*args, &blk); end
       #
-      #   sig { returns(T.nilable(::Category)) }
-      #   def category; end
+      #     sig { returns(T.nilable(::Category)) }
+      #     def category; end
       #
-      #   sig { params(value: T.nilable(::Category)).void }
-      #   def category=(value); end
+      #     sig { params(value: T.nilable(::Category)).void }
+      #     def category=(value); end
       #
-      #   sig { returns(T::Array[T.untyped]) }
-      #   def comment_ids; end
+      #     sig { returns(T::Array[T.untyped]) }
+      #     def comment_ids; end
       #
-      #   sig { params(ids: T::Array[T.untyped]).returns(T::Array[T.untyped]) }
-      #   def comment_ids=(ids); end
+      #     sig { params(ids: T::Array[T.untyped]).returns(T::Array[T.untyped]) }
+      #     def comment_ids=(ids); end
       #
-      #   sig { returns(::ActiveRecord::Associations::CollectionProxy[Comment]) }
-      #   def comments; end
+      #     sig { returns(::ActiveRecord::Associations::CollectionProxy[Comment]) }
+      #     def comments; end
       #
-      #   sig { params(value: T::Enumerable[::Comment]).void }
-      #   def comments=(value); end
+      #     sig { params(value: T::Enumerable[::Comment]).void }
+      #     def comments=(value); end
       #
-      #   sig { params(args: T.untyped, blk: T.untyped).returns(::User) }
-      #   def create_author(*args, &blk); end
+      #     sig { params(args: T.untyped, blk: T.untyped).returns(::User) }
+      #     def create_author(*args, &blk); end
       #
-      #   sig { params(args: T.untyped, blk: T.untyped).returns(::User) }
-      #   def create_author!(*args, &blk); end
+      #     sig { params(args: T.untyped, blk: T.untyped).returns(::User) }
+      #     def create_author!(*args, &blk); end
       #
-      #   sig { params(args: T.untyped, blk: T.untyped).returns(::Category) }
-      #   def create_category(*args, &blk); end
+      #     sig { params(args: T.untyped, blk: T.untyped).returns(::Category) }
+      #     def create_category(*args, &blk); end
       #
-      #   sig { params(args: T.untyped, blk: T.untyped).returns(::Category) }
-      #   def create_category!(*args, &blk); end
+      #     sig { params(args: T.untyped, blk: T.untyped).returns(::Category) }
+      #     def create_category!(*args, &blk); end
       #
-      #   sig { returns(T.nilable(::User)) }
-      #   def reload_author; end
+      #     sig { returns(T.nilable(::User)) }
+      #     def reload_author; end
       #
-      #   sig { returns(T.nilable(::Category)) }
-      #   def reload_category; end
+      #     sig { returns(T.nilable(::Category)) }
+      #     def reload_category; end
+      #   end
       # end
       # ~~~
       class ActiveRecordAssociations < Base
@@ -99,19 +99,20 @@ module Tapioca
         def decorate(root, constant)
           return if constant.reflections.empty?
 
-          module_name = "#{constant}::GeneratedAssociationMethods"
-          root.create_module(module_name) do |mod|
-            constant.reflections.each do |association_name, reflection|
-              if reflection.collection?
-                populate_collection_assoc_getter_setter(mod, constant, association_name, reflection)
-              else
-                populate_single_assoc_getter_setter(mod, constant, association_name, reflection)
+          root.path(constant) do |model|
+            module_name = "GeneratedAssociationMethods"
+
+            model.create_module(module_name) do |mod|
+              constant.reflections.each do |association_name, reflection|
+                if reflection.collection?
+                  populate_collection_assoc_getter_setter(mod, constant, association_name, reflection)
+                else
+                  populate_single_assoc_getter_setter(mod, constant, association_name, reflection)
+                end
               end
             end
-          end
 
-          root.path(constant) do |klass|
-            klass.create_include(module_name)
+            model.create_include(module_name)
           end
         end
 

--- a/lib/tapioca/compilers/dsl/active_record_enum.rb
+++ b/lib/tapioca/compilers/dsl/active_record_enum.rb
@@ -31,26 +31,30 @@ module Tapioca
       # # post.rbi
       # # typed: true
       # class Post
-      #   sig { void }
-      #   def all_title!; end
+      #   include EnumMethodsModule
       #
-      #   sig { returns(T::Boolean) }
-      #   def all_title?; end
+      #   module EnumMethodsModule
+      #     sig { void }
+      #     def all_title!; end
       #
-      #   sig { returns(T::Hash[T.any(String, Symbol), Integer]) }
-      #   def self.title_types; end
+      #     sig { returns(T::Boolean) }
+      #     def all_title?; end
       #
-      #   sig { void }
-      #   def book_title!; end
+      #     sig { returns(T::Hash[T.any(String, Symbol), Integer]) }
+      #     def self.title_types; end
       #
-      #   sig { returns(T::Boolean) }
-      #   def book_title?; end
+      #     sig { void }
+      #     def book_title!; end
       #
-      #   sig { void }
-      #   def web_title!; end
+      #     sig { returns(T::Boolean) }
+      #     def book_title?; end
       #
-      #   sig { returns(T::Boolean) }
-      #   def web_title?; end
+      #     sig { void }
+      #     def web_title!; end
+      #
+      #     sig { returns(T::Boolean) }
+      #     def web_title?; end
+      #   end
       # end
       # ~~~
       class ActiveRecordEnum < Base
@@ -60,17 +64,18 @@ module Tapioca
         def decorate(root, constant)
           return if constant.defined_enums.empty?
 
-          module_name = "#{constant}::EnumMethodsModule"
-          root.create_module(module_name) do |mod|
-            generate_instance_methods(constant, mod)
-          end
+          root.path(constant) do |model|
+            module_name = "EnumMethodsModule"
 
-          root.path(constant) do |k|
-            k.create_include(module_name)
+            model.create_module(module_name) do |mod|
+              generate_instance_methods(constant, mod)
+            end
+
+            model.create_include(module_name)
 
             constant.defined_enums.each do |name, enum_map|
               type = type_for_enum(enum_map)
-              create_method(k, name.pluralize, class_method: true, return_type: type)
+              create_method(model, name.pluralize, class_method: true, return_type: type)
             end
           end
         end

--- a/lib/tapioca/compilers/dsl/active_record_scope.rb
+++ b/lib/tapioca/compilers/dsl/active_record_scope.rb
@@ -31,15 +31,15 @@ module Tapioca
       # # post.rbi
       # # typed: true
       # class Post
-      #   extend Post::GeneratedRelationMethods
-      # end
+      #   extend GeneratedRelationMethods
       #
-      # module Post::GeneratedRelationMethods
-      #   sig { params(args: T.untyped, blk: T.untyped).returns(T.untyped) }
-      #   def private_kind(*args, &blk); end
+      #   module GeneratedRelationMethods
+      #     sig { params(args: T.untyped, blk: T.untyped).returns(T.untyped) }
+      #     def private_kind(*args, &blk); end
       #
-      #   sig { params(args: T.untyped, blk: T.untyped).returns(T.untyped) }
-      #   def public_kind(*args, &blk); end
+      #     sig { params(args: T.untyped, blk: T.untyped).returns(T.untyped) }
+      #     def public_kind(*args, &blk); end
+      #   end
       # end
       # ~~~
       class ActiveRecordScope < Base
@@ -55,15 +55,16 @@ module Tapioca
           scope_method_names = constant.send(:generated_relation_methods).instance_methods(false)
           return if scope_method_names.empty?
 
-          module_name = "#{constant}::GeneratedRelationMethods"
-          root.create_module(module_name) do |mod|
-            scope_method_names.each do |scope_method|
-              generate_scope_method(scope_method, mod)
-            end
-          end
+          root.path(constant) do |model|
+            module_name = "GeneratedRelationMethods"
 
-          root.path(constant) do |k|
-            k.create_extend(module_name)
+            model.create_module(module_name) do |mod|
+              scope_method_names.each do |scope_method|
+                generate_scope_method(scope_method, mod)
+              end
+            end
+
+            model.create_extend(module_name)
           end
         end
 

--- a/lib/tapioca/compilers/dsl/active_record_typed_store.rb
+++ b/lib/tapioca/compilers/dsl/active_record_typed_store.rb
@@ -101,13 +101,14 @@ module Tapioca
           stores = constant.typed_stores
           return if stores.values.flat_map(&:accessors).empty?
 
-          root.path(constant) do |k|
+          root.path(constant) do |model|
             stores.values.each do |store_data|
               store_data.accessors.each do |accessor|
                 field = store_data.fields[accessor]
                 type = type_for(field.type_sym)
                 type = "T.nilable(#{type})" if field.null && type != "T.untyped"
-                generate_methods(field.name.to_s, type, k)
+
+                generate_methods(model, field.name.to_s, type)
               end
             end
           end
@@ -141,13 +142,13 @@ module Tapioca
 
         sig do
           params(
+            klass: Parlour::RbiGenerator::Namespace,
             name: String,
-            type: String,
-            klass: Parlour::RbiGenerator::Namespace
+            type: String
           )
             .void
         end
-        def generate_methods(name, type, klass)
+        def generate_methods(klass, name, type)
           klass.create_method(
             "#{name}=",
             parameters: [Parlour::RbiGenerator::Parameter.new(name, type: type)],

--- a/lib/tapioca/compilers/dsl/active_resource.rb
+++ b/lib/tapioca/compilers/dsl/active_resource.rb
@@ -71,9 +71,10 @@ module Tapioca
         end
         def decorate(root, constant)
           return if constant.schema.blank?
-          root.path(constant) do |klass|
+
+          root.path(constant) do |resource|
             constant.schema.each do |attribute, type|
-              create_schema_methods(klass, attribute, type)
+              create_schema_methods(resource, attribute, type)
             end
           end
         end

--- a/lib/tapioca/compilers/dsl/active_support_current_attributes.rb
+++ b/lib/tapioca/compilers/dsl/active_support_current_attributes.rb
@@ -75,20 +75,20 @@ module Tapioca
           instance_methods = instance_methods_for(constant) - dynamic_methods
           return if dynamic_methods.empty? && instance_methods.empty?
 
-          root.path(constant) do |k|
+          root.path(constant) do |current_attributes|
             dynamic_methods.each do |method|
               method = method.to_s
               # We want to generate each method both on the class
-              generate_method(k, method, class_method: true)
+              generate_method(current_attributes, method, class_method: true)
               # and on the instance
-              generate_method(k, method, class_method: false)
+              generate_method(current_attributes, method, class_method: false)
             end
 
             instance_methods.each do |method|
               # instance methods are only elevated to class methods
               # no need to add separate instance methods for them
               method = constant.instance_method(method)
-              create_method_from_def(k, method, class_method: true)
+              create_method_from_def(current_attributes, method, class_method: true)
             end
           end
         end

--- a/lib/tapioca/compilers/dsl/frozen_record.rb
+++ b/lib/tapioca/compilers/dsl/frozen_record.rb
@@ -41,27 +41,27 @@ module Tapioca
       # # Student.rbi
       # # typed: strong
       # class Student
-      #   include Student::FrozenRecordAttributeMethods
-      # end
+      #   include FrozenRecordAttributeMethods
       #
-      # module Student::FrozenRecordAttributeMethods
-      #   sig { returns(T.untyped) }
-      #   def first_name; end
+      #   module FrozenRecordAttributeMethods
+      #     sig { returns(T.untyped) }
+      #     def first_name; end
       #
-      #   sig { returns(T::Boolean) }
-      #   def first_name?; end
+      #     sig { returns(T::Boolean) }
+      #     def first_name?; end
       #
-      #   sig { returns(T.untyped) }
-      #   def id; end
+      #     sig { returns(T.untyped) }
+      #     def id; end
       #
-      #   sig { returns(T::Boolean) }
-      #   def id?; end
+      #     sig { returns(T::Boolean) }
+      #     def id?; end
       #
-      #   sig { returns(T.untyped) }
-      #   def last_name; end
+      #     sig { returns(T.untyped) }
+      #     def last_name; end
       #
-      #   sig { returns(T::Boolean) }
-      #   def last_name?; end
+      #     sig { returns(T::Boolean) }
+      #     def last_name?; end
+      #   end
       # end
       # ~~~
       class FrozenRecord < Base
@@ -72,17 +72,17 @@ module Tapioca
           attributes = constant.attributes
           return if attributes.empty?
 
-          module_name = "#{constant}::FrozenRecordAttributeMethods"
+          root.path(constant) do |record|
+            module_name = "FrozenRecordAttributeMethods"
 
-          root.create_module(module_name) do |mod|
-            attributes.each do |attribute|
-              create_method(mod, "#{attribute}?", return_type: 'T::Boolean')
-              create_method(mod, attribute.to_s, return_type: 'T.untyped')
+            record.create_module(module_name) do |mod|
+              attributes.each do |attribute|
+                create_method(mod, "#{attribute}?", return_type: 'T::Boolean')
+                create_method(mod, attribute.to_s, return_type: 'T.untyped')
+              end
             end
-          end
 
-          root.path(constant) do |klass|
-            klass.create_include(module_name)
+            record.create_include(module_name)
           end
         end
 

--- a/lib/tapioca/compilers/dsl/identity_cache.rb
+++ b/lib/tapioca/compilers/dsl/identity_cache.rb
@@ -83,25 +83,25 @@ module Tapioca
           cache_indexes = constant.send(:cache_indexes)
           return if caches.empty? && cache_indexes.empty?
 
-          root.path(constant) do |k|
+          root.path(constant) do |model|
             cache_manys = constant.send(:cached_has_manys)
             cache_ones = constant.send(:cached_has_ones)
             cache_belongs = constant.send(:cached_belongs_tos)
 
             cache_indexes.each do |field|
-              create_fetch_by_methods(field, k, constant)
+              create_fetch_by_methods(field, model, constant)
             end
 
             cache_manys.values.each do |field|
-              create_fetch_field_methods(field, k, returns_collection: true)
+              create_fetch_field_methods(field, model, returns_collection: true)
             end
 
             cache_ones.values.each do |field|
-              create_fetch_field_methods(field, k, returns_collection: false)
+              create_fetch_field_methods(field, model, returns_collection: false)
             end
 
             cache_belongs.values.each do |field|
-              create_fetch_field_methods(field, k, returns_collection: false)
+              create_fetch_field_methods(field, model, returns_collection: false)
             end
           end
         end

--- a/lib/tapioca/compilers/dsl/state_machines.rb
+++ b/lib/tapioca/compilers/dsl/state_machines.rb
@@ -47,75 +47,75 @@ module Tapioca
       # # vehicle.rbi
       # # typed: true
       # class Vehicle
-      #   include Vehicle::StateMachineInstanceHelperModule
-      #   extend Vehicle::StateMachineClassHelperModule
-      # end
+      #   include StateMachineInstanceHelperModule
+      #   extend StateMachineClassHelperModule
       #
-      # module Vehicle::StateMachineClassHelperModule
-      #   sig { params(event: T.any(String, Symbol)).returns(String) }
-      #   def human_alarm_state_event_name(event); end
+      #   module StateMachineClassHelperModule
+      #     sig { params(event: T.any(String, Symbol)).returns(String) }
+      #     def human_alarm_state_event_name(event); end
       #
-      #   sig { params(state: T.any(String, Symbol)).returns(String) }
-      #   def human_alarm_state_name(state); end
-      # end
+      #     sig { params(state: T.any(String, Symbol)).returns(String) }
+      #     def human_alarm_state_name(state); end
+      #   end
       #
-      # module Vehicle::StateMachineInstanceHelperModule
-      #   sig { returns(T::Boolean) }
-      #   def alarm_active?; end
+      #   module StateMachineInstanceHelperModule
+      #     sig { returns(T::Boolean) }
+      #     def alarm_active?; end
       #
-      #   sig { returns(T::Boolean) }
-      #   def alarm_off?; end
+      #     sig { returns(T::Boolean) }
+      #     def alarm_off?; end
       #
-      #   sig { returns(Integer) }
-      #   def alarm_state; end
+      #     sig { returns(Integer) }
+      #     def alarm_state; end
       #
-      #   sig { params(value: Integer).returns(Integer) }
-      #   def alarm_state=(value); end
+      #     sig { params(value: Integer).returns(Integer) }
+      #     def alarm_state=(value); end
       #
-      #   sig { params(state: T.any(String, Symbol)).returns(T::Boolean) }
-      #   def alarm_state?(state); end
+      #     sig { params(state: T.any(String, Symbol)).returns(T::Boolean) }
+      #     def alarm_state?(state); end
       #
-      #   sig { params(args: T.untyped).returns(T::Array[T.any(String, Symbol)]) }
-      #   def alarm_state_events(*args); end
+      #     sig { params(args: T.untyped).returns(T::Array[T.any(String, Symbol)]) }
+      #     def alarm_state_events(*args); end
       #
-      #   sig { returns(T.any(String, Symbol)) }
-      #   def alarm_state_name; end
+      #     sig { returns(T.any(String, Symbol)) }
+      #     def alarm_state_name; end
       #
-      #   sig { params(args: T.untyped).returns(T::Array[::StateMachines::Transition]) }
-      #   def alarm_state_paths(*args); end
+      #     sig { params(args: T.untyped).returns(T::Array[::StateMachines::Transition]) }
+      #     def alarm_state_paths(*args); end
       #
-      #   sig { params(args: T.untyped).returns(T::Array[::StateMachines::Transition]) }
-      #   def alarm_state_transitions(*args); end
+      #     sig { params(args: T.untyped).returns(T::Array[::StateMachines::Transition]) }
+      #     def alarm_state_transitions(*args); end
       #
-      #   sig { returns(T::Boolean) }
-      #   def can_disable_alarm?; end
+      #     sig { returns(T::Boolean) }
+      #     def can_disable_alarm?; end
       #
-      #   sig { returns(T::Boolean) }
-      #   def can_enable_alarm?; end
+      #     sig { returns(T::Boolean) }
+      #     def can_enable_alarm?; end
       #
-      #   sig { params(args: T.untyped).returns(T::Boolean) }
-      #   def disable_alarm(*args); end
+      #     sig { params(args: T.untyped).returns(T::Boolean) }
+      #     def disable_alarm(*args); end
       #
-      #   sig { params(args: T.untyped).returns(T::Boolean) }
-      #   def disable_alarm!(*args); end
+      #     sig { params(args: T.untyped).returns(T::Boolean) }
+      #     def disable_alarm!(*args); end
       #
-      #   sig { params(args: T.untyped).returns(T.nilable(::StateMachines::Transition)) }
-      #   def disable_alarm_transition(*args); end
+      #     sig { params(args: T.untyped).returns(T.nilable(::StateMachines::Transition)) }
+      #     def disable_alarm_transition(*args); end
       #
-      #   sig { params(args: T.untyped).returns(T::Boolean) }
-      #   def enable_alarm(*args); end
+      #     sig { params(args: T.untyped).returns(T::Boolean) }
+      #     def enable_alarm(*args); end
       #
-      #   sig { params(args: T.untyped).returns(T::Boolean) }
-      #   def enable_alarm!(*args); end
+      #     sig { params(args: T.untyped).returns(T::Boolean) }
+      #     def enable_alarm!(*args); end
       #
-      #   sig { params(args: T.untyped).returns(T.nilable(::StateMachines::Transition)) }
-      #   def enable_alarm_transition(*args); end
+      #     sig { params(args: T.untyped).returns(T.nilable(::StateMachines::Transition)) }
+      #     def enable_alarm_transition(*args); end
       #
-      #   sig { params(event: T.any(String, Symbol), args: T.untyped).returns(T::Boolean) }
-      #   def fire_alarm_state_event(event, *args); end
+      #     sig { params(event: T.any(String, Symbol), args: T.untyped).returns(T::Boolean) }
+      #     def fire_alarm_state_event(event, *args); end
       #
-      #   sig { returns(String) }
-      #   def human_alarm_state_name; end
+      #     sig { returns(String) }
+      #     def human_alarm_state_name; end
+      #   end
       # end
       # ~~~
       class StateMachines < Base
@@ -125,34 +125,34 @@ module Tapioca
         def decorate(root, constant)
           return if constant.state_machines.empty?
 
-          instance_module_name = "#{constant}::StateMachineInstanceHelperModule"
-          class_module_name = "#{constant}::StateMachineClassHelperModule"
-
-          instance_module = root.create_module(instance_module_name)
-          class_module = root.create_module(class_module_name)
-
-          constant.state_machines.each_value do |machine|
-            state_type = state_type_for(machine)
-
-            define_state_accessor(instance_module, machine, state_type)
-            define_state_predicate(instance_module, machine)
-            define_event_helpers(instance_module, machine)
-            define_path_helpers(instance_module, machine)
-            define_name_helpers(instance_module, class_module, machine)
-            define_scopes(class_module, machine)
-
-            define_state_methods(instance_module, machine)
-            define_event_methods(instance_module, machine)
-          end
-
-          matching_integration_name = ::StateMachines::Integrations.match(constant)&.integration_name
-
-          case matching_integration_name
-          when :active_record
-            define_activerecord_methods(instance_module)
-          end
-
           root.path(constant) do |klass|
+            instance_module_name = "StateMachineInstanceHelperModule"
+            class_module_name = "StateMachineClassHelperModule"
+
+            instance_module = klass.create_module(instance_module_name)
+            class_module = klass.create_module(class_module_name)
+
+            constant.state_machines.each_value do |machine|
+              state_type = state_type_for(machine)
+
+              define_state_accessor(instance_module, machine, state_type)
+              define_state_predicate(instance_module, machine)
+              define_event_helpers(instance_module, machine)
+              define_path_helpers(instance_module, machine)
+              define_name_helpers(instance_module, class_module, machine)
+              define_scopes(class_module, machine)
+
+              define_state_methods(instance_module, machine)
+              define_event_methods(instance_module, machine)
+            end
+
+            matching_integration_name = ::StateMachines::Integrations.match(constant)&.integration_name
+
+            case matching_integration_name
+            when :active_record
+              define_activerecord_methods(instance_module)
+            end
+
             klass.create_include(instance_module_name)
             klass.create_extend(class_module_name)
           end

--- a/lib/tapioca/compilers/dsl/url_helpers.rb
+++ b/lib/tapioca/compilers/dsl/url_helpers.rb
@@ -130,8 +130,8 @@ module Tapioca
         sig { params(root: Parlour::RbiGenerator::Namespace, constant: T.class_of(Module)).void }
         def generate_module_for(root, constant)
           root.create_module(T.must(constant.name)) do |mod|
-            mod.create_include("ActionDispatch::Routing::UrlFor")
-            mod.create_include("ActionDispatch::Routing::PolymorphicRoutes")
+            mod.create_include("::ActionDispatch::Routing::UrlFor")
+            mod.create_include("::ActionDispatch::Routing::PolymorphicRoutes")
 
             constant.instance_methods(false).each do |method|
               mod.create_method(

--- a/manual/generator_actioncontrollerhelpers.md
+++ b/manual/generator_actioncontrollerhelpers.md
@@ -37,21 +37,21 @@ this generator will produce an RBI file `user_controller.rbi` with the following
 # user_controller.rbi
 # typed: strong
 class UserController
-  sig { returns(UserController::HelperProxy) }
+  module HelperMethods
+    include MyHelper
+
+    sig { params(user: T.untyped).returns(T.untyped) }
+    def age(user); end
+
+    sig { returns(T.untyped) }
+    def current_user_name; end
+  end
+
+  class HelperProxy < ::ActionView::Base
+    include HelperMethods
+  end
+
+  sig { returns(HelperProxy) }
   def helpers; end
-end
-
-module UserController::HelperMethods
-   include MyHelper
-
-   sig { params(user: T.untyped).returns(T.untyped) }
-   def age(user); end
-
-   sig { returns(T.untyped) }
-   def current_user_name; end
- end
-
-class UserController::HelperProxy < ::ActionView::Base
-  include UserController::HelperMethods
 end
 ~~~

--- a/manual/generator_activerecordassociations.md
+++ b/manual/generator_activerecordassociations.md
@@ -24,55 +24,55 @@ this generator will produce the following methods in the RBI file
 
 class Post
   include Post::GeneratedAssociationMethods
-end
 
-module Post::GeneratedAssociationMethods
-  sig { returns(T.nilable(::User)) }
-  def author; end
+  module Post::GeneratedAssociationMethods
+    sig { returns(T.nilable(::User)) }
+    def author; end
 
-  sig { params(value: T.nilable(::User)).void }
-  def author=(value); end
+    sig { params(value: T.nilable(::User)).void }
+    def author=(value); end
 
-  sig { params(args: T.untyped, blk: T.untyped).returns(::User) }
-  def build_author(*args, &blk); end
+    sig { params(args: T.untyped, blk: T.untyped).returns(::User) }
+    def build_author(*args, &blk); end
 
-  sig { params(args: T.untyped, blk: T.untyped).returns(::Category) }
-  def build_category(*args, &blk); end
+    sig { params(args: T.untyped, blk: T.untyped).returns(::Category) }
+    def build_category(*args, &blk); end
 
-  sig { returns(T.nilable(::Category)) }
-  def category; end
+    sig { returns(T.nilable(::Category)) }
+    def category; end
 
-  sig { params(value: T.nilable(::Category)).void }
-  def category=(value); end
+    sig { params(value: T.nilable(::Category)).void }
+    def category=(value); end
 
-  sig { returns(T::Array[T.untyped]) }
-  def comment_ids; end
+    sig { returns(T::Array[T.untyped]) }
+    def comment_ids; end
 
-  sig { params(ids: T::Array[T.untyped]).returns(T::Array[T.untyped]) }
-  def comment_ids=(ids); end
+    sig { params(ids: T::Array[T.untyped]).returns(T::Array[T.untyped]) }
+    def comment_ids=(ids); end
 
-  sig { returns(::ActiveRecord::Associations::CollectionProxy[Comment]) }
-  def comments; end
+    sig { returns(::ActiveRecord::Associations::CollectionProxy[Comment]) }
+    def comments; end
 
-  sig { params(value: T::Enumerable[::Comment]).void }
-  def comments=(value); end
+    sig { params(value: T::Enumerable[::Comment]).void }
+    def comments=(value); end
 
-  sig { params(args: T.untyped, blk: T.untyped).returns(::User) }
-  def create_author(*args, &blk); end
+    sig { params(args: T.untyped, blk: T.untyped).returns(::User) }
+    def create_author(*args, &blk); end
 
-  sig { params(args: T.untyped, blk: T.untyped).returns(::User) }
-  def create_author!(*args, &blk); end
+    sig { params(args: T.untyped, blk: T.untyped).returns(::User) }
+    def create_author!(*args, &blk); end
 
-  sig { params(args: T.untyped, blk: T.untyped).returns(::Category) }
-  def create_category(*args, &blk); end
+    sig { params(args: T.untyped, blk: T.untyped).returns(::Category) }
+    def create_category(*args, &blk); end
 
-  sig { params(args: T.untyped, blk: T.untyped).returns(::Category) }
-  def create_category!(*args, &blk); end
+    sig { params(args: T.untyped, blk: T.untyped).returns(::Category) }
+    def create_category!(*args, &blk); end
 
-  sig { returns(T.nilable(::User)) }
-  def reload_author; end
+    sig { returns(T.nilable(::User)) }
+    def reload_author; end
 
-  sig { returns(T.nilable(::Category)) }
-  def reload_category; end
+    sig { returns(T.nilable(::Category)) }
+    def reload_category; end
+  end
 end
 ~~~

--- a/manual/generator_activerecordcolumns.md
+++ b/manual/generator_activerecordcolumns.md
@@ -42,53 +42,57 @@ this generator will produce the following methods in the RBI file
 # post.rbi
 # typed: true
 class Post
-  sig { returns(T.nilable(::String)) }
-  def body; end
+  include GeneratedAttributeMethods
 
-  sig { params(value: T.nilable(::String)).returns(T.nilable(::String)) }
-  def body=; end
+  module GeneratedAttributeMethods
+    sig { returns(T.nilable(::String)) }
+    def body; end
 
-  sig { params(args: T.untyped).returns(T::Boolean) }
-  def body?; end
+    sig { params(value: T.nilable(::String)).returns(T.nilable(::String)) }
+    def body=; end
 
-  sig { returns(T.nilable(::ActiveSupport::TimeWithZone)) }
-  def created_at; end
+    sig { params(args: T.untyped).returns(T::Boolean) }
+    def body?; end
 
-  sig { params(value: ::ActiveSupport::TimeWithZone).returns(::ActiveSupport::TimeWithZone) }
-  def created_at=; end
+    sig { returns(T.nilable(::ActiveSupport::TimeWithZone)) }
+    def created_at; end
 
-  sig { params(args: T.untyped).returns(T::Boolean) }
-  def created_at?; end
+    sig { params(value: ::ActiveSupport::TimeWithZone).returns(::ActiveSupport::TimeWithZone) }
+    def created_at=; end
 
-  sig { returns(T.nilable(T::Boolean)) }
-  def published; end
+    sig { params(args: T.untyped).returns(T::Boolean) }
+    def created_at?; end
 
-  sig { params(value: T::Boolean).returns(T::Boolean) }
-  def published=; end
+    sig { returns(T.nilable(T::Boolean)) }
+    def published; end
 
-  sig { params(args: T.untyped).returns(T::Boolean) }
-  def published?; end
+    sig { params(value: T::Boolean).returns(T::Boolean) }
+    def published=; end
 
-  sig { returns(::String) }
-  def title; end
+    sig { params(args: T.untyped).returns(T::Boolean) }
+    def published?; end
 
-  sig { params(value: ::String).returns(::String) }
-  def title=(value); end
+    sig { returns(::String) }
+    def title; end
 
-  sig { params(args: T.untyped).returns(T::Boolean) }
-  def title?(*args); end
+    sig { params(value: ::String).returns(::String) }
+    def title=(value); end
 
-  sig { returns(T.nilable(::ActiveSupport::TimeWithZone)) }
-  def updated_at; end
+    sig { params(args: T.untyped).returns(T::Boolean) }
+    def title?(*args); end
 
-  sig { params(value: ::ActiveSupport::TimeWithZone).returns(::ActiveSupport::TimeWithZone) }
-  def updated_at=; end
+    sig { returns(T.nilable(::ActiveSupport::TimeWithZone)) }
+    def updated_at; end
 
-  sig { params(args: T.untyped).returns(T::Boolean) }
-  def updated_at?; end
+    sig { params(value: ::ActiveSupport::TimeWithZone).returns(::ActiveSupport::TimeWithZone) }
+    def updated_at=; end
 
-  ## Also the methods added by https://api.rubyonrails.org/classes/ActiveRecord/AttributeMethods/Dirty.html
-  ## Also the methods added by https://api.rubyonrails.org/classes/ActiveModel/Dirty.html
-  ## Also the methods added by https://api.rubyonrails.org/classes/ActiveRecord/AttributeMethods/BeforeTypeCast.html
+    sig { params(args: T.untyped).returns(T::Boolean) }
+    def updated_at?; end
+
+    ## Also the methods added by https://api.rubyonrails.org/classes/ActiveRecord/AttributeMethods/Dirty.html
+    ## Also the methods added by https://api.rubyonrails.org/classes/ActiveModel/Dirty.html
+    ## Also the methods added by https://api.rubyonrails.org/classes/ActiveRecord/AttributeMethods/BeforeTypeCast.html
+  end
 end
 ~~~

--- a/manual/generator_activerecordenum.md
+++ b/manual/generator_activerecordenum.md
@@ -17,25 +17,29 @@ this generator will produce the RBI file `post.rbi` with the following content:
 # post.rbi
 # typed: true
 class Post
-  sig { void }
-  def all_title!; end
+  include EnumMethodsModule
 
-  sig { returns(T::Boolean) }
-  def all_title?; end
+  module EnumMethodsModule
+    sig { void }
+    def all_title!; end
 
-  sig { returns(T::Hash[T.any(String, Symbol), Integer]) }
-  def self.title_types; end
+    sig { returns(T::Boolean) }
+    def all_title?; end
 
-  sig { void }
-  def book_title!; end
+    sig { returns(T::Hash[T.any(String, Symbol), Integer]) }
+    def self.title_types; end
 
-  sig { returns(T::Boolean) }
-  def book_title?; end
+    sig { void }
+    def book_title!; end
 
-  sig { void }
-  def web_title!; end
+    sig { returns(T::Boolean) }
+    def book_title?; end
 
-  sig { returns(T::Boolean) }
-  def web_title?; end
+    sig { void }
+    def web_title!; end
+
+    sig { returns(T::Boolean) }
+    def web_title?; end
+  end
 end
 ~~~

--- a/manual/generator_activerecordscope.md
+++ b/manual/generator_activerecordscope.md
@@ -19,14 +19,14 @@ this generator will produce the RBI file `post.rbi` with the following content:
 # post.rbi
 # typed: true
 class Post
-  extend Post::GeneratedRelationMethods
-end
+  extend GeneratedRelationMethods
 
-module Post::GeneratedRelationMethods
-  sig { params(args: T.untyped, blk: T.untyped).returns(T.untyped) }
-  def private_kind(*args, &blk); end
+  module GeneratedRelationMethods
+    sig { params(args: T.untyped, blk: T.untyped).returns(T.untyped) }
+    def private_kind(*args, &blk); end
 
-  sig { params(args: T.untyped, blk: T.untyped).returns(T.untyped) }
-  def public_kind(*args, &blk); end
+    sig { params(args: T.untyped, blk: T.untyped).returns(T.untyped) }
+    def public_kind(*args, &blk); end
+  end
 end
 ~~~

--- a/manual/generator_frozenrecord.md
+++ b/manual/generator_frozenrecord.md
@@ -29,26 +29,26 @@ this generator will produce the RBI file `student.rbi` with the following conten
 # Student.rbi
 # typed: strong
 class Student
-  include Student::FrozenRecordAttributeMethods
-end
+  include FrozenRecordAttributeMethods
 
-module Student::FrozenRecordAttributeMethods
-  sig { returns(T.untyped) }
-  def first_name; end
+  module FrozenRecordAttributeMethods
+    sig { returns(T.untyped) }
+    def first_name; end
 
-  sig { returns(T::Boolean) }
-  def first_name?; end
+    sig { returns(T::Boolean) }
+    def first_name?; end
 
-  sig { returns(T.untyped) }
-  def id; end
+    sig { returns(T.untyped) }
+    def id; end
 
-  sig { returns(T::Boolean) }
-  def id?; end
+    sig { returns(T::Boolean) }
+    def id?; end
 
-  sig { returns(T.untyped) }
-  def last_name; end
+    sig { returns(T.untyped) }
+    def last_name; end
 
-  sig { returns(T::Boolean) }
-  def last_name?; end
+    sig { returns(T::Boolean) }
+    def last_name?; end
+  end
 end
 ~~~

--- a/manual/generator_statemachines.md
+++ b/manual/generator_statemachines.md
@@ -32,74 +32,74 @@ this generator will produce the RBI file `vehicle.rbi` with the following conten
 # vehicle.rbi
 # typed: true
 class Vehicle
-  include Vehicle::StateMachineInstanceHelperModule
-  extend Vehicle::StateMachineClassHelperModule
-end
+  include StateMachineInstanceHelperModule
+  extend StateMachineClassHelperModule
 
-module Vehicle::StateMachineClassHelperModule
-  sig { params(event: T.any(String, Symbol)).returns(String) }
-  def human_alarm_state_event_name(event); end
+  module StateMachineClassHelperModule
+    sig { params(event: T.any(String, Symbol)).returns(String) }
+    def human_alarm_state_event_name(event); end
 
-  sig { params(state: T.any(String, Symbol)).returns(String) }
-  def human_alarm_state_name(state); end
-end
+    sig { params(state: T.any(String, Symbol)).returns(String) }
+    def human_alarm_state_name(state); end
+  end
 
-module Vehicle::StateMachineInstanceHelperModule
-  sig { returns(T::Boolean) }
-  def alarm_active?; end
+  module StateMachineInstanceHelperModule
+    sig { returns(T::Boolean) }
+    def alarm_active?; end
 
-  sig { returns(T::Boolean) }
-  def alarm_off?; end
+    sig { returns(T::Boolean) }
+    def alarm_off?; end
 
-  sig { returns(Integer) }
-  def alarm_state; end
+    sig { returns(Integer) }
+    def alarm_state; end
 
-  sig { params(value: Integer).returns(Integer) }
-  def alarm_state=(value); end
+    sig { params(value: Integer).returns(Integer) }
+    def alarm_state=(value); end
 
-  sig { params(state: T.any(String, Symbol)).returns(T::Boolean) }
-  def alarm_state?(state); end
+    sig { params(state: T.any(String, Symbol)).returns(T::Boolean) }
+    def alarm_state?(state); end
 
-  sig { params(args: T.untyped).returns(T::Array[T.any(String, Symbol)]) }
-  def alarm_state_events(*args); end
+    sig { params(args: T.untyped).returns(T::Array[T.any(String, Symbol)]) }
+    def alarm_state_events(*args); end
 
-  sig { returns(T.any(String, Symbol)) }
-  def alarm_state_name; end
+    sig { returns(T.any(String, Symbol)) }
+    def alarm_state_name; end
 
-  sig { params(args: T.untyped).returns(T::Array[::StateMachines::Transition]) }
-  def alarm_state_paths(*args); end
+    sig { params(args: T.untyped).returns(T::Array[::StateMachines::Transition]) }
+    def alarm_state_paths(*args); end
 
-  sig { params(args: T.untyped).returns(T::Array[::StateMachines::Transition]) }
-  def alarm_state_transitions(*args); end
+    sig { params(args: T.untyped).returns(T::Array[::StateMachines::Transition]) }
+    def alarm_state_transitions(*args); end
 
-  sig { returns(T::Boolean) }
-  def can_disable_alarm?; end
+    sig { returns(T::Boolean) }
+    def can_disable_alarm?; end
 
-  sig { returns(T::Boolean) }
-  def can_enable_alarm?; end
+    sig { returns(T::Boolean) }
+    def can_enable_alarm?; end
 
-  sig { params(args: T.untyped).returns(T::Boolean) }
-  def disable_alarm(*args); end
+    sig { params(args: T.untyped).returns(T::Boolean) }
+    def disable_alarm(*args); end
 
-  sig { params(args: T.untyped).returns(T::Boolean) }
-  def disable_alarm!(*args); end
+    sig { params(args: T.untyped).returns(T::Boolean) }
+    def disable_alarm!(*args); end
 
-  sig { params(args: T.untyped).returns(T.nilable(::StateMachines::Transition)) }
-  def disable_alarm_transition(*args); end
+    sig { params(args: T.untyped).returns(T.nilable(::StateMachines::Transition)) }
+    def disable_alarm_transition(*args); end
 
-  sig { params(args: T.untyped).returns(T::Boolean) }
-  def enable_alarm(*args); end
+    sig { params(args: T.untyped).returns(T::Boolean) }
+    def enable_alarm(*args); end
 
-  sig { params(args: T.untyped).returns(T::Boolean) }
-  def enable_alarm!(*args); end
+    sig { params(args: T.untyped).returns(T::Boolean) }
+    def enable_alarm!(*args); end
 
-  sig { params(args: T.untyped).returns(T.nilable(::StateMachines::Transition)) }
-  def enable_alarm_transition(*args); end
+    sig { params(args: T.untyped).returns(T.nilable(::StateMachines::Transition)) }
+    def enable_alarm_transition(*args); end
 
-  sig { params(event: T.any(String, Symbol), args: T.untyped).returns(T::Boolean) }
-  def fire_alarm_state_event(event, *args); end
+    sig { params(event: T.any(String, Symbol), args: T.untyped).returns(T::Boolean) }
+    def fire_alarm_state_event(event, *args); end
 
-  sig { returns(String) }
-  def human_alarm_state_name; end
+    sig { returns(String) }
+    def human_alarm_state_name; end
+  end
 end
 ~~~

--- a/spec/tapioca/compilers/dsl/action_controller_helpers_spec.rb
+++ b/spec/tapioca/compilers/dsl/action_controller_helpers_spec.rb
@@ -75,15 +75,15 @@ class Tapioca::Compilers::Dsl::ActionControllerHelpersSpec < DslSpec
       expected = <<~RUBY
         # typed: strong
         class UserController
-          sig { returns(UserController::HelperProxy) }
+          module HelperMethods
+          end
+
+          class HelperProxy < ::ActionView::Base
+            include HelperMethods
+          end
+
+          sig { returns(HelperProxy) }
           def helpers; end
-        end
-
-        module UserController::HelperMethods
-        end
-
-        class UserController::HelperProxy < ::ActionView::Base
-          include UserController::HelperMethods
         end
       RUBY
 
@@ -114,20 +114,20 @@ class Tapioca::Compilers::Dsl::ActionControllerHelpersSpec < DslSpec
       expected = <<~RUBY
         # typed: strong
         class UserController
-          sig { returns(UserController::HelperProxy) }
+          module HelperMethods
+            sig { returns(T.untyped) }
+            def current_user_name; end
+
+            sig { params(user_id: Integer).void }
+            def notify_user(user_id); end
+          end
+
+          class HelperProxy < ::ActionView::Base
+            include HelperMethods
+          end
+
+          sig { returns(HelperProxy) }
           def helpers; end
-        end
-
-        module UserController::HelperMethods
-          sig { returns(T.untyped) }
-          def current_user_name; end
-
-          sig { params(user_id: Integer).void }
-          def notify_user(user_id); end
-        end
-
-        class UserController::HelperProxy < ::ActionView::Base
-          include UserController::HelperMethods
         end
       RUBY
 
@@ -158,20 +158,20 @@ class Tapioca::Compilers::Dsl::ActionControllerHelpersSpec < DslSpec
       expected = <<~RUBY
         # typed: strong
         class UserController
-          sig { returns(UserController::HelperProxy) }
+          module HelperMethods
+            sig { params(user: T.untyped).returns(T.untyped) }
+            def greet(user); end
+
+            sig { params(user_id: Integer).void }
+            def notify_user(user_id); end
+          end
+
+          class HelperProxy < ::ActionView::Base
+            include HelperMethods
+          end
+
+          sig { returns(HelperProxy) }
           def helpers; end
-        end
-
-        module UserController::HelperMethods
-          sig { params(user: T.untyped).returns(T.untyped) }
-          def greet(user); end
-
-          sig { params(user_id: Integer).void }
-          def notify_user(user_id); end
-        end
-
-        class UserController::HelperProxy < ::ActionView::Base
-          include UserController::HelperMethods
         end
       RUBY
 
@@ -202,16 +202,16 @@ class Tapioca::Compilers::Dsl::ActionControllerHelpersSpec < DslSpec
       expected = <<~RUBY
         # typed: strong
         class UserController
-          sig { returns(UserController::HelperProxy) }
+          module HelperMethods
+            include GreetHelper
+          end
+
+          class HelperProxy < ::ActionView::Base
+            include HelperMethods
+          end
+
+          sig { returns(HelperProxy) }
           def helpers; end
-        end
-
-        module UserController::HelperMethods
-          include GreetHelper
-        end
-
-        class UserController::HelperProxy < ::ActionView::Base
-          include UserController::HelperMethods
         end
       RUBY
 

--- a/spec/tapioca/compilers/dsl/action_controller_helpers_spec.rb
+++ b/spec/tapioca/compilers/dsl/action_controller_helpers_spec.rb
@@ -203,7 +203,7 @@ class Tapioca::Compilers::Dsl::ActionControllerHelpersSpec < DslSpec
         # typed: strong
         class UserController
           module HelperMethods
-            include GreetHelper
+            include ::GreetHelper
           end
 
           class HelperProxy < ::ActionView::Base

--- a/spec/tapioca/compilers/dsl/active_record_associations_spec.rb
+++ b/spec/tapioca/compilers/dsl/active_record_associations_spec.rb
@@ -86,45 +86,45 @@ class Tapioca::Compilers::Dsl::ActiveRecordAssociationsSpec < DslSpec
       expected = <<~RUBY
         # typed: strong
         class Post
-          include Post::GeneratedAssociationMethods
-        end
+          include GeneratedAssociationMethods
 
-        module Post::GeneratedAssociationMethods
-          sig { returns(T.nilable(::User)) }
-          def author; end
+          module GeneratedAssociationMethods
+            sig { returns(T.nilable(::User)) }
+            def author; end
 
-          sig { params(value: T.nilable(::User)).void }
-          def author=(value); end
+            sig { params(value: T.nilable(::User)).void }
+            def author=(value); end
 
-          sig { params(args: T.untyped, blk: T.untyped).returns(::User) }
-          def build_author(*args, &blk); end
+            sig { params(args: T.untyped, blk: T.untyped).returns(::User) }
+            def build_author(*args, &blk); end
 
-          sig { params(args: T.untyped, blk: T.untyped).returns(::Category) }
-          def build_category(*args, &blk); end
+            sig { params(args: T.untyped, blk: T.untyped).returns(::Category) }
+            def build_category(*args, &blk); end
 
-          sig { returns(T.nilable(::Category)) }
-          def category; end
+            sig { returns(T.nilable(::Category)) }
+            def category; end
 
-          sig { params(value: T.nilable(::Category)).void }
-          def category=(value); end
+            sig { params(value: T.nilable(::Category)).void }
+            def category=(value); end
 
-          sig { params(args: T.untyped, blk: T.untyped).returns(::User) }
-          def create_author(*args, &blk); end
+            sig { params(args: T.untyped, blk: T.untyped).returns(::User) }
+            def create_author(*args, &blk); end
 
-          sig { params(args: T.untyped, blk: T.untyped).returns(::User) }
-          def create_author!(*args, &blk); end
+            sig { params(args: T.untyped, blk: T.untyped).returns(::User) }
+            def create_author!(*args, &blk); end
 
-          sig { params(args: T.untyped, blk: T.untyped).returns(::Category) }
-          def create_category(*args, &blk); end
+            sig { params(args: T.untyped, blk: T.untyped).returns(::Category) }
+            def create_category(*args, &blk); end
 
-          sig { params(args: T.untyped, blk: T.untyped).returns(::Category) }
-          def create_category!(*args, &blk); end
+            sig { params(args: T.untyped, blk: T.untyped).returns(::Category) }
+            def create_category!(*args, &blk); end
 
-          sig { returns(T.nilable(::User)) }
-          def reload_author; end
+            sig { returns(T.nilable(::User)) }
+            def reload_author; end
 
-          sig { returns(T.nilable(::Category)) }
-          def reload_category; end
+            sig { returns(T.nilable(::Category)) }
+            def reload_category; end
+          end
         end
       RUBY
 
@@ -141,18 +141,18 @@ class Tapioca::Compilers::Dsl::ActiveRecordAssociationsSpec < DslSpec
       expected = <<~RUBY
         # typed: strong
         class Post
-          include Post::GeneratedAssociationMethods
-        end
+          include GeneratedAssociationMethods
 
-        module Post::GeneratedAssociationMethods
-          sig { returns(T.nilable(T.untyped)) }
-          def category; end
+          module GeneratedAssociationMethods
+            sig { returns(T.nilable(T.untyped)) }
+            def category; end
 
-          sig { params(value: T.nilable(T.untyped)).void }
-          def category=(value); end
+            sig { params(value: T.nilable(T.untyped)).void }
+            def category=(value); end
 
-          sig { returns(T.nilable(T.untyped)) }
-          def reload_category; end
+            sig { returns(T.nilable(T.untyped)) }
+            def reload_category; end
+          end
         end
       RUBY
 
@@ -179,27 +179,27 @@ class Tapioca::Compilers::Dsl::ActiveRecordAssociationsSpec < DslSpec
       expected = <<~RUBY
         # typed: strong
         class Post
-          include Post::GeneratedAssociationMethods
-        end
+          include GeneratedAssociationMethods
 
-        module Post::GeneratedAssociationMethods
-          sig { returns(T.nilable(::User)) }
-          def author; end
+          module GeneratedAssociationMethods
+            sig { returns(T.nilable(::User)) }
+            def author; end
 
-          sig { params(value: T.nilable(::User)).void }
-          def author=(value); end
+            sig { params(value: T.nilable(::User)).void }
+            def author=(value); end
 
-          sig { params(args: T.untyped, blk: T.untyped).returns(::User) }
-          def build_author(*args, &blk); end
+            sig { params(args: T.untyped, blk: T.untyped).returns(::User) }
+            def build_author(*args, &blk); end
 
-          sig { params(args: T.untyped, blk: T.untyped).returns(::User) }
-          def create_author(*args, &blk); end
+            sig { params(args: T.untyped, blk: T.untyped).returns(::User) }
+            def create_author(*args, &blk); end
 
-          sig { params(args: T.untyped, blk: T.untyped).returns(::User) }
-          def create_author!(*args, &blk); end
+            sig { params(args: T.untyped, blk: T.untyped).returns(::User) }
+            def create_author!(*args, &blk); end
 
-          sig { returns(T.nilable(::User)) }
-          def reload_author; end
+            sig { returns(T.nilable(::User)) }
+            def reload_author; end
+          end
         end
       RUBY
 
@@ -219,21 +219,21 @@ class Tapioca::Compilers::Dsl::ActiveRecordAssociationsSpec < DslSpec
       expected = <<~RUBY
         # typed: strong
         class Post
-          include Post::GeneratedAssociationMethods
-        end
+          include GeneratedAssociationMethods
 
-        module Post::GeneratedAssociationMethods
-          sig { returns(T::Array[T.untyped]) }
-          def comment_ids; end
+          module GeneratedAssociationMethods
+            sig { returns(T::Array[T.untyped]) }
+            def comment_ids; end
 
-          sig { params(ids: T::Array[T.untyped]).returns(T::Array[T.untyped]) }
-          def comment_ids=(ids); end
+            sig { params(ids: T::Array[T.untyped]).returns(T::Array[T.untyped]) }
+            def comment_ids=(ids); end
 
-          sig { returns(::ActiveRecord::Associations::CollectionProxy[Comment]) }
-          def comments; end
+            sig { returns(::ActiveRecord::Associations::CollectionProxy[Comment]) }
+            def comments; end
 
-          sig { params(value: T::Enumerable[T.untyped]).void }
-          def comments=(value); end
+            sig { params(value: T::Enumerable[T.untyped]).void }
+            def comments=(value); end
+          end
         end
       RUBY
 
@@ -268,33 +268,33 @@ class Tapioca::Compilers::Dsl::ActiveRecordAssociationsSpec < DslSpec
       expected = <<~RUBY
         # typed: strong
         class Post
-          include Post::GeneratedAssociationMethods
-        end
+          include GeneratedAssociationMethods
 
-        module Post::GeneratedAssociationMethods
-          sig { returns(T::Array[T.untyped]) }
-          def comment_ids; end
+          module GeneratedAssociationMethods
+            sig { returns(T::Array[T.untyped]) }
+            def comment_ids; end
 
-          sig { params(ids: T::Array[T.untyped]).returns(T::Array[T.untyped]) }
-          def comment_ids=(ids); end
+            sig { params(ids: T::Array[T.untyped]).returns(T::Array[T.untyped]) }
+            def comment_ids=(ids); end
 
-          sig { returns(T::Array[T.untyped]) }
-          def commenter_ids; end
+            sig { returns(T::Array[T.untyped]) }
+            def commenter_ids; end
 
-          sig { params(ids: T::Array[T.untyped]).returns(T::Array[T.untyped]) }
-          def commenter_ids=(ids); end
+            sig { params(ids: T::Array[T.untyped]).returns(T::Array[T.untyped]) }
+            def commenter_ids=(ids); end
 
-          sig { returns(::ActiveRecord::Associations::CollectionProxy[Commenter]) }
-          def commenters; end
+            sig { returns(::ActiveRecord::Associations::CollectionProxy[Commenter]) }
+            def commenters; end
 
-          sig { params(value: T::Enumerable[::Commenter]).void }
-          def commenters=(value); end
+            sig { params(value: T::Enumerable[::Commenter]).void }
+            def commenters=(value); end
 
-          sig { returns(::ActiveRecord::Associations::CollectionProxy[Comment]) }
-          def comments; end
+            sig { returns(::ActiveRecord::Associations::CollectionProxy[Comment]) }
+            def comments; end
 
-          sig { params(value: T::Enumerable[::Comment]).void }
-          def comments=(value); end
+            sig { params(value: T::Enumerable[::Comment]).void }
+            def comments=(value); end
+          end
         end
       RUBY
 
@@ -315,21 +315,21 @@ class Tapioca::Compilers::Dsl::ActiveRecordAssociationsSpec < DslSpec
       expected = <<~RUBY
         # typed: strong
         class Post
-          include Post::GeneratedAssociationMethods
-        end
+          include GeneratedAssociationMethods
 
-        module Post::GeneratedAssociationMethods
-          sig { returns(T::Array[T.untyped]) }
-          def commenter_ids; end
+          module GeneratedAssociationMethods
+            sig { returns(T::Array[T.untyped]) }
+            def commenter_ids; end
 
-          sig { params(ids: T::Array[T.untyped]).returns(T::Array[T.untyped]) }
-          def commenter_ids=(ids); end
+            sig { params(ids: T::Array[T.untyped]).returns(T::Array[T.untyped]) }
+            def commenter_ids=(ids); end
 
-          sig { returns(::ActiveRecord::Associations::CollectionProxy[Commenter]) }
-          def commenters; end
+            sig { returns(::ActiveRecord::Associations::CollectionProxy[Commenter]) }
+            def commenters; end
 
-          sig { params(value: T::Enumerable[T.untyped]).void }
-          def commenters=(value); end
+            sig { params(value: T::Enumerable[T.untyped]).void }
+            def commenters=(value); end
+          end
         end
       RUBY
 

--- a/spec/tapioca/compilers/dsl/active_record_columns_spec.rb
+++ b/spec/tapioca/compilers/dsl/active_record_columns_spec.rb
@@ -68,66 +68,66 @@ class Tapioca::Compilers::Dsl::ActiveRecordColumnsSpec < DslSpec
         expected = <<~RUBY
           # typed: strong
           class Post
-            include Post::GeneratedAttributeMethods
-          end
+            include GeneratedAttributeMethods
 
-          module Post::GeneratedAttributeMethods
-            sig { returns(T.nilable(::Integer)) }
-            def id; end
+            module GeneratedAttributeMethods
+              sig { returns(T.nilable(::Integer)) }
+              def id; end
 
-            sig { params(value: ::Integer).returns(::Integer) }
-            def id=(value); end
+              sig { params(value: ::Integer).returns(::Integer) }
+              def id=(value); end
 
-            sig { returns(T::Boolean) }
-            def id?; end
+              sig { returns(T::Boolean) }
+              def id?; end
 
-            sig { returns(T.nilable(::Integer)) }
-            def id_before_last_save; end
+              sig { returns(T.nilable(::Integer)) }
+              def id_before_last_save; end
 
-            sig { returns(T.untyped) }
-            def id_before_type_cast; end
+              sig { returns(T.untyped) }
+              def id_before_type_cast; end
 
-            sig { returns(T::Boolean) }
-            def id_came_from_user?; end
+              sig { returns(T::Boolean) }
+              def id_came_from_user?; end
 
-            sig { returns(T.nilable([T.nilable(::Integer), T.nilable(::Integer)])) }
-            def id_change; end
+              sig { returns(T.nilable([T.nilable(::Integer), T.nilable(::Integer)])) }
+              def id_change; end
 
-            sig { returns(T.nilable([T.nilable(::Integer), T.nilable(::Integer)])) }
-            def id_change_to_be_saved; end
+              sig { returns(T.nilable([T.nilable(::Integer), T.nilable(::Integer)])) }
+              def id_change_to_be_saved; end
 
-            sig { returns(T::Boolean) }
-            def id_changed?; end
+              sig { returns(T::Boolean) }
+              def id_changed?; end
 
-            sig { returns(T.nilable(::Integer)) }
-            def id_in_database; end
+              sig { returns(T.nilable(::Integer)) }
+              def id_in_database; end
 
-            sig { returns(T.nilable([T.nilable(::Integer), T.nilable(::Integer)])) }
-            def id_previous_change; end
+              sig { returns(T.nilable([T.nilable(::Integer), T.nilable(::Integer)])) }
+              def id_previous_change; end
 
-            sig { returns(T::Boolean) }
-            def id_previously_changed?; end
+              sig { returns(T::Boolean) }
+              def id_previously_changed?; end
 
-            sig { returns(T.nilable(::Integer)) }
-            def id_previously_was; end
+              sig { returns(T.nilable(::Integer)) }
+              def id_previously_was; end
 
-            sig { returns(T.nilable(::Integer)) }
-            def id_was; end
+              sig { returns(T.nilable(::Integer)) }
+              def id_was; end
 
-            sig { void }
-            def id_will_change!; end
+              sig { void }
+              def id_will_change!; end
 
-            sig { void }
-            def restore_id!; end
+              sig { void }
+              def restore_id!; end
 
-            sig { returns(T.nilable([T.nilable(::Integer), T.nilable(::Integer)])) }
-            def saved_change_to_id; end
+              sig { returns(T.nilable([T.nilable(::Integer), T.nilable(::Integer)])) }
+              def saved_change_to_id; end
 
-            sig { returns(T::Boolean) }
-            def saved_change_to_id?; end
+              sig { returns(T::Boolean) }
+              def saved_change_to_id?; end
 
-            sig { returns(T::Boolean) }
-            def will_save_change_to_id?; end
+              sig { returns(T::Boolean) }
+              def will_save_change_to_id?; end
+            end
           end
         RUBY
 
@@ -156,8 +156,8 @@ class Tapioca::Compilers::Dsl::ActiveRecordColumnsSpec < DslSpec
           RUBY
         }
 
-        expected = <<~RUBY
-          module Post::GeneratedAttributeMethods
+        expected = indented(<<~RUBY, 2)
+          module GeneratedAttributeMethods
             sig { returns(T.nilable(::String)) }
             def body; end
 
@@ -192,8 +192,8 @@ class Tapioca::Compilers::Dsl::ActiveRecordColumnsSpec < DslSpec
           RUBY
         }
 
-        expected = <<~RUBY
-          module Post::GeneratedAttributeMethods
+        expected = indented(<<~RUBY, 2)
+          module GeneratedAttributeMethods
             sig { returns(T.untyped) }
             def body; end
 
@@ -233,7 +233,7 @@ class Tapioca::Compilers::Dsl::ActiveRecordColumnsSpec < DslSpec
 
         output = rbi_for(:Post, files)
 
-        expected = indented(<<~RUBY, 2)
+        expected = indented(<<~RUBY, 4)
           sig { returns(T.nilable(::String)) }
           def body; end
 
@@ -245,7 +245,7 @@ class Tapioca::Compilers::Dsl::ActiveRecordColumnsSpec < DslSpec
         RUBY
         assert_includes(output, expected)
 
-        expected = indented(<<~RUBY, 2)
+        expected = indented(<<~RUBY, 4)
           sig { returns(::String) }
           def title; end
 
@@ -288,43 +288,43 @@ class Tapioca::Compilers::Dsl::ActiveRecordColumnsSpec < DslSpec
 
         output = rbi_for(:Post, files)
 
-        expected = indented(<<~RUBY, 2)
+        expected = indented(<<~RUBY, 4)
           sig { params(value: T.nilable(::Integer)).returns(T.nilable(::Integer)) }
           def integer_column=(value); end
         RUBY
         assert_includes(output, expected)
 
-        expected = indented(<<~RUBY, 2)
+        expected = indented(<<~RUBY, 4)
           sig { params(value: T.nilable(::String)).returns(T.nilable(::String)) }
           def string_column=(value); end
         RUBY
         assert_includes(output, expected)
 
-        expected = indented(<<~RUBY, 2)
+        expected = indented(<<~RUBY, 4)
           sig { params(value: T.nilable(::Date)).returns(T.nilable(::Date)) }
           def date_column=(value); end
         RUBY
         assert_includes(output, expected)
 
-        expected = indented(<<~RUBY, 2)
+        expected = indented(<<~RUBY, 4)
           sig { params(value: T.nilable(::BigDecimal)).returns(T.nilable(::BigDecimal)) }
           def decimal_column=(value); end
         RUBY
         assert_includes(output, expected)
 
-        expected = indented(<<~RUBY, 2)
+        expected = indented(<<~RUBY, 4)
           sig { params(value: T.nilable(::Float)).returns(T.nilable(::Float)) }
           def float_column=(value); end
         RUBY
         assert_includes(output, expected)
 
-        expected = indented(<<~RUBY, 2)
+        expected = indented(<<~RUBY, 4)
           sig { params(value: T.nilable(T::Boolean)).returns(T.nilable(T::Boolean)) }
           def boolean_column=(value); end
         RUBY
         assert_includes(output, expected)
 
-        expected = indented(<<~RUBY, 2)
+        expected = indented(<<~RUBY, 4)
           sig { params(value: T.nilable(::DateTime)).returns(T.nilable(::DateTime)) }
           def datetime_column=(value); end
         RUBY
@@ -358,19 +358,19 @@ class Tapioca::Compilers::Dsl::ActiveRecordColumnsSpec < DslSpec
 
         output = rbi_for(:Post, files)
 
-        expected = indented(<<~RUBY, 2)
+        expected = indented(<<~RUBY, 4)
           sig { params(value: T.nilable(::ActiveSupport::TimeWithZone)).returns(T.nilable(::ActiveSupport::TimeWithZone)) }
           def timestamp_column=(value); end
         RUBY
         assert_includes(output, expected)
 
-        expected = indented(<<~RUBY, 2)
+        expected = indented(<<~RUBY, 4)
           sig { params(value: T.nilable(::ActiveSupport::TimeWithZone)).returns(T.nilable(::ActiveSupport::TimeWithZone)) }
           def datetime_column=(value); end
         RUBY
         assert_includes(output, expected)
 
-        expected = indented(<<~RUBY, 2)
+        expected = indented(<<~RUBY, 4)
           sig { params(value: T.nilable(::ActiveSupport::TimeWithZone)).returns(T.nilable(::ActiveSupport::TimeWithZone)) }
           def time_column=(value); end
         RUBY
@@ -402,8 +402,8 @@ class Tapioca::Compilers::Dsl::ActiveRecordColumnsSpec < DslSpec
 
         output = rbi_for(:Post, files)
 
-        expected = <<~RUBY
-          module Post::GeneratedAttributeMethods
+        expected = indented(<<~RUBY, 2)
+          module GeneratedAttributeMethods
             sig { returns(T.nilable(::String)) }
             def author; end
 
@@ -448,13 +448,13 @@ class Tapioca::Compilers::Dsl::ActiveRecordColumnsSpec < DslSpec
         RUBY
         assert_includes(output, expected)
 
-        expected = indented(<<~RUBY, 2)
+        expected = indented(<<~RUBY, 4)
           sig { void }
           def restore_author!; end
         RUBY
         assert_includes(output, expected)
 
-        expected = indented(<<~RUBY, 2)
+        expected = indented(<<~RUBY, 4)
           sig { returns(T.nilable([T.nilable(::String), T.nilable(::String)])) }
           def saved_change_to_author; end
 
@@ -463,7 +463,7 @@ class Tapioca::Compilers::Dsl::ActiveRecordColumnsSpec < DslSpec
         RUBY
         assert_includes(output, expected)
 
-        expected = indented(<<~RUBY, 2)
+        expected = indented(<<~RUBY, 4)
           sig { returns(T::Boolean) }
           def will_save_change_to_author?; end
         RUBY
@@ -495,8 +495,8 @@ class Tapioca::Compilers::Dsl::ActiveRecordColumnsSpec < DslSpec
 
         output = rbi_for(:Post, files)
 
-        expected = <<~RUBY
-          module Post::GeneratedAttributeMethods
+        expected = indented(<<~RUBY, 2)
+          module GeneratedAttributeMethods
             sig { returns(T.nilable(::String)) }
             def body; end
 
@@ -544,13 +544,13 @@ class Tapioca::Compilers::Dsl::ActiveRecordColumnsSpec < DslSpec
         RUBY
         assert_includes(output, expected)
 
-        expected = indented(<<~RUBY, 2)
+        expected = indented(<<~RUBY, 4)
           sig { void }
           def restore_body!; end
         RUBY
         assert_includes(output, expected)
 
-        expected = indented(<<~RUBY, 2)
+        expected = indented(<<~RUBY, 4)
           sig { returns(T.nilable([T.nilable(::String), T.nilable(::String)])) }
           def saved_change_to_body; end
 
@@ -559,7 +559,7 @@ class Tapioca::Compilers::Dsl::ActiveRecordColumnsSpec < DslSpec
         RUBY
         assert_includes(output, expected)
 
-        expected = indented(<<~RUBY, 2)
+        expected = indented(<<~RUBY, 4)
           sig { returns(T::Boolean) }
           def will_save_change_to_body?; end
         RUBY
@@ -607,7 +607,7 @@ class Tapioca::Compilers::Dsl::ActiveRecordColumnsSpec < DslSpec
           RUBY
         }
 
-        expected = indented(<<~RUBY, 2)
+        expected = indented(<<~RUBY, 4)
           sig { returns(T.nilable(Money)) }
           def cost; end
 
@@ -661,7 +661,7 @@ class Tapioca::Compilers::Dsl::ActiveRecordColumnsSpec < DslSpec
           RUBY
         }
 
-        expected = indented(<<~RUBY, 2)
+        expected = indented(<<~RUBY, 4)
           sig { returns(T.nilable(T.any(Money, Numeric))) }
           def cost; end
 
@@ -714,7 +714,7 @@ class Tapioca::Compilers::Dsl::ActiveRecordColumnsSpec < DslSpec
           RUBY
         }
 
-        expected = indented(<<~RUBY, 2)
+        expected = indented(<<~RUBY, 4)
           sig { returns(T.nilable(Money)) }
           def cost; end
 
@@ -764,7 +764,7 @@ class Tapioca::Compilers::Dsl::ActiveRecordColumnsSpec < DslSpec
           RUBY
         }
 
-        expected = indented(<<~RUBY, 2)
+        expected = indented(<<~RUBY, 4)
           sig { returns(T.nilable(T.untyped)) }
           def cost; end
 
@@ -815,7 +815,7 @@ class Tapioca::Compilers::Dsl::ActiveRecordColumnsSpec < DslSpec
           RUBY
         }
 
-        expected = indented(<<~RUBY, 2)
+        expected = indented(<<~RUBY, 4)
           sig { returns(T.nilable(T.untyped)) }
           def cost; end
 

--- a/spec/tapioca/compilers/dsl/active_record_enum_spec.rb
+++ b/spec/tapioca/compilers/dsl/active_record_enum_spec.rb
@@ -38,24 +38,24 @@ class Tapioca::Compilers::Dsl::ActiveRecordEnumSpec < DslSpec
       expected = <<~RUBY
         # typed: strong
         class Conversation
-          include Conversation::EnumMethodsModule
+          include EnumMethodsModule
+
+          module EnumMethodsModule
+            sig { void }
+            def active!; end
+
+            sig { returns(T::Boolean) }
+            def active?; end
+
+            sig { void }
+            def archived!; end
+
+            sig { returns(T::Boolean) }
+            def archived?; end
+          end
 
           sig { returns(T::Hash[T.any(String, Symbol), Integer]) }
           def self.statuses; end
-        end
-
-        module Conversation::EnumMethodsModule
-          sig { void }
-          def active!; end
-
-          sig { returns(T::Boolean) }
-          def active?; end
-
-          sig { void }
-          def archived!; end
-
-          sig { returns(T::Boolean) }
-          def archived?; end
         end
       RUBY
 
@@ -73,24 +73,24 @@ class Tapioca::Compilers::Dsl::ActiveRecordEnumSpec < DslSpec
       expected = <<~RUBY
         # typed: strong
         class Conversation
-          include Conversation::EnumMethodsModule
+          include EnumMethodsModule
+
+          module EnumMethodsModule
+            sig { void }
+            def active!; end
+
+            sig { returns(T::Boolean) }
+            def active?; end
+
+            sig { void }
+            def archived!; end
+
+            sig { returns(T::Boolean) }
+            def archived?; end
+          end
 
           sig { returns(T::Hash[T.any(String, Symbol), String]) }
           def self.statuses; end
-        end
-
-        module Conversation::EnumMethodsModule
-          sig { void }
-          def active!; end
-
-          sig { returns(T::Boolean) }
-          def active?; end
-
-          sig { void }
-          def archived!; end
-
-          sig { returns(T::Boolean) }
-          def archived?; end
         end
       RUBY
 
@@ -108,30 +108,30 @@ class Tapioca::Compilers::Dsl::ActiveRecordEnumSpec < DslSpec
       expected = <<~RUBY
         # typed: strong
         class Conversation
-          include Conversation::EnumMethodsModule
+          include EnumMethodsModule
+
+          module EnumMethodsModule
+            sig { void }
+            def active!; end
+
+            sig { returns(T::Boolean) }
+            def active?; end
+
+            sig { void }
+            def archived!; end
+
+            sig { returns(T::Boolean) }
+            def archived?; end
+
+            sig { void }
+            def inactive!; end
+
+            sig { returns(T::Boolean) }
+            def inactive?; end
+          end
 
           sig { returns(T::Hash[T.any(String, Symbol), T.any(Integer, TrueClass, String)]) }
           def self.statuses; end
-        end
-
-        module Conversation::EnumMethodsModule
-          sig { void }
-          def active!; end
-
-          sig { returns(T::Boolean) }
-          def active?; end
-
-          sig { void }
-          def archived!; end
-
-          sig { returns(T::Boolean) }
-          def archived?; end
-
-          sig { void }
-          def inactive!; end
-
-          sig { returns(T::Boolean) }
-          def inactive?; end
         end
       RUBY
 
@@ -150,39 +150,39 @@ class Tapioca::Compilers::Dsl::ActiveRecordEnumSpec < DslSpec
       expected = <<~RUBY
         # typed: strong
         class Conversation
-          include Conversation::EnumMethodsModule
+          include EnumMethodsModule
+
+          module EnumMethodsModule
+            sig { void }
+            def active!; end
+
+            sig { returns(T::Boolean) }
+            def active?; end
+
+            sig { void }
+            def archived!; end
+
+            sig { returns(T::Boolean) }
+            def archived?; end
+
+            sig { void }
+            def off!; end
+
+            sig { returns(T::Boolean) }
+            def off?; end
+
+            sig { void }
+            def on!; end
+
+            sig { returns(T::Boolean) }
+            def on?; end
+          end
 
           sig { returns(T::Hash[T.any(String, Symbol), Integer]) }
           def self.comments_statuses; end
 
           sig { returns(T::Hash[T.any(String, Symbol), Integer]) }
           def self.statuses; end
-        end
-
-        module Conversation::EnumMethodsModule
-          sig { void }
-          def active!; end
-
-          sig { returns(T::Boolean) }
-          def active?; end
-
-          sig { void }
-          def archived!; end
-
-          sig { returns(T::Boolean) }
-          def archived?; end
-
-          sig { void }
-          def off!; end
-
-          sig { returns(T::Boolean) }
-          def off?; end
-
-          sig { void }
-          def on!; end
-
-          sig { returns(T::Boolean) }
-          def on?; end
         end
       RUBY
 
@@ -201,57 +201,57 @@ class Tapioca::Compilers::Dsl::ActiveRecordEnumSpec < DslSpec
       expected = <<~RUBY
         # typed: strong
         class Conversation
-          include Conversation::EnumMethodsModule
+          include EnumMethodsModule
+
+          module EnumMethodsModule
+            sig { void }
+            def active!; end
+
+            sig { returns(T::Boolean) }
+            def active?; end
+
+            sig { void }
+            def archived!; end
+
+            sig { returns(T::Boolean) }
+            def archived?; end
+
+            sig { void }
+            def inactive!; end
+
+            sig { returns(T::Boolean) }
+            def inactive?; end
+
+            sig { void }
+            def off!; end
+
+            sig { returns(T::Boolean) }
+            def off?; end
+
+            sig { void }
+            def on!; end
+
+            sig { returns(T::Boolean) }
+            def on?; end
+
+            sig { void }
+            def ongoing!; end
+
+            sig { returns(T::Boolean) }
+            def ongoing?; end
+
+            sig { void }
+            def topic!; end
+
+            sig { returns(T::Boolean) }
+            def topic?; end
+          end
 
           sig { returns(T::Hash[T.any(String, Symbol), T.any(Integer, FalseClass, String, Array)]) }
           def self.comments_statuses; end
 
           sig { returns(T::Hash[T.any(String, Symbol), T.any(Integer, TrueClass, String)]) }
           def self.statuses; end
-        end
-
-        module Conversation::EnumMethodsModule
-          sig { void }
-          def active!; end
-
-          sig { returns(T::Boolean) }
-          def active?; end
-
-          sig { void }
-          def archived!; end
-
-          sig { returns(T::Boolean) }
-          def archived?; end
-
-          sig { void }
-          def inactive!; end
-
-          sig { returns(T::Boolean) }
-          def inactive?; end
-
-          sig { void }
-          def off!; end
-
-          sig { returns(T::Boolean) }
-          def off?; end
-
-          sig { void }
-          def on!; end
-
-          sig { returns(T::Boolean) }
-          def on?; end
-
-          sig { void }
-          def ongoing!; end
-
-          sig { returns(T::Boolean) }
-          def ongoing?; end
-
-          sig { void }
-          def topic!; end
-
-          sig { returns(T::Boolean) }
-          def topic?; end
         end
       RUBY
 
@@ -269,24 +269,24 @@ class Tapioca::Compilers::Dsl::ActiveRecordEnumSpec < DslSpec
       expected = <<~RUBY
         # typed: strong
         class Conversation
-          include Conversation::EnumMethodsModule
+          include EnumMethodsModule
+
+          module EnumMethodsModule
+            sig { void }
+            def active_status!; end
+
+            sig { returns(T::Boolean) }
+            def active_status?; end
+
+            sig { void }
+            def archived_status!; end
+
+            sig { returns(T::Boolean) }
+            def archived_status?; end
+          end
 
           sig { returns(T::Hash[T.any(String, Symbol), Integer]) }
           def self.statuses; end
-        end
-
-        module Conversation::EnumMethodsModule
-          sig { void }
-          def active_status!; end
-
-          sig { returns(T::Boolean) }
-          def active_status?; end
-
-          sig { void }
-          def archived_status!; end
-
-          sig { returns(T::Boolean) }
-          def archived_status?; end
         end
       RUBY
 
@@ -304,24 +304,24 @@ class Tapioca::Compilers::Dsl::ActiveRecordEnumSpec < DslSpec
       expected = <<~RUBY
         # typed: strong
         class Conversation
-          include Conversation::EnumMethodsModule
+          include EnumMethodsModule
+
+          module EnumMethodsModule
+            sig { void }
+            def comments_active!; end
+
+            sig { returns(T::Boolean) }
+            def comments_active?; end
+
+            sig { void }
+            def comments_archived!; end
+
+            sig { returns(T::Boolean) }
+            def comments_archived?; end
+          end
 
           sig { returns(T::Hash[T.any(String, Symbol), Integer]) }
           def self.statuses; end
-        end
-
-        module Conversation::EnumMethodsModule
-          sig { void }
-          def comments_active!; end
-
-          sig { returns(T::Boolean) }
-          def comments_active?; end
-
-          sig { void }
-          def comments_archived!; end
-
-          sig { returns(T::Boolean) }
-          def comments_archived?; end
         end
       RUBY
 

--- a/spec/tapioca/compilers/dsl/active_record_scope_spec.rb
+++ b/spec/tapioca/compilers/dsl/active_record_scope_spec.rb
@@ -53,12 +53,12 @@ class Tapioca::Compilers::Dsl::ActiveRecordScopeSpec < DslSpec
       expected = <<~RUBY
         # typed: strong
         class Post
-          extend Post::GeneratedRelationMethods
-        end
+          extend GeneratedRelationMethods
 
-        module Post::GeneratedRelationMethods
-          sig { params(args: T.untyped, blk: T.untyped).returns(T.untyped) }
-          def public_kind(*args, &blk); end
+          module GeneratedRelationMethods
+            sig { params(args: T.untyped, blk: T.untyped).returns(T.untyped) }
+            def public_kind(*args, &blk); end
+          end
         end
       RUBY
 
@@ -77,15 +77,15 @@ class Tapioca::Compilers::Dsl::ActiveRecordScopeSpec < DslSpec
       expected = <<~RUBY
         # typed: strong
         class Post
-          extend Post::GeneratedRelationMethods
-        end
+          extend GeneratedRelationMethods
 
-        module Post::GeneratedRelationMethods
-          sig { params(args: T.untyped, blk: T.untyped).returns(T.untyped) }
-          def private_kind(*args, &blk); end
+          module GeneratedRelationMethods
+            sig { params(args: T.untyped, blk: T.untyped).returns(T.untyped) }
+            def private_kind(*args, &blk); end
 
-          sig { params(args: T.untyped, blk: T.untyped).returns(T.untyped) }
-          def public_kind(*args, &blk); end
+            sig { params(args: T.untyped, blk: T.untyped).returns(T.untyped) }
+            def public_kind(*args, &blk); end
+          end
         end
       RUBY
 

--- a/spec/tapioca/compilers/dsl/frozen_record_spec.rb
+++ b/spec/tapioca/compilers/dsl/frozen_record_spec.rb
@@ -68,27 +68,27 @@ class Tapioca::Compilers::Dsl::FrozenRecordSpec < DslSpec
       expected = <<~RUBY
         # typed: strong
         class Student
-          include Student::FrozenRecordAttributeMethods
-        end
+          include FrozenRecordAttributeMethods
 
-        module Student::FrozenRecordAttributeMethods
-          sig { returns(T.untyped) }
-          def first_name; end
+          module FrozenRecordAttributeMethods
+            sig { returns(T.untyped) }
+            def first_name; end
 
-          sig { returns(T::Boolean) }
-          def first_name?; end
+            sig { returns(T::Boolean) }
+            def first_name?; end
 
-          sig { returns(T.untyped) }
-          def id; end
+            sig { returns(T.untyped) }
+            def id; end
 
-          sig { returns(T::Boolean) }
-          def id?; end
+            sig { returns(T::Boolean) }
+            def id?; end
 
-          sig { returns(T.untyped) }
-          def last_name; end
+            sig { returns(T.untyped) }
+            def last_name; end
 
-          sig { returns(T::Boolean) }
-          def last_name?; end
+            sig { returns(T::Boolean) }
+            def last_name?; end
+          end
         end
       RUBY
 

--- a/spec/tapioca/compilers/dsl/state_machines_spec.rb
+++ b/spec/tapioca/compilers/dsl/state_machines_spec.rb
@@ -49,75 +49,75 @@ class Tapioca::Compilers::Dsl::StateMachinesSpec < DslSpec
       expected = <<~RUBY
         # typed: strong
         class Vehicle
-          include Vehicle::StateMachineInstanceHelperModule
-          extend Vehicle::StateMachineClassHelperModule
-        end
+          include StateMachineInstanceHelperModule
+          extend StateMachineClassHelperModule
 
-        module Vehicle::StateMachineClassHelperModule
-          sig { params(event: T.any(String, Symbol)).returns(String) }
-          def human_alarm_state_event_name(event); end
+          module StateMachineClassHelperModule
+            sig { params(event: T.any(String, Symbol)).returns(String) }
+            def human_alarm_state_event_name(event); end
 
-          sig { params(state: T.any(String, Symbol)).returns(String) }
-          def human_alarm_state_name(state); end
-        end
+            sig { params(state: T.any(String, Symbol)).returns(String) }
+            def human_alarm_state_name(state); end
+          end
 
-        module Vehicle::StateMachineInstanceHelperModule
-          sig { returns(T::Boolean) }
-          def alarm_active?; end
+          module StateMachineInstanceHelperModule
+            sig { returns(T::Boolean) }
+            def alarm_active?; end
 
-          sig { returns(T::Boolean) }
-          def alarm_off?; end
+            sig { returns(T::Boolean) }
+            def alarm_off?; end
 
-          sig { returns(Integer) }
-          def alarm_state; end
+            sig { returns(Integer) }
+            def alarm_state; end
 
-          sig { params(value: Integer).returns(Integer) }
-          def alarm_state=(value); end
+            sig { params(value: Integer).returns(Integer) }
+            def alarm_state=(value); end
 
-          sig { params(state: T.any(String, Symbol)).returns(T::Boolean) }
-          def alarm_state?(state); end
+            sig { params(state: T.any(String, Symbol)).returns(T::Boolean) }
+            def alarm_state?(state); end
 
-          sig { params(args: T.untyped).returns(T::Array[T.any(String, Symbol)]) }
-          def alarm_state_events(*args); end
+            sig { params(args: T.untyped).returns(T::Array[T.any(String, Symbol)]) }
+            def alarm_state_events(*args); end
 
-          sig { returns(T.any(String, Symbol)) }
-          def alarm_state_name; end
+            sig { returns(T.any(String, Symbol)) }
+            def alarm_state_name; end
 
-          sig { params(args: T.untyped).returns(T::Array[::StateMachines::Transition]) }
-          def alarm_state_paths(*args); end
+            sig { params(args: T.untyped).returns(T::Array[::StateMachines::Transition]) }
+            def alarm_state_paths(*args); end
 
-          sig { params(args: T.untyped).returns(T::Array[::StateMachines::Transition]) }
-          def alarm_state_transitions(*args); end
+            sig { params(args: T.untyped).returns(T::Array[::StateMachines::Transition]) }
+            def alarm_state_transitions(*args); end
 
-          sig { returns(T::Boolean) }
-          def can_disable_alarm?; end
+            sig { returns(T::Boolean) }
+            def can_disable_alarm?; end
 
-          sig { returns(T::Boolean) }
-          def can_enable_alarm?; end
+            sig { returns(T::Boolean) }
+            def can_enable_alarm?; end
 
-          sig { params(args: T.untyped).returns(T::Boolean) }
-          def disable_alarm(*args); end
+            sig { params(args: T.untyped).returns(T::Boolean) }
+            def disable_alarm(*args); end
 
-          sig { params(args: T.untyped).returns(T::Boolean) }
-          def disable_alarm!(*args); end
+            sig { params(args: T.untyped).returns(T::Boolean) }
+            def disable_alarm!(*args); end
 
-          sig { params(args: T.untyped).returns(T.nilable(::StateMachines::Transition)) }
-          def disable_alarm_transition(*args); end
+            sig { params(args: T.untyped).returns(T.nilable(::StateMachines::Transition)) }
+            def disable_alarm_transition(*args); end
 
-          sig { params(args: T.untyped).returns(T::Boolean) }
-          def enable_alarm(*args); end
+            sig { params(args: T.untyped).returns(T::Boolean) }
+            def enable_alarm(*args); end
 
-          sig { params(args: T.untyped).returns(T::Boolean) }
-          def enable_alarm!(*args); end
+            sig { params(args: T.untyped).returns(T::Boolean) }
+            def enable_alarm!(*args); end
 
-          sig { params(args: T.untyped).returns(T.nilable(::StateMachines::Transition)) }
-          def enable_alarm_transition(*args); end
+            sig { params(args: T.untyped).returns(T.nilable(::StateMachines::Transition)) }
+            def enable_alarm_transition(*args); end
 
-          sig { params(event: T.any(String, Symbol), args: T.untyped).returns(T::Boolean) }
-          def fire_alarm_state_event(event, *args); end
+            sig { params(event: T.any(String, Symbol), args: T.untyped).returns(T::Boolean) }
+            def fire_alarm_state_event(event, *args); end
 
-          sig { returns(String) }
-          def human_alarm_state_name; end
+            sig { returns(String) }
+            def human_alarm_state_name; end
+          end
         end
       RUBY
 
@@ -141,17 +141,16 @@ class Tapioca::Compilers::Dsl::StateMachinesSpec < DslSpec
 
       expected = <<~RUBY
         class Vehicle
-          include Vehicle::StateMachineInstanceHelperModule
-          extend Vehicle::StateMachineClassHelperModule
-        end
+          include StateMachineInstanceHelperModule
+          extend StateMachineClassHelperModule
 
-        module Vehicle::StateMachineClassHelperModule
-          sig { params(event: T.any(String, Symbol)).returns(String) }
-          def human_alarm_state_event_name(event); end
+          module StateMachineClassHelperModule
+            sig { params(event: T.any(String, Symbol)).returns(String) }
+            def human_alarm_state_event_name(event); end
 
-          sig { params(state: T.any(String, Symbol)).returns(String) }
-          def human_alarm_state_name(state); end
-        end
+            sig { params(state: T.any(String, Symbol)).returns(String) }
+            def human_alarm_state_name(state); end
+          end
       RUBY
 
       assert_includes(rbi_for(:Vehicle, content), expected)
@@ -167,8 +166,8 @@ class Tapioca::Compilers::Dsl::StateMachinesSpec < DslSpec
         end
       RUBY
 
-      expected = <<~RUBY
-        module Vehicle::StateMachineInstanceHelperModule
+      expected = indented(<<~RUBY, 2)
+        module StateMachineInstanceHelperModule
           sig { returns(T::Boolean) }
           def alarm_active?; end
 
@@ -218,9 +217,9 @@ class Tapioca::Compilers::Dsl::StateMachinesSpec < DslSpec
         end
       RUBY
 
-      expected = <<~RUBY
+      expected = indented(<<~RUBY, 4)
         sig { params(args: T.untyped).returns(T::Array[::StateMachines::Transition]) }
-          def state_paths(*args); end
+        def state_paths(*args); end
       RUBY
 
       assert_includes(rbi_for(:Vehicle, content), expected)
@@ -249,7 +248,7 @@ class Tapioca::Compilers::Dsl::StateMachinesSpec < DslSpec
         end
       RUBY
 
-      expected = indented(<<~RUBY, 2)
+      expected = indented(<<~RUBY, 4)
         sig { params(states: T.any(String, Symbol)).returns(T.untyped) }
         def with_state(*states); end
 
@@ -283,7 +282,7 @@ class Tapioca::Compilers::Dsl::StateMachinesSpec < DslSpec
         end
       RUBY
 
-      expected = indented(<<~RUBY, 2)
+      expected = indented(<<~RUBY, 4)
         sig { returns(T.nilable(Symbol)) }
         def state_event; end
 

--- a/spec/tapioca/compilers/dsl/url_helpers_spec.rb
+++ b/spec/tapioca/compilers/dsl/url_helpers_spec.rb
@@ -159,8 +159,8 @@ class Tapioca::Compilers::Dsl::UrlHelpersSpec < DslSpec
       expected = <<~RUBY
         # typed: strong
         module GeneratedUrlHelpersModule
-          include ActionDispatch::Routing::PolymorphicRoutes
-          include ActionDispatch::Routing::UrlFor
+          include ::ActionDispatch::Routing::PolymorphicRoutes
+          include ::ActionDispatch::Routing::UrlFor
         end
       RUBY
 
@@ -179,8 +179,8 @@ class Tapioca::Compilers::Dsl::UrlHelpersSpec < DslSpec
       expected = <<~RUBY
         # typed: strong
         module GeneratedPathHelpersModule
-          include ActionDispatch::Routing::PolymorphicRoutes
-          include ActionDispatch::Routing::UrlFor
+          include ::ActionDispatch::Routing::PolymorphicRoutes
+          include ::ActionDispatch::Routing::UrlFor
 
           sig { params(args: T.untyped).returns(String) }
           def edit_index_path(*args); end
@@ -208,8 +208,8 @@ class Tapioca::Compilers::Dsl::UrlHelpersSpec < DslSpec
       expected = <<~RUBY
         # typed: strong
         module GeneratedUrlHelpersModule
-          include ActionDispatch::Routing::PolymorphicRoutes
-          include ActionDispatch::Routing::UrlFor
+          include ::ActionDispatch::Routing::PolymorphicRoutes
+          include ::ActionDispatch::Routing::UrlFor
 
           sig { params(args: T.untyped).returns(String) }
           def edit_index_url(*args); end


### PR DESCRIPTION
### Motivation

Since Sorbet has started checking for accessing private constants and erroring out on referencing a private constant off of its parent, our generated DSL RBI files have started raising errors.

If the declaration of `Bar` was:
```ruby
module Foo
  class Bar
    # some definition
  end
  private_constant :Bar
end
```

then it is illegal to reference `Bar` as `Foo::Bar`. But we had been generating things like:
```ruby
module Foo
  class Bar
    include Foo::Bar::GeneratedMethods
  end
end

module Foo::Bar::GeneratedMethods
end
```

which raises the following error on recent Sorbet versions:
```
Non-private reference to private constant Foo::Bar referenced https://srb.help/5061
      3 |     include Foo::Bar::GeneratedMethods
                      ^^^^^^^^
```

### Implementation

The fix is to generate everything in a nested way, which actually ended up making the code simpler and easier to read as well.

The idea is to generate nested modules on the generated class/module namespace instead of the `root` namespace, which results in the output like below for the example above:
```ruby
module Foo
  class Bar
    include GeneratedMethods

	module GeneratedMethods
	end
  end
end
```

### Tests

No extra tests added, but current ones are updated with new expectations.