### PR TITLE
Add support for AR nested attributes for associations

### DIFF
--- a/lib/tapioca/compilers/dsl/active_record_associations.rb
+++ b/lib/tapioca/compilers/dsl/active_record_associations.rb
@@ -24,6 +24,8 @@ module Tapioca
       #   belongs_to :category
       #   has_many :comments
       #   has_one :author, class_name: "User"
+      #
+      #   accepts_nested_attributes_for :category, :comments, :author
       # end
       # ~~~
       #
@@ -44,6 +46,9 @@ module Tapioca
       #     sig { params(value: T.nilable(::User)).void }
       #     def author=(value); end
       #
+      #     sig { params(attributes: T.untyped).returns(T.untyped) }
+      #     def author_attributes=(attributes); end
+      #
       #     sig { params(args: T.untyped, blk: T.untyped).returns(::User) }
       #     def build_author(*args, &blk); end
       #
@@ -56,6 +61,9 @@ module Tapioca
       #     sig { params(value: T.nilable(::Category)).void }
       #     def category=(value); end
       #
+      #     sig { params(attributes: T.untyped).returns(T.untyped) }
+      #     def category_attributes=(attributes); end
+      #
       #     sig { returns(T::Array[T.untyped]) }
       #     def comment_ids; end
       #
@@ -67,6 +75,9 @@ module Tapioca
       #
       #     sig { params(value: T::Enumerable[::Comment]).void }
       #     def comments=(value); end
+      #
+      #     sig { params(attributes: T.untyped).returns(T.untyped) }
+      #     def comments_attributes=(attributes); end
       #
       #     sig { params(args: T.untyped, blk: T.untyped).returns(::User) }
       #     def create_author(*args, &blk); end

--- a/manual/generator_activerecordassociations.md
+++ b/manual/generator_activerecordassociations.md
@@ -12,6 +12,8 @@ class Post < ActiveRecord::Base
   belongs_to :category
   has_many :comments
   has_one :author, class_name: "User"
+
+  accepts_nested_attributes_for :category, :comments, :author
 end
 ~~~
 
@@ -32,6 +34,9 @@ class Post
     sig { params(value: T.nilable(::User)).void }
     def author=(value); end
 
+    sig { params(attributes: T.untyped).returns(T.untyped) }
+    def author_attributes=(attributes); end
+
     sig { params(args: T.untyped, blk: T.untyped).returns(::User) }
     def build_author(*args, &blk); end
 
@@ -44,6 +49,9 @@ class Post
     sig { params(value: T.nilable(::Category)).void }
     def category=(value); end
 
+    sig { params(attributes: T.untyped).returns(T.untyped) }
+    def category_attributes=(attributes); end
+
     sig { returns(T::Array[T.untyped]) }
     def comment_ids; end
 
@@ -55,6 +63,9 @@ class Post
 
     sig { params(value: T::Enumerable[::Comment]).void }
     def comments=(value); end
+
+    sig { params(attributes: T.untyped).returns(T.untyped) }
+    def comments_attributes=(attributes); end
 
     sig { params(args: T.untyped, blk: T.untyped).returns(::User) }
     def create_author(*args, &blk); end

--- a/spec/tapioca/compilers/dsl/active_record_associations_spec.rb
+++ b/spec/tapioca/compilers/dsl/active_record_associations_spec.rb
@@ -88,6 +88,8 @@ class Tapioca::Compilers::Dsl::ActiveRecordAssociationsSpec < DslSpec
         class Post < ActiveRecord::Base
           belongs_to :category
           belongs_to :author, class_name: "User"
+
+          accepts_nested_attributes_for :category, :author
         end
       RUBY
 
@@ -103,6 +105,9 @@ class Tapioca::Compilers::Dsl::ActiveRecordAssociationsSpec < DslSpec
             sig { params(value: T.nilable(::User)).void }
             def author=(value); end
 
+            sig { params(attributes: T.untyped).returns(T.untyped) }
+            def author_attributes=(attributes); end
+
             sig { params(args: T.untyped, blk: T.untyped).returns(::User) }
             def build_author(*args, &blk); end
 
@@ -114,6 +119,9 @@ class Tapioca::Compilers::Dsl::ActiveRecordAssociationsSpec < DslSpec
 
             sig { params(value: T.nilable(::Category)).void }
             def category=(value); end
+
+            sig { params(attributes: T.untyped).returns(T.untyped) }
+            def category_attributes=(attributes); end
 
             sig { params(args: T.untyped, blk: T.untyped).returns(::User) }
             def create_author(*args, &blk); end
