### PR TITLE
Make generic type creation safe for sealed classes

### DIFF
--- a/spec/tapioca/compilers/symbol_table_compiler_spec.rb
+++ b/spec/tapioca/compilers/symbol_table_compiler_spec.rb
@@ -2404,6 +2404,34 @@ class Tapioca::Compilers::SymbolTableCompilerSpec < Minitest::HooksSpec
       assert_equal(output, compile)
     end
 
+    it("can compile sealed generics") do
+      add_ruby_file("sealed_generic.rb", <<~RUBY)
+        class Foo
+          extend T::Sig
+          extend T::Helpers
+          extend T::Generic
+
+          sealed!
+
+          Elem = type_member
+        end
+
+        Foo[Integer] # this should not trigger an error
+      RUBY
+
+      output = template(<<~RBI)
+        class Foo
+          sealed!
+
+          extend T::Generic
+
+          Elem = type_member
+        end
+      RBI
+
+      assert_equal(output, compile)
+    end
+
     it("compiles structs with default values") do
       add_ruby_file("foo.rb", <<~RUBY)
         class Foo < T::Struct


### PR DESCRIPTION
### Motivation

Sealed classes refuse to be subclassed in any file outside the original file they were declared in, but we use subclassing to represent concrete generic types at runtime. So for a generic sealed type, we need to jump through extra hoops to trick Sorbet runtime into thinking that what we are doing is safe.

### Implementation

Just some hacky state changing wrt the internals of how `sealed!` operates when doing the subclassing.

### Tests

Added an extra test that fails in the absence of the new code path.
