### PR TITLE
Refactor test helpers

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,8 +18,6 @@ Minitest.parallel_executor = Minitest::ForkExecutor.new
 module Minitest
   class Test
     extend T::Sig
-    include ContentHelper
-    include TemplateHelper
 
     Minitest::Test.make_my_diffs_pretty!
   end

--- a/spec/tapioca/cli_spec.rb
+++ b/spec/tapioca/cli_spec.rb
@@ -60,6 +60,8 @@ module Contents
 end
 
 class Tapioca::CliSpec < Minitest::HooksSpec
+  include TemplateHelper
+
   attr_reader :outdir
   attr_reader :repo_path
 

--- a/spec/tapioca/compilers/dsl/active_record_enum_spec.rb
+++ b/spec/tapioca/compilers/dsl/active_record_enum_spec.rb
@@ -6,11 +6,11 @@ require "spec_helper"
 class Tapioca::Compilers::Dsl::ActiveRecordEnumSpec < DslSpec
   describe("#initialize") do
     it("gathers no constants if there are no ActiveRecord classes") do
-      assert_empty(constants_from(""))
+      assert_empty(gathered_constants)
     end
 
     it("gathers only ActiveRecord constants with no abstract classes") do
-      content = <<~RUBY
+      add_ruby_file("content.rb", <<~RUBY)
         class Conversation < ActiveRecord::Base
         end
 
@@ -22,20 +22,19 @@ class Tapioca::Compilers::Dsl::ActiveRecordEnumSpec < DslSpec
         end
       RUBY
 
-      assert_equal(["Conversation"], constants_from(content))
+      assert_equal(["Conversation"], gathered_constants)
     end
   end
 
   describe("#decorate") do
     it("generates RBI file for classes with an enum attribute") do
-      content = <<~RUBY
+      add_ruby_file("conversation.rb", <<~RUBY)
         class Conversation < ActiveRecord::Base
           enum status: [ :active, :archived ]
         end
-
       RUBY
 
-      expected = <<~RUBY
+      expected = <<~RBI
         # typed: strong
         class Conversation
           include EnumMethodsModule
@@ -57,20 +56,20 @@ class Tapioca::Compilers::Dsl::ActiveRecordEnumSpec < DslSpec
           sig { returns(T::Hash[T.any(String, Symbol), Integer]) }
           def self.statuses; end
         end
-      RUBY
+      RBI
 
-      assert_equal(expected, rbi_for(:Conversation, content))
+      assert_equal(expected, rbi_for(:Conversation))
     end
 
     it("generates RBI file for classes with an enum attribute with string values") do
-      content = <<~RUBY
+      add_ruby_file("conversation.rb", <<~RUBY)
         class Conversation < ActiveRecord::Base
           enum status: { active: "0", archived: "1" }
         end
 
       RUBY
 
-      expected = <<~RUBY
+      expected = <<~RBI
         # typed: strong
         class Conversation
           include EnumMethodsModule
@@ -92,20 +91,19 @@ class Tapioca::Compilers::Dsl::ActiveRecordEnumSpec < DslSpec
           sig { returns(T::Hash[T.any(String, Symbol), String]) }
           def self.statuses; end
         end
-      RUBY
+      RBI
 
-      assert_equal(expected, rbi_for(:Conversation, content))
+      assert_equal(expected, rbi_for(:Conversation))
     end
 
     it("generates RBI file for classes with an enum attribute with mix value types") do
-      content = <<~RUBY
+      add_ruby_file("conversation.rb", <<~RUBY)
         class Conversation < ActiveRecord::Base
           enum status: { active: 0, archived: true, inactive: "Inactive" }
         end
-
       RUBY
 
-      expected = <<~RUBY
+      expected = <<~RBI
         # typed: strong
         class Conversation
           include EnumMethodsModule
@@ -133,21 +131,20 @@ class Tapioca::Compilers::Dsl::ActiveRecordEnumSpec < DslSpec
           sig { returns(T::Hash[T.any(String, Symbol), T.any(Integer, TrueClass, String)]) }
           def self.statuses; end
         end
-      RUBY
+      RBI
 
-      assert_equal(expected, rbi_for(:Conversation, content))
+      assert_equal(expected, rbi_for(:Conversation))
     end
 
     it("generates RBI file for classes with multiple enum attributes") do
-      content = <<~RUBY
+      add_ruby_file("conversation.rb", <<~RUBY)
         class Conversation < ActiveRecord::Base
           enum status: [ :active, :archived ]
           enum comments_status: [:on, :off]
         end
-
       RUBY
 
-      expected = <<~RUBY
+      expected = <<~RBI
         # typed: strong
         class Conversation
           include EnumMethodsModule
@@ -184,21 +181,20 @@ class Tapioca::Compilers::Dsl::ActiveRecordEnumSpec < DslSpec
           sig { returns(T::Hash[T.any(String, Symbol), Integer]) }
           def self.statuses; end
         end
-      RUBY
+      RBI
 
-      assert_equal(expected, rbi_for(:Conversation, content))
+      assert_equal(expected, rbi_for(:Conversation))
     end
 
     it("generates RBI file for classes with multiple enum attributes with mix value types") do
