### PR TITLE
Fix ActiveRecordColumns spec wrt StrongTypeGeneration

### DIFF
--- a/lib/tapioca/compilers/dsl/active_record_columns.rb
+++ b/lib/tapioca/compilers/dsl/active_record_columns.rb
@@ -17,19 +17,7 @@ module Tapioca
       # This generator is only responsible for defining the attribute methods that would be
       # created for the columns that are defined in the Active Record model.
       #
-      # **Note:** This generator, by default, generates weak signatures for column methods and treats each
-      # column to be `T.untyped`. This is done on purpose to ensure that the nilability of Active Record
-      # columns do not make it hard for existing code to adopt gradual typing. It is possible, however, to
-      # generate stricter type signatures for your Active Record column types. If your Active Record model extends
-      # a module with name `StrongTypeGeneration`, this generator will generate stricter signatures that follow
-      # closely with the types defined in the schema.
-      #
-      # The `StrongTypeGeneration` module you define in your application should add an `after_initialize` callback
-      # to the model and ensure that all the non-nilable attributes of the model are actually initialized with non-`nil`
-      # values.
-      #
       # For example, with the following model class:
-      #
       # ~~~rb
       # class Post < ActiveRecord::Base
       # end
@@ -63,7 +51,7 @@ module Tapioca
       #     sig { params(value: T.nilable(::String)).returns(T.nilable(::String)) }
       #     def body=; end
       #
-      #     sig { params(args: T.untyped).returns(T::Boolean) }
+      #     sig { returns(T::Boolean) }
       #     def body?; end
       #
       #     sig { returns(T.nilable(::ActiveSupport::TimeWithZone)) }
@@ -72,7 +60,7 @@ module Tapioca
       #     sig { params(value: ::ActiveSupport::TimeWithZone).returns(::ActiveSupport::TimeWithZone) }
       #     def created_at=; end
       #
-      #     sig { params(args: T.untyped).returns(T::Boolean) }
+      #     sig { returns(T::Boolean) }
       #     def created_at?; end
       #
       #     sig { returns(T.nilable(T::Boolean)) }
@@ -81,7 +69,7 @@ module Tapioca
       #     sig { params(value: T::Boolean).returns(T::Boolean) }
       #     def published=; end
       #
-      #     sig { params(args: T.untyped).returns(T::Boolean) }
+      #     sig { returns(T::Boolean) }
       #     def published?; end
       #
       #     sig { returns(::String) }
@@ -90,7 +78,7 @@ module Tapioca
       #     sig { params(value: ::String).returns(::String) }
       #     def title=(value); end
       #
-      #     sig { params(args: T.untyped).returns(T::Boolean) }
+      #     sig { returns(T::Boolean) }
       #     def title?(*args); end
       #
       #     sig { returns(T.nilable(::ActiveSupport::TimeWithZone)) }
@@ -99,7 +87,7 @@ module Tapioca
       #     sig { params(value: ::ActiveSupport::TimeWithZone).returns(::ActiveSupport::TimeWithZone) }
       #     def updated_at=; end
       #
-      #     sig { params(args: T.untyped).returns(T::Boolean) }
+      #     sig { returns(T::Boolean) }
       #     def updated_at?; end
       #
       #     ## Also the methods added by https://api.rubyonrails.org/classes/ActiveRecord/AttributeMethods/Dirty.html

--- a/manual/generator_activerecordcolumns.md
+++ b/manual/generator_activerecordcolumns.md
@@ -5,19 +5,7 @@
 This generator is only responsible for defining the attribute methods that would be
 created for the columns that are defined in the Active Record model.
 
-**Note:** This generator, by default, generates weak signatures for column methods and treats each
-column to be `T.untyped`. This is done on purpose to ensure that the nilability of Active Record
-columns do not make it hard for existing code to adopt gradual typing. It is possible, however, to
-generate stricter type signatures for your Active Record column types. If your Active Record model extends
-a module with name `StrongTypeGeneration`, this generator will generate stricter signatures that follow
-closely with the types defined in the schema.
-
-The `StrongTypeGeneration` module you define in your application should add an `after_initialize` callback
-to the model and ensure that all the non-nilable attributes of the model are actually initialized with non-`nil`
-values.
-
 For example, with the following model class:
-
 ~~~rb
 class Post < ActiveRecord::Base
 end
@@ -51,7 +39,7 @@ class Post
     sig { params(value: T.nilable(::String)).returns(T.nilable(::String)) }
     def body=; end
 
-    sig { params(args: T.untyped).returns(T::Boolean) }
+    sig { returns(T::Boolean) }
     def body?; end
 
     sig { returns(T.nilable(::ActiveSupport::TimeWithZone)) }
@@ -60,7 +48,7 @@ class Post
     sig { params(value: ::ActiveSupport::TimeWithZone).returns(::ActiveSupport::TimeWithZone) }
     def created_at=; end
 
-    sig { params(args: T.untyped).returns(T::Boolean) }
+    sig { returns(T::Boolean) }
     def created_at?; end
 
     sig { returns(T.nilable(T::Boolean)) }
@@ -69,7 +57,7 @@ class Post
     sig { params(value: T::Boolean).returns(T::Boolean) }
     def published=; end
 
-    sig { params(args: T.untyped).returns(T::Boolean) }
+    sig { returns(T::Boolean) }
     def published?; end
 
     sig { returns(::String) }
@@ -78,7 +66,7 @@ class Post
     sig { params(value: ::String).returns(::String) }
     def title=(value); end
 
-    sig { params(args: T.untyped).returns(T::Boolean) }
+    sig { returns(T::Boolean) }
     def title?(*args); end
 
     sig { returns(T.nilable(::ActiveSupport::TimeWithZone)) }
@@ -87,7 +75,7 @@ class Post
     sig { params(value: ::ActiveSupport::TimeWithZone).returns(::ActiveSupport::TimeWithZone) }
     def updated_at=; end
 
-    sig { params(args: T.untyped).returns(T::Boolean) }
+    sig { returns(T::Boolean) }
     def updated_at?; end
 
     ## Also the methods added by https://api.rubyonrails.org/classes/ActiveRecord/AttributeMethods/Dirty.html

--- a/spec/tapioca/compilers/dsl/active_record_columns_spec.rb
+++ b/spec/tapioca/compilers/dsl/active_record_columns_spec.rb
@@ -44,786 +44,952 @@ class Tapioca::Compilers::Dsl::ActiveRecordColumnsSpec < DslSpec
         )
       end
 
