### PR TITLE
Add check command

### DIFF
--- a/lib/tapioca/cli.rb
+++ b/lib/tapioca/cli.rb
@@ -74,9 +74,17 @@ module Tapioca
       aliases: ["--gen", "-g"],
       banner: "generator [generator ...]",
       desc: "Only run supplied DSL generators"
+    option :verify,
+      type: :boolean,
+      default: false,
+      desc: "Verifies correctness of RBIs"
     def dsl(*constants)
       Tapioca.silence_warnings do
-        generator.build_dsl(constants)
+        if options[:verify]
+          generator.verify_dsl(constants)
+        else
+          generator.build_dsl(constants)
+        end
       end
     end
 

--- a/lib/tapioca/cli.rb
+++ b/lib/tapioca/cli.rb
@@ -81,7 +81,7 @@ module Tapioca
     def dsl(*constants)
       Tapioca.silence_warnings do
         if options[:verify]
-          generator.verify_dsl(constants)
+          generator.build_dsl(constants, should_verify: true)
         else
           generator.build_dsl(constants)
         end

--- a/lib/tapioca/cli.rb
+++ b/lib/tapioca/cli.rb
@@ -77,14 +77,10 @@ module Tapioca
     option :verify,
       type: :boolean,
       default: false,
-      desc: "Verifies correctness of RBIs"
+      desc: "Verifies RBIs are up-to-date"
     def dsl(*constants)
       Tapioca.silence_warnings do
-        if options[:verify]
-          generator.build_dsl(constants, should_verify: true)
-        else
-          generator.build_dsl(constants)
-        end
+        generator.build_dsl(constants, should_verify: options[:verify])
       end
     end
 

--- a/lib/tapioca/config_builder.rb
+++ b/lib/tapioca/config_builder.rb
@@ -44,7 +44,7 @@ module Tapioca
       def default_command
         command = File.basename($PROGRAM_NAME)
         # Hack to avoid flags ending up in the header of the RBIs
-        args = ARGV.reject { |arg| arg.include?("--") }.join(" ")
+        args = ARGV.grep_v(/^-/).join(" ")
 
         "#{command} #{args}".strip
       end

--- a/lib/tapioca/config_builder.rb
+++ b/lib/tapioca/config_builder.rb
@@ -43,7 +43,8 @@ module Tapioca
       sig { returns(String) }
       def default_command
         command = File.basename($PROGRAM_NAME)
-        args = ARGV.join(" ")
+        # Hack to avoid flags ending up in the header of the RBIs
+        args = ARGV.reject { |arg| arg.include?("--") }.join(" ")
 
         "#{command} #{args}".strip
       end

--- a/lib/tapioca/generator.rb
+++ b/lib/tapioca/generator.rb
@@ -149,7 +149,7 @@ module Tapioca
         rbi_files_to_purge.delete(filename) if filename
       end
 
-      if !rbi_files_to_purge.empty? && !should_verify
+      if rbi_files_to_purge.any? && !should_verify
         say("")
         say("Removing stale RBI files...")
 
@@ -568,7 +568,7 @@ module Tapioca
 
     sig { params(dir: Pathname).returns(T::Array[Pathname]) }
     def get_file_list(dir:)
-      Dir.glob("#{dir}/**/*.rbi").reject { |e| e =~ /gems/ }.map { |f| Pathname.new(f) }
+      Dir.glob("#{dir}/**/*.rbi").reject { |e| e =~ /gems|shims/ }.map { |f| Pathname.new(f) }
     end
   end
 end

--- a/lib/tapioca/generator.rb
+++ b/lib/tapioca/generator.rb
@@ -160,7 +160,7 @@ module Tapioca
 
       say("")
       if should_verify
-        if error = verify_dsl_rbi(tmp_dir: Pathname.new(outpath))
+        if (error = verify_dsl_rbi(tmp_dir: Pathname.new(outpath)))
           say("RBI files are out-of-date, please run `#{config.generate_command}` to update.")
           say("Reason: ", [:red])
           say(error)

--- a/lib/tapioca/generator.rb
+++ b/lib/tapioca/generator.rb
@@ -165,7 +165,7 @@ module Tapioca
         begin
           verify_dsl_rbi(tmp_dir: Pathname.new(outpath))
         rescue OutOfSyncError => e
