### PR TITLE
Print full command line for `tapioca dsl` in verify

### DIFF
--- a/spec/tapioca/cli_spec.rb
+++ b/spec/tapioca/cli_spec.rb
@@ -637,8 +637,15 @@ class Tapioca::CliSpec < Minitest::HooksSpec
         it 'advises of new file(s) and returns exit_status 1' do
           output = execute("dsl", "--verify")
 
-          assert_includes(output, <<~OUTPUT)
-            RBI files are out-of-date, please run `bin/tapioca dsl` to update.
+          assert_equal(output, <<~OUTPUT)
+            Loading Rails application... Done
+            Loading DSL generator classes... Done
+            Checking for out-of-date RBIs...
+
+
+            RBI files are out-of-date, please run:
+              `bin/tapioca dsl Image`
+
             Reason:
               File(s) added:
               - #{outdir}/image.rbi
@@ -680,8 +687,15 @@ class Tapioca::CliSpec < Minitest::HooksSpec
         it 'advises of modified file(s) and returns exit status 1' do
           output = execute("dsl", "--verify")
 
-          assert_includes(output, <<~OUTPUT)
-            RBI files are out-of-date, please run `bin/tapioca dsl` to update.
+          assert_equal(output, <<~OUTPUT)
+            Loading Rails application... Done
+            Loading DSL generator classes... Done
+            Checking for out-of-date RBIs...
+
+
+            RBI files are out-of-date, please run:
+              `bin/tapioca dsl Image`
+
             Reason:
               File(s) changed:
               - #{outdir}/image.rbi


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->

I realized that we can keep a file name to constant name lookup table as we are doing DSL generation and then we can use that when reporting the diff in a verify run to report the exact command they can run to make RBI files complete.

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
- Maintain a filename to constant name lookup table as we are doing DSL generation.
- Change the diff output to be a filename to cause lookup.
- When reporting the error, build a list of the constant names from the files in the diff and print them at the end of the `bin/tapioca dsl` command.
- Print the diff by grouping the filename to cause lookup by the cause and printing all the files for a given cause in the output.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->
Updates existing tests for changed expectations.