@@ -143,6 +151,8 @@ class Tapioca::Compilers::Dsl::ActiveRecordAssociationsSpec < DslSpec
       add_ruby_file("post.rb", <<~RUBY)
         class Post < ActiveRecord::Base
           belongs_to :category, polymorphic: true
+
+          accepts_nested_attributes_for :category
         end
       RUBY
 
@@ -157,6 +167,9 @@ class Tapioca::Compilers::Dsl::ActiveRecordAssociationsSpec < DslSpec
 
             sig { params(value: T.nilable(T.untyped)).void }
             def category=(value); end
+
+            sig { params(attributes: T.untyped).returns(T.untyped) }
+            def category_attributes=(attributes); end
 
             sig { returns(T.nilable(T.untyped)) }
             def reload_category; end
@@ -185,6 +198,8 @@ class Tapioca::Compilers::Dsl::ActiveRecordAssociationsSpec < DslSpec
       add_ruby_file("post.rb", <<~RUBY)
         class Post < ActiveRecord::Base
           has_one :author, class_name: "User"
+
+          accepts_nested_attributes_for :author
         end
       RUBY
 
@@ -199,6 +214,9 @@ class Tapioca::Compilers::Dsl::ActiveRecordAssociationsSpec < DslSpec
 
             sig { params(value: T.nilable(::User)).void }
             def author=(value); end
+
+            sig { params(attributes: T.untyped).returns(T.untyped) }
+            def author_attributes=(attributes); end
 
             sig { params(args: T.untyped, blk: T.untyped).returns(::User) }
             def build_author(*args, &blk); end
@@ -227,6 +245,8 @@ class Tapioca::Compilers::Dsl::ActiveRecordAssociationsSpec < DslSpec
       add_ruby_file("post.rb", <<~RUBY)
         class Post < ActiveRecord::Base
           has_many :comments
+
+          accepts_nested_attributes_for :comments
         end
       RUBY
 
@@ -247,6 +267,9 @@ class Tapioca::Compilers::Dsl::ActiveRecordAssociationsSpec < DslSpec
 
             sig { params(value: T::Enumerable[T.untyped]).void }
             def comments=(value); end
+
+            sig { params(attributes: T.untyped).returns(T.untyped) }
+            def comments_attributes=(attributes); end
           end
         end
       RBI
@@ -282,6 +305,8 @@ class Tapioca::Compilers::Dsl::ActiveRecordAssociationsSpec < DslSpec
         class Post < ActiveRecord::Base
           has_many :comments
           has_many :commenters, through: :comments
+
+          accepts_nested_attributes_for :commenters
         end
       RUBY
 
@@ -309,6 +334,9 @@ class Tapioca::Compilers::Dsl::ActiveRecordAssociationsSpec < DslSpec
             sig { params(value: T::Enumerable[::Commenter]).void }
             def commenters=(value); end
 
+            sig { params(attributes: T.untyped).returns(T.untyped) }
+            def commenters_attributes=(attributes); end
+
             sig { returns(::ActiveRecord::Associations::CollectionProxy[Comment]) }
             def comments; end
 
@@ -331,6 +359,8 @@ class Tapioca::Compilers::Dsl::ActiveRecordAssociationsSpec < DslSpec
       add_ruby_file("post.rb", <<~RUBY)
         class Post < ActiveRecord::Base
           has_and_belongs_to_many :commenters
+
+          accepts_nested_attributes_for :commenters
         end
       RUBY
 
@@ -351,6 +381,9 @@ class Tapioca::Compilers::Dsl::ActiveRecordAssociationsSpec < DslSpec
 
             sig { params(value: T::Enumerable[T.untyped]).void }
             def commenters=(value); end
+
+            sig { params(attributes: T.untyped).returns(T.untyped) }
+            def commenters_attributes=(attributes); end
           end
         end
       RBI


### PR DESCRIPTION
### Motivation

Add support for [Active Record Nested Attributes](https://api.rubyonrails.org/v6.1.0/classes/ActiveRecord/NestedAttributes/ClassMethods.html)

### Implementation

Each nested attribute definition [adds an entry in the `nested_attributes_options` attribute of the AR model class](https://github.com/rails/rails/blob/914caca2d31bd753f47f9168f2a375921d9e91cc/activerecord/lib/active_record/nested_attributes.rb#L343-L345). Thus, enumerating the keys of the `nested_attributes_options` hash gives us all the attribute values for which `accepts_nested_attributes_for` was called. For each of these association names, the name of the generated setter method can [easily be generated](https://github.com/rails/rails/blob/914caca2d31bd753f47f9168f2a375921d9e91cc/activerecord/lib/active_record/nested_attributes.rb#L370).

### Tests

Expanded current tests to also include `accepts_nested_attributes_for` calls for the associations.