-      content = <<~RUBY
+      add_ruby_file("conversation.rb", <<~RUBY)
         class Conversation < ActiveRecord::Base
           enum status: { active: 0, archived: true, inactive: "Inactive" }
           enum comments_status: { on: 0, off: false, ongoing: "Ongoing", topic: [1,2,3] }
         end
-
       RUBY
 
-      expected = <<~RUBY
+      expected = <<~RBI
         # typed: strong
         class Conversation
           include EnumMethodsModule
@@ -253,20 +249,19 @@ class Tapioca::Compilers::Dsl::ActiveRecordEnumSpec < DslSpec
           sig { returns(T::Hash[T.any(String, Symbol), T.any(Integer, TrueClass, String)]) }
           def self.statuses; end
         end
-      RUBY
+      RBI
 
-      assert_equal(expected, rbi_for(:Conversation, content))
+      assert_equal(expected, rbi_for(:Conversation))
     end
 
     it("generates RBI file for classes with enum attribute with suffix specified") do
-      content = <<~RUBY
+      add_ruby_file("conversation.rb", <<~RUBY)
         class Conversation < ActiveRecord::Base
           enum status: [:active, :archived], _suffix: true
         end
-
       RUBY
 
-      expected = <<~RUBY
+      expected = <<~RBI
         # typed: strong
         class Conversation
           include EnumMethodsModule
@@ -288,20 +283,19 @@ class Tapioca::Compilers::Dsl::ActiveRecordEnumSpec < DslSpec
           sig { returns(T::Hash[T.any(String, Symbol), Integer]) }
           def self.statuses; end
         end
-      RUBY
+      RBI
 
-      assert_equal(expected, rbi_for(:Conversation, content))
+      assert_equal(expected, rbi_for(:Conversation))
     end
 
     it("generates RBI file for classes with enum attribute with prefix specified") do
-      content = <<~RUBY
+      add_ruby_file("conversation.rb", <<~RUBY)
         class Conversation < ActiveRecord::Base
           enum status: [:active, :archived], _prefix: :comments
         end
-
       RUBY
 
-      expected = <<~RUBY
+      expected = <<~RBI
         # typed: strong
         class Conversation
           include EnumMethodsModule
@@ -323,9 +317,9 @@ class Tapioca::Compilers::Dsl::ActiveRecordEnumSpec < DslSpec
           sig { returns(T::Hash[T.any(String, Symbol), Integer]) }
           def self.statuses; end
         end
-      RUBY
+      RBI
 
-      assert_equal(expected, rbi_for(:Conversation, content))
+      assert_equal(expected, rbi_for(:Conversation))
     end
   end
 end

--- a/spec/tapioca/compilers/dsl/active_resource_spec.rb
+++ b/spec/tapioca/compilers/dsl/active_resource_spec.rb
@@ -6,11 +6,11 @@ require "spec_helper"
 class Tapioca::Compilers::Dsl::ActiveResourceSpec < DslSpec
   describe("#initialize") do
     it("gathers no constants if there are no ActiveResource classes") do
-      assert_empty(constants_from(""))
+      assert_empty(gathered_constants)
     end
 
     it("gathers only ActiveResource constants ") do
-      content = <<~RUBY
+      add_ruby_file("content.rb", <<~RUBY)
         class Post < ActiveResource::Base
         end
 
@@ -21,22 +21,21 @@ class Tapioca::Compilers::Dsl::ActiveResourceSpec < DslSpec
         end
       RUBY
 
-      assert_equal(["Post", "Product"], constants_from(content))
+      assert_equal(["Post", "Product"], gathered_constants)
     end
   end
 
   describe("#decorate") do
     it("generates RBI file for ActiveResource classes with an integer schema field") do
-      content = <<~RUBY
+      add_ruby_file("post.rb", <<~RUBY)
         class Post < ActiveResource::Base
           schema do
             integer 'id'
           end
         end
-
       RUBY
 
-      expected = <<~RUBY
+      expected = <<~RBI
         # typed: strong
         class Post
           sig { returns(Integer) }
@@ -48,22 +47,21 @@ class Tapioca::Compilers::Dsl::ActiveResourceSpec < DslSpec
           sig { returns(T::Boolean) }
           def id?; end
         end
-      RUBY
+      RBI
 
-      assert_equal(expected, rbi_for(:Post, content))
+      assert_equal(expected, rbi_for(:Post))
     end
 
     it("generates RBI file for ActiveResource classes with multiple integer schema fields") do
-      content = <<~RUBY
+      add_ruby_file("post.rb", <<~RUBY)
         class Post < ActiveResource::Base
           schema do
             integer 'id', 'month', 'year'
           end
         end
-
       RUBY
 
-      expected = <<~RUBY
+      expected = <<~RBI
         # typed: strong
         class Post
           sig { returns(Integer) }
@@ -93,23 +91,22 @@ class Tapioca::Compilers::Dsl::ActiveResourceSpec < DslSpec
           sig { returns(T::Boolean) }
           def year?; end
         end
-      RUBY
+      RBI
 
-      assert_equal(expected, rbi_for(:Post, content))
+      assert_equal(expected, rbi_for(:Post))
     end
 
     it("generates RBI file for ActiveResource classes with schema with different types") do
