### PR TITLE
Use the collection proxies

### DIFF
--- a/lib/tapioca/compilers/dsl/active_record_associations.rb
+++ b/lib/tapioca/compilers/dsl/active_record_associations.rb
@@ -70,7 +70,7 @@ module Tapioca
       #     sig { params(ids: T::Array[T.untyped]).returns(T::Array[T.untyped]) }
       #     def comment_ids=(ids); end
       #
-      #     sig { returns(::Comment::ActiveRecord_Associations_CollectionProxy) }
+      #     sig { returns(::Comment::PrivateCollectionProxy) }
       #     def comments; end
       #
       #     sig { params(value: T::Enumerable[::Comment]).void }
@@ -277,7 +277,7 @@ module Tapioca
           "ActiveRecord::Associations::CollectionProxy" if !constant.table_exists? ||
                                                             polymorphic_association?(reflection)
 
-          "::#{reflection.klass.name}::ActiveRecord_Associations_CollectionProxy"
+          "::#{reflection.klass.name}::PrivateCollectionProxy"
         end
 
         sig do

--- a/lib/tapioca/compilers/dsl/active_record_associations.rb
+++ b/lib/tapioca/compilers/dsl/active_record_associations.rb
@@ -70,7 +70,7 @@ module Tapioca
       #     sig { params(ids: T::Array[T.untyped]).returns(T::Array[T.untyped]) }
       #     def comment_ids=(ids); end
       #
-      #     sig { returns(::ActiveRecord::Associations::CollectionProxy[Comment]) }
+      #     sig { returns(::Comment::ActiveRecord_Associations_CollectionProxy) }
       #     def comments; end
       #
       #     sig { params(value: T::Enumerable[::Comment]).void }
@@ -277,8 +277,7 @@ module Tapioca
           "ActiveRecord::Associations::CollectionProxy" if !constant.table_exists? ||
                                                             polymorphic_association?(reflection)
 
-          # Change to: "::#{reflection.klass.name}::ActiveRecord_Associations_CollectionProxy"
-          "::ActiveRecord::Associations::CollectionProxy[#{reflection.klass.name}]"
+          "::#{reflection.klass.name}::ActiveRecord_Associations_CollectionProxy"
         end
 
         sig do

--- a/lib/tapioca/compilers/dsl/active_record_scope.rb
+++ b/lib/tapioca/compilers/dsl/active_record_scope.rb
@@ -33,7 +33,7 @@ module Tapioca
       # class Post
       #   extend GeneratedRelationMethods
       #
-      #   class ActiveRecord_Associations_CollectionProxy < ActiveRecord::Relation
+      #   class PrivateCollectionProxy
       #     include GeneratedRelationMethods
       #   end
       #
@@ -61,9 +61,9 @@ module Tapioca
 
           root.path(constant) do |model|
             module_name = "GeneratedRelationMethods"
-            class_name = "ActiveRecord_Associations_CollectionProxy"
+            class_name = "PrivateCollectionProxy"
 
-            model.create_class(class_name, superclass: "ActiveRecord::Relation") do |cls|
+            model.create_class(class_name) do |cls|
               cls.create_include(module_name)
             end
 

--- a/lib/tapioca/compilers/dsl/active_record_scope.rb
+++ b/lib/tapioca/compilers/dsl/active_record_scope.rb
@@ -33,6 +33,10 @@ module Tapioca
       # class Post
       #   extend GeneratedRelationMethods
       #
+      #   class ActiveRecord_Associations_CollectionProxy < ActiveRecord::Relation
+      #     include GeneratedRelationMethods
+      #   end
+      #
       #   module GeneratedRelationMethods
       #     sig { params(args: T.untyped, blk: T.untyped).returns(T.untyped) }
       #     def private_kind(*args, &blk); end
@@ -57,6 +61,11 @@ module Tapioca
 
           root.path(constant) do |model|
             module_name = "GeneratedRelationMethods"
+            class_name = "ActiveRecord_Associations_CollectionProxy"
+
+            model.create_class(class_name, superclass: "ActiveRecord::Relation") do |cls|
+              cls.create_include(module_name)
+            end
 
             model.create_module(module_name) do |mod|
               scope_method_names.each do |scope_method|

--- a/manual/generator_activerecordassociations.md
+++ b/manual/generator_activerecordassociations.md
@@ -58,7 +58,7 @@ class Post
     sig { params(ids: T::Array[T.untyped]).returns(T::Array[T.untyped]) }
     def comment_ids=(ids); end
 
