### PR TITLE
Change with_clean_env to with_unbundled_env

### DIFF
--- a/sorbet/rbi/shims/bundler.rbi
+++ b/sorbet/rbi/shims/bundler.rbi
@@ -3785,7 +3785,7 @@ module Bundler
 
   def self.which(executable); end
 
-  def self.with_clean_env(); end
+  def self.with_unbundled_env(); end
 
   def self.with_original_env(); end
 end

--- a/spec/tapioca/cli_spec.rb
+++ b/spec/tapioca/cli_spec.rb
@@ -80,7 +80,7 @@ class Tapioca::CliSpec < Minitest::HooksSpec
       *args,
     ]
 
-    Bundler.with_clean_env do
+    Bundler.with_unbundled_env do
       IO.popen(
         exec_command.join(' '),
         chdir: repo_path,
@@ -91,7 +91,7 @@ class Tapioca::CliSpec < Minitest::HooksSpec
 
   before(:all) do
     @repo_path = (Pathname.new(__dir__) / ".." / "support" / "repo").expand_path
-    Bundler.with_clean_env do
+    Bundler.with_unbundled_env do
       IO.popen(["bundle", "install", "--quiet"], chdir: @repo_path).read
       IO.popen(["bundle", "lock", "--add-platform=ruby"], chdir: @repo_path).read
     end


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
Removes the deprecation warnings for `.with_clean_env`.

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
Use the recommended change as provided by `Bundler`. Switch from `.with_clean_env` to `.with_unbundled_env`.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->
Only changed within the `cli_spec.rb` file.

