### PR TITLE
Use `polymorphic?` instead of `constructable?`

### DIFF
--- a/lib/tapioca/compilers/dsl/active_record_associations.rb
+++ b/lib/tapioca/compilers/dsl/active_record_associations.rb
@@ -152,7 +152,7 @@ module Tapioca
             "reload_#{association_name}",
             return_type: association_type,
           )
-          if reflection.constructable?
+          unless reflection.polymorphic?
             create_method(
               klass,
               "build_#{association_name}",


### PR DESCRIPTION
We've got reports of `tapioca dsl` failing with:

```
undefined method constructable?' for #<ActiveRecord::Reflection::BelongsToReflection> (NoMethodError)`
```

This seems to be related to an API change on Rails master: https://github.com/rails/rails/commit/371b4800266cbf1c659a9068f58412cb7a88e244

This PR uses `polymorphic?` instead of the now removed `constructable?` method.