### PR TITLE
Fix bug in compile_alias when constant names are mismatched

### DIFF
--- a/lib/tapioca/compilers/symbol_table/symbol_generator.rb
+++ b/lib/tapioca/compilers/symbol_table/symbol_generator.rb
@@ -122,8 +122,9 @@ module Tapioca
         def compile_alias(name, constant)
           return if symbol_ignored?(name)
 
-          constant_name = name_of(constant)
-          target = constant_name.nil? ? "#{constant.class}.new" : constant_name
+          target = name_of(constant)
+          # If target has no name, let's make it an anonymous class or module with `Class.new` or `Module.new`
+          target = "#{constant.class}.new" unless target
 
           add_to_alias_namespace(name)
 

--- a/lib/tapioca/compilers/symbol_table/symbol_generator.rb
+++ b/lib/tapioca/compilers/symbol_table/symbol_generator.rb
@@ -792,7 +792,6 @@ module Tapioca
           return name if name
           name = raw_name_of(constant)
           return if name.nil?
-          return unless are_equal?(constant, resolve_constant(name, inherit: true))
           name = "Struct" if name =~ /^(::)?Struct::[^:]+$/
           name
         end

--- a/lib/tapioca/compilers/symbol_table/symbol_generator.rb
+++ b/lib/tapioca/compilers/symbol_table/symbol_generator.rb
@@ -123,11 +123,13 @@ module Tapioca
           return if symbol_ignored?(name)
 
           constant_name = name_of(constant)
+          target = constant_name.nil? ? "#{constant.class}.new" : constant_name
+
           add_to_alias_namespace(name)
 
           return if IGNORED_SYMBOLS.include?(name)
 
-          indented("#{name} = #{constant_name}")
+          indented("#{name} = #{target}")
         end
 
         sig do
@@ -792,6 +794,7 @@ module Tapioca
           return name if name
           name = raw_name_of(constant)
           return if name.nil?
+          return unless are_equal?(constant, resolve_constant(name, inherit: true))
           name = "Struct" if name =~ /^(::)?Struct::[^:]+$/
           name
         end

--- a/spec/tapioca/compilers/symbol_table_compiler_spec.rb
+++ b/spec/tapioca/compilers/symbol_table_compiler_spec.rb
@@ -532,7 +532,7 @@ class Tapioca::Compilers::SymbolTableCompilerSpec < Minitest::HooksSpec
     end
 
     it("compiles a constant which is aliased to a constant that has been overwritten as a placeholder") do
-      add_ruby_file("bar.rb", <<~RUBY)
+      add_ruby_file("overwritten_class_module_references.rb", <<~RUBY)
         class MyClient
         end
 

--- a/spec/tapioca/compilers/symbol_table_compiler_spec.rb
+++ b/spec/tapioca/compilers/symbol_table_compiler_spec.rb
@@ -531,6 +531,37 @@ class Tapioca::Compilers::SymbolTableCompilerSpec < Minitest::HooksSpec
       assert_equal(output, compile)
     end
 
+    it("compiles a constant which is aliased to a constant that has been overwritten and the names don't match") do
+      add_ruby_file("bar.rb", <<~RUBY)
+        class MyClient
+        end
+
+        module MyModule
+          # The test above doesn't catch this because the names are different
+          OriginalClient = ::MyClient
+        end
+
+        class MockClient < MyClient
+        end
+
+        MyClient = MockClient
+      RUBY
+
+      output = template(<<~RBI)
+        class MockClient
+        end
+
+        MyClient = MockClient
+
+        module MyModule
+        end
+
+        MyModule::OriginalClient = MyClient
+      RBI
+
+      assert_equal(output, compile)
+    end
+
     it("compiles a class with an anchored superclass") do
       add_ruby_file("baz.rb", <<~RUBY)
         class Baz


### PR DESCRIPTION
### Motivation

Fixing an RBI typo I found. When compiling, there is a chance the constant name that we want to use for an alias doesn't match because that name has itself been overwritten with something.

```ruby
class MyClient
end

module MyModule
  OriginalClient = ::MyClient
end

class MockClient < MyClient
end

MyClient = MockClient
```

In this case, we do a `name_of` on `OriginalClient` which is pointing to `MyClient` but `resolve_constant` results in a `MockClient` because of the last line there. So `are_equal?(constant, resolve_constant(name, inherit: true))` is false and we end up with an empty assignment like `MyModule::OriginalClient =`

### Implementation

~Remove the equality check... It seems to work just fine when running it on my project also.~

~**I don't actually know if this is OK**. So I defer to y'all. @paracycle what was the reason for this equality check in the first place?~

Removing the equality check was actually not OK.
Instead, if `name` turns up blank, we'll set it to an anonymous class or module with `"#{constant.class}.new"`

### Tests

I did add tests! ~If you add the equality check back in that I removed, you'll see the test fail and OriginalClient won't be assigned to anything at all.~
If you remove the lines I've added to symbol_generator.rb, you'll see the test start to fail 👍 