-      it("generates RBI file for class without custom attributes with StrongTypeGeneration") do
-        files = {
-          "file.rb" => <<~RUBY,
-            module StrongTypeGeneration
-            end
+      describe("by default") do
+        it("generates default columns with strong types") do
+          files = {
+            "file.rb" => <<~RUBY,
+              class Post < ActiveRecord::Base
+              end
+            RUBY
 
-            class Post < ActiveRecord::Base
-              extend StrongTypeGeneration
-            end
-          RUBY
-
-          "schema.rb" => <<~RUBY,
-            ActiveRecord::Migration.suppress_messages do
-              ActiveRecord::Schema.define do
-                create_table :posts do |t|
+            "schema.rb" => <<~RUBY,
+              ActiveRecord::Migration.suppress_messages do
+                ActiveRecord::Schema.define do
+                  create_table :posts do |t|
+                  end
                 end
+              end
+            RUBY
+          }
+
+          expected = <<~RUBY
+            # typed: strong
+            class Post
+              include GeneratedAttributeMethods
+
+              module GeneratedAttributeMethods
+                sig { returns(T.nilable(::Integer)) }
+                def id; end
+
+                sig { params(value: ::Integer).returns(::Integer) }
+                def id=(value); end
+
+                sig { returns(T::Boolean) }
+                def id?; end
+
+                sig { returns(T.nilable(::Integer)) }
+                def id_before_last_save; end
+
+                sig { returns(T.untyped) }
+                def id_before_type_cast; end
+
+                sig { returns(T::Boolean) }
+                def id_came_from_user?; end
+
+                sig { returns(T.nilable([T.nilable(::Integer), T.nilable(::Integer)])) }
+                def id_change; end
+
+                sig { returns(T.nilable([T.nilable(::Integer), T.nilable(::Integer)])) }
+                def id_change_to_be_saved; end
+
+                sig { returns(T::Boolean) }
+                def id_changed?; end
+
+                sig { returns(T.nilable(::Integer)) }
+                def id_in_database; end
+
+                sig { returns(T.nilable([T.nilable(::Integer), T.nilable(::Integer)])) }
+                def id_previous_change; end
+
+                sig { returns(T::Boolean) }
+                def id_previously_changed?; end
+
+                sig { returns(T.nilable(::Integer)) }
+                def id_previously_was; end
+
+                sig { returns(T.nilable(::Integer)) }
+                def id_was; end
+
+                sig { void }
+                def id_will_change!; end
+
+                sig { void }
+                def restore_id!; end
+
+                sig { returns(T.nilable([T.nilable(::Integer), T.nilable(::Integer)])) }
+                def saved_change_to_id; end
+
+                sig { returns(T::Boolean) }
+                def saved_change_to_id?; end
+
+                sig { returns(T::Boolean) }
+                def will_save_change_to_id?; end
               end
             end
           RUBY
-        }
 
-        expected = <<~RUBY
-          # typed: strong
-          class Post
-            include GeneratedAttributeMethods
+          assert_equal(expected, rbi_for(:Post, files))
+        end
 
+        it("generates attributes with strong types") do
+          files = {
+            "file.rb" => <<~RUBY,
+              class Post < ActiveRecord::Base
+              end
+            RUBY
+
+            "schema.rb" => <<~RUBY,
+              ActiveRecord::Migration.suppress_messages do
+                ActiveRecord::Schema.define do
+                  create_table :posts do |t|
+                    t.string :body
+                  end
+                end
+              end
+            RUBY
+          }
+
+          expected = indented(<<~RUBY, 2)
             module GeneratedAttributeMethods
-              sig { returns(T.nilable(::Integer)) }
-              def id; end
+              sig { returns(T.nilable(::String)) }
+              def body; end
 
-              sig { params(value: ::Integer).returns(::Integer) }
-              def id=(value); end
+              sig { params(value: T.nilable(::String)).returns(T.nilable(::String)) }
+              def body=(value); end
 
               sig { returns(T::Boolean) }
-              def id?; end
+              def body?; end
+          RUBY
 
-              sig { returns(T.nilable(::Integer)) }
-              def id_before_last_save; end
+          assert_includes(rbi_for(:Post, files), expected)
+        end
+
+        it("respects nullability of attributes") do
+          files = {
+            "file.rb" => <<~RUBY,
+              class Post < ActiveRecord::Base
+              end
+            RUBY
+
+            "schema.rb" => <<~RUBY,
+              ActiveRecord::Migration.suppress_messages do
+                ActiveRecord::Schema.define do
+                  create_table :posts do |t|
+                    t.string :title, null: false
+                    t.string :body, null: true
+                    t.timestamps
+                  end
+                end
+              end
+            RUBY
+          }
+
+          output = rbi_for(:Post, files)
+
+          expected = indented(<<~RUBY, 4)
+            sig { returns(T.nilable(::String)) }
+            def body; end
+
+            sig { params(value: T.nilable(::String)).returns(T.nilable(::String)) }
+            def body=(value); end
+
+            sig { returns(T::Boolean) }
+            def body?; end
+          RUBY
+          assert_includes(output, expected)
+
+          expected = indented(<<~RUBY, 4)
+            sig { returns(::String) }
+            def title; end
+
+            sig { params(value: ::String).returns(::String) }
+            def title=(value); end
+
+            sig { returns(T::Boolean) }
+            def title?; end
+          RUBY
+          assert_includes(output, expected)
+        end
+
+        it("generates a proper type for every ActiveRecord column type") do
+          files = {
+            "file.rb" => <<~RUBY,
+              class Post < ActiveRecord::Base
+              end
+            RUBY
+
+            "schema.rb" => <<~RUBY,
+              ActiveRecord::Migration.suppress_messages do
+                ActiveRecord::Schema.define do
+                  create_table :posts do |t|
+                    t.integer :integer_column
+                    t.string :string_column
+                    t.date :date_column
+                    t.decimal :decimal_column
+                    t.float :float_column
+                    t.boolean :boolean_column
+                    t.datetime :datetime_column
+                  end
+                end
+              end
+            RUBY
+          }
+
+          output = rbi_for(:Post, files)
+
+          expected = indented(<<~RUBY, 4)
+            sig { params(value: T.nilable(::Integer)).returns(T.nilable(::Integer)) }
+            def integer_column=(value); end
+          RUBY
+          assert_includes(output, expected)
+
+          expected = indented(<<~RUBY, 4)
+            sig { params(value: T.nilable(::String)).returns(T.nilable(::String)) }
+            def string_column=(value); end
+          RUBY
+          assert_includes(output, expected)
+
+          expected = indented(<<~RUBY, 4)
+            sig { params(value: T.nilable(::Date)).returns(T.nilable(::Date)) }
+            def date_column=(value); end
+          RUBY
+          assert_includes(output, expected)
+
+          expected = indented(<<~RUBY, 4)
+            sig { params(value: T.nilable(::BigDecimal)).returns(T.nilable(::BigDecimal)) }
+            def decimal_column=(value); end
+          RUBY
+          assert_includes(output, expected)
+
+          expected = indented(<<~RUBY, 4)
+            sig { params(value: T.nilable(::Float)).returns(T.nilable(::Float)) }
+            def float_column=(value); end
+          RUBY
+          assert_includes(output, expected)
+
+          expected = indented(<<~RUBY, 4)
+            sig { params(value: T.nilable(T::Boolean)).returns(T.nilable(T::Boolean)) }
+            def boolean_column=(value); end
+          RUBY
+          assert_includes(output, expected)
+
+          expected = indented(<<~RUBY, 4)
+            sig { params(value: T.nilable(::DateTime)).returns(T.nilable(::DateTime)) }
+            def datetime_column=(value); end
+          RUBY
+          assert_includes(output, expected)
+        end
+
+        it("generates proper types for time_zone_aware_attributes") do
+          files = {
+            "file.rb" => <<~RUBY,
+              class Post < ActiveRecord::Base
+              end
+            RUBY
+
+            "schema.rb" => <<~RUBY,
+              ActiveRecord::Base.time_zone_aware_attributes = true
+              ActiveRecord::Migration.suppress_messages do
+                ActiveRecord::Schema.define do
+                  create_table :posts do |t|
+                    t.timestamp :timestamp_column
+                    t.datetime :datetime_column
+                    t.time :time_column
+                  end
+                end
+              end
+            RUBY
+          }
+
+          output = rbi_for(:Post, files)
+
+          expected = indented(<<~RUBY, 4)
+            sig { params(value: T.nilable(::ActiveSupport::TimeWithZone)).returns(T.nilable(::ActiveSupport::TimeWithZone)) }
+            def timestamp_column=(value); end
+          RUBY
+          assert_includes(output, expected)
+
+          expected = indented(<<~RUBY, 4)
+            sig { params(value: T.nilable(::ActiveSupport::TimeWithZone)).returns(T.nilable(::ActiveSupport::TimeWithZone)) }
+            def datetime_column=(value); end
+          RUBY
+          assert_includes(output, expected)
+
+          expected = indented(<<~RUBY, 4)
+            sig { params(value: T.nilable(::ActiveSupport::TimeWithZone)).returns(T.nilable(::ActiveSupport::TimeWithZone)) }
+            def time_column=(value); end
+          RUBY
+          assert_includes(output, expected)
+        end
+
+        it("generates methods for alias_attributes") do
+          files = {
+            "file.rb" => <<~RUBY,
+              class Post < ActiveRecord::Base
+                alias_attribute :author, :name
+              end
+            RUBY
+
+            "schema.rb" => <<~RUBY,
+              ActiveRecord::Migration.suppress_messages do
+                ActiveRecord::Schema.define do
+                  create_table :posts do |t|
+                    t.string :name
+                  end
+                end
+              end
+            RUBY
+          }
+
+          output = rbi_for(:Post, files)
+
+          expected = indented(<<~RUBY, 2)
+            module GeneratedAttributeMethods
+              sig { returns(T.nilable(::String)) }
+              def author; end
+
+              sig { params(value: T.nilable(::String)).returns(T.nilable(::String)) }
+              def author=(value); end
+
+              sig { returns(T::Boolean) }
+              def author?; end
+
+              sig { returns(T.nilable(::String)) }
+              def author_before_last_save; end
 
               sig { returns(T.untyped) }
