### PR TITLE
Improve binstub generation with output

### DIFF
--- a/lib/tapioca/cli/main.rb
+++ b/lib/tapioca/cli/main.rb
@@ -114,9 +114,15 @@ module Tapioca
       end
 
       def generate_binstub
+        bin_stub_exists = File.exist?("bin/tapioca")
         installer = Bundler::Installer.new(Bundler.root, Bundler.definition)
         spec = Bundler.definition.specs.find { |s| s.name == "tapioca" }
         installer.generate_bundler_executable_stubs(spec, { force: true })
+        if bin_stub_exists
+          shell.say_status(:force, "bin/tapioca", :yellow)
+        else
+          shell.say_status(:create, "bin/tapioca", :green)
+        end
       end
 
       no_commands do

--- a/spec/tapioca/cli_spec.rb
+++ b/spec/tapioca/cli_spec.rb
@@ -73,7 +73,7 @@ class Tapioca::CliSpec < Minitest::HooksSpec
     exec_command = [
       "bundle",
       "exec",
-      "bin/tapioca",
+      "tapioca",
       command,
       *flags,
       *args,
@@ -122,11 +122,13 @@ class Tapioca::CliSpec < Minitest::HooksSpec
 
   describe("#init") do
     it 'must create proper files' do
+      FileUtils.rm_f(repo_path / "bin/tapioca")
       output = execute("init")
 
       assert_equal(<<-OUTPUT, output)
       create  sorbet/config
       create  sorbet/tapioca/require.rb
+      create  bin/tapioca
       OUTPUT
 
       assert_path_exists(repo_path / "sorbet/config")
@@ -147,7 +149,9 @@ class Tapioca::CliSpec < Minitest::HooksSpec
 
     it 'must not overwrite files' do
       FileUtils.mkdir_p(repo_path / "sorbet/tapioca")
+      FileUtils.mkdir_p(repo_path / "bin")
       FileUtils.touch([
+        repo_path / "bin/tapioca",
         repo_path / "sorbet/config",
         repo_path / "sorbet/tapioca/require.rb",
       ])
@@ -157,6 +161,7 @@ class Tapioca::CliSpec < Minitest::HooksSpec
       assert_equal(<<-OUTPUT, output)
         skip  sorbet/config
         skip  sorbet/tapioca/require.rb
+       force  bin/tapioca
       OUTPUT
 
       assert_empty(File.read(repo_path / "sorbet/config"))


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->

We haven't been showing any output for binstub generation.

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
Add output that `bin/tapioca` was created or force created depending the existence of `bin/tapioca`

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->
Updated tests to check for the `bin/tapioca` output. Also changed test to run `bundle exec tapioca` and not `bundle exec bin/tapioca` since (a) we cannot rely on the binstub existing and (b) if running the binstub, it is meaningless to prepend a `bundle exec` to it.
