### PR TITLE
Change loader behaviour to support pre-Rails 6 apps

### DIFF
--- a/spec/support/repo/config/application.rb
+++ b/spec/support/repo/config/application.rb
@@ -7,11 +7,12 @@ require 'baz'
 
 # Fake as much of Rails as we can
 module Rails
-  def self.autoloaders
-    []
+  class Application
+    attr_reader :config
   end
 
   def self.application
+    Application.new
   end
 end
 


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->

Fixes: #239

`Rails.autoloaders` did not exist in Rails pre-6.0, so we should not assume that it will be there. We were faking this by defining an `autoloaders` method on the fake `Rails` module defined in our test repo, but we really should not be doing that.

Moreover, we were not actually trying to eager load a Rails app in a way that is compatible with pre-6.0 versions, which this commit aims to add as well.

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->

Mostly extra checks to see if methods are defined as we expect and a simplification of the test repo.

I've also added an eager loading method via `config.eager_load_namespaces` that should work in pre-6.0 apps as well. However, I am assuming that `Rails.application.config` will always exist in a sensible Rails app.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->

No extra tests.
