### PR TITLE
Revert verbose command output upon verify failure

### DIFF
--- a/lib/tapioca/generator.rb
+++ b/lib/tapioca/generator.rb
@@ -145,8 +145,6 @@ module Tapioca
         }
       )
 
-      constant_lookup = {}
-
       compiler.run do |constant, contents|
         constant_name = Module.instance_method(:name).bind(constant).call
 
@@ -159,13 +157,12 @@ module Tapioca
 
         if filename
           rbi_files_to_purge.delete(filename)
-          constant_lookup[filename.relative_path_from(outpath)] = constant_name
         end
       end
       say("")
 
       if should_verify
-        perform_dsl_verification(outpath, constant_lookup)
+        perform_dsl_verification(outpath)
       else
         purge_stale_dsl_rbi_files(rbi_files_to_purge)
 
@@ -596,17 +593,15 @@ module Tapioca
       end.sort
     end
 
-    sig { params(dir: Pathname, constant_lookup: T::Hash[String, String]).void }
-    def perform_dsl_verification(dir, constant_lookup)
+    sig { params(dir: Pathname).void }
+    def perform_dsl_verification(dir)
       diff = verify_dsl_rbi(tmp_dir: dir)
 
       if diff.empty?
         say("Nothing to do, all RBIs are up-to-date.")
       else
-        constants = T.unsafe(constant_lookup).values_at(*diff.keys).join(" ")
-
         say("RBI files are out-of-date, please run:")
-        say("  `#{Config::DEFAULT_COMMAND} dsl #{constants}`")
+        say("  `#{Config::DEFAULT_COMMAND} dsl`")
 
         say("")
 

--- a/spec/tapioca/cli_spec.rb
+++ b/spec/tapioca/cli_spec.rb
@@ -644,7 +644,7 @@ class Tapioca::CliSpec < Minitest::HooksSpec
 
 
             RBI files are out-of-date, please run:
-              `bin/tapioca dsl Image`
+              `bin/tapioca dsl`
 
             Reason:
               File(s) added:
@@ -694,7 +694,7 @@ class Tapioca::CliSpec < Minitest::HooksSpec
 
 
             RBI files are out-of-date, please run:
-              `bin/tapioca dsl Image`
+              `bin/tapioca dsl`
 
             Reason:
               File(s) changed:


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->

A [previous PR](https://github.com/Shopify/tapioca/pull/275) had tried to make the command that was output when the `--verify` step failed to be more surgical so that users can run a command that would potentially be faster.

However, the constants that we collect as Tapioca is generating DSL RBI files do not necessarily map to real constants inside the application. Some of the constants are synthetic, for example `GeneratedUrlHelpersModule`, and would not work if supplied on a `tapioca dsl` command line. Thus, the verbose output ends up doing more harm than good.

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
Just removing the list of "constants" from the command line that is output.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->
Updated tests.
