### PR TITLE
Improve verify logic

### DIFF
--- a/spec/tapioca/cli_spec.rb
+++ b/spec/tapioca/cli_spec.rb
@@ -619,7 +619,9 @@ class Tapioca::CliSpec < Minitest::HooksSpec
 
           assert_includes(output, <<~OUTPUT)
             RBI files are out-of-date, please run `bin/tapioca dsl` to update.
-            Reason: New file(s) introduced.
+            Reason:
+              File(s) added:
+              - #{outdir}/image.rbi
           OUTPUT
           assert_includes($?.to_s, "exit 1") # rubocop:disable Style/SpecialGlobalVars
         end
@@ -660,8 +662,9 @@ class Tapioca::CliSpec < Minitest::HooksSpec
 
           assert_includes(output, <<~OUTPUT)
             RBI files are out-of-date, please run `bin/tapioca dsl` to update.
-            Reason: File(s) updated:
-              - sorbet/rbi/dsl/image.rbi
+            Reason:
+              File(s) changed:
+              - #{outdir}/image.rbi
           OUTPUT
           assert_includes($?.to_s, "exit 1") # rubocop:disable Style/SpecialGlobalVars
         end


### PR DESCRIPTION
### Motivation

Make the logic less dependent on hard-coded paths and make it possible to print the files that were added to the output.

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
Instead of dealing with absolute filenames when comparing file lists, if we just handle relative filenames, then we can have two lists that are easy to diff using array difference and intersection operations.

That way, we can print added, removed and changed files, where we can use the `output` path for printing the file names. This makes the code much easier to read and less brittle.

I've added a case for removed RBI files, even though we don't expect that to ever be triggered. I thought it would be good future-proofing if we ever change the auto-removal for stale RBI files.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->

Updated existing tests.
