### PR TITLE
Properly handle types that override `<`

### DIFF
--- a/lib/tapioca/compilers/symbol_table/symbol_generator.rb
+++ b/lib/tapioca/compilers/symbol_table/symbol_generator.rb
@@ -221,7 +221,7 @@ module Tapioca
 
         sig { params(constant: Module).returns(String) }
         def compile_enums(constant)
-          return "" unless constant < T::Enum
+          return "" unless T::Enum > constant
 
           enums = T.cast(constant, T::Enum).values.map do |enum_type|
             enum_type.instance_variable_get(:@const_name).to_s

--- a/spec/support/repo/Gemfile
+++ b/spec/support/repo/Gemfile
@@ -10,6 +10,9 @@ gem("baz", path: "../gems/baz")
 gem("qux", path: "../gems/qux", require: false)
 gem("tapioca", path: "../../../")
 
+# Temp fix for https://github.com/sorbet/sorbet/pull/4074
+gem("sorbet-runtime", "< 0.5.6331")
+
 gem("psych")
 # `extras` gem is causing problems by modifying
 # `Shellwords` functionaly. Depending on it to

--- a/spec/tapioca/compilers/symbol_table_compiler_spec.rb
+++ b/spec/tapioca/compilers/symbol_table_compiler_spec.rb
@@ -2099,6 +2099,31 @@ class Tapioca::Compilers::SymbolTableCompilerSpec < Minitest::HooksSpec
       assert_equal(output, compile)
     end
 
+    it("does not think random types that override < are T::Enum") do
+      add_ruby_file("foo.rb", <<~RUBY)
+        class Foo
+          def self.<(other)
+            true
+          end
+
+          def self.values
+            []
+          end
+        end
+      RUBY
+
+      output = template(<<~RBI)
+        class Foo
+          class << self
+            def <(other); end
+            def values; end
+          end
+        end
+      RBI
+
+      assert_equal(output, compile)
+    end
+
     it("compiles signatures and structs in source files") do
       add_ruby_file("foo.rb", <<~RUBY)
         class Foo


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
The `T::Enum` detection code was giving us a false-positive match for the [`XPath` constant from the `xpath` gem that defines a custom `<` class method](https://github.com/teamcapybara/xpath/blob/9860a6b20b31be97f6bd23a42ff6573c35f910c3/lib/xpath/dsl.rb#L122). Since `XPath` does not also have a `values` method, we were getting a hard failure.

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
Since `constant < X` actually means `constant.<(X)`, when we try to run `constant < T::Enum`, if `constant` has a custom `<` (class) method defined, then the check would not mean what we want to detect, i.e. inheritance.
    
On the other hand, we are pretty much guaranteed `T::Enum > constant` will work since we don't expect `T::Enum` to have an overridden `>` method.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->

Added a test to trigger this case explicitly to make sure we don't regress.

/cc @jeffcarbs 