### PR TITLE
Ignore ActionControllerHelpers DSL generation for anonymous classes

### DIFF
--- a/lib/tapioca/compilers/dsl/action_controller_helpers.rb
+++ b/lib/tapioca/compilers/dsl/action_controller_helpers.rb
@@ -76,6 +76,8 @@ module Tapioca
             .void
         end
         def decorate(root, constant)
+          return unless constant.name
+
           helper_proxy_name = "#{constant}::HelperProxy"
           helper_methods_name = "#{constant}::HelperMethods"
           proxied_helper_methods = constant._helper_methods.map(&:to_s).map(&:to_sym)

--- a/lib/tapioca/compilers/dsl/action_controller_helpers.rb
+++ b/lib/tapioca/compilers/dsl/action_controller_helpers.rb
@@ -76,8 +76,6 @@ module Tapioca
             .void
         end
         def decorate(root, constant)
-          return unless constant.name
-
           helper_proxy_name = "#{constant}::HelperProxy"
           helper_methods_name = "#{constant}::HelperMethods"
           proxied_helper_methods = constant._helper_methods.map(&:to_s).map(&:to_sym)
@@ -113,7 +111,7 @@ module Tapioca
 
         sig { override.returns(T::Enumerable[Module]) }
         def gather_constants
-          ::ActionController::Base.descendants.reject(&:abstract?)
+          ::ActionController::Base.descendants.reject(&:abstract?).select(&:name)
         end
 
         private

--- a/spec/tapioca/compilers/dsl/action_controller_helpers_spec.rb
+++ b/spec/tapioca/compilers/dsl/action_controller_helpers_spec.rb
@@ -58,6 +58,14 @@ class Tapioca::Compilers::Dsl::ActionControllerHelpersSpec < DslSpec
 
       assert_equal(["UserController"], constants_from(content))
     end
+
+    it("ignores anonymous subclasses of ActionController") do
+      content = <<~RUBY
+        Class.new(ActionController::Base)
+      RUBY
+
+      assert_equal([], constants_from(content))
+    end
   end
 
   describe("#decorate") do
@@ -216,20 +224,6 @@ class Tapioca::Compilers::Dsl::ActionControllerHelpersSpec < DslSpec
       RUBY
 
       assert_equal(expected, rbi_for(:UserController, files))
-    end
-
-    it("generates an empty rbi file for anonymous classes") do
-      anonymous_class = T.unsafe(Class.new(ActionController::Base))
-      action_controller_helpers_dsl = ::Tapioca::Compilers::Dsl::ActionControllerHelpers.new
-      parlour = Parlour::RbiGenerator.new(sort_namespaces: true)
-      action_controller_helpers_dsl.decorate(parlour.root, anonymous_class)
-
-      expected = <<~RUBY
-        # typed: strong
-
-      RUBY
-
-      assert_equal(expected, parlour.rbi)
     end
   end
 end

--- a/spec/tapioca/compilers/dsl/action_controller_helpers_spec.rb
+++ b/spec/tapioca/compilers/dsl/action_controller_helpers_spec.rb
@@ -217,5 +217,19 @@ class Tapioca::Compilers::Dsl::ActionControllerHelpersSpec < DslSpec
 
       assert_equal(expected, rbi_for(:UserController, files))
     end
+
+    it("generates an empty rbi file for anonymous classes") do
+      anonymous_class = T.unsafe(Class.new(ActionController::Base))
+      action_controller_helpers_dsl = ::Tapioca::Compilers::Dsl::ActionControllerHelpers.new
+      parlour = Parlour::RbiGenerator.new(sort_namespaces: true)
+      action_controller_helpers_dsl.decorate(parlour.root, anonymous_class)
+
+      expected = <<~RUBY
+        # typed: strong
+
+      RUBY
+
+      assert_equal(expected, parlour.rbi)
+    end
   end
 end


### PR DESCRIPTION
### Motivation

