### PR TITLE
Stop exporting internals from the gem

### DIFF
--- a/exe/tapioca
+++ b/exe/tapioca
@@ -1,6 +1,21 @@
 #! /usr/bin/env ruby
 # frozen_string_literal: true
 
-require_relative "../lib/tapioca"
+require 'sorbet-runtime'
+
+begin
+  T::Configuration.default_checked_level = :never
+  # Suppresses errors caused by T.cast, T.let, T.must, etc.
+  T::Configuration.inline_type_error_handler = ->(*) {}
+  # Suppresses errors caused by incorrect parameter ordering
+  T::Configuration.sig_validation_error_handler = ->(*) {}
+rescue
+  # Need this rescue so that if another gem has
+  # already set the checked level by the time we
+  # get to it, we don't fail outright.
+  nil
+end
+
+require_relative "../lib/tapioca/internal"
 
 Tapioca::Cli.start(ARGV)

--- a/lib/tapioca.rb
+++ b/lib/tapioca.rb
@@ -17,31 +17,5 @@ module Tapioca
   class Error < StandardError; end
 end
 
-begin
-  T::Configuration.default_checked_level = :never
-  # Suppresses errors caused by T.cast, T.let, T.must, etc.
-  T::Configuration.inline_type_error_handler = ->(*) {}
-  # Suppresses errors caused by incorrect parameter ordering
-  T::Configuration.sig_validation_error_handler = ->(*) {}
-rescue
-  # Need this rescue so that if another gem has
-  # already set the checked level by the time we
-  # get to it, we don't fail outright.
-  nil
-end
-
-require "tapioca/loader"
-require "tapioca/constant_locator"
-require "tapioca/config"
-require "tapioca/config_builder"
-require "tapioca/generator"
-require "tapioca/cli"
-require "tapioca/gemfile"
-require "tapioca/compilers/sorbet"
-require "tapioca/compilers/requires_compiler"
-require "tapioca/compilers/symbol_table_compiler"
-require "tapioca/compilers/symbol_table/symbol_generator"
-require "tapioca/compilers/symbol_table/symbol_loader"
-require "tapioca/compilers/todos_compiler"
-require "tapioca/compilers/dsl_compiler"
+require "tapioca/compilers/dsl/base"
 require "tapioca/version"

--- a/lib/tapioca/compilers/dsl/active_record_scope.rb
+++ b/lib/tapioca/compilers/dsl/active_record_scope.rb
@@ -60,7 +60,7 @@ module Tapioca
 
             model.create_module(module_name) do |mod|
               scope_method_names.each do |scope_method|
-                generate_scope_method(scope_method, mod)
+                generate_scope_method(scope_method.to_s, mod)
               end
             end
 

--- a/lib/tapioca/compilers/dsl/base.rb
+++ b/lib/tapioca/compilers/dsl/base.rb
@@ -123,7 +123,7 @@ module Tapioca
         # Compile a Ruby method return type into a Parlour type
         sig do
           params(method_def: T.any(Method, UnboundMethod))
-            .returns(String)
+            .returns(T.nilable(String))
         end
         def compile_method_return_type_to_parlour(method_def)
           signature = T::Private::Methods.signature_for_method(method_def)

--- a/lib/tapioca/compilers/dsl/url_helpers.rb
+++ b/lib/tapioca/compilers/dsl/url_helpers.rb
@@ -89,7 +89,7 @@ module Tapioca
       class UrlHelpers < Base
         extend T::Sig
 
-        sig { override.params(root: Parlour::RbiGenerator::Namespace, constant: T.class_of(Module)).void }
+        sig { override.params(root: Parlour::RbiGenerator::Namespace, constant: Module).void }
         def decorate(root, constant)
           case constant
           when GeneratedPathHelpersModule.singleton_class, GeneratedUrlHelpersModule.singleton_class
@@ -127,7 +127,7 @@ module Tapioca
 
         private
 
-        sig { params(root: Parlour::RbiGenerator::Namespace, constant: T.class_of(Module)).void }
+        sig { params(root: Parlour::RbiGenerator::Namespace, constant: Module).void }
         def generate_module_for(root, constant)
           root.create_module(T.must(constant.name)) do |mod|
             mod.create_include("::ActionDispatch::Routing::UrlFor")
@@ -143,7 +143,7 @@ module Tapioca
           end
         end
 
-        sig { params(mod: Parlour::RbiGenerator::Namespace, constant: T.class_of(Module), helper_module: Module).void }
+        sig { params(mod: Parlour::RbiGenerator::Namespace, constant: Module, helper_module: Module).void }
         def create_mixins_for(mod, constant, helper_module)
           include_helper = constant.ancestors.include?(helper_module) || NON_DISCOVERABLE_INCLUDERS.include?(constant)
           extend_helper = constant.singleton_class.ancestors.include?(helper_module)

--- a/lib/tapioca/compilers/symbol_table/symbol_generator.rb
+++ b/lib/tapioca/compilers/symbol_table/symbol_generator.rb
@@ -223,7 +223,7 @@ module Tapioca
         def compile_enums(constant)
           return "" unless T::Enum > constant
 
-          enums = T.cast(constant, T::Enum).values.map do |enum_type|
+          enums = T.unsafe(constant).values.map do |enum_type|
             enum_type.instance_variable_get(:@const_name).to_s
           end
 
@@ -859,7 +859,7 @@ module Tapioca
           nil
         end
 
-        sig { params(constant: Module).returns(String) }
+        sig { params(constant: T::Types::Base).returns(String) }
         def type_of(constant)
           constant.to_s.gsub(/\bAttachedClass\b/, "T.attached_class")
         end

--- a/lib/tapioca/internal.rb
+++ b/lib/tapioca/internal.rb
@@ -1,0 +1,18 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "tapioca"
+require "tapioca/loader"
+require "tapioca/constant_locator"
+require "tapioca/config"
+require "tapioca/config_builder"
+require "tapioca/generator"
+require "tapioca/cli"
+require "tapioca/gemfile"
+require "tapioca/compilers/sorbet"
+require "tapioca/compilers/requires_compiler"
+require "tapioca/compilers/symbol_table_compiler"
+require "tapioca/compilers/symbol_table/symbol_generator"
+require "tapioca/compilers/symbol_table/symbol_loader"
+require "tapioca/compilers/todos_compiler"
+require "tapioca/compilers/dsl_compiler"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,7 @@
 # typed: strict
 # frozen_string_literal: true
 
-require "tapioca"
+require "tapioca/internal"
 require "minitest/autorun"
 require "minitest/spec"
 require "minitest/hooks/default"


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->

Tapioca should have never really been exporting its internal types from the gem. All the compilers, etc are for the CLI to operate properly and should not be exported by default.

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
Moved all the internal requires to `tapioca/internal.rb`. Also, moved the `sorbet-runtime` initialization and configuration to `tapioca/cli.rb` since that is the application which should be configuring the runtime.

Moving the Sorbet runtime configuration to CLI entrypoint also meant that we are running runtime typechecking during test runs now. That surfaced a few type errors that are fixed in this PR as well.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->
No extra added tests.