-          say("RBI files are out-of-date, please run `bundle exec tapioca dsl` to update.")
+          say("RBI files are out-of-date, please run `#{config.generate_command}` to update.")
           say("Reason: ", [:red])
           say(e.message.to_s)
           exit(1)

--- a/spec/support/repo/config/application.rb
+++ b/spec/support/repo/config/application.rb
@@ -16,20 +16,6 @@ module Rails
   end
 end
 
-# A type with a DSL
-class Post
-  include SmartProperties
-  property :title, accepts: String
-end
-
-# Another type with a DSL in a namespace
-module Namespace
-  class Comment
-    include SmartProperties
-    property! :body, accepts: String
-  end
-end
-
-# A simple type
-class User
+Dir[File.expand_path("../../lib/**/*.rb", __FILE__)].sort.each do |file|
+  require(file)
 end

--- a/spec/support/repo/lib/comment.rb
+++ b/spec/support/repo/lib/comment.rb
@@ -1,0 +1,9 @@
+# typed: true
+# frozen_string_literal: true
+
+module Namespace
+  class Comment
+    include SmartProperties
+    property! :body, accepts: String
+  end
+end

--- a/spec/support/repo/lib/post.rb
+++ b/spec/support/repo/lib/post.rb
@@ -1,0 +1,7 @@
+# typed: true
+# frozen_string_literal: true
+
+class Post
+  include SmartProperties
+  property :title, accepts: String
+end

--- a/spec/support/repo/lib/user.rb
+++ b/spec/support/repo/lib/user.rb
@@ -1,0 +1,5 @@
+# typed: true
+# frozen_string_literal: true
+
+class User
+end

--- a/spec/tapioca/cli_spec.rb
+++ b/spec/tapioca/cli_spec.rb
@@ -90,7 +90,7 @@ class Tapioca::CliSpec < Minitest::HooksSpec
       )
       body = process.read
       process.close
-      @exit_status = $?.to_s.include?("1") ? 1 : 0
+      @exit_status = $CHILD_STATUS.to_s.include?("1") ? 1 : 0
       body
     end
   end
@@ -591,7 +591,7 @@ class Tapioca::CliSpec < Minitest::HooksSpec
         end
 
         it ' returns the correct exit code' do
-          output = execute("dsl", "--verify")
+          execute("dsl", "--verify")
           assert_equal(0, @exit_status)
         end
       end
@@ -625,7 +625,7 @@ class Tapioca::CliSpec < Minitest::HooksSpec
         end
 
         it 'returns the correct exit code' do
-          output = execute("dsl", "--verify")
+          execute("dsl", "--verify")
           assert_equal(1, @exit_status)
         end
       end
@@ -671,7 +671,7 @@ class Tapioca::CliSpec < Minitest::HooksSpec
         end
 
         it 'returns the correct exit code' do
-          output = execute("dsl", "--verify")
+          execute("dsl", "--verify")
           assert_equal(1, @exit_status)
         end
       end

--- a/spec/tapioca/cli_spec.rb
+++ b/spec/tapioca/cli_spec.rb
@@ -585,7 +585,7 @@ class Tapioca::CliSpec < Minitest::HooksSpec
           assert_includes(output, <<~OUTPUT)
             Nothing to do, all RBIs are up-to-date.
           OUTPUT
-          assert_includes(Process.last_status.to_s, "exit 0")
+          assert_includes($?.to_s, "exit 0") # rubocop:disable Style/SpecialGlobalVars
         end
       end
 
@@ -615,7 +615,7 @@ class Tapioca::CliSpec < Minitest::HooksSpec
             RBI files are out-of-date, please run `generate command` to update.
             Reason: New file(s) introduced.
           OUTPUT
-          assert_includes(Process.last_status.to_s, "exit 1")
+          assert_includes($?.to_s, "exit 1") # rubocop:disable Style/SpecialGlobalVars
         end
       end
 
@@ -657,7 +657,7 @@ class Tapioca::CliSpec < Minitest::HooksSpec
             Reason: File(s) updated:
               - sorbet/rbi/dsl/image.rbi
           OUTPUT
-          assert_includes(Process.last_status.to_s, "exit 1")
+          assert_includes($?.to_s, "exit 1") # rubocop:disable Style/SpecialGlobalVars
         end
       end
     end

