### PR TITLE
Support for modules with multiple helpers

### DIFF
--- a/lib/tapioca/compilers/symbol_table/symbol_generator.rb
+++ b/lib/tapioca/compilers/symbol_table/symbol_generator.rb
@@ -192,15 +192,12 @@ module Tapioca
         def compile_module_helpers(constant)
           abstract_type = T::Private::Abstract::Data.get(constant, :abstract_type)
 
-          if abstract_type
-            indented("#{abstract_type}!")
-          elsif T::Private::Final.final_module?(constant)
-            indented("final!")
-          elsif T::Private::Sealed.sealed_module?(constant)
-            indented("sealed!")
-          else
-            ""
-          end
+          helpers = []
+          helpers << indented("#{abstract_type}!") if abstract_type
+          helpers << indented("final!") if T::Private::Final.final_module?(constant)
+          helpers << indented("sealed!") if T::Private::Sealed.sealed_module?(constant)
+
+          helpers.join("\n")
         end
 
         sig { params(constant: Module).returns(String) }

--- a/spec/tapioca/compilers/symbol_table_compiler_spec.rb
+++ b/spec/tapioca/compilers/symbol_table_compiler_spec.rb
@@ -2094,6 +2094,7 @@ class Tapioca::Compilers::SymbolTableCompilerSpec < Minitest::HooksSpec
         module Adt
           extend(T::Sig)
           extend(T::Helpers)
+
           interface!
           sealed!
 

--- a/spec/tapioca/compilers/symbol_table_compiler_spec.rb
+++ b/spec/tapioca/compilers/symbol_table_compiler_spec.rb
@@ -2090,7 +2090,32 @@ class Tapioca::Compilers::SymbolTableCompilerSpec < Minitest::HooksSpec
         end
       RUBY
 
+      add_ruby_file("adt.rb", <<~RUBY)
+        module Adt
+          extend(T::Sig)
+          extend(T::Helpers)
+          interface!
+          sealed!
+
+          class Foo; include Adt; end
+          class Bar; include Adt; end
+        end
+      RUBY
+
       output = template(<<~RBI)
+        module Adt
+          interface!
+          sealed!
+        end
+
+        class Adt::Bar
+          include(::Adt)
+        end
+
+        class Adt::Foo
+          include(::Adt)
+        end
+
         class Bar < ::T::Struct
           const :foo, Integer
           prop :bar, String


### PR DESCRIPTION
### Motivation

The code to generate module helpers currently assumes that a module can have a single helper. For example, it's either an `interface!` or `abstract!` or `sealed!`, etc. But Sorbet allows a module to have multiple. For example, algebraic data types often use `interface!` and `sealed!` together.

### Implementation

We modify the `compile_module_helpers` method to assemble all possible helpers instead of picking the first that matches.

### Tests

I updated the test for signatures and structs to check for an algebraic data type example.