-    sig { returns(::ActiveRecord::Associations::CollectionProxy[Comment]) }
+    sig { returns(::Comment::ActiveRecord_Associations_CollectionProxy) }
     def comments; end
 
     sig { params(value: T::Enumerable[::Comment]).void }

--- a/manual/generator_activerecordassociations.md
+++ b/manual/generator_activerecordassociations.md
@@ -58,7 +58,7 @@ class Post
     sig { params(ids: T::Array[T.untyped]).returns(T::Array[T.untyped]) }
     def comment_ids=(ids); end
 
-    sig { returns(::Comment::ActiveRecord_Associations_CollectionProxy) }
+    sig { returns(::Comment::PrivateCollectionProxy) }
     def comments; end
 
     sig { params(value: T::Enumerable[::Comment]).void }

--- a/manual/generator_activerecordscope.md
+++ b/manual/generator_activerecordscope.md
@@ -21,7 +21,7 @@ this generator will produce the RBI file `post.rbi` with the following content:
 class Post
   extend GeneratedRelationMethods
 
-  class ActiveRecord_Associations_CollectionProxy < ActiveRecord::Relation
+  class PrivateCollectionProxy
     include GeneratedRelationMethods
   end
 

--- a/manual/generator_activerecordscope.md
+++ b/manual/generator_activerecordscope.md
@@ -21,6 +21,10 @@ this generator will produce the RBI file `post.rbi` with the following content:
 class Post
   extend GeneratedRelationMethods
 
+  class ActiveRecord_Associations_CollectionProxy < ActiveRecord::Relation
+    include GeneratedRelationMethods
+  end
+
   module GeneratedRelationMethods
     sig { params(args: T.untyped, blk: T.untyped).returns(T.untyped) }
     def private_kind(*args, &blk); end

--- a/spec/tapioca/compilers/dsl/active_record_associations_spec.rb
+++ b/spec/tapioca/compilers/dsl/active_record_associations_spec.rb
@@ -262,7 +262,7 @@ class Tapioca::Compilers::Dsl::ActiveRecordAssociationsSpec < DslSpec
             sig { params(ids: T::Array[T.untyped]).returns(T::Array[T.untyped]) }
             def comment_ids=(ids); end
 
-            sig { returns(::Comment::ActiveRecord_Associations_CollectionProxy) }
+            sig { returns(::Comment::PrivateCollectionProxy) }
             def comments; end
 
             sig { params(value: T::Enumerable[T.untyped]).void }
@@ -328,7 +328,7 @@ class Tapioca::Compilers::Dsl::ActiveRecordAssociationsSpec < DslSpec
             sig { params(ids: T::Array[T.untyped]).returns(T::Array[T.untyped]) }
             def commenter_ids=(ids); end
 
-            sig { returns(::Commenter::ActiveRecord_Associations_CollectionProxy) }
+            sig { returns(::Commenter::PrivateCollectionProxy) }
             def commenters; end
 
             sig { params(value: T::Enumerable[::Commenter]).void }
@@ -337,7 +337,7 @@ class Tapioca::Compilers::Dsl::ActiveRecordAssociationsSpec < DslSpec
             sig { params(attributes: T.untyped).returns(T.untyped) }
             def commenters_attributes=(attributes); end
 
-            sig { returns(::Comment::ActiveRecord_Associations_CollectionProxy) }
+            sig { returns(::Comment::PrivateCollectionProxy) }
             def comments; end
 
             sig { params(value: T::Enumerable[::Comment]).void }
@@ -376,7 +376,7 @@ class Tapioca::Compilers::Dsl::ActiveRecordAssociationsSpec < DslSpec
             sig { params(ids: T::Array[T.untyped]).returns(T::Array[T.untyped]) }
             def commenter_ids=(ids); end
 
-            sig { returns(::Commenter::ActiveRecord_Associations_CollectionProxy) }
+            sig { returns(::Commenter::PrivateCollectionProxy) }
             def commenters; end
 
             sig { params(value: T::Enumerable[T.untyped]).void }

--- a/spec/tapioca/compilers/dsl/active_record_associations_spec.rb
+++ b/spec/tapioca/compilers/dsl/active_record_associations_spec.rb
@@ -262,7 +262,7 @@ class Tapioca::Compilers::Dsl::ActiveRecordAssociationsSpec < DslSpec
             sig { params(ids: T::Array[T.untyped]).returns(T::Array[T.untyped]) }
             def comment_ids=(ids); end
 
-            sig { returns(::ActiveRecord::Associations::CollectionProxy[Comment]) }
+            sig { returns(::Comment::ActiveRecord_Associations_CollectionProxy) }
             def comments; end
 
             sig { params(value: T::Enumerable[T.untyped]).void }
