### PR TITLE
Allow for custom sorbet executables via TPC_SORBET_EXE env var

### DIFF
--- a/lib/tapioca/compilers/sorbet.rb
+++ b/lib/tapioca/compilers/sorbet.rb
@@ -8,6 +8,7 @@ module Tapioca
   module Compilers
     module Sorbet
       SORBET = Pathname.new(Gem::Specification.find_by_name("sorbet-static").full_gem_path) / "libexec" / "sorbet"
+      EXE_PATH_ENV_VAR = "TAPIOCA_SORBET_EXE"
 
       class << self
         extend(T::Sig)
@@ -26,7 +27,7 @@ module Tapioca
 
         sig { returns(String) }
         def sorbet_path
-          sorbet_path = ENV.fetch("TAPIOCA_SORBET_EXE", SORBET)
+          sorbet_path = ENV.fetch(EXE_PATH_ENV_VAR, SORBET)
           sorbet_path = SORBET if sorbet_path.empty?
           sorbet_path.to_s.shellescape
         end

--- a/lib/tapioca/compilers/sorbet.rb
+++ b/lib/tapioca/compilers/sorbet.rb
@@ -26,7 +26,12 @@ module Tapioca
 
         sig { returns(String) }
         def sorbet_path
-          SORBET.to_s.shellescape
+          custom_sorbet_path = ENV["TPC_SORBET_EXE"]
+          if custom_sorbet_path.nil? || custom_sorbet_path.empty?
+            SORBET.to_s.shellescape
+          else
+            custom_sorbet_path.shellescape
+          end
         end
       end
     end

--- a/lib/tapioca/compilers/sorbet.rb
+++ b/lib/tapioca/compilers/sorbet.rb
@@ -26,12 +26,9 @@ module Tapioca
 
         sig { returns(String) }
         def sorbet_path
-          custom_sorbet_path = ENV["TPC_SORBET_EXE"]
-          if custom_sorbet_path.nil? || custom_sorbet_path.empty?
-            SORBET.to_s.shellescape
-          else
-            custom_sorbet_path.shellescape
-          end
+          sorbet_path = ENV.fetch("TAPIOCA_SORBET_EXE", SORBET)
+          sorbet_path = SORBET if sorbet_path.empty?
+          sorbet_path.to_s.shellescape
         end
       end
     end

--- a/spec/tapioca/compilers/sorbet_spec.rb
+++ b/spec/tapioca/compilers/sorbet_spec.rb
@@ -26,4 +26,11 @@ class Tapioca::Compilers::SorbetSpec < Minitest::Spec
       assert_equal(Tapioca::Compilers::Sorbet.sorbet_path, default_path)
     end
   end
+
+  it("returns the default sorbet path if TAPIOCA_SORBET_EXE is not set") do
+    default_path = Tapioca::Compilers::Sorbet::SORBET.to_s.shellescape
+    with_custom_sorbet_exe_path(nil) do
+      assert_equal(Tapioca::Compilers::Sorbet.sorbet_path, default_path)
+    end
+  end
 end

--- a/spec/tapioca/compilers/sorbet_spec.rb
+++ b/spec/tapioca/compilers/sorbet_spec.rb
@@ -1,0 +1,29 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "spec_helper"
+
+class Tapioca::Compilers::SorbetSpec < Minitest::Spec
+  before do
+    @temp_env_value = ENV["TPC_SORBET_EXE"]
+  end
+
+  after do
+    ENV["TPC_SORBET_EXE"] = @temp_env_value
+  end
+
+  it("returns the value of TPC_SORBET_EXE if set") do
+    custom_path = 'bin/custom-sorbet-static'
+    ENV["TPC_SORBET_EXE"] = custom_path
+    sorbet_path = Tapioca::Compilers::Sorbet.sorbet_path
+    assert_equal(sorbet_path, custom_path)
+  end
+
+  it("returns the default sorbet path if TPC_SORBET_EXE is not set") do
+    ENV["TPC_SORBET_EXE"] = ''
+    gem_path = Gem::Specification.find_by_name("sorbet-static").full_gem_path
+    default_path = File.join(gem_path, "libexec", "sorbet")
+    sorbet_path = Tapioca::Compilers::Sorbet.sorbet_path
+    assert_equal(sorbet_path, default_path)
+  end
+end

--- a/spec/tapioca/compilers/sorbet_spec.rb
+++ b/spec/tapioca/compilers/sorbet_spec.rb
@@ -6,12 +6,12 @@ require "spec_helper"
 class Tapioca::Compilers::SorbetSpec < Minitest::Spec
   sig { params(path: T.nilable(String), block: T.proc.params(custom_path: T.nilable(String)).void).void }
   def with_custom_sorbet_exe_path(path, &block)