-      content = <<~RUBY
+      add_ruby_file("post.rb", <<~RUBY)
         class Post < ActiveResource::Base
           schema do
             integer 'month'
             string  'title'
           end
         end
-
       RUBY
 
-      expected = <<~RUBY
+      expected = <<~RBI
         # typed: strong
         class Post
           sig { returns(Integer) }
@@ -130,22 +127,21 @@ class Tapioca::Compilers::Dsl::ActiveResourceSpec < DslSpec
           sig { returns(T::Boolean) }
           def title?; end
         end
-      RUBY
+      RBI
 
-      assert_equal(expected, rbi_for(:Post, content))
+      assert_equal(expected, rbi_for(:Post))
     end
 
     it("generates methods for ActiveResource classes with an unsupported schema type") do
-      content = <<~RUBY
+      add_ruby_file("post.rb", <<~RUBY)
         class Post < ActiveResource::Base
           schema  do
             attribute 'id',nil
           end
         end
-
       RUBY
 
-      expected = <<~RUBY
+      expected = <<~RBI
         # typed: strong
         class Post
           sig { returns(T.untyped) }
@@ -157,12 +153,12 @@ class Tapioca::Compilers::Dsl::ActiveResourceSpec < DslSpec
           sig { returns(T::Boolean) }
           def id?; end
         end
-      RUBY
+      RBI
 
-      assert_equal(expected, rbi_for(:Post, content))
+      assert_equal(expected, rbi_for(:Post))
     end
     it("generates methods for ActiveResource classes including all types in schema field") do
-      content = <<~RUBY
+      add_ruby_file("post.rb", <<~RUBY)
         class Post < ActiveResource::Base
           schema do
             boolean  'reviewed'
@@ -177,60 +173,59 @@ class Tapioca::Compilers::Dsl::ActiveResourceSpec < DslSpec
             text     'message'
           end
         end
-
       RUBY
 
-      rbi_output = rbi_for(:Post, content)
+      rbi_output = rbi_for(:Post)
 
-      assert_includes(rbi_output, indented(<<~RUBY, 2))
+      assert_includes(rbi_output, indented(<<~RBI, 2))
         sig { params(value: T::Boolean).returns(T::Boolean) }
         def reviewed=(value); end
-      RUBY
+      RBI
 
-      assert_includes(rbi_output, indented(<<~RUBY, 2))
+      assert_includes(rbi_output, indented(<<~RBI, 2))
         sig { params(value: Integer).returns(Integer) }
         def id=(value); end
-      RUBY
+      RBI
 
-      assert_includes(rbi_output, indented(<<~RUBY, 2))
+      assert_includes(rbi_output, indented(<<~RBI, 2))
         sig { params(value: String).returns(String) }
         def title=(value); end
-      RUBY
+      RBI
 
-      assert_includes(rbi_output, indented(<<~RUBY, 2))
+      assert_includes(rbi_output, indented(<<~RBI, 2))
         sig { params(value: Float).returns(Float) }
         def price=(value); end
-      RUBY
+      RBI
 
-      assert_includes(rbi_output, indented(<<~RUBY, 2))
+      assert_includes(rbi_output, indented(<<~RBI, 2))
         sig { params(value: Date).returns(Date) }
         def month=(value); end
-      RUBY
+      RBI
 
-      assert_includes(rbi_output, indented(<<~RUBY, 2))
+      assert_includes(rbi_output, indented(<<~RBI, 2))
         sig { params(value: Time).returns(Time) }
         def post_time=(value); end
-      RUBY
+      RBI
 
-      assert_includes(rbi_output, indented(<<~RUBY, 2))
+      assert_includes(rbi_output, indented(<<~RBI, 2))
         sig { params(value: DateTime).returns(DateTime) }
         def review_time=(value); end
-      RUBY
+      RBI
 
-      assert_includes(rbi_output, indented(<<~RUBY, 2))
+      assert_includes(rbi_output, indented(<<~RBI, 2))
         sig { params(value: BigDecimal).returns(BigDecimal) }
         def credit_point=(value); end
-      RUBY
+      RBI
 
-      assert_includes(rbi_output, indented(<<~RUBY, 2))
+      assert_includes(rbi_output, indented(<<~RBI, 2))
         sig { params(value: String).returns(String) }
         def active=(value); end
-      RUBY
+      RBI
 
-      assert_includes(rbi_output, indented(<<~RUBY, 2))
+      assert_includes(rbi_output, indented(<<~RBI, 2))
         sig { params(value: String).returns(String) }
         def message=(value); end
-      RUBY
+      RBI
     end
   end
 end

--- a/spec/tapioca/compilers/dsl/smart_properties_spec.rb
+++ b/spec/tapioca/compilers/dsl/smart_properties_spec.rb
@@ -6,11 +6,11 @@ require "spec_helper"
 class Tapioca::Compilers::Dsl::SmartPropertiesSpec < DslSpec
   describe("#initialize") do
     it("gathers no constants if there are no SmartProperty classes") do
-      assert_empty(constants_from(""))
+      assert_empty(gathered_constants)
     end
 
     it("gathers only SmartProperty classes") do
-      content = <<~RUBY
+      add_ruby_file("content.rb", <<~RUBY)
         class Post
           include ::SmartProperties
         end
