### PR TITLE
Purge stale DSL RBI files during `dsl` operation

### DIFF
--- a/lib/tapioca/generator.rb
+++ b/lib/tapioca/generator.rb
@@ -358,6 +358,7 @@ module Tapioca
 
     sig { params(filename: Pathname).void }
     def remove(filename)
+      return unless filename.exist?
       say("-- Removing: #{filename}")
       filename.unlink
     end


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->

Do a better job of keeping DSL RBI files in sync by removing stale RBI files during generation.

### Implementation

We collect the set of existing DSL RBI files in the filesystem before we start any DSL RBI generation. We then remove items from the set as RBI files are generated. Whatever we are left with in that set should be RBI files that are no longer needed.

The only complication for this strategy is the fact that the user can supply a list of requested constant names, in which case, we need to build the initial list as the filenames of the RBIs that those constant names would have generated.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->

See included tests.
