### PR TITLE
Stop assuming that constants will have sensible hashes

### DIFF
--- a/lib/tapioca/compilers/symbol_table/symbol_generator.rb
+++ b/lib/tapioca/compilers/symbol_table/symbol_generator.rb
@@ -294,8 +294,7 @@ module Tapioca
         def compile_mixins(constant)
           ignorable_ancestors =
             if constant.is_a?(Class)
-              ancestors = constant.superclass&.ancestors || Object.ancestors
-              Set.new(ancestors)
+              constant.superclass&.ancestors || Object.ancestors
             else
               Module.ancestors
             end
@@ -307,8 +306,7 @@ module Tapioca
               Module.ancestors
             end
 
-          interesting_ancestors =
-            constant.ancestors.reject { |mod| ignorable_ancestors.include?(mod) }
+          interesting_ancestors = constant.ancestors - ignorable_ancestors
 
           prepend = interesting_ancestors.take_while { |c| !are_equal?(constant, c) }
           include = interesting_ancestors.drop(prepend.size + 1)

--- a/lib/tapioca/compilers/symbol_table/symbol_generator.rb
+++ b/lib/tapioca/compilers/symbol_table/symbol_generator.rb
@@ -306,7 +306,9 @@ module Tapioca
               Module.ancestors
             end
 
-          interesting_ancestors = constant.ancestors - ignorable_ancestors
+          interesting_ancestors = constant.ancestors.reject do |mod|
+            ignorable_ancestors.any? { |ignorable_ancestor| are_equal?(mod, ignorable_ancestor) }
+          end
 
           prepend = interesting_ancestors.take_while { |c| !are_equal?(constant, c) }
           include = interesting_ancestors.drop(prepend.size + 1)

--- a/spec/tapioca/compilers/symbol_table_compiler_spec.rb
+++ b/spec/tapioca/compilers/symbol_table_compiler_spec.rb
@@ -601,34 +601,25 @@ class Tapioca::Compilers::SymbolTableCompilerSpec < Minitest::HooksSpec
       assert_equal(output, compile)
     end
 
-    it("compiles constants that have horrible ==, eql? or equal? overrides") do
+    it("compiles constants that have horrible eql? or equal? overrides") do
       add_ruby_file("foo.rb", <<~RUBY)
-        class Foo
-          class << self
-            def ==(other)
-              false
-            end
-          end
-
+        module Foo
           module Bar
             def self.equal?
-              false
+              raise RuntimeError
             end
           end
 
           class Baz
             def self.eql?
-              false
+              raise RuntimeError
             end
           end
         end
       RUBY
 
       output = <<~RBI
-        class Foo
-          class << self
-            def ==(other); end
-          end
+        module Foo
         end
 
         module Foo::Bar

--- a/spec/tapioca/compilers/symbol_table_compiler_spec.rb
+++ b/spec/tapioca/compilers/symbol_table_compiler_spec.rb
@@ -564,13 +564,13 @@ class Tapioca::Compilers::SymbolTableCompilerSpec < Minitest::HooksSpec
             end
           end
 
-          class Baz
+          module Bar
             def self.hash
               {}
             end
           end
 
-          module Bar
+          class Baz
             def self.hash
               {}
             end
@@ -594,6 +594,52 @@ class Tapioca::Compilers::SymbolTableCompilerSpec < Minitest::HooksSpec
         class Foo::Baz
           class << self
             def hash; end
+          end
+        end
+      RBI
+
+      assert_equal(output, compile)
+    end
+
+    it("compiles constants that have horrible ==, eql? or equal? overrides") do
+      add_ruby_file("foo.rb", <<~RUBY)
+        class Foo
+          class << self
+            def ==(other)
+              false
+            end
+          end
+
+          module Bar
+            def self.equal?
+              false
+            end
+          end
+
+          class Baz
+            def self.eql?
+              false
+            end
+          end
+        end
+      RUBY
+
+      output = <<~RBI
+        class Foo
+          class << self
+            def ==(other); end
+          end
+        end
+
+        module Foo::Bar
+          class << self
+            def equal?; end
+          end
+        end
+
+        class Foo::Baz
+          class << self
+            def eql?; end
           end
         end
       RBI

--- a/spec/tapioca/compilers/symbol_table_compiler_spec.rb
+++ b/spec/tapioca/compilers/symbol_table_compiler_spec.rb
@@ -555,6 +555,52 @@ class Tapioca::Compilers::SymbolTableCompilerSpec < Minitest::HooksSpec
       assert_equal(output, compile)
     end
 
+    it("compiles constants that have a hash method on the constant which does not return an Integer") do
+      add_ruby_file("foo.rb", <<~RUBY)
+        class Foo
+          class << self
+            def hash
+              {}
+            end
+          end
+
+          class Baz
+            def self.hash
+              {}
+            end
+          end
+
+          module Bar
+            def self.hash
+              {}
+            end
+          end
+        end
+      RUBY
+
+      output = <<~RBI
+        class Foo
+          class << self
+            def hash; end
+          end
+        end
+
+        module Foo::Bar
+          class << self
+            def hash; end
+          end
+        end
+
+        class Foo::Baz
+          class << self
+            def hash; end
+          end
+        end
+      RBI
+
+      assert_equal(output, compile)
+    end
+
     it("compiles a class which effectively has itself as a superclass") do
       add_ruby_file("foo.rb", <<~RUBY)
         module Foo


### PR DESCRIPTION
### Motivation

Fixes #191

If a constant overrides the `hash` method at the constant level in an incompatible way by returning a value that is not an `Integer`, then `Set` stops working for that constant.

However, we were using a `Set` for filtering out ignorable ancestors when discovering mixins, which was failing with a cryptic error message if it ever came across a constant that did such a thing.

### Implementation

~The solution is to use array difference rather than sets and enumeration, which actually makes the code simpler in the process.~

The new implementation uses a `Set` of `object_id`s to compare the inherited ancestors against the ancestors of the `constant` or the singleton class of the `constant` to find interesting ancestors. This allows us to not depend on `==`, `eql?`, `equal?` or `hash` for comparing ancestors.

### Tests

Added an expanded version of the reported failure case as a test and a test that makes sure that overridden `==`, `eql?` and `equal?` methods don't affect us.
