### PR TITLE
Compile T.type_alias

### DIFF
--- a/lib/tapioca/compilers/symbol_table/symbol_generator.rb
+++ b/lib/tapioca/compilers/symbol_table/symbol_generator.rb
@@ -139,6 +139,11 @@ module Tapioca
           klass = class_of(value)
           klass_name = name_of(klass)
 
+          if klass_name == "T::Private::Types::TypeAlias"
+            tree << RBI::Const.new(name, "T.type_alias { #{T.unsafe(value).aliased_type} }")
+            return
+          end
+
           return if klass_name&.start_with?("T::Types::", "T::Private::")
 
           type_name = public_module?(klass) && klass_name || "T.untyped"

--- a/spec/tapioca/compilers/symbol_table_compiler_spec.rb
+++ b/spec/tapioca/compilers/symbol_table_compiler_spec.rb
@@ -72,6 +72,28 @@ class Tapioca::Compilers::SymbolTableCompilerSpec < Minitest::HooksSpec
         end
 
         Bar::Arr = T.let(T.unsafe(nil), Array)
+        Bar::Foo = T.type_alias { T.any(String, Symbol) }
+      RBI
+
+      assert_equal(output, compile)
+    end
+
+    it("compiles complex type aliases") do
+      add_ruby_file("bar.rb", <<~RUBY)
+        module Bar
+          module A
+            class B; end
+
+            Foo = ::T.type_alias { T.any(String, Symbol, A, B) }
+          end
+        end
+      RUBY
+
+      output = template(<<~RBI)
+        module Bar; end
+        module Bar::A; end
+        class Bar::A::B; end
+        Bar::A::Foo = T.type_alias { T.any(Bar::A, Bar::A::B, String, Symbol) }
       RBI
 
       assert_equal(output, compile)


### PR DESCRIPTION
### Motivation

We're have a `T.type_alias` defined in an internal gem that we want to use inside a consuming application. Seems like it ought to come over in the RBI since the constant is available at runtime.

### Implementation

Currently tapioca ignores `T.type_alias` since it starts with `T::Private::Types::`. This PR updates the spot where that bailout happens and adds a special case to handle it.

### Tests

Extended one test and added another.