-    sorbet_exe_env_value = ENV["TAPIOCA_SORBET_EXE"]
+    sorbet_exe_env_value = ENV[Tapioca::Compilers::Sorbet::EXE_PATH_ENV_VAR]
     begin
-      ENV["TAPIOCA_SORBET_EXE"] = path
+      ENV[Tapioca::Compilers::Sorbet::EXE_PATH_ENV_VAR] = path
       block.call(path)
     ensure
-      ENV["TAPIOCA_SORBET_EXE"] = sorbet_exe_env_value
+      ENV[Tapioca::Compilers::Sorbet::EXE_PATH_ENV_VAR] = sorbet_exe_env_value
     end
   end
 

--- a/spec/tapioca/compilers/sorbet_spec.rb
+++ b/spec/tapioca/compilers/sorbet_spec.rb
@@ -23,7 +23,7 @@ class Tapioca::Compilers::SorbetSpec < Minitest::Spec
   it("returns the default sorbet path if TPC_SORBET_EXE is not set") do
     ENV["TPC_SORBET_EXE"] = ''
     gem_path = Gem::Specification.find_by_name("sorbet-static").full_gem_path
-    default_path = File.join(gem_path, "libexec", "sorbet")
+    default_path = Tapioca::Compilers::Sorbet::SORBET
     sorbet_path = Tapioca::Compilers::Sorbet.sorbet_path
     assert_equal(sorbet_path, default_path)
   end

--- a/spec/tapioca/compilers/sorbet_spec.rb
+++ b/spec/tapioca/compilers/sorbet_spec.rb
@@ -6,22 +6,22 @@ require "spec_helper"
 class Tapioca::Compilers::SorbetSpec < Minitest::Spec
   before do
     @temp_env_value = T.let(nil, T.nilable(String))
-    @temp_env_value = ENV["TPC_SORBET_EXE"]
+    @temp_env_value = ENV["TAPIOCA_SORBET_EXE"]
   end
 
   after do
-    ENV["TPC_SORBET_EXE"] = @temp_env_value
+    ENV["TAPIOCA_SORBET_EXE"] = @temp_env_value
   end
 
-  it("returns the value of TPC_SORBET_EXE if set") do
+  it("returns the value of TAPIOCA_SORBET_EXE if set") do
     custom_path = 'bin/custom-sorbet-static'
-    ENV["TPC_SORBET_EXE"] = custom_path
+    ENV["TAPIOCA_SORBET_EXE"] = custom_path
     sorbet_path = Tapioca::Compilers::Sorbet.sorbet_path
     assert_equal(sorbet_path, custom_path)
   end
 
-  it("returns the default sorbet path if TPC_SORBET_EXE is not set") do
-    ENV["TPC_SORBET_EXE"] = ''
+  it("returns the default sorbet path if TAPIOCA_SORBET_EXE is not set") do
+    ENV["TAPIOCA_SORBET_EXE"] = ''
     gem_path = Gem::Specification.find_by_name("sorbet-static").full_gem_path
     default_path = Tapioca::Compilers::Sorbet::SORBET
     sorbet_path = Tapioca::Compilers::Sorbet.sorbet_path

--- a/spec/tapioca/compilers/sorbet_spec.rb
+++ b/spec/tapioca/compilers/sorbet_spec.rb
@@ -4,6 +4,7 @@
 require "spec_helper"
 
 class Tapioca::Compilers::SorbetSpec < Minitest::Spec
+  sig { params(path: T.nilable(String), block: T.proc.params(custom_path: T.nilable(String)).void).void }
   def with_custom_sorbet_exe_path(path, &block)
     sorbet_exe_env_value = ENV["TAPIOCA_SORBET_EXE"]
     begin

--- a/spec/tapioca/compilers/sorbet_spec.rb
+++ b/spec/tapioca/compilers/sorbet_spec.rb
@@ -5,6 +5,7 @@ require "spec_helper"
 
 class Tapioca::Compilers::SorbetSpec < Minitest::Spec
   before do
+    @temp_env_value = T.let(nil, T.nilable(String))
     @temp_env_value = ENV["TPC_SORBET_EXE"]
   end
 


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->

Fixes #245. Allows users to specify an alternative installation path for `sorbet-static` via `TPC_SORBET_EXE`, similar to the `SRB_SORBET_EXE` used by `srb`.

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->

The path to `sorbet-static` was hardcoded in `lib/tapioca/compilers/sorbet.rb`. I added a conditional to check if `TPC_SORBET_EXE` is set, and if so use that value instead. If `TPC_SORBET_EXE` is not set, behavior should be unchanged.

I wasn't sure where/if I should add documentation to let users know `TPC_SORBET_EXE` exists. Open to suggestions!

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->

Unit tests added in `spec/tapioca/compilers/sorbet_spec.rb`. I also ran my fork of tapioca on my system with my custom sorbet executable, to confirm it works. Not sure if it makes sense to add any integration or e2e tests for this change.