@@ -23,11 +23,11 @@ class Tapioca::Compilers::Dsl::SmartPropertiesSpec < DslSpec
         end
       RUBY
 
-      assert_equal(["Post", "User"], constants_from(content))
+      assert_equal(["Post", "User"], gathered_constants)
     end
 
     it("ignores SmartProperty classes without a name") do
-      content = <<~RUBY
+      add_ruby_file("content.rb", <<~RUBY)
         class Post
           include ::SmartProperties
 
@@ -37,35 +37,35 @@ class Tapioca::Compilers::Dsl::SmartPropertiesSpec < DslSpec
         end
       RUBY
 
-      assert_empty(constants_from(content))
+      assert_empty(gathered_constants)
     end
   end
 
   describe("#decorate") do
     it("generates empty RBI file if there are no smart properties") do
-      content = <<~RUBY
+      add_ruby_file("post.rb", <<~RUBY)
         class Post
           include SmartProperties
         end
       RUBY
 
-      expected = <<~RUBY
+      expected = <<~RBI
         # typed: strong
 
-      RUBY
+      RBI
 
-      assert_equal(expected, rbi_for(:Post, content))
+      assert_equal(expected, rbi_for(:Post))
     end
 
     it("generates RBI file for simple smart property") do
-      content = <<~RUBY
+      add_ruby_file("post.rb", <<~RUBY)
         class Post
           include SmartProperties
           property :title, accepts: String
         end
       RUBY
 
-      expected = <<~RUBY
+      expected = <<~RBI
         # typed: strong
         class Post
           sig { returns(T.nilable(::String)) }
@@ -74,20 +74,20 @@ class Tapioca::Compilers::Dsl::SmartPropertiesSpec < DslSpec
           sig { params(title: T.nilable(::String)).returns(T.nilable(::String)) }
           def title=(title); end
         end
-      RUBY
+      RBI
 
-      assert_equal(expected, rbi_for(:Post, content))
+      assert_equal(expected, rbi_for(:Post))
     end
 
     it("generates RBI file for required smart property") do
-      content = <<~RUBY
+      add_ruby_file("post.rb", <<~RUBY)
         class Post
           include SmartProperties
           property! :description, accepts: String
         end
       RUBY
 
-      expected = <<~RUBY
+      expected = <<~RBI
         # typed: strong
         class Post
           sig { returns(::String) }
@@ -96,20 +96,20 @@ class Tapioca::Compilers::Dsl::SmartPropertiesSpec < DslSpec
           sig { params(description: ::String).returns(::String) }
           def description=(description); end
         end
-      RUBY
+      RBI
 
-      assert_equal(expected, rbi_for(:Post, content))
+      assert_equal(expected, rbi_for(:Post))
     end
 
     it("defaults to T.untyped for smart property that does not have an accepter") do
-      content = <<~RUBY
+      add_ruby_file("post.rb", <<~RUBY)
         class Post
           include SmartProperties
           property :title
         end
       RUBY
 
-      expected = <<~RUBY
+      expected = <<~RBI
         # typed: strong
         class Post
           sig { returns(T.untyped) }
@@ -118,20 +118,20 @@ class Tapioca::Compilers::Dsl::SmartPropertiesSpec < DslSpec
           sig { params(title: T.untyped).returns(T.untyped) }
           def title=(title); end
         end
-      RUBY
+      RBI
 
-      assert_equal(expected, rbi_for(:Post, content))
+      assert_equal(expected, rbi_for(:Post))
     end
 
     it("defaults to T::Array for smart property that accepts Arrays") do
-      content = <<~RUBY
+      add_ruby_file("post.rb", <<~RUBY)
         class Post
           include SmartProperties
           property :categories, accepts: Array
         end
       RUBY
 
-      expected = <<~RUBY
+      expected = <<~RBI
         # typed: strong
         class Post
           sig { returns(T.nilable(T::Array[T.untyped])) }
@@ -140,20 +140,20 @@ class Tapioca::Compilers::Dsl::SmartPropertiesSpec < DslSpec
           sig { params(categories: T.nilable(T::Array[T.untyped])).returns(T.nilable(T::Array[T.untyped])) }
           def categories=(categories); end
         end
-      RUBY
+      RBI
 
-      assert_equal(expected, rbi_for(:Post, content))
+      assert_equal(expected, rbi_for(:Post))
     end
 
     it("generates RBI file for smart property that accepts booleans") do
-      content = <<~RUBY
+      add_ruby_file("post.rb", <<~RUBY)
         class Post
           include SmartProperties
           property :published, accepts: [true, false]
         end
       RUBY
 
-      expected = <<~RUBY
+      expected = <<~RBI
         # typed: strong
         class Post
           sig { returns(T.nilable(T::Boolean)) }
@@ -162,20 +162,20 @@ class Tapioca::Compilers::Dsl::SmartPropertiesSpec < DslSpec
           sig { params(published: T.nilable(T::Boolean)).returns(T.nilable(T::Boolean)) }
           def published=(published); end
         end
-      RUBY
+      RBI
 
-      assert_equal(expected, rbi_for(:Post, content))
+      assert_equal(expected, rbi_for(:Post))
     end
 
     it("generates RBI file for smart property that accepts an array of values") do
