### PR TITLE
Fix RBI compile for constant aliases

### DIFF
--- a/lib/tapioca/compilers/symbol_table/symbol_generator.rb
+++ b/lib/tapioca/compilers/symbol_table/symbol_generator.rb
@@ -74,9 +74,9 @@ module Tapioca
           compile(symbol, constant)
         end
 
-        sig { params(symbol: String).returns(BasicObject).checked(:never) }
-        def resolve_constant(symbol)
-          Object.const_get(symbol, false)
+        sig { params(symbol: String, inherit: T::Boolean).returns(BasicObject).checked(:never) }
+        def resolve_constant(symbol, inherit: false)
+          Object.const_get(symbol, inherit)
         rescue NameError, LoadError, RuntimeError, ArgumentError, TypeError
           nil
         end
@@ -792,7 +792,7 @@ module Tapioca
           return name if name
           name = raw_name_of(constant)
           return if name.nil?
-          return unless are_equal?(constant, resolve_constant(name))
+          return unless are_equal?(constant, resolve_constant(name, inherit: true))
           name = "Struct" if name =~ /^(::)?Struct::[^:]+$/
           name
         end


### PR DESCRIPTION
### Motivation

Tapioca is compiling RBI files that contain syntax errors in some cases where a class ends up overwriting its own superclass by aliasing that superclass to itself.

### Implementation

We can fix this by having `resolve_constant` take an optional `inherit` parameter which defaults to `false`. In the codepath where this comes up, we're comparing the name of the constant we see with the name of the constant returned by calling `Object.const_get` with that name. It seems like sort of a sanity check. Like, checking that this constant does in fact exist and we can find it, I guess? So we don't mind passing `inherit: true` to const_get here _I don't think_. Correct me if I'm wrong.

@paracycle was wondering if we even needed this `are_equal?` check in this case at all, and I think he was going to look into that.

### Tests

If you take away the optional `inherit` flag OR set it to `false` in the `name_of` method, the test will fail as the RBI generated will look as follows:

```ruby
        HTTPClient = WebMockHTTPClient

        class WebAgent
        end

        WebAgent::CookieManager =  # This is the problem

        class WebMockHTTPClient
        end
```

Note that I think this bug was hidden for a while simply because having that empty assignment doesn't make a typecheck fail unless it's the last line of the RBI file! So I got lucky to find it. I think this actually affects a lot more than just httpclient but that's where I noticed it.

Also: Thanks @paracycle and @KaanOzkan for helping me figure this out 💖

Resolves https://github.com/Shopify/tapioca/issues/201