### PR TITLE
Add a silent option for DSL generation

### DIFF
--- a/lib/tapioca/cli/main.rb
+++ b/lib/tapioca/cli/main.rb
@@ -66,9 +66,13 @@ module Tapioca
         type: :boolean,
         default: false,
         desc: "Verifies RBIs are up-to-date"
+      option :silent,
+        aliases: ["-s"],
+        type: :boolean,
+        desc: "Silences file creation output"
       def dsl(*constants)
         Tapioca.silence_warnings do
-          generator.build_dsl(constants, should_verify: options[:verify])
+          generator.build_dsl(constants, should_verify: options[:verify], silent: options[:silent])
         end
       end
 

--- a/lib/tapioca/generator.rb
+++ b/lib/tapioca/generator.rb
@@ -146,7 +146,12 @@ module Tapioca
       )
 
       compiler.run do |constant, contents|
-        filename = compile_dsl_rbi(constant, contents, outpath: Pathname.new(outpath), silent: silent)
+        filename = compile_dsl_rbi(
+          constant,
+          contents,
+          outpath: Pathname.new(outpath),
+          silent: should_verify || silent
+        )
         rbi_files_to_purge.delete(filename) if filename
       end
       say("")

--- a/spec/tapioca/cli_spec.rb
+++ b/spec/tapioca/cli_spec.rb
@@ -501,6 +501,26 @@ class Tapioca::CliSpec < Minitest::HooksSpec
       CONTENTS
     end
 
+    it 'can generates RBI files silently' do
+      output = execute("dsl", "--silent")
+
+      assert_equal(<<~OUTPUT, output)
+        Loading Rails application... Done
+        Loading DSL generator classes... Done
+        Compiling DSL RBI files...
+
+
+        Done
+        All operations performed in working directory.
+        Please review changes and commit them.
+      OUTPUT
+
+      assert_path_exists("#{outdir}/baz/role.rbi")
+      assert_path_exists("#{outdir}/post.rbi")
+      assert_path_exists("#{outdir}/namespace/comment.rbi")
+      refute_path_exists("#{outdir}/user.rbi")
+    end
+
     it 'removes stale RBI files' do
       FileUtils.mkdir_p("#{outdir}/to_be_deleted")
       FileUtils.touch("#{outdir}/to_be_deleted/foo.rbi")


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->

We print a lot of output in DSL generation which is not always helpful. Moreover, the DSL output in `--verify` mode is never helpful, just the final changed/added/removed message is good enough.

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->

Added a `--silent` option for DSL generation and forced the `--verify` mode to activate the silent mode.

The silent mode only changes the output of files generated and nothing else for now.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->
Added a test to ensure that `--silent` behaves as expected.