-      content = <<~RUBY
+      add_ruby_file("post.rb", <<~RUBY)
         class Post
           include SmartProperties
           property :status, accepts: [String, Integer]
         end
       RUBY
 
-      expected = <<~RUBY
+      expected = <<~RBI
         # typed: strong
         class Post
           sig { returns(T.nilable(T.any(::String, ::Integer))) }
@@ -184,20 +184,20 @@ class Tapioca::Compilers::Dsl::SmartPropertiesSpec < DslSpec
           sig { params(status: T.nilable(T.any(::String, ::Integer))).returns(T.nilable(T.any(::String, ::Integer))) }
           def status=(status); end
         end
-      RUBY
+      RBI
 
-      assert_equal(expected, rbi_for(:Post, content))
+      assert_equal(expected, rbi_for(:Post))
     end
 
     it("defaults to T.untyped if a converter is defined") do
-      content = <<~RUBY
+      add_ruby_file("post.rb", <<~RUBY)
         class Post
           include SmartProperties
           property :status, accepts: Integer, converts: :to_s
         end
       RUBY
 
-      expected = <<~RUBY
+      expected = <<~RBI
         # typed: strong
         class Post
           sig { returns(T.untyped) }
@@ -206,20 +206,20 @@ class Tapioca::Compilers::Dsl::SmartPropertiesSpec < DslSpec
           sig { params(status: T.untyped).returns(T.untyped) }
           def status=(status); end
         end
-      RUBY
+      RBI
 
-      assert_equal(expected, rbi_for(:Post, content))
+      assert_equal(expected, rbi_for(:Post))
     end
 
     it("ignores required if it is a lambda") do
-      content = <<~RUBY
+      add_ruby_file("post.rb", <<~RUBY)
         class Post
           include SmartProperties
           property :status, accepts: Integer, required: -> { true }
         end
       RUBY
 
-      expected = <<~RUBY
+      expected = <<~RBI
         # typed: strong
         class Post
           sig { returns(T.nilable(::Integer)) }
@@ -228,20 +228,20 @@ class Tapioca::Compilers::Dsl::SmartPropertiesSpec < DslSpec
           sig { params(status: T.nilable(::Integer)).returns(T.nilable(::Integer)) }
           def status=(status); end
         end
-      RUBY
+      RBI
 
-      assert_equal(expected, rbi_for(:Post, content))
+      assert_equal(expected, rbi_for(:Post))
     end
 
     it("ignores required if property is not typed") do
-      content = <<~RUBY
+      add_ruby_file("post.rb", <<~RUBY)
         class Post
           include SmartProperties
           property :status, required: true
         end
       RUBY
 
-      expected = <<~RUBY
+      expected = <<~RBI
         # typed: strong
         class Post
           sig { returns(T.untyped) }
@@ -250,20 +250,20 @@ class Tapioca::Compilers::Dsl::SmartPropertiesSpec < DslSpec
           sig { params(status: T.untyped).returns(T.untyped) }
           def status=(status); end
         end
-      RUBY
+      RBI
 
-      assert_equal(expected, rbi_for(:Post, content))
+      assert_equal(expected, rbi_for(:Post))
     end
 
     it("generates a reader that has been renamed correctly") do
-      content = <<~RUBY
+      add_ruby_file("post.rb", <<~RUBY)
         class Post
           include SmartProperties
           property :status, accepts: Integer, reader: :reader_for_status
         end
       RUBY
 
-      expected = <<~RUBY
+      expected = <<~RBI
         # typed: strong
         class Post
           sig { returns(T.nilable(::Integer)) }
@@ -272,20 +272,20 @@ class Tapioca::Compilers::Dsl::SmartPropertiesSpec < DslSpec
           sig { params(status: T.nilable(::Integer)).returns(T.nilable(::Integer)) }
           def status=(status); end
         end
-      RUBY
+      RBI
 
-      assert_equal(expected, rbi_for(:Post, content))
+      assert_equal(expected, rbi_for(:Post))
     end
 
     it("generates RBI file for smart property that accepts boolean and has a default") do
-      content = <<~RUBY
+      add_ruby_file("post.rb", <<~RUBY)
         class Post
           include SmartProperties
           property :enabled, accepts: [true, false], default: false
         end
       RUBY
 
-      expected = <<~RUBY
+      expected = <<~RBI
         # typed: strong
         class Post
           sig { returns(T.nilable(T::Boolean)) }
@@ -294,20 +294,20 @@ class Tapioca::Compilers::Dsl::SmartPropertiesSpec < DslSpec
           sig { params(enabled: T.nilable(T::Boolean)).returns(T.nilable(T::Boolean)) }
           def enabled=(enabled); end
         end
-      RUBY
+      RBI
 
-      assert_equal(expected, rbi_for(:Post, content))
+      assert_equal(expected, rbi_for(:Post))
     end
 
     it("generates RBI file for smart property that accepts a lambda") do
-      content = <<~RUBY
+      add_ruby_file("post.rb", <<~RUBY)
         class Post
           include SmartProperties
           property :title, accepts: lambda { |title| /^Lorem \w+$/ =~ title }
         end
       RUBY
 
