### PR TITLE
Fix problem with missing gem specs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,6 @@ group(:deployment, :development) do
   gem("rake")
 end
 
-gem("bundler", ">= 2")
 gem("yard", "~> 0.9.25")
 gem("pry-byebug")
 gem("minitest")

--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ group(:deployment, :development) do
   gem("rake")
 end
 
-gem("bundler", "~> 1.17")
+gem("bundler", ">= 2")
 gem("yard", "~> 0.9.25")
 gem("pry-byebug")
 gem("minitest")

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -188,6 +188,13 @@ GEM
       sorbet-static (= 0.5.6231)
     sorbet-runtime (0.5.6231)
     sorbet-static (0.5.6231-universal-darwin-14)
+    sorbet-static (0.5.6231-universal-darwin-15)
+    sorbet-static (0.5.6231-universal-darwin-16)
+    sorbet-static (0.5.6231-universal-darwin-17)
+    sorbet-static (0.5.6231-universal-darwin-18)
+    sorbet-static (0.5.6231-universal-darwin-19)
+    sorbet-static (0.5.6231-universal-darwin-20)
+    sorbet-static (0.5.6231-x86_64-linux)
     spoom (1.0.8)
       colorize
       sorbet (~> 0.5.5)
@@ -219,7 +226,7 @@ DEPENDENCIES
   activemodel-serializers-xml (~> 1.0)
   activerecord-typedstore (~> 1.3)
   activeresource (~> 5.1)
-  bundler (~> 1.17)
+  bundler (>= 2)
   cityhash!
   frozen_record (>= 0.17)
   google-protobuf (~> 3.12.0)
@@ -243,4 +250,4 @@ DEPENDENCIES
   yard (~> 0.9.25)
 
 BUNDLED WITH
-   1.17.3
+   2.2.6

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,6 +9,7 @@ PATH
   remote: .
   specs:
     tapioca (0.4.13)
+      bundler (>= 1.17.3)
       parlour (>= 2.1.0)
       pry (>= 0.12.2)
       sorbet-runtime
@@ -226,7 +227,6 @@ DEPENDENCIES
   activemodel-serializers-xml (~> 1.0)
   activerecord-typedstore (~> 1.3)
   activeresource (~> 5.1)
-  bundler (>= 2)
   cityhash!
   frozen_record (>= 0.17)
   google-protobuf (~> 3.12.0)

--- a/lib/tapioca/gemfile.rb
+++ b/lib/tapioca/gemfile.rb
@@ -30,9 +30,12 @@ module Tapioca
       @dependencies ||= begin
         specs = definition.locked_gems.specs.to_a
 
+        # TODO: Somehow display these missing specs to the user?!
+        missing_specs = Array.new # rubocop:disable Style/EmptyLiteral
+
         definition
           .resolve
-          .materialize(specs)
+          .materialize(specs, missing_specs)
           .map { |spec| Gem.new(spec) }
           .reject { |gem| gem.ignore?(dir) }
           .uniq(&:rbi_file_name)

--- a/lib/tapioca/generator.rb
+++ b/lib/tapioca/generator.rb
@@ -192,6 +192,10 @@ module Tapioca
         exit(1)
       end
       say(" Done", :green)
+      unless bundle.missing_specs.empty?
+        say("  completed with missing specs: ")
+        say(bundle.missing_specs.join(', '), :yellow)
+      end
       puts
     end
 

--- a/spec/support/repo/Gemfile
+++ b/spec/support/repo/Gemfile
@@ -2,6 +2,8 @@
 
 source("https://rubygems.org")
 
+nokogiri_installable = Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("2.5")
+
 gem("foo", path: "../gems/foo")
 gem("bar", path: "../gems/bar")
 gem("baz", path: "../gems/baz")
@@ -20,4 +22,4 @@ gem("activesupport")
 # Needed to test Git gems
 gem("ast", git: "https://github.com/whitequark/ast", ref: "e07a4f66e05ac7972643a8841e336d327ea78ae1")
 # Needed to test missing gems
-gem("nokogiri", ">= 1.11.1")
+gem("nokogiri", ">= 1.11.1") if nokogiri_installable

--- a/spec/support/repo/Gemfile
+++ b/spec/support/repo/Gemfile
@@ -19,3 +19,5 @@ gem("smart_properties")
 gem("activesupport")
 # Needed to test Git gems
 gem("ast", git: "https://github.com/whitequark/ast", ref: "e07a4f66e05ac7972643a8841e336d327ea78ae1")
+# Needed to test missing gems
+gem("nokogiri", ">= 1.11.1")

