### PR TITLE
Adjust void return for props

### DIFF
--- a/lib/tapioca/compilers/symbol_table/symbol_generator.rb
+++ b/lib/tapioca/compilers/symbol_table/symbol_generator.rb
@@ -207,7 +207,7 @@ module Tapioca
           constant.props.map do |name, prop|
             method = "prop"
             method = "const" if prop.fetch(:immutable, false)
-            type = prop.fetch(:type_object, "T.untyped")
+            type = prop.fetch(:type_object, "T.untyped").to_s.gsub(".returns(<VOID>)", ".void")
 
             if prop.key?(:default)
               indented("#{method} :#{name}, #{type}, default: T.unsafe(nil)")

--- a/spec/tapioca/compilers/symbol_table_compiler_spec.rb
+++ b/spec/tapioca/compilers/symbol_table_compiler_spec.rb
@@ -2043,6 +2043,7 @@ class Tapioca::Compilers::SymbolTableCompilerSpec < Minitest::HooksSpec
 
           const :foo, Integer
           prop :bar, String
+          const :baz, T.proc.params(arg0: String).void
         end
       RUBY
 
@@ -2140,6 +2141,7 @@ class Tapioca::Compilers::SymbolTableCompilerSpec < Minitest::HooksSpec
         class Buzz
           const :foo, Integer
           prop :bar, String
+          const :baz, T.proc.params(arg0: String).void
         end
 
         class Foo


### PR DESCRIPTION
### Motivation

A `prop` can be a `Proc`; if the return type of the `Proc` is `void`, the current code generates `returns(<VOID>)`, which is incorrect.

### Implementation

I reused the approach used elsewhere in the same file, which simply `gsub`s the string from `.returns(<VOID>)` to `.void`.

### Tests

Included a `prop` with the issue in the test cases.