--- a/spec/tapioca/cli_spec.rb
+++ b/spec/tapioca/cli_spec.rb
@@ -4,7 +4,6 @@
 require "spec_helper"
 require "pathname"
 require "shellwords"
-require "pry"
 
 module Contents
   FOO_RBI = <<~CONTENTS
@@ -586,7 +585,7 @@ class Tapioca::CliSpec < Minitest::HooksSpec
           assert_includes(output, <<~OUTPUT)
             Nothing to do, all RBIs are up-to-date.
           OUTPUT
-          assert_includes($CHILD_STATUS.to_s, "exit 0")
+          assert_includes($?.to_s, "exit 0")
         end
       end
 
@@ -616,7 +615,7 @@ class Tapioca::CliSpec < Minitest::HooksSpec
             RBI files are out-of-date, please run `generate command` to update.
             Reason: New file(s) introduced.
           OUTPUT
-          assert_includes($CHILD_STATUS.to_s, "exit 1")
+          assert_includes($?.to_s, "exit 1")
         end
       end
 
@@ -658,7 +657,7 @@ class Tapioca::CliSpec < Minitest::HooksSpec
             Reason: File(s) updated:
               - sorbet/rbi/dsl/image.rbi
           OUTPUT
-          assert_includes($CHILD_STATUS.to_s, "exit 1")
+          assert_includes($?.to_s, "exit 1")
         end
       end
     end

--- a/spec/tapioca/cli_spec.rb
+++ b/spec/tapioca/cli_spec.rb
@@ -605,7 +605,7 @@ class Tapioca::CliSpec < Minitest::HooksSpec
         end
 
         after do
-          File.delete(repo_path / "lib" / "image.rb") if File.exist?(repo_path / "lib" / "image.rb")
+          FileUtils.rm_f(repo_path / "lib" / "image.rb")
         end
 
         it 'advises of new file(s) and returns exit_status 1' do
@@ -646,7 +646,7 @@ class Tapioca::CliSpec < Minitest::HooksSpec
         end
 
         after do
-          File.delete(repo_path / "lib" / "image.rb") if File.exist?(repo_path / "lib" / "image.rb")
+          FileUtils.rm_f(repo_path / "lib" / "image.rb")
         end
 
         it 'advises of modified file(s) and returns exit status 1' do

--- a/spec/tapioca/cli_spec.rb
+++ b/spec/tapioca/cli_spec.rb
@@ -585,7 +585,7 @@ class Tapioca::CliSpec < Minitest::HooksSpec
           assert_includes(output, <<~OUTPUT)
             Nothing to do, all RBIs are up-to-date.
           OUTPUT
-          assert_includes($?.to_s, "exit 0")
+          assert_includes(Process.last_status.to_s, "exit 0")
         end
       end
 
@@ -615,7 +615,7 @@ class Tapioca::CliSpec < Minitest::HooksSpec
             RBI files are out-of-date, please run `generate command` to update.
             Reason: New file(s) introduced.
           OUTPUT
-          assert_includes($?.to_s, "exit 1")
+          assert_includes(Process.last_status.to_s, "exit 1")
         end
       end
 
@@ -657,7 +657,7 @@ class Tapioca::CliSpec < Minitest::HooksSpec
             Reason: File(s) updated:
               - sorbet/rbi/dsl/image.rbi
           OUTPUT
-          assert_includes($?.to_s, "exit 1")
+          assert_includes(Process.last_status.to_s, "exit 1")
         end
       end
     end


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
We need an easy way to check whether or not the RBI files are out-of-date after updates are made to files, Gems are bumped, etc. This adds a `check` command to `tapioca` that will re-generate the DSL (excluding Gems) to diff against to determine whether or not `tapioca dsl` needs to be run. 

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
Create a `tmpdir` using [`Dir.mktmpdir`](https://ruby-doc.org/stdlib-2.7.2/libdoc/tmpdir/rdoc/Dir.html), generate the DSL in the temp directory, and diff against that to determine if RBIs are out of sync.

The command returns with an exit status of `0` if no changes are detected, and `1` if changes are detected. This will allow for it to be used in CI pipelines.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->
Adds two additional tests that ensure that the command returns the correct exit code as well as messaging to advise on correct next steps.