```
$ bundle exec tapioca dsl

Loading Rails application... Done
Loading DSL generator classes... Done
Compiling DSL RBI files...

bundler: failed to load command: tapioca (/Users/jeffreygoldsmith/.gem/ruby/2.6.6/bin/tapioca)
NameError: wrong constant name #<Class:0x00007f84c8f15550>
  /Users/jeffreygoldsmith/.gem/ruby/2.6.6/gems/parlour-2.1.0/lib/parlour/rbi_generator/namespace.rb:101:in `const_get'
  /Users/jeffreygoldsmith/.gem/ruby/2.6.6/gems/parlour-2.1.0/lib/parlour/rbi_generator/namespace.rb:101:in `block in path'
  /Users/jeffreygoldsmith/.gem/ruby/2.6.6/gems/parlour-2.1.0/lib/parlour/rbi_generator/namespace.rb:100:in `times'
  /Users/jeffreygoldsmith/.gem/ruby/2.6.6/gems/parlour-2.1.0/lib/parlour/rbi_generator/namespace.rb:100:in `each'
  /Users/jeffreygoldsmith/.gem/ruby/2.6.6/gems/parlour-2.1.0/lib/parlour/rbi_generator/namespace.rb:100:in `map'
  /Users/jeffreygoldsmith/.gem/ruby/2.6.6/gems/parlour-2.1.0/lib/parlour/rbi_generator/namespace.rb:100:in `path'
  /Users/jeffreygoldsmith/.gem/ruby/2.6.6/gems/sorbet-runtime-0.5.6006/lib/types/private/methods/_methods.rb:230:in `call'
  /Users/jeffreygoldsmith/.gem/ruby/2.6.6/gems/sorbet-runtime-0.5.6006/lib/types/private/methods/_methods.rb:230:in `block in _on_method_added'
  /Users/jeffreygoldsmith/.gem/ruby/2.6.6/gems/tapioca-0.4.10/lib/tapioca/compilers/dsl/action_controller_helpers.rb:108:in `decorate'
  /Users/jeffreygoldsmith/.gem/ruby/2.6.6/gems/sorbet-runtime-0.5.6006/lib/types/private/methods/_methods.rb:230:in `call'
  /Users/jeffreygoldsmith/.gem/ruby/2.6.6/gems/sorbet-runtime-0.5.6006/lib/types/private/methods/_methods.rb:230:in `block in _on_method_added'
  /Users/jeffreygoldsmith/.gem/ruby/2.6.6/gems/tapioca-0.4.10/lib/tapioca/compilers/dsl_compiler.rb:89:in `block in rbi_for_constant'
  /Users/jeffreygoldsmith/.gem/ruby/2.6.6/gems/tapioca-0.4.10/lib/tapioca/compilers/dsl_compiler.rb:87:in `each'
  /Users/jeffreygoldsmith/.gem/ruby/2.6.6/gems/tapioca-0.4.10/lib/tapioca/compilers/dsl_compiler.rb:87:in `rbi_for_constant'
  /Users/jeffreygoldsmith/.gem/ruby/2.6.6/gems/sorbet-runtime-0.5.6006/lib/types/private/methods/_methods.rb:230:in `call'
  /Users/jeffreygoldsmith/.gem/ruby/2.6.6/gems/sorbet-runtime-0.5.6006/lib/types/private/methods/_methods.rb:230:in `block in _on_method_added'
  /Users/jeffreygoldsmith/.gem/ruby/2.6.6/gems/tapioca-0.4.10/lib/tapioca/compilers/dsl_compiler.rb:48:in `block in run'
  /Users/jeffreygoldsmith/.gem/ruby/2.6.6/gems/tapioca-0.4.10/lib/tapioca/compilers/dsl_compiler.rb:47:in `each'
  /Users/jeffreygoldsmith/.gem/ruby/2.6.6/gems/tapioca-0.4.10/lib/tapioca/compilers/dsl_compiler.rb:47:in `run'
  /Users/jeffreygoldsmith/.gem/ruby/2.6.6/gems/sorbet-runtime-0.5.6006/lib/types/private/methods/_methods.rb:230:in `call'
  /Users/jeffreygoldsmith/.gem/ruby/2.6.6/gems/sorbet-runtime-0.5.6006/lib/types/private/methods/_methods.rb:230:in `block in _on_method_added'
  /Users/jeffreygoldsmith/.gem/ruby/2.6.6/gems/tapioca-0.4.10/lib/tapioca/generator.rb:135:in `build_dsl'
  /Users/jeffreygoldsmith/.gem/ruby/2.6.6/gems/sorbet-runtime-0.5.6006/lib/types/private/methods/_methods.rb:230:in `call'
  /Users/jeffreygoldsmith/.gem/ruby/2.6.6/gems/sorbet-runtime-0.5.6006/lib/types/private/methods/_methods.rb:230:in `block in _on_method_added'
  /Users/jeffreygoldsmith/.gem/ruby/2.6.6/gems/tapioca-0.4.10/lib/tapioca/cli.rb:79:in `block in dsl'
  /Users/jeffreygoldsmith/.gem/ruby/2.6.6/gems/tapioca-0.4.10/lib/tapioca.rb:11:in `block in silence_warnings'
  /opt/rubies/2.6.6/lib/ruby/2.6.0/rubygems/user_interaction.rb:47:in `use_ui'
  /Users/jeffreygoldsmith/.gem/ruby/2.6.6/gems/tapioca-0.4.10/lib/tapioca.rb:10:in `silence_warnings'
  /Users/jeffreygoldsmith/.gem/ruby/2.6.6/gems/tapioca-0.4.10/lib/tapioca/cli.rb:78:in `dsl'
  /Users/jeffreygoldsmith/.gem/ruby/2.6.6/gems/thor-1.0.1/lib/thor/command.rb:27:in `run'
  /Users/jeffreygoldsmith/.gem/ruby/2.6.6/gems/thor-1.0.1/lib/thor/invocation.rb:127:in `invoke_command'
  /Users/jeffreygoldsmith/.gem/ruby/2.6.6/gems/thor-1.0.1/lib/thor.rb:392:in `dispatch'
  /Users/jeffreygoldsmith/.gem/ruby/2.6.6/gems/thor-1.0.1/lib/thor/base.rb:485:in `start'
  /Users/jeffreygoldsmith/.gem/ruby/2.6.6/gems/tapioca-0.4.10/exe/tapioca:6:in `<top (required)>'
  /Users/jeffreygoldsmith/.gem/ruby/2.6.6/bin/tapioca:23:in `load'
  /Users/jeffreygoldsmith/.gem/ruby/2.6.6/bin/tapioca:23:in `<top (required)>'
```

If the `ActionControllerHelpers` DSL generator comes upon an anonymous class, it fails. It should instead ignore these classes and proceed as usual.

### Implementation

Filter out all classes where the class name does not exist

### Tests

A simple gather phase test