-      expected = <<~RUBY
+      expected = <<~RBI
         # typed: strong
         class Post
           sig { returns(T.untyped) }
@@ -316,15 +316,16 @@ class Tapioca::Compilers::Dsl::SmartPropertiesSpec < DslSpec
           sig { params(title: T.untyped).returns(T.untyped) }
           def title=(title); end
         end
-      RUBY
+      RBI
 
-      assert_equal(expected, rbi_for(:Post, content))
+      assert_equal(expected, rbi_for(:Post))
     end
 
     it("generates RBI file for smart property that accepts another ObjectClass") do
-      content = <<~RUBY
+      add_ruby_file("post.rb", <<~RUBY)
         class Post
           include SmartProperties
+
           class TrackingInfoInput
             include SmartProperties
 
@@ -332,11 +333,12 @@ class Tapioca::Compilers::Dsl::SmartPropertiesSpec < DslSpec
             property :carrier_id, accepts: String
             property :url, accepts: String
           end
+
           property :title, accepts: TrackingInfoInput
         end
       RUBY
 
-      expected = <<~RUBY
+      expected = <<~RBI
         # typed: strong
         class Post
           sig { returns(T.nilable(::Post::TrackingInfoInput)) }
@@ -345,9 +347,36 @@ class Tapioca::Compilers::Dsl::SmartPropertiesSpec < DslSpec
           sig { params(title: T.nilable(::Post::TrackingInfoInput)).returns(T.nilable(::Post::TrackingInfoInput)) }
           def title=(title); end
         end
-      RUBY
+      RBI
 
-      assert_equal(expected, rbi_for(:Post, content))
+      assert_equal(expected, rbi_for(:Post))
+
+      expected = <<~RBI
+        # typed: strong
+        class Post
+          class TrackingInfoInput
+            sig { returns(T.nilable(::String)) }
+            def carrier_id; end
+
+            sig { params(carrier_id: T.nilable(::String)).returns(T.nilable(::String)) }
+            def carrier_id=(carrier_id); end
+
+            sig { returns(::String) }
+            def number; end
+
+            sig { params(number: ::String).returns(::String) }
+            def number=(number); end
+
+            sig { returns(T.nilable(::String)) }
+            def url; end
+
+            sig { params(url: T.nilable(::String)).returns(T.nilable(::String)) }
+            def url=(url); end
+          end
+        end
+      RBI
+
+      assert_equal(expected, rbi_for("Post::TrackingInfoInput"))
     end
   end
 end

--- a/spec/tapioca/compilers/dsl/url_helpers_spec.rb
+++ b/spec/tapioca/compilers/dsl/url_helpers_spec.rb
@@ -6,7 +6,7 @@ require "spec_helper"
 class Tapioca::Compilers::Dsl::UrlHelpersSpec < DslSpec
   describe("#initialize") do
     it("does not gather constants when url_helpers is not included") do
-      content = <<~RUBY
+      add_ruby_file("content.rb", <<~RUBY)
         class Application < Rails::Application
         end
 
@@ -19,11 +19,11 @@ class Tapioca::Compilers::Dsl::UrlHelpersSpec < DslSpec
         "ActionView::Helpers",
         "GeneratedPathHelpersModule",
         "GeneratedUrlHelpersModule",
-      ], constants_from(content))
+      ], gathered_constants)
     end
 
     it("gathers constants that include url_helpers") do
-      content = <<~RUBY
+      add_ruby_file("content.rb", <<~RUBY)
         class Application < Rails::Application
         end
 
@@ -38,11 +38,11 @@ class Tapioca::Compilers::Dsl::UrlHelpersSpec < DslSpec
         "GeneratedPathHelpersModule",
         "GeneratedUrlHelpersModule",
         "MyClass",
-      ], constants_from(content))
+      ], gathered_constants)
     end
 
     it("gathers constants that extend url_helpers") do
-      content = <<~RUBY
+      add_ruby_file("content.rb", <<~RUBY)
         class Application < Rails::Application
         end
 
@@ -57,11 +57,11 @@ class Tapioca::Compilers::Dsl::UrlHelpersSpec < DslSpec
         "GeneratedPathHelpersModule",
         "GeneratedUrlHelpersModule",
         "MyClass",
-      ], constants_from(content))
+      ], gathered_constants)
     end
 
     it("gathers constants that have a singleton class that includes url_helpers") do
-      content = <<~RUBY
+      add_ruby_file("content.rb", <<~RUBY)
         class Application < Rails::Application
         end
 
@@ -78,11 +78,11 @@ class Tapioca::Compilers::Dsl::UrlHelpersSpec < DslSpec
         "GeneratedPathHelpersModule",
         "GeneratedUrlHelpersModule",
         "MyClass",
-      ], constants_from(content))
+      ], gathered_constants)
     end
 
     it("does not gather constants when its superclass includes url_helpers") do
-      content = <<~RUBY
+      add_ruby_file("content.rb", <<~RUBY)
         class Application < Rails::Application
         end
 
@@ -100,11 +100,11 @@ class Tapioca::Compilers::Dsl::UrlHelpersSpec < DslSpec
         "GeneratedPathHelpersModule",
         "GeneratedUrlHelpersModule",
         "SuperClass",
