### PR TITLE
Copy IsolationHelper from ActiveSupport

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,6 @@ gem("yard", "~> 0.9.25")
 gem("pry-byebug")
 gem("minitest")
 gem("minitest-hooks")
-gem("minitest-fork_executor")
 gem("minitest-reporters")
 gem("sorbet")
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -108,8 +108,6 @@ GEM
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.14.2)
-    minitest-fork_executor (1.0.1)
-      minitest
     minitest-hooks (1.5.0)
       minitest (> 5.3)
     minitest-reporters (1.4.2)
@@ -218,7 +216,6 @@ DEPENDENCIES
   google-protobuf (~> 3.12.0)
   identity_cache (~> 1.0)
   minitest
-  minitest-fork_executor
   minitest-hooks
   minitest-reporters
   pry-byebug

--- a/spec/dsl_spec.rb
+++ b/spec/dsl_spec.rb
@@ -5,11 +5,13 @@ require "sorbet-runtime"
 require "minitest/spec"
 require "content_helper"
 require "template_helper"
+require "isolation_helper"
 
 class DslSpec < Minitest::Spec
   extend T::Sig
   include ContentHelper
   include TemplateHelper
+  include IsolationHelper
 
   sig { void }
   def after_setup

--- a/spec/isolation_helper.rb
+++ b/spec/isolation_helper.rb
@@ -1,0 +1,109 @@
+# typed: true
+# frozen_string_literal: true
+
+# Copied from ActiveSupport::Testing::Isolation since we cannot require
+# constants from ActiveSupport without polluting the global namespace.
+module IsolationHelper
+  require "thread"
+
+  def self.forking_env?
+    !ENV["NO_FORK"] && Process.respond_to?(:fork)
+  end
+
+  def run
+    serialized = T.unsafe(self).run_in_isolation do
+      super
+    end
+
+    Marshal.load(serialized)
+  end
+
+  module Forking
+    def run_in_isolation(&_blk)
+      read, write = IO.pipe
+      read.binmode
+      write.binmode
+
+      this = T.cast(self, Minitest::Test)
+      pid = Kernel.fork do
+        read.close
+        yield
+        begin
+          if this.error?
+            this.failures.map! do |e|
+              begin
+                Marshal.dump(e)
+                e
+              rescue TypeError
+                ex = Exception.new(e.message)
+                ex.set_backtrace(e.backtrace)
+                Minitest::UnexpectedError.new(ex)
+              end
+            end
+          end
+          test_result = defined?(Minitest::Result) ? Minitest::Result.from(self) : this.dup
+          result = Marshal.dump(test_result)
+        end
+
+        write.puts [result].pack("m")
+        Kernel.exit!(false)
+      end
+
+      write.close
+      result = read.read
+      Process.wait2(T.must(pid))
+      T.must(result).unpack1("m")
+    end
+  end
+
+  module Subprocess
+    ORIG_ARGV = ARGV.dup unless defined?(ORIG_ARGV)
+
+    # Crazy H4X to get this working in windows / jruby with
+    # no forking.
+    def run_in_isolation(&_blk)
+      this = T.cast(self, Minitest::Test)
+      Kernel.require "tempfile"
+
+      if ENV["ISOLATION_TEST"]
+        yield
+        test_result = defined?(Minitest::Result) ? Minitest::Result.from(self) : this.dup
+        File.open(T.must(ENV["ISOLATION_OUTPUT"]), "w") do |file|
+          file.puts [Marshal.dump(test_result)].pack("m")
+        end
+        Kernel.exit!(false)
+      else
+        Tempfile.open("isolation") do |tmpfile|
+          env = {
+            "ISOLATION_TEST" => this.class.name,
+            "ISOLATION_OUTPUT" => tmpfile.path,
+          }
+
+          test_opts = "-n#{this.class.name}##{this.name}"
+
+          load_path_args = []
+          $-I.each do |p|
+            load_path_args << "-I"
+            load_path_args << File.expand_path(p)
+          end
+
+          child = IO.popen([env, Gem.ruby, *load_path_args, $PROGRAM_NAME, *ORIG_ARGV, test_opts])
+
+          begin
+            Process.wait(child.pid)
+          rescue Errno::ECHILD # The child process may exit before we wait
+            nil
+          end
+
+          return T.must(tmpfile.read).unpack1("m")
+        end
+      end
+    end
+  end
+
+  if forking_env?
+    include(Forking)
+  else
+    include(Subprocess)
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,15 +5,14 @@ require "tapioca"
 require "minitest/autorun"
 require "minitest/spec"
 require "minitest/hooks/default"
-require "minitest/fork_executor"
 require "minitest/reporters"
 
 require "content_helper"
 require "template_helper"
+require "isolation_helper"
 require "dsl_spec"
 
 Minitest::Reporters.use!(Minitest::Reporters::SpecReporter.new(color: true))
-Minitest.parallel_executor = Minitest::ForkExecutor.new
 
 module Minitest
   class Test

--- a/spec/tapioca/compilers/symbol_table_compiler_spec.rb
+++ b/spec/tapioca/compilers/symbol_table_compiler_spec.rb
@@ -9,6 +9,7 @@ require "bundler"
 class Tapioca::Compilers::SymbolTableCompilerSpec < Minitest::HooksSpec
   include ContentHelper
   include TemplateHelper
+  include IsolationHelper
 
   describe("compile") do
     sig { returns(String) }


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->

Get rid of the parallel fork executor, so that we can provide a test helper for user code that is trying to write a test for their own custom DSL generator. This commit just adds the `IsolationHelper` module to optionally provide the isolation to the test classes that want it. A future change will add a test helper that consumers of Tapioca can import into their test code as well.

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
Mostly copied the `ActiveSupport::Testing::Isolation` module, with slight modifications to adhere to our code style.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->
No tests for `IsolationHelper` (yet), since it is not a library file (yet).
