### PR TITLE
Stop generating more methods than necessary

### DIFF
--- a/spec/tapioca/compilers/symbol_table_compiler_spec.rb
+++ b/spec/tapioca/compilers/symbol_table_compiler_spec.rb
@@ -2306,16 +2306,10 @@ class Tapioca::Compilers::SymbolTableCompilerSpec < Minitest::HooksSpec
           prop :bar, String
           const :baz, T::Hash[String, T.untyped]
           prop :quux, T.untyped, default: T.unsafe(nil)
-
-          class << self
-            def inherited(s); end
-          end
         end
 
         class Baz
           abstract!
-
-          def initialize(*args, &blk); end
 
           sig { abstract.void }
           def do_it; end
@@ -2452,10 +2446,6 @@ class Tapioca::Compilers::SymbolTableCompilerSpec < Minitest::HooksSpec
           Elem = type_member
 
           const :foo, T.untyped
-
-          class << self
-            def inherited(s); end
-          end
         end
       RBI
 
@@ -2530,10 +2520,6 @@ class Tapioca::Compilers::SymbolTableCompilerSpec < Minitest::HooksSpec
           prop :l, T::Array[Foo], default: T.unsafe(nil)
           prop :m, T::Hash[Foo, Foo], default: T.unsafe(nil)
           prop :n, Foo, default: T.unsafe(nil)
-
-          class << self
-            def inherited(s); end
-          end
         end
       RBI
 


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->

We used to treat methods that didn't have a source location the same as methods that explicitly were not defined in the current gem. That resulted in Tapioca creating more method definitions than necessary.

We would only skip method generation for a method if the constant it was on was an ignored type (i.e. a built-in type), so that we wouldn't keep redefining methods for built-in types. However, for all other types, especially types that come from other gems, we would just keep on generating all the methods regardless of if they were defined by this gem or not.

Moreover, the source location check was happening at the wrong location, before unwrapping the method signature. Thus, many methods with signatures would not be generated when the previous problem was fixed, since our code would see them as being defined in Sorbet runtime.

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->

The fix is to return a more fine-grained result from `method_in_gem?` which signals yes/no/don't-have-source-location. Based on that we can skip generating don't-have-source-location cases if they are for built-in types and totally ignore the methods that have a source location and are definitely not defined in the current gem.

Additionally, if we try to unwrap the method signature and we get an exception, that means the signature block raised an error. If we continue with the method as is, the source location checks would think the method definition does not belong in the gem (since the method is still wrapped), and we would thus skip the method generation. To avoid that, the `signature_for` method is not raising a custom exception to signal that exceptional case, so that we can at least continue generating "a" method definition.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->

Updated existing tests.