-              def id_before_type_cast; end
+              def author_before_type_cast; end
 
               sig { returns(T::Boolean) }
-              def id_came_from_user?; end
+              def author_came_from_user?; end
 
-              sig { returns(T.nilable([T.nilable(::Integer), T.nilable(::Integer)])) }
-              def id_change; end
+              sig { returns(T.nilable([T.nilable(::String), T.nilable(::String)])) }
+              def author_change; end
 
-              sig { returns(T.nilable([T.nilable(::Integer), T.nilable(::Integer)])) }
-              def id_change_to_be_saved; end
-
-              sig { returns(T::Boolean) }
-              def id_changed?; end
-
-              sig { returns(T.nilable(::Integer)) }
-              def id_in_database; end
-
-              sig { returns(T.nilable([T.nilable(::Integer), T.nilable(::Integer)])) }
-              def id_previous_change; end
+              sig { returns(T.nilable([T.nilable(::String), T.nilable(::String)])) }
+              def author_change_to_be_saved; end
 
               sig { returns(T::Boolean) }
-              def id_previously_changed?; end
+              def author_changed?; end
 
-              sig { returns(T.nilable(::Integer)) }
-              def id_previously_was; end
+              sig { returns(T.nilable(::String)) }
+              def author_in_database; end
 
-              sig { returns(T.nilable(::Integer)) }
-              def id_was; end
+              sig { returns(T.nilable([T.nilable(::String), T.nilable(::String)])) }
+              def author_previous_change; end
+
+              sig { returns(T::Boolean) }
+              def author_previously_changed?; end
+
+              sig { returns(T.nilable(::String)) }
+              def author_was; end
 
               sig { void }
-              def id_will_change!; end
+              def author_will_change!; end
+          RUBY
+          assert_includes(output, expected)
+
+          expected = indented(<<~RUBY, 4)
+            sig { void }
+            def restore_author!; end
+          RUBY
+          assert_includes(output, expected)
+
+          expected = indented(<<~RUBY, 4)
+            sig { returns(T.nilable([T.nilable(::String), T.nilable(::String)])) }
+            def saved_change_to_author; end
+
+            sig { returns(T::Boolean) }
+            def saved_change_to_author?; end
+          RUBY
+          assert_includes(output, expected)
+
+          expected = indented(<<~RUBY, 4)
+            sig { returns(T::Boolean) }
+            def will_save_change_to_author?; end
+          RUBY
+          assert_includes(output, expected)
+        end
+
+        it("ignores conflicting alias_attributes") do
+          files = {
+            "file.rb" => <<~RUBY,
+              class Post < ActiveRecord::Base
+                alias_attribute :body?, :body
+              end
+            RUBY
+
+            "schema.rb" => <<~RUBY,
+              ActiveRecord::Migration.suppress_messages do
+                ActiveRecord::Schema.define do
+                  create_table :posts do |t|
+                    t.string :body
+                  end
+                end
+              end
+            RUBY
+          }
+
+          output = rbi_for(:Post, files)
+
+          expected = indented(<<~RUBY, 2)
+            module GeneratedAttributeMethods
+              sig { returns(T.nilable(::String)) }
+              def body; end
+
+              sig { params(value: T.nilable(::String)).returns(T.nilable(::String)) }
+              def body=(value); end
+
+              sig { returns(T::Boolean) }
+              def body?; end
+
+              sig { returns(T.nilable(::String)) }
+              def body_before_last_save; end
+
+              sig { returns(T.untyped) }
+              def body_before_type_cast; end
+
+              sig { returns(T::Boolean) }
+              def body_came_from_user?; end
+
+              sig { returns(T.nilable([T.nilable(::String), T.nilable(::String)])) }
+              def body_change; end
+
+              sig { returns(T.nilable([T.nilable(::String), T.nilable(::String)])) }
+              def body_change_to_be_saved; end
+
+              sig { returns(T::Boolean) }
+              def body_changed?; end
+
+              sig { returns(T.nilable(::String)) }
+              def body_in_database; end
+
+              sig { returns(T.nilable([T.nilable(::String), T.nilable(::String)])) }
+              def body_previous_change; end
+
+              sig { returns(T::Boolean) }
+              def body_previously_changed?; end
+
+              sig { returns(T.nilable(::String)) }
+              def body_previously_was; end
+
+              sig { returns(T.nilable(::String)) }
+              def body_was; end
 
               sig { void }