-      ], constants_from(content))
+      ], gathered_constants)
     end
 
     it("gathers constants when its superclass extends url_helpers") do
-      content = <<~RUBY
+      add_ruby_file("content.rb", <<~RUBY)
         class Application < Rails::Application
         end
 
@@ -122,11 +122,11 @@ class Tapioca::Compilers::Dsl::UrlHelpersSpec < DslSpec
         "GeneratedPathHelpersModule",
         "GeneratedUrlHelpersModule",
         "SuperClass",
-      ], constants_from(content))
+      ], gathered_constants)
     end
 
     it("does not gather constants when the constant and its superclass includes url_helpers") do
-      content = <<~RUBY
+      add_ruby_file("content.rb", <<~RUBY)
         class Application < Rails::Application
         end
 
@@ -145,30 +145,30 @@ class Tapioca::Compilers::Dsl::UrlHelpersSpec < DslSpec
         "GeneratedPathHelpersModule",
         "GeneratedUrlHelpersModule",
         "SuperClass",
-      ], constants_from(content))
+      ], gathered_constants)
     end
   end
 
   describe("#decorate") do
     it("generates RBI when there are no helper methods") do
-      content = <<~RUBY
+      add_ruby_file("routes.rb", <<~RUBY)
         class Application < Rails::Application
         end
       RUBY
 
-      expected = <<~RUBY
+      expected = <<~RBI
         # typed: strong
         module GeneratedUrlHelpersModule
           include ::ActionDispatch::Routing::PolymorphicRoutes
           include ::ActionDispatch::Routing::UrlFor
         end
-      RUBY
+      RBI
 
-      assert_equal(expected, rbi_for(:GeneratedUrlHelpersModule, content))
+      assert_equal(expected, rbi_for(:GeneratedUrlHelpersModule))
     end
 
     it("generates RBI for GeneratedPathHelpersModule with helper methods") do
-      content = <<~RUBY
+      add_ruby_file("routes.rb", <<~RUBY)
         class Application < Rails::Application
           routes.draw do
             resource :index
@@ -176,7 +176,7 @@ class Tapioca::Compilers::Dsl::UrlHelpersSpec < DslSpec
         end
       RUBY
 
-      expected = <<~RUBY
+      expected = <<~RBI
         # typed: strong
         module GeneratedPathHelpersModule
           include ::ActionDispatch::Routing::PolymorphicRoutes
@@ -191,13 +191,13 @@ class Tapioca::Compilers::Dsl::UrlHelpersSpec < DslSpec
           sig { params(args: T.untyped).returns(String) }
           def new_index_path(*args); end
         end
-      RUBY
+      RBI
 
-      assert_equal(expected, rbi_for(:GeneratedPathHelpersModule, content))
+      assert_equal(expected, rbi_for(:GeneratedPathHelpersModule))
     end
 
     it("generates RBI for GeneratedUrlHelpersModule with helper methods") do
-      content = <<~RUBY
+      add_ruby_file("routes.rb", <<~RUBY)
         class Application < Rails::Application
           routes.draw do
             resource :index
@@ -205,7 +205,7 @@ class Tapioca::Compilers::Dsl::UrlHelpersSpec < DslSpec
         end
       RUBY
 
-      expected = <<~RUBY
+      expected = <<~RBI
         # typed: strong
         module GeneratedUrlHelpersModule
           include ::ActionDispatch::Routing::PolymorphicRoutes
@@ -220,18 +220,18 @@ class Tapioca::Compilers::Dsl::UrlHelpersSpec < DslSpec
           sig { params(args: T.untyped).returns(String) }
           def new_index_url(*args); end
         end
-      RUBY
+      RBI
 
-      assert_equal(expected, rbi_for(:GeneratedUrlHelpersModule, content))
+      assert_equal(expected, rbi_for(:GeneratedUrlHelpersModule))
     end
 
     it("generates RBI for ActionDispatch::IntegrationTest") do
-      content = <<~RUBY
+      add_ruby_file("routes.rb", <<~RUBY)
         class Application < Rails::Application
         end
       RUBY
 
-      expected = <<~RUBY
+      expected = <<~RBI
         # typed: strong
         module ActionDispatch
           class IntegrationTest
@@ -239,18 +239,18 @@ class Tapioca::Compilers::Dsl::UrlHelpersSpec < DslSpec
             include GeneratedUrlHelpersModule
           end
         end
-      RUBY
+      RBI
 
-      assert_equal(expected, rbi_for("ActionDispatch::IntegrationTest", content))
+      assert_equal(expected, rbi_for("ActionDispatch::IntegrationTest"))
     end
 
     it("generates RBI for ActionView::Helpers") do
-      content = <<~RUBY
+      add_ruby_file("routes.rb", <<~RUBY)
         class Application < Rails::Application
         end
       RUBY
 
-      expected = <<~RUBY
+      expected = <<~RBI
         # typed: strong
         module ActionView
           module Helpers
@@ -258,65 +258,71 @@ class Tapioca::Compilers::Dsl::UrlHelpersSpec < DslSpec
             include GeneratedUrlHelpersModule
           end
         end
-      RUBY
+      RBI
 
-      assert_equal(expected, rbi_for("ActionView::Helpers", content))
+      assert_equal(expected, rbi_for("ActionView::Helpers"))
     end
 
     it("generates RBI for constant that includes url_helpers") do
