### PR TITLE
Make Rubocop TargetRubyVersion match gemspec

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,7 +7,7 @@ require:
  - rubocop-sorbet
 
 AllCops:
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 2.4
   Exclude:
   - 'vendor/**/*'
 


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
Rubocop should target the minimum ruby version required by the gem.

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
Updated `.rubocop.yml` to match the minimum required by `tapioca.gemspec`.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->
None, but this can be enforced by enabling `Gemspec/RequiredRubyVersion`. I recommend doing so in https://github.com/Shopify/ruby-style-guide