-              def restore_id!; end
+              def body_will_change!; end
+          RUBY
+          assert_includes(output, expected)
 
-              sig { returns(T.nilable([T.nilable(::Integer), T.nilable(::Integer)])) }
-              def saved_change_to_id; end
+          expected = indented(<<~RUBY, 4)
+            sig { void }
+            def restore_body!; end
+          RUBY
+          assert_includes(output, expected)
+
+          expected = indented(<<~RUBY, 4)
+            sig { returns(T.nilable([T.nilable(::String), T.nilable(::String)])) }
+            def saved_change_to_body; end
+
+            sig { returns(T::Boolean) }
+            def saved_change_to_body?; end
+          RUBY
+          assert_includes(output, expected)
+
+          expected = indented(<<~RUBY, 4)
+            sig { returns(T::Boolean) }
+            def will_save_change_to_body?; end
+          RUBY
+          assert_includes(output, expected)
+        end
+
+        it("discovers custom type from signature on deserialize method") do
+          files = {
+            "file.rb" => <<~RUBY,
+              class Money
+                attr_accessor :value
+
+                def initialize(number = 0.0)
+                  @value = number
+                end
+
+                class Type < ActiveRecord::Type::Value
+                  extend(T::Sig)
+
+                  sig { params(value: Numeric).returns(::Money)}
+                  def deserialize(value)
+                    Money.new(value)
+                  end
+                end
+              end
+
+              class Post < ActiveRecord::Base
+                attribute :cost, Money::Type.new
+              end
+            RUBY
+
+            "schema.rb" => <<~RUBY,
+              ActiveRecord::Migration.suppress_messages do
+                ActiveRecord::Schema.define do
+                  create_table :posts do |t|
+                    t.decimal :cost
+                  end
+                end
+              end
+            RUBY
+          }
+
+          expected = indented(<<~RUBY, 4)
+            sig { returns(T.nilable(Money)) }
+            def cost; end
+
+            sig { params(value: T.nilable(Money)).returns(T.nilable(Money)) }
+            def cost=(value); end
+          RUBY
+
+          assert_includes(rbi_for(:Post, files), expected)
+        end
+
+        it("discovers custom type from signature on cast method") do
+          files = {
+            "file.rb" => <<~RUBY,
+              class Money
+                attr_accessor :value
+
+                def initialize(number = 0.0)
+                  @value = number
+                end
+
+                class Type < ActiveRecord::Type::Value
+                  extend(T::Sig)
+
+                  sig { params(value: ::Numeric).returns(T.any(::Money, Numeric)) }
+                  def cast(value)
+                    decimal = super
+                    return Money.new(decimal) if decimal
+                    decimal
+                  end
+                end
+              end
+
+              class Post < ActiveRecord::Base
+                attribute :cost, Money::Type.new
+              end
+            RUBY
+
+            "schema.rb" => <<~RUBY,
+              ActiveRecord::Migration.suppress_messages do
+                ActiveRecord::Schema.define do
+                  create_table :posts do |t|
+                    t.decimal :cost
+                  end
+                end
+              end
+            RUBY
+          }
+
+          expected = indented(<<~RUBY, 4)
+            sig { returns(T.nilable(T.any(Money, Numeric))) }
+            def cost; end
+
+            sig { params(value: T.nilable(T.any(Money, Numeric))).returns(T.nilable(T.any(Money, Numeric))) }
+            def cost=(value); end
+          RUBY
+
+          assert_includes(rbi_for(:Post, files), expected)
+        end
+
+        it("discovers custom type from signature on serialize method") do
+          files = {
+            "file.rb" => <<~RUBY,
+              class Money
+                attr_accessor :value
+
+                def initialize(number = 0.0)
+                  @value = number
+                end
+
+                class Type < ActiveRecord::Type::Value
+                  extend(T::Sig)
+
+                  sig { params(money: ::Money).returns(Numeric) }
+                  def serialize(money)
+                    money = super unless money.is_a?(::Money)
+                    money.value unless money.nil?
+                  end
+                end
+              end
+
+              class Post < ActiveRecord::Base
+                attribute :cost, Money::Type.new
+              end
+            RUBY
+
+            "schema.rb" => <<~RUBY,
+              ActiveRecord::Migration.suppress_messages do
+                ActiveRecord::Schema.define do
+                  create_table :posts do |t|
+                    t.decimal :cost
+                  end
+                end
+              end
+            RUBY
+          }
+
+          expected = indented(<<~RUBY, 4)
+            sig { returns(T.nilable(Money)) }
+            def cost; end
+
+            sig { params(value: T.nilable(Money)).returns(T.nilable(Money)) }
+            def cost=(value); end
+          RUBY
+
+          assert_includes(rbi_for(:Post, files), expected)
+        end
+
+        it("generates a weak type if custom type is generic") do
+          files = {
+            "file.rb" => <<~RUBY,
+              class ValueType
+                extend T::Generic
+
+                Elem = type_member
+              end
+
+              class ColumnType < ActiveRecord::Type::Value
+                extend(T::Sig)
+
+                sig { params(value: ::ValueType[Integer]).returns(Numeric) }
+                def serialize(value)
+                  super
+                end
+              end
+
+              class Post < ActiveRecord::Base
+                attribute :cost, ColumnType.new
+              end
+            RUBY
+
+            "schema.rb" => <<~RUBY,
+              ActiveRecord::Migration.suppress_messages do
+                ActiveRecord::Schema.define do
+                  create_table :posts do |t|
+                    t.decimal :cost
+                  end
+                end
+              end
+            RUBY
+          }
+
+          expected = indented(<<~RUBY, 4)
+            sig { returns(T.nilable(T.untyped)) }
+            def cost; end
+
+            sig { params(value: T.nilable(T.untyped)).returns(T.nilable(T.untyped)) }
+            def cost=(value); end
+          RUBY
+
+          assert_includes(rbi_for(:Post, files), expected)
+        end
+
+        it("generates a weak type if custom type cannot be discovered from signatures") do
+          files = {
+            "file.rb" => <<~RUBY,
+              class Money
+                attr_accessor :value
+
+                def initialize(number = 0.0)
+                  @value = number
+                end
+
+                class Type < ActiveRecord::Type::Value
+                  extend(T::Sig)
+
+                  def deserialize(value)
+                    Money.new(value)
+                  end
+                end
+              end
+
+              class Post < ActiveRecord::Base
+                attribute :cost, Money::Type.new
+              end
+            RUBY
+
+            "schema.rb" => <<~RUBY,
+              ActiveRecord::Migration.suppress_messages do
+                ActiveRecord::Schema.define do
+                  create_table :posts do |t|
+                    t.decimal :cost
+                  end
+                end
+              end
+            RUBY
+          }
+
+          expected = indented(<<~RUBY, 4)
+            sig { returns(T.nilable(T.untyped)) }
+            def cost; end
+
+            sig { params(value: T.nilable(T.untyped)).returns(T.nilable(T.untyped)) }
+            def cost=(value); end
+          RUBY
+
+          assert_includes(rbi_for(:Post, files), expected)
+        end
+      end
+
+      describe("when StrongTypeGeneration is defined") do
+        sig { returns(T::Hash[String, String]) }
+        def default_files
+          {
+            "strong_type_generation.rb" => <<~RUBY,
+              module StrongTypeGeneration
+              end
+            RUBY
+          }
+        end
+
+        it("generates default columns with strong types if model extends StrongTypeGeneration") do
+          files = default_files.merge({
+            "file.rb" => <<~RUBY,
+              class Post < ActiveRecord::Base
+                extend StrongTypeGeneration
+              end
+            RUBY
+
+            "schema.rb" => <<~RUBY,
+              ActiveRecord::Migration.suppress_messages do
+                ActiveRecord::Schema.define do
+                  create_table :posts do |t|
+                  end
+                end
+              end
+            RUBY
+          })
+
+          expected = <<~RUBY
+            # typed: strong
+            class Post
+              include GeneratedAttributeMethods
+
+              module GeneratedAttributeMethods
+                sig { returns(T.nilable(::Integer)) }
+                def id; end
+
+                sig { params(value: ::Integer).returns(::Integer) }
+                def id=(value); end
+
+                sig { returns(T::Boolean) }
+                def id?; end
+
+                sig { returns(T.nilable(::Integer)) }
+                def id_before_last_save; end
+
+                sig { returns(T.untyped) }
+                def id_before_type_cast; end
+
+                sig { returns(T::Boolean) }
+                def id_came_from_user?; end
+
+                sig { returns(T.nilable([T.nilable(::Integer), T.nilable(::Integer)])) }
+                def id_change; end
+
+                sig { returns(T.nilable([T.nilable(::Integer), T.nilable(::Integer)])) }
+                def id_change_to_be_saved; end
+
+                sig { returns(T::Boolean) }
+                def id_changed?; end
+
+                sig { returns(T.nilable(::Integer)) }
+                def id_in_database; end
+
+                sig { returns(T.nilable([T.nilable(::Integer), T.nilable(::Integer)])) }
+                def id_previous_change; end
+
+                sig { returns(T::Boolean) }
+                def id_previously_changed?; end
+
+                sig { returns(T.nilable(::Integer)) }
+                def id_previously_was; end
+
+                sig { returns(T.nilable(::Integer)) }
+                def id_was; end
+
+                sig { void }
+                def id_will_change!; end
+
+                sig { void }
+                def restore_id!; end
+
+                sig { returns(T.nilable([T.nilable(::Integer), T.nilable(::Integer)])) }
+                def saved_change_to_id; end
+
+                sig { returns(T::Boolean) }
+                def saved_change_to_id?; end
+
+                sig { returns(T::Boolean) }
+                def will_save_change_to_id?; end
+              end
+            end
+          RUBY
+
+          assert_equal(expected, rbi_for(:Post, files))
+        end
+
+        it("generates default columns with weak types if model does not extend StrongTypeGeneration") do
+          files = default_files.merge({
+            "file.rb" => <<~RUBY,
+              class Post < ActiveRecord::Base
+                # StrongTypeGeneration is not extended
+              end
+            RUBY
+
+            "schema.rb" => <<~RUBY,
+              ActiveRecord::Migration.suppress_messages do
+                ActiveRecord::Schema.define do
+                  create_table :posts do |t|
+                  end
+                end
+              end
+            RUBY
+          })
+
+          expected = <<~RUBY
+            # typed: strong
+            class Post
+              include GeneratedAttributeMethods
+
+              module GeneratedAttributeMethods
+                sig { returns(T.untyped) }
+                def id; end
+
+                sig { params(value: T.untyped).returns(T.untyped) }
+                def id=(value); end
+
+                sig { returns(T::Boolean) }
+                def id?; end
+
+                sig { returns(T.nilable(T.untyped)) }
+                def id_before_last_save; end
+
+                sig { returns(T.untyped) }
+                def id_before_type_cast; end
+
+                sig { returns(T::Boolean) }
+                def id_came_from_user?; end
+
+                sig { returns(T.nilable([T.untyped, T.untyped])) }
+                def id_change; end
+
+                sig { returns(T.nilable([T.untyped, T.untyped])) }
+                def id_change_to_be_saved; end
+
+                sig { returns(T::Boolean) }
+                def id_changed?; end
+
+                sig { returns(T.nilable(T.untyped)) }
+                def id_in_database; end
+
+                sig { returns(T.nilable([T.untyped, T.untyped])) }
+                def id_previous_change; end
+
+                sig { returns(T::Boolean) }
+                def id_previously_changed?; end
+
+                sig { returns(T.nilable(T.untyped)) }
+                def id_previously_was; end
+
+                sig { returns(T.nilable(T.untyped)) }
+                def id_was; end
+
+                sig { void }
+                def id_will_change!; end
+
+                sig { void }
+                def restore_id!; end
+
+                sig { returns(T.nilable([T.untyped, T.untyped])) }
+                def saved_change_to_id; end
+
+                sig { returns(T::Boolean) }
+                def saved_change_to_id?; end
+
+                sig { returns(T::Boolean) }
+                def will_save_change_to_id?; end
+              end
+            end
+          RUBY
+
+          assert_equal(expected, rbi_for(:Post, files))
+        end
+
+        it("generates attributes with strong types if model extends StrongTypeGeneration") do
+          files = default_files.merge({
+            "file.rb" => <<~RUBY,
+              class Post < ActiveRecord::Base
+                extend StrongTypeGeneration
+              end
+            RUBY
+
+            "schema.rb" => <<~RUBY,
+              ActiveRecord::Migration.suppress_messages do
+                ActiveRecord::Schema.define do
+                  create_table :posts do |t|
+                    t.string :body
+                  end
+                end
+              end
+            RUBY
+          })
+
+          expected = indented(<<~RUBY, 2)
+            module GeneratedAttributeMethods
+              sig { returns(T.nilable(::String)) }
+              def body; end
+
+              sig { params(value: T.nilable(::String)).returns(T.nilable(::String)) }
+              def body=(value); end
 
               sig { returns(T::Boolean) }
