### PR TITLE
Mixed in class methods detection should be best effort

### DIFF
--- a/lib/tapioca/compilers/symbol_table/symbol_generator.rb
+++ b/lib/tapioca/compilers/symbol_table/symbol_generator.rb
@@ -364,9 +364,13 @@ module Tapioca
             end
 
             define_singleton_method(:include) do |mod|
-              before = singleton_class.ancestors
-              super(mod).tap do
-                mixins_from_modules[mod] = singleton_class.ancestors - before
+              begin
+                before = singleton_class.ancestors
+                super(mod).tap do
+                  mixins_from_modules[mod] = singleton_class.ancestors - before
+                end
+              rescue Exception # rubocop:disable Lint/RescueException
+                # this is a best effort, bail if we can't perform this
               end
             end
 


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->

Fixes: #237

We try to do something sneaky to detect modules that are mixed into a class through inclusion of another module, where we try to infer that information from the change in the ancestor list of a test class after including the said module to that class.

However, that operation is risky since a `self.included` method on the target module could potentially run any Ruby code and it turns out some code in the wild even try to require optional gems when the concern is being included.

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->

Since this detection is best effort, it should be fine to catch all kinds of `Exception`s during `include` and bail out of the operation without further side-effects.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->

Added a test to verify that we can still generate module definitions even if `self.included` fails.