@@ -328,7 +328,7 @@ class Tapioca::Compilers::Dsl::ActiveRecordAssociationsSpec < DslSpec
             sig { params(ids: T::Array[T.untyped]).returns(T::Array[T.untyped]) }
             def commenter_ids=(ids); end
 
-            sig { returns(::ActiveRecord::Associations::CollectionProxy[Commenter]) }
+            sig { returns(::Commenter::ActiveRecord_Associations_CollectionProxy) }
             def commenters; end
 
             sig { params(value: T::Enumerable[::Commenter]).void }
@@ -337,7 +337,7 @@ class Tapioca::Compilers::Dsl::ActiveRecordAssociationsSpec < DslSpec
             sig { params(attributes: T.untyped).returns(T.untyped) }
             def commenters_attributes=(attributes); end
 
-            sig { returns(::ActiveRecord::Associations::CollectionProxy[Comment]) }
+            sig { returns(::Comment::ActiveRecord_Associations_CollectionProxy) }
             def comments; end
 
             sig { params(value: T::Enumerable[::Comment]).void }
@@ -376,7 +376,7 @@ class Tapioca::Compilers::Dsl::ActiveRecordAssociationsSpec < DslSpec
             sig { params(ids: T::Array[T.untyped]).returns(T::Array[T.untyped]) }
             def commenter_ids=(ids); end
 
-            sig { returns(::ActiveRecord::Associations::CollectionProxy[Commenter]) }
+            sig { returns(::Commenter::ActiveRecord_Associations_CollectionProxy) }
             def commenters; end
 
             sig { params(value: T::Enumerable[T.untyped]).void }

--- a/spec/tapioca/compilers/dsl/active_record_scope_spec.rb
+++ b/spec/tapioca/compilers/dsl/active_record_scope_spec.rb
@@ -53,6 +53,10 @@ class Tapioca::Compilers::Dsl::ActiveRecordScopeSpec < DslSpec
         class Post
           extend GeneratedRelationMethods
 
+          class ActiveRecord_Associations_CollectionProxy < ActiveRecord::Relation
+            include GeneratedRelationMethods
+          end
+
           module GeneratedRelationMethods
             sig { params(args: T.untyped, blk: T.untyped).returns(T.untyped) }
             def public_kind(*args, &blk); end
@@ -75,6 +79,10 @@ class Tapioca::Compilers::Dsl::ActiveRecordScopeSpec < DslSpec
         # typed: strong
         class Post
           extend GeneratedRelationMethods
+
+          class ActiveRecord_Associations_CollectionProxy < ActiveRecord::Relation
+            include GeneratedRelationMethods
+          end
 
           module GeneratedRelationMethods
             sig { params(args: T.untyped, blk: T.untyped).returns(T.untyped) }

--- a/spec/tapioca/compilers/dsl/active_record_scope_spec.rb
+++ b/spec/tapioca/compilers/dsl/active_record_scope_spec.rb
@@ -53,13 +53,13 @@ class Tapioca::Compilers::Dsl::ActiveRecordScopeSpec < DslSpec
         class Post
           extend GeneratedRelationMethods
 
-          class ActiveRecord_Associations_CollectionProxy < ActiveRecord::Relation
-            include GeneratedRelationMethods
-          end
-
           module GeneratedRelationMethods
             sig { params(args: T.untyped, blk: T.untyped).returns(T.untyped) }
             def public_kind(*args, &blk); end
+          end
+
+          class PrivateCollectionProxy
+            include GeneratedRelationMethods
           end
         end
       RBI
@@ -80,16 +80,16 @@ class Tapioca::Compilers::Dsl::ActiveRecordScopeSpec < DslSpec
         class Post
           extend GeneratedRelationMethods
 
-          class ActiveRecord_Associations_CollectionProxy < ActiveRecord::Relation
-            include GeneratedRelationMethods
-          end
-
           module GeneratedRelationMethods
             sig { params(args: T.untyped, blk: T.untyped).returns(T.untyped) }
             def private_kind(*args, &blk); end
 
             sig { params(args: T.untyped, blk: T.untyped).returns(T.untyped) }
             def public_kind(*args, &blk); end
+          end
+
+          class PrivateCollectionProxy
+            include GeneratedRelationMethods
           end
         end
       RBI


### PR DESCRIPTION
### Motivation

This ensures that the associations generated will receive the generated scopes as well.

### Implementation

Putting a `ActiveRecord_Associations_CollectionProxy` class onto the generated classes. I wasn't sure if you wanted this to be a different DSL, which I could see a case for as well. Just let me know.