-              def saved_change_to_id?; end
+              def body?; end
+          RUBY
+          assert_includes(rbi_for(:Post, files), expected)
+        end
+
+        it("generates attributes with weak types if model does not extend StrongTypeGeneration") do
+          files = default_files.merge({
+            "file.rb" => <<~RUBY,
+              class Post < ActiveRecord::Base
+                # StrongTypeGeneration is not extended
+              end
+            RUBY
+
+            "schema.rb" => <<~RUBY,
+              ActiveRecord::Migration.suppress_messages do
+                ActiveRecord::Schema.define do
+                  create_table :posts do |t|
+                    t.string :body
+                  end
+                end
+              end
+            RUBY
+          })
+
+          expected = indented(<<~RUBY, 2)
+            module GeneratedAttributeMethods
+              sig { returns(T.untyped) }
+              def body; end
+
+              sig { params(value: T.untyped).returns(T.untyped) }
+              def body=(value); end
 
               sig { returns(T::Boolean) }
-              def will_save_change_to_id?; end
-            end
-          end
-        RUBY
-
-        assert_equal(expected, rbi_for(:Post, files))
-      end
-
-      it("generates RBI file for custom attributes with strong type generation") do
-        files = {
-          "file.rb" => <<~RUBY,
-            module StrongTypeGeneration
-            end
-
-            class Post < ActiveRecord::Base
-              extend StrongTypeGeneration
-            end
+              def body?; end
           RUBY
 
-          "schema.rb" => <<~RUBY,
-            ActiveRecord::Migration.suppress_messages do
-              ActiveRecord::Schema.define do
-                create_table :posts do |t|
-                  t.string :body
-                end
-              end
-            end
-          RUBY
-        }
-
-        expected = indented(<<~RUBY, 2)
-          module GeneratedAttributeMethods
-            sig { returns(T.nilable(::String)) }
-            def body; end
-
-            sig { params(value: T.nilable(::String)).returns(T.nilable(::String)) }
-            def body=(value); end
-
-            sig { returns(T::Boolean) }
-            def body?; end
-        RUBY
-        assert_includes(rbi_for(:Post, files), expected)
-      end
-
-      it("generates RBI file for custom attributes without strong type generation") do
-        files = {
-          "file.rb" => <<~RUBY,
-            module StrongTypeGeneration
-            end
-
-            class Post < ActiveRecord::Base
-              # StrongTypeGeneration is not extended
-            end
-          RUBY
-
-          "schema.rb" => <<~RUBY,
-            ActiveRecord::Migration.suppress_messages do
-              ActiveRecord::Schema.define do
-                create_table :posts do |t|
-                  t.string :body
-                end
-              end
-            end
-          RUBY
-        }
-
-        expected = indented(<<~RUBY, 2)
-          module GeneratedAttributeMethods
-            sig { returns(T.untyped) }
-            def body; end
-
-            sig { params(value: T.untyped).returns(T.untyped) }
-            def body=(value); end
-
-            sig { returns(T::Boolean) }
-            def body?; end
-        RUBY
-
-        assert_includes(rbi_for(:Post, files), expected)
-      end
-
-      it("generates RBI file given nullability of an attribute") do
-        files = {
-          "file.rb" => <<~RUBY,
-            module StrongTypeGeneration
-            end
-
-            class Post < ActiveRecord::Base
-              extend StrongTypeGeneration
-            end
-          RUBY
-
-          "schema.rb" => <<~RUBY,
-            ActiveRecord::Migration.suppress_messages do
-              ActiveRecord::Schema.define do
-                create_table :posts do |t|
-                  t.string :title, null: false
-                  t.string :body, null: true
-                  t.timestamps
-                end
-              end
-            end
-          RUBY
-        }
-
-        output = rbi_for(:Post, files)
-
-        expected = indented(<<~RUBY, 4)
-          sig { returns(T.nilable(::String)) }
-          def body; end
-
-          sig { params(value: T.nilable(::String)).returns(T.nilable(::String)) }
-          def body=(value); end
-
-          sig { returns(T::Boolean) }
-          def body?; end
-        RUBY
-        assert_includes(output, expected)
-
-        expected = indented(<<~RUBY, 4)
-          sig { returns(::String) }
-          def title; end
-
-          sig { params(value: ::String).returns(::String) }
-          def title=(value); end
-
-          sig { returns(T::Boolean) }
-          def title?; end
-        RUBY
-        assert_includes(output, expected)
-      end
-
-      it("generates RBI file containing every ActiveRecord column type") do
-        files = {
-          "file.rb" => <<~RUBY,
-            module StrongTypeGeneration
-            end
-
-            class Post < ActiveRecord::Base
-              extend StrongTypeGeneration
-            end
-          RUBY
-
-          "schema.rb" => <<~RUBY,
-            ActiveRecord::Migration.suppress_messages do
-              ActiveRecord::Schema.define do
-                create_table :posts do |t|
-                  t.integer :integer_column
-                  t.string :string_column
-                  t.date :date_column
-                  t.decimal :decimal_column
-                  t.float :float_column
-                  t.boolean :boolean_column
-                  t.datetime :datetime_column
-                end
-              end
-            end
-          RUBY
-        }
-
-        output = rbi_for(:Post, files)
-
-        expected = indented(<<~RUBY, 4)
-          sig { params(value: T.nilable(::Integer)).returns(T.nilable(::Integer)) }
-          def integer_column=(value); end
-        RUBY
-        assert_includes(output, expected)
-
-        expected = indented(<<~RUBY, 4)
-          sig { params(value: T.nilable(::String)).returns(T.nilable(::String)) }
-          def string_column=(value); end
-        RUBY
-        assert_includes(output, expected)
-
-        expected = indented(<<~RUBY, 4)
-          sig { params(value: T.nilable(::Date)).returns(T.nilable(::Date)) }
-          def date_column=(value); end
-        RUBY
-        assert_includes(output, expected)
-
-        expected = indented(<<~RUBY, 4)
-          sig { params(value: T.nilable(::BigDecimal)).returns(T.nilable(::BigDecimal)) }
-          def decimal_column=(value); end
-        RUBY
-        assert_includes(output, expected)
-
-        expected = indented(<<~RUBY, 4)
-          sig { params(value: T.nilable(::Float)).returns(T.nilable(::Float)) }
-          def float_column=(value); end
-        RUBY
-        assert_includes(output, expected)
-
-        expected = indented(<<~RUBY, 4)
-          sig { params(value: T.nilable(T::Boolean)).returns(T.nilable(T::Boolean)) }
-          def boolean_column=(value); end
-        RUBY
-        assert_includes(output, expected)
-
-        expected = indented(<<~RUBY, 4)
-          sig { params(value: T.nilable(::DateTime)).returns(T.nilable(::DateTime)) }
-          def datetime_column=(value); end
-        RUBY
-        assert_includes(output, expected)
-      end
-
-      it("generates RBI file for time_zone_aware_attributes") do
-        files = {
-          "file.rb" => <<~RUBY,
-            module StrongTypeGeneration
-            end
-
-            class Post < ActiveRecord::Base
-              extend StrongTypeGeneration
-            end
-          RUBY
-
-          "schema.rb" => <<~RUBY,
-            ActiveRecord::Base.time_zone_aware_attributes = true
-            ActiveRecord::Migration.suppress_messages do
-              ActiveRecord::Schema.define do
-                create_table :posts do |t|
-                  t.timestamp :timestamp_column
-                  t.datetime :datetime_column
-                  t.time :time_column
-                end
-              end
-            end
-          RUBY
-        }
-
-        output = rbi_for(:Post, files)
-
-        expected = indented(<<~RUBY, 4)
-          sig { params(value: T.nilable(::ActiveSupport::TimeWithZone)).returns(T.nilable(::ActiveSupport::TimeWithZone)) }
-          def timestamp_column=(value); end
-        RUBY
-        assert_includes(output, expected)
-
-        expected = indented(<<~RUBY, 4)
-          sig { params(value: T.nilable(::ActiveSupport::TimeWithZone)).returns(T.nilable(::ActiveSupport::TimeWithZone)) }
-          def datetime_column=(value); end
-        RUBY
-        assert_includes(output, expected)
-
-        expected = indented(<<~RUBY, 4)
-          sig { params(value: T.nilable(::ActiveSupport::TimeWithZone)).returns(T.nilable(::ActiveSupport::TimeWithZone)) }
-          def time_column=(value); end
-        RUBY
-        assert_includes(output, expected)
-      end
-
-      it("generates RBI file for alias_attributes") do
-        files = {
-          "file.rb" => <<~RUBY,
-            module StrongTypeGeneration
-            end
-
-            class Post < ActiveRecord::Base
-              extend StrongTypeGeneration
-              alias_attribute :author, :name
-            end
-          RUBY
-
-          "schema.rb" => <<~RUBY,
-            ActiveRecord::Migration.suppress_messages do
-              ActiveRecord::Schema.define do
-                create_table :posts do |t|
-                  t.string :name
-                end
-              end
-            end
-          RUBY
-        }
-
-        output = rbi_for(:Post, files)
-
-        expected = indented(<<~RUBY, 2)
-          module GeneratedAttributeMethods
-            sig { returns(T.nilable(::String)) }
-            def author; end
-
-            sig { params(value: T.nilable(::String)).returns(T.nilable(::String)) }
-            def author=(value); end
-
-            sig { returns(T::Boolean) }
-            def author?; end
-
-            sig { returns(T.nilable(::String)) }
-            def author_before_last_save; end
-
-            sig { returns(T.untyped) }
-            def author_before_type_cast; end
-
-            sig { returns(T::Boolean) }
-            def author_came_from_user?; end
-
-            sig { returns(T.nilable([T.nilable(::String), T.nilable(::String)])) }
-            def author_change; end
-
-            sig { returns(T.nilable([T.nilable(::String), T.nilable(::String)])) }
-            def author_change_to_be_saved; end
-
-            sig { returns(T::Boolean) }
-            def author_changed?; end
-
-            sig { returns(T.nilable(::String)) }
-            def author_in_database; end
-
-            sig { returns(T.nilable([T.nilable(::String), T.nilable(::String)])) }
-            def author_previous_change; end
-
-            sig { returns(T::Boolean) }
-            def author_previously_changed?; end
-
-            sig { returns(T.nilable(::String)) }
-            def author_was; end
-
-            sig { void }
-            def author_will_change!; end
-        RUBY
-        assert_includes(output, expected)
-
-        expected = indented(<<~RUBY, 4)
-          sig { void }
-          def restore_author!; end
-        RUBY
-        assert_includes(output, expected)
-
-        expected = indented(<<~RUBY, 4)
-          sig { returns(T.nilable([T.nilable(::String), T.nilable(::String)])) }
-          def saved_change_to_author; end
-
-          sig { returns(T::Boolean) }
-          def saved_change_to_author?; end
-        RUBY
-        assert_includes(output, expected)
-
-        expected = indented(<<~RUBY, 4)
-          sig { returns(T::Boolean) }
-          def will_save_change_to_author?; end
-        RUBY
-        assert_includes(output, expected)
-      end
-
-      it("generated RBI file ignores conflicting alias_attributes") do
-        files = {
-          "file.rb" => <<~RUBY,
-            module StrongTypeGeneration
-            end
-
-            class Post < ActiveRecord::Base
-              extend StrongTypeGeneration
-              alias_attribute :body?, :body
-            end
-          RUBY
-
-          "schema.rb" => <<~RUBY,
-            ActiveRecord::Migration.suppress_messages do
-              ActiveRecord::Schema.define do
-                create_table :posts do |t|
-                  t.string :body
-                end
-              end
-            end
-          RUBY
-        }
-
-        output = rbi_for(:Post, files)
-
-        expected = indented(<<~RUBY, 2)
-          module GeneratedAttributeMethods
-            sig { returns(T.nilable(::String)) }
-            def body; end
-
-            sig { params(value: T.nilable(::String)).returns(T.nilable(::String)) }
-            def body=(value); end
-
-            sig { returns(T::Boolean) }
-            def body?; end
-
-            sig { returns(T.nilable(::String)) }
-            def body_before_last_save; end
-
-            sig { returns(T.untyped) }
-            def body_before_type_cast; end
-
-            sig { returns(T::Boolean) }
-            def body_came_from_user?; end
-
-            sig { returns(T.nilable([T.nilable(::String), T.nilable(::String)])) }
-            def body_change; end
-
-            sig { returns(T.nilable([T.nilable(::String), T.nilable(::String)])) }
-            def body_change_to_be_saved; end
-
-            sig { returns(T::Boolean) }
-            def body_changed?; end
-
-            sig { returns(T.nilable(::String)) }
-            def body_in_database; end
-
-            sig { returns(T.nilable([T.nilable(::String), T.nilable(::String)])) }
-            def body_previous_change; end
-
-            sig { returns(T::Boolean) }
-            def body_previously_changed?; end
-
-            sig { returns(T.nilable(::String)) }
-            def body_previously_was; end
-
-            sig { returns(T.nilable(::String)) }
-            def body_was; end
-
-            sig { void }
-            def body_will_change!; end
-        RUBY
-        assert_includes(output, expected)
-
-        expected = indented(<<~RUBY, 4)
-          sig { void }
-          def restore_body!; end
-        RUBY
-        assert_includes(output, expected)
-
-        expected = indented(<<~RUBY, 4)
-          sig { returns(T.nilable([T.nilable(::String), T.nilable(::String)])) }
-          def saved_change_to_body; end
-
-          sig { returns(T::Boolean) }
-          def saved_change_to_body?; end
-        RUBY
-        assert_includes(output, expected)
-
-        expected = indented(<<~RUBY, 4)
-          sig { returns(T::Boolean) }
-          def will_save_change_to_body?; end
-        RUBY
-        assert_includes(output, expected)
-      end
-
-      it("generates RBI file for custom type with signature on deserialize method") do
-        files = {
-          "file.rb" => <<~RUBY,
-            module StrongTypeGeneration
-            end
-
-            class Money
-              attr_accessor :value
-
-              def initialize(number = 0.0)
-                @value = number
-              end
-
-              class Type < ActiveRecord::Type::Value
-                extend(T::Sig)
-
-                sig { params(value: Numeric).returns(::Money)}
-                def deserialize(value)
-                  Money.new(value)
-                end
-              end
-            end
-
-            class Post < ActiveRecord::Base
-              extend StrongTypeGeneration
-
-              attribute :cost, Money::Type.new
-            end
-          RUBY
-
-          "schema.rb" => <<~RUBY,
-            ActiveRecord::Migration.suppress_messages do
-              ActiveRecord::Schema.define do
-                create_table :posts do |t|
-                  t.decimal :cost
-                end
-              end
-            end
-          RUBY
-        }
-
-        expected = indented(<<~RUBY, 4)
-          sig { returns(T.nilable(Money)) }
-          def cost; end
-
-          sig { params(value: T.nilable(Money)).returns(T.nilable(Money)) }
-          def cost=(value); end
-        RUBY
-
-        assert_includes(rbi_for(:Post, files), expected)
-      end
-
-      it("generates RBI file for custom type with signature on cast method") do
-        files = {
-          "file.rb" => <<~RUBY,
-            module StrongTypeGeneration
-            end
-
-            class Money
-              attr_accessor :value
-
-              def initialize(number = 0.0)
-                @value = number
-              end
-
-              class Type < ActiveRecord::Type::Value
-                extend(T::Sig)
-
-                sig { params(value: ::Numeric).returns(T.any(::Money, Numeric)) }
-                def cast(value)
-                  decimal = super
-                  return Money.new(decimal) if decimal
-                  decimal
-                end
-              end
-            end
-
-            class Post < ActiveRecord::Base
-              extend StrongTypeGeneration
-
-              attribute :cost, Money::Type.new
-            end
-          RUBY
-
-          "schema.rb" => <<~RUBY,
-            ActiveRecord::Migration.suppress_messages do
-              ActiveRecord::Schema.define do
-                create_table :posts do |t|
-                  t.decimal :cost
-                end
-              end
-            end
-          RUBY
-        }
-
-        expected = indented(<<~RUBY, 4)
-          sig { returns(T.nilable(T.any(Money, Numeric))) }
-          def cost; end
-
-          sig { params(value: T.nilable(T.any(Money, Numeric))).returns(T.nilable(T.any(Money, Numeric))) }
-          def cost=(value); end
-        RUBY
-
-        assert_includes(rbi_for(:Post, files), expected)
-      end
-
-      it("generates RBI file for custom type with signature on serialize method") do
-        files = {
-          "file.rb" => <<~RUBY,
-            module StrongTypeGeneration
-            end
-
-            class Money
-              attr_accessor :value
-
-              def initialize(number = 0.0)
-                @value = number
-              end
-
-              class Type < ActiveRecord::Type::Value
-                extend(T::Sig)
-
-                sig { params(money: ::Money).returns(Numeric) }
-                def serialize(money)
-                  money = super unless money.is_a?(::Money)
-                  money.value unless money.nil?
-                end
-              end
-            end
-
-            class Post < ActiveRecord::Base
-              extend StrongTypeGeneration
-
-              attribute :cost, Money::Type.new
-            end
-          RUBY
-
-          "schema.rb" => <<~RUBY,
-            ActiveRecord::Migration.suppress_messages do
-              ActiveRecord::Schema.define do
-                create_table :posts do |t|
-                  t.decimal :cost
-                end
-              end
-            end
-          RUBY
-        }
-
-        expected = indented(<<~RUBY, 4)
-          sig { returns(T.nilable(Money)) }
-          def cost; end
-
-          sig { params(value: T.nilable(Money)).returns(T.nilable(Money)) }
-          def cost=(value); end
-        RUBY
-
-        assert_includes(rbi_for(:Post, files), expected)
-      end
-
-      it("generates RBI file for custom type that returns a generic type") do
-        files = {
-          "file.rb" => <<~RUBY,
-            module StrongTypeGeneration
-            end
-
-            class ValueType
-              extend T::Generic
-
-              Elem = type_member
-            end
-
-            class ColumnType < ActiveRecord::Type::Value
-              extend(T::Sig)
-
-              sig { params(value: ::ValueType[Integer]).returns(Numeric) }
-              def serialize(value)
-                super
-              end
-            end
-
-            class Post < ActiveRecord::Base
-              extend StrongTypeGeneration
-
-              attribute :cost, ColumnType.new
-            end
-          RUBY
-
-          "schema.rb" => <<~RUBY,
-            ActiveRecord::Migration.suppress_messages do
-              ActiveRecord::Schema.define do
-                create_table :posts do |t|
-                  t.decimal :cost
-                end
-              end
-            end
-          RUBY
-        }
-
-        expected = indented(<<~RUBY, 4)
-          sig { returns(T.nilable(T.untyped)) }
-          def cost; end
-
-          sig { params(value: T.nilable(T.untyped)).returns(T.nilable(T.untyped)) }
-          def cost=(value); end
-        RUBY
-
-        assert_includes(rbi_for(:Post, files), expected)
-      end
-
-      it("generates RBI file for custom type without signatures") do
-        files = {
-          "file.rb" => <<~RUBY,
-            module StrongTypeGeneration
-            end
-
-            class Money
-              attr_accessor :value
-
-              def initialize(number = 0.0)
-                @value = number
-              end
-
-              class Type < ActiveRecord::Type::Value
-                extend(T::Sig)
-
-                def deserialize(value)
-                  Money.new(value)
-                end
-              end
-            end
-
-            class Post < ActiveRecord::Base
-              extend StrongTypeGeneration
-
-              attribute :cost, Money::Type.new
-            end
-          RUBY
-
-          "schema.rb" => <<~RUBY,
-            ActiveRecord::Migration.suppress_messages do
-              ActiveRecord::Schema.define do
-                create_table :posts do |t|
-                  t.decimal :cost
-                end
-              end
-            end
-          RUBY
-        }
-
-        expected = indented(<<~RUBY, 4)
-          sig { returns(T.nilable(T.untyped)) }
-          def cost; end
-
-          sig { params(value: T.nilable(T.untyped)).returns(T.nilable(T.untyped)) }
-          def cost=(value); end
-        RUBY
-
-        assert_includes(rbi_for(:Post, files), expected)
+          assert_includes(rbi_for(:Post, files), expected)
+        end
       end
     end
   end


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->

Contrary to what the documentation of `ActiveRecordColumns` generator says, we actually generate strong types for models if `StrongTypeGeneration` is not defined in the user application as a constant.

We only generate weak types if a constant named `StrongTypeGeneration` is defined in the user application and the current model does not extend from it.

Because of this disconnect, we were never really testing cases where we didn't have `StrongTypeGeneration` defined. However, that is usually our default state, so most test cases should have really be testing that.

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->

Added separate test cases that test default behaviour and behaviour when `StrongTypeGeneration` is defined.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->
Tests are updated to reflect the true state of affairs.