### PR TITLE
Use requires_ancestor in ContentHelper

### DIFF
--- a/sorbet/config
+++ b/sorbet/config
@@ -1,3 +1,4 @@
 --dir
 .
 --ignore=/vendor
+--enable-experimental-requires-ancestor

--- a/spec/content_helper.rb
+++ b/spec/content_helper.rb
@@ -5,8 +5,9 @@ require "fileutils"
 
 module ContentHelper
   extend T::Sig
+  extend T::Helpers
 
-  include Kernel
+  requires_ancestor Kernel
 
   sig { void }
   def teardown


### PR DESCRIPTION
Use `requires_ancestor` instead of `include Kernel`.