--- a/spec/tapioca/cli_spec.rb
+++ b/spec/tapioca/cli_spec.rb
@@ -571,6 +571,15 @@ class Tapioca::CliSpec < Minitest::HooksSpec
       assert_equal(Contents::BAZ_RBI, File.read("#{outdir}/baz@0.0.2.rbi"))
     end
 
+    it 'must not generate RBIs for missing gem specs' do
+      output = execute("generate")
+
+      refute_includes(output, <<~OUTPUT)
+        Processing 'mini_portile2' gem:
+          Compiling mini_portile2, this may take a few seconds...   Done
+      OUTPUT
+    end
+
     it 'must generate git gem RBIs with source revision numbers' do
       output = execute("generate", "ast")
 

--- a/spec/tapioca/cli_spec.rb
+++ b/spec/tapioca/cli_spec.rb
@@ -92,10 +92,8 @@ class Tapioca::CliSpec < Minitest::HooksSpec
   before(:all) do
     @repo_path = (Pathname.new(__dir__) / ".." / "support" / "repo").expand_path
     Bundler.with_clean_env do
-      IO.popen(
-        ["bundle", "install", "--quiet"],
-        chdir: @repo_path
-      ).read
+      IO.popen(["bundle", "install", "--quiet"], chdir: @repo_path).read
+      IO.popen(["bundle", "lock", "--add-platform=ruby"], chdir: @repo_path).read
     end
   end
 

--- a/spec/tapioca/cli_spec.rb
+++ b/spec/tapioca/cli_spec.rb
@@ -574,7 +574,12 @@ class Tapioca::CliSpec < Minitest::HooksSpec
     it 'must not generate RBIs for missing gem specs' do
       output = execute("generate")
 
-      refute_includes(output, <<~OUTPUT)
+      assert_includes(output, <<~OUTPUT.strip) if ruby_version(">= 2.5")
+        Requiring all gems to prepare for compiling...  Done
+          completed with missing specs: mini_portile2
+      OUTPUT
+
+      refute_includes(output, <<~OUTPUT.strip)
         Processing 'mini_portile2' gem:
           Compiling mini_portile2, this may take a few seconds...   Done
       OUTPUT

--- a/spec/template_helper.rb
+++ b/spec/template_helper.rb
@@ -4,32 +4,23 @@
 require "erb"
 
 module TemplateHelper
+  include Kernel
   extend T::Sig
+  ERB_SUPPORTS_KVARGS = T.let(::ERB.instance_method(:initialize).parameters.assoc(:key), T.nilable([Symbol, Symbol]))
 
-  class ErbBinding
-    extend T::Sig
-
-    ERB_SUPPORTS_KVARGS = T.let(::ERB.instance_method(:initialize).parameters.assoc(:key), T.nilable([Symbol, Symbol]))
-
-    sig { params(selector: String).returns(T::Boolean) }
-    def ruby_version(selector)
-      Gem::Requirement.new(selector).satisfied_by?(Gem::Version.new(RUBY_VERSION))
-    end
-
-    sig { returns(Binding) }
-    def erb_bindings
-      binding
-    end
+  sig { params(selector: String).returns(T::Boolean) }
+  def ruby_version(selector)
+    Gem::Requirement.new(selector).satisfied_by?(Gem::Version.new(RUBY_VERSION))
   end
 
   sig { params(src: String).returns(String) }
   def template(src)
-    erb = if ErbBinding::ERB_SUPPORTS_KVARGS
+    erb = if ERB_SUPPORTS_KVARGS
       ::ERB.new(src, trim_mode: ">")
     else
       ::ERB.new(src, nil, ">")
     end
 
-    erb.result(ErbBinding.new.erb_bindings)
+    erb.result(binding)
   end
 end

--- a/tapioca.gemspec
+++ b/tapioca.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |spec|
 
   spec.metadata['allowed_push_host'] = "https://rubygems.org"
 
+  spec.add_dependency("bundler", ">= 1.17.3")
   spec.add_dependency("pry", ">= 0.12.2")
   spec.add_dependency("sorbet-static", ">= 0.4.4471")
   spec.add_dependency("sorbet-runtime")


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being 
solved, not the solution. -->

Fix #208.

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->

`Bundler::SpecSet#materialize` has an optional extra parameter that can be supplied an array, which will be used to collect the names of the missing gem specs when materializing. This prevents missing gem specs from raising errors, so by passing an empty array for this parameter, we can prevent Tapioca from crashing when it runs into missing specs for dependencies that don't make sense for the current platform.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->

Added a `nokogiri` dependency on the test repo and added a test to ensure that its optional dependency does not get processed.