-      content = <<~RUBY
+      add_ruby_file("routes.rb", <<~RUBY)
         class Application < Rails::Application
         end
+      RUBY
 
+      add_ruby_file("my_class.rb", <<~RUBY)
         class MyClass
           include Rails.application.routes.url_helpers
         end
       RUBY
 
-      expected = <<~RUBY
+      expected = <<~RBI
         # typed: strong
         class MyClass
           include GeneratedPathHelpersModule
           include GeneratedUrlHelpersModule
         end
-      RUBY
+      RBI
 
-      assert_equal(expected, rbi_for(:MyClass, content))
+      assert_equal(expected, rbi_for(:MyClass))
     end
 
     it("generates RBI for constant that extends url_helpers") do
-      content = <<~RUBY
+      add_ruby_file("routes.rb", <<~RUBY)
         class Application < Rails::Application
         end
+      RUBY
 
+      add_ruby_file("my_class.rb", <<~RUBY)
         class MyClass
           extend Rails.application.routes.url_helpers
         end
       RUBY
 
-      expected = <<~RUBY
+      expected = <<~RBI
         # typed: strong
         class MyClass
           extend GeneratedPathHelpersModule
           extend GeneratedUrlHelpersModule
         end
-      RUBY
+      RBI
 
-      assert_equal(expected, rbi_for(:MyClass, content))
+      assert_equal(expected, rbi_for(:MyClass))
     end
 
     it("generates RBI for constant that includes and extends url_helpers") do
-      content = <<~RUBY
+      add_ruby_file("routes.rb", <<~RUBY)
         class Application < Rails::Application
         end
+      RUBY
 
+      add_ruby_file("my_class.rb", <<~RUBY)
         class MyClass
           include Rails.application.routes.url_helpers
           extend Rails.application.routes.url_helpers
         end
       RUBY
 
-      expected = <<~RUBY
+      expected = <<~RBI
         # typed: strong
         class MyClass
           include GeneratedPathHelpersModule
@@ -324,16 +330,18 @@ class Tapioca::Compilers::Dsl::UrlHelpersSpec < DslSpec
           extend GeneratedPathHelpersModule
           extend GeneratedUrlHelpersModule
         end
-      RUBY
+      RBI
 
-      assert_equal(expected, rbi_for(:MyClass, content))
+      assert_equal(expected, rbi_for(:MyClass))
     end
 
     it("generates RBI for constant that has a singleton class which includes url_helpers") do
-      content = <<~RUBY
+      add_ruby_file("routes.rb", <<~RUBY)
         class Application < Rails::Application
         end
+      RUBY
 
+      add_ruby_file("my_class.rb", <<~RUBY)
         class MyClass
           class << self
             include Rails.application.routes.url_helpers
@@ -341,22 +349,24 @@ class Tapioca::Compilers::Dsl::UrlHelpersSpec < DslSpec
         end
       RUBY
 
-      expected = <<~RUBY
+      expected = <<~RBI
         # typed: strong
         class MyClass
           extend GeneratedPathHelpersModule
           extend GeneratedUrlHelpersModule
         end
-      RUBY
+      RBI
 
-      assert_equal(expected, rbi_for(:MyClass, content))
+      assert_equal(expected, rbi_for(:MyClass))
     end
 
     it("generates RBI when constant itself and its singleton class includes url_helpers") do
-      content = <<~RUBY
+      add_ruby_file("routes.rb", <<~RUBY)
         class Application < Rails::Application
         end
+      RUBY
 
+      add_ruby_file("my_class.rb", <<~RUBY)
         class MyClass
           include Rails.application.routes.url_helpers
           class << self
@@ -365,7 +375,7 @@ class Tapioca::Compilers::Dsl::UrlHelpersSpec < DslSpec
         end
       RUBY
 
-      expected = <<~RUBY
+      expected = <<~RBI
         # typed: strong
         class MyClass
           include GeneratedPathHelpersModule
@@ -373,9 +383,9 @@ class Tapioca::Compilers::Dsl::UrlHelpersSpec < DslSpec
           extend GeneratedPathHelpersModule
           extend GeneratedUrlHelpersModule
         end
-      RUBY
+      RBI
 
-      assert_equal(expected, rbi_for(:MyClass, content))
+      assert_equal(expected, rbi_for(:MyClass))
     end
   end
 end

--- a/spec/template_helper.rb
+++ b/spec/template_helper.rb
@@ -1,6 +1,8 @@
 # typed: strict
 # frozen_string_literal: true
 
+require "erb"
+
 module TemplateHelper
   extend T::Sig
 


### PR DESCRIPTION

### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->

The motivation is to separate test file creation operations from the test mechanism so that
test helpers can depend on less context.

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->

In the new setup, tests are responsible for declaring Ruby files they want as part of their setup using `add_ruby_file` which creates and requires the file by default. To add non-Ruby files, tests can call `add_content_file` which creates the file under the given path in the temp directory.

All test operations operate on files in the temp directory, by default, and the content helper removes the temp directory during teardown.

This allows for a more declarative test style and we don't have to keep passing around hashes of loosely structured data into test helper methods.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->

Existing tests are refactored.
