### PR TITLE
Fix Ruby 3.0 compat

### DIFF
--- a/lib/tapioca/compilers/dsl/base.rb
+++ b/lib/tapioca/compilers/dsl/base.rb
@@ -61,7 +61,7 @@ module Tapioca
         end
         def create_method(namespace, name, options = {})
           return unless valid_method_name?(name)
-          T.unsafe(namespace).create_method(name, options)
+          T.unsafe(namespace).create_method(name, **options)
         end
 
         # Create a Parlour method inside `namespace` from its Ruby definition


### PR DESCRIPTION
This is the fix from https://github.com/Shopify/tapioca/pull/203, but without all the changes to try to make the suite pass on 3.0.

THere is a pile of dependency issues to run CI on 3.0:

  - Bundler is too old
  - Rails etc is too old
  - google-protobuf won't install on 3.0 right now
  - probably other stuffs I haven't figured yet.

So I'm thinking in the meantime we can simply merge the fix without testing it on CI.