### PR TITLE
Compile T::Enum with the `enums` block

### DIFF
--- a/lib/tapioca/compilers/symbol_table/symbol_generator.rb
+++ b/lib/tapioca/compilers/symbol_table/symbol_generator.rb
@@ -95,6 +95,7 @@ module Tapioca
           return if alias_namespaced?(name)
           return if seen?(name)
           return unless parent_declares_constant?(name)
+          return if T::Enum === constant # T::Enum instances are defined via `compile_enums`
 
           mark_seen(name)
           compile_constant(name, constant)
@@ -183,6 +184,7 @@ module Tapioca
               compile_mixins(constant),
               compile_mixes_in_class_methods(constant),
               compile_props(constant),
+              compile_enums(constant),
               methods,
             ].select { |b| b != "" }.join("\n\n")
           end
@@ -215,6 +217,25 @@ module Tapioca
               indented("#{method} :#{name}, #{type}")
             end
           end.join("\n")
+        end
+
+        sig { params(constant: Module).returns(String) }
+        def compile_enums(constant)
+          return "" unless T::Enum > constant
+
+          # T::Enum doesn't currently give a nice way to get the actual enum name so you
+          # need to parse it from the string representation which is in the form `#<SomeEnum::A>`
+          enums = T.cast(constant, T::Enum).values.map do |value|
+            value.to_s.match(/#<([\w:]+)>/)[1].split('::').last
+          end
+
+          content = [
+            indented('enums do'),
+            *enums.map { |e| indented("  #{e} = new") }.join("\n"),
+            indented('end'),
+          ]
+
+          content.join("\n")
         end
 
         sig { params(name: String, constant: Module).returns(T.nilable(String)) }

--- a/lib/tapioca/compilers/symbol_table/symbol_generator.rb
+++ b/lib/tapioca/compilers/symbol_table/symbol_generator.rb
@@ -221,12 +221,10 @@ module Tapioca
 
         sig { params(constant: Module).returns(String) }
         def compile_enums(constant)
-          return "" unless T::Enum > constant
+          return "" unless constant < T::Enum
 
-          # T::Enum doesn't currently give a nice way to get the actual enum name so you
-          # need to parse it from the string representation which is in the form `#<SomeEnum::A>`
-          enums = T.cast(constant, T::Enum).values.map do |value|
-            value.to_s.match(/#<([\w:]+)>/)[1].split('::').last
+          enums = T.cast(constant, T::Enum).values.map do |enum_type|
+            enum_type.instance_variable_get(:@const_name).to_s
           end
 
           content = [

--- a/sorbet/rbi/shims/sorbet.rbi
+++ b/sorbet/rbi/shims/sorbet.rbi
@@ -20,3 +20,7 @@ module T::Private
     end
   end
 end
+
+class T::Enum
+  def values; end
+end

--- a/spec/tapioca/compilers/symbol_table_compiler_spec.rb
+++ b/spec/tapioca/compilers/symbol_table_compiler_spec.rb
@@ -1995,6 +1995,57 @@ class Tapioca::Compilers::SymbolTableCompilerSpec < Minitest::HooksSpec
       assert_equal(output, compile)
     end
 
+    it("compiles T::Enum") do
+      add_ruby_file("foo.rb", <<~RUBY)
+        class Bar
+          class Baz < T::Enum
+            enums do
+              A = new('abc')
+              B = new
+            end
+          end
+        end
+
+        class Foo < T::Enum
+          enums do
+            A = new
+            B = new('xyz')
+          end
+
+          CONSTANT = 123
+
+          class C
+          end
+        end
+      RUBY
+
+      output = template(<<~RBI)
+        class Bar
+        end
+
+        class Bar::Baz < ::T::Enum
+          enums do
+            A = new
+            B = new
+          end
+        end
+
+        class Foo < ::T::Enum
+          enums do
+            A = new
+            B = new
+          end
+        end
+
+        class Foo::C
+        end
+
+        Foo::CONSTANT = T.let(T.unsafe(nil), Integer)
+      RBI
+
+      assert_equal(output, compile)
+    end
+
     it("compiles signatures and structs in source files") do
       add_ruby_file("foo.rb", <<~RUBY)
         class Foo


### PR DESCRIPTION
### Motivation

With sorbet's `T::Enum` the enum values themselves are actually instances of the class that inherits from `T::Enum`. Tapioca doesn't handle these specially which affects sorbet's ability to perform exhaustiveness checking. Here's a repro [on sorbet.run](https://sorbet.run/#%23%20typed%3A%20true%0Aextend%20T%3A%3ASig%0A%0A%23%20Normal%20enum%20defintion%0Aclass%20Foo%20%3C%20T%3A%3AEnum%0A%20%20enums%20do%0A%20%20%20%20A%20%3D%20new%0A%20%20end%0Aend%0A%0A%23%20What%20tapoica%20generates%0Aclass%20TapiocaFoo%20%3C%20T%3A%3AEnum%0Aend%0ATapiocaFoo%3A%3AA%20%3D%20T.let(T.unsafe(nil)%2C%20TapiocaFoo)%0A%0A%23%20Test%20normal%0Asig%20%7B%20params(arg0%3A%20Foo).void%20%7D%0Adef%20test_normal(arg0)%0A%20%20case%20arg0%0A%20%20when%20Foo%3A%3AA%0A%20%20else%0A%20%20%20%20T.absurd(arg0)%0A%20%20end%0Aend%0A%0A%23%20Test%20tapioca%0Asig%20%7B%20params(arg0%3A%20TapiocaFoo).void%20%7D%0Adef%20test_tapioca(arg0)%0A%20%20case%20arg0%0A%20%20when%20TapiocaFoo%3A%3AA%0A%20%20else%0A%20%20%20%20T.absurd(arg0)%0A%20%20end%0Aend).

### Implementation

Specially handle `T::Enum` to define the enums using the `enums do ... end` block and ignore the enum values from the normal compilation.

### Tests

See updated tests.

