### PR TITLE
Fix RBI generation for gems

### DIFF
--- a/lib/tapioca/compilers/symbol_table/symbol_generator.rb
+++ b/lib/tapioca/compilers/symbol_table/symbol_generator.rb
@@ -592,18 +592,12 @@ module Tapioca
           sig = RBI::Sig.new
 
           parameters.each do |_, name|
-            type = parameter_types[name.to_sym].to_s
-              .gsub(".returns(<VOID>)", ".void")
-              .gsub("<NOT-TYPED>", "T.untyped")
-              .gsub(".params()", "")
-
+            type = sanitize_signature_types(parameter_types[name.to_sym].to_s)
             sig << RBI::SigParam.new(name, type)
           end
 
-          sig.return_type = type_of(signature.return_type)
-            .gsub("<VOID>", "void")
-            .gsub("<NOT-TYPED>", "T.untyped")
-            .gsub(".params()", "")
+          return_type = type_of(signature.return_type)
+          sig.return_type = sanitize_signature_types(return_type)
 
           parameter_types.values.join(", ").scan(TYPE_PARAMETER_MATCHER).flatten.uniq.each do |k, _|
             sig.type_params << k
@@ -830,6 +824,15 @@ module Tapioca
           T::Private::Methods.signature_for_method(method)
         rescue LoadError, StandardError
           nil
+        end
+
+        sig { params(sig_string: String).returns(String) }
+        def sanitize_signature_types(sig_string)
+          sig_string
+            .gsub(".returns(<VOID>)", ".void")
+            .gsub("<VOID>", "void")
+            .gsub("<NOT-TYPED>", "T.untyped")
+            .gsub(".params()", "")
         end
 
         sig { params(constant: T::Types::Base).returns(String) }

--- a/lib/tapioca/rbi/rewriters/group_nodes.rb
+++ b/lib/tapioca/rbi/rewriters/group_nodes.rb
@@ -48,16 +48,14 @@ module Tapioca
       sig { returns(Group::Kind) }
       def group_kind
         case self
-        when Include
-          Group::Kind::Includes
-        when Extend
-          Group::Kind::Extends
+        when Include, Extend
+          Group::Kind::Mixins
         when Helper
           Group::Kind::Helpers
         when TypeMember
           Group::Kind::TypeMembers
         when MixesInClassMethods
-          Group::Kind::Mixes
+          Group::Kind::MixesInClassMethods
         when TStructField
           Group::Kind::TStructFields
         when TEnumBlock
@@ -92,16 +90,15 @@ module Tapioca
 
       class Kind < T::Enum
         enums do
-          Includes      = new
-          Extends       = new
-          Helpers       = new
-          TypeMembers   = new
-          Mixes         = new
-          TStructFields = new
-          TEnums        = new
-          Inits         = new
-          Methods       = new
-          Consts        = new
+          Mixins              = new
+          Helpers             = new
+          TypeMembers         = new
+          MixesInClassMethods = new
+          TStructFields       = new
+          TEnums              = new
+          Inits               = new
+          Methods             = new
+          Consts              = new
         end
       end
     end

--- a/lib/tapioca/rbi/rewriters/sort_nodes.rb
+++ b/lib/tapioca/rbi/rewriters/sort_nodes.rb
@@ -24,13 +24,12 @@ module Tapioca
         def node_rank(node)
           case node
           when Group                then kind_rank(node.kind)
-          when Include              then 0
-          when Extend               then 1
-          when Helper               then 2
-          when TypeMember           then 3
-          when MixesInClassMethods  then 4
-          when TStructField         then 5
-          when TEnumBlock           then 6
+          when Include, Extend      then 0
+          when Helper               then 1
+          when TypeMember           then 2
+          when MixesInClassMethods  then 3
+          when TStructField         then 4
+          when TEnumBlock           then 5
           when Method
             if node.name == "initialize"
               7
@@ -46,16 +45,15 @@ module Tapioca
         sig { params(kind: Group::Kind).returns(Integer) }
         def kind_rank(kind)
           case kind
-          when Group::Kind::Includes      then 0
-          when Group::Kind::Extends       then 1
-          when Group::Kind::Helpers       then 2
-          when Group::Kind::TypeMembers   then 3
-          when Group::Kind::Mixes         then 4
-          when Group::Kind::TStructFields then 5
-          when Group::Kind::TEnums        then 6
-          when Group::Kind::Inits         then 7
-          when Group::Kind::Methods       then 8
-          when Group::Kind::Consts        then 9
+          when Group::Kind::Mixins              then 0
+          when Group::Kind::Helpers             then 1
+          when Group::Kind::TypeMembers         then 2
+          when Group::Kind::MixesInClassMethods then 3
+          when Group::Kind::TStructFields       then 4
+          when Group::Kind::TEnums              then 5
+          when Group::Kind::Inits               then 6
+          when Group::Kind::Methods             then 7
+          when Group::Kind::Consts              then 8
           else
             T.absurd(kind)
           end

--- a/spec/tapioca/cli_spec.rb
+++ b/spec/tapioca/cli_spec.rb
@@ -49,7 +49,6 @@ module Contents
 
     class Baz::Role
       include ::SmartProperties
-
       extend ::SmartProperties::ClassMethods
     end
 

--- a/spec/tapioca/compilers/symbol_table_compiler_spec.rb
+++ b/spec/tapioca/compilers/symbol_table_compiler_spec.rb
@@ -137,7 +137,6 @@ class Tapioca::Compilers::SymbolTableCompilerSpec < Minitest::HooksSpec
           include ::ModuleA
           include ::ModuleB
           include ::ModuleC
-
           extend ::ModuleC
           extend ::ModuleB
           extend ::ModuleA
@@ -226,7 +225,6 @@ class Tapioca::Compilers::SymbolTableCompilerSpec < Minitest::HooksSpec
           include ::Comparable
           include ::JSON::Ext::Generator::GeneratorMethods::String
           include ::Colorize::InstanceMethods
-
           extend ::JSON::Ext::Generator::GeneratorMethods::String::Extend
           extend ::Colorize::ClassMethods
 
@@ -746,7 +744,6 @@ class Tapioca::Compilers::SymbolTableCompilerSpec < Minitest::HooksSpec
         class Bar < ::Baz
           include ::Tutu
           include ::Foo
-
           extend ::Toto
         end
 
@@ -1555,10 +1552,9 @@ class Tapioca::Compilers::SymbolTableCompilerSpec < Minitest::HooksSpec
         end
 
         module Baz
+          extend ::SomeOtherConcern
           include ::FooConcern
           include ::BarConcern
-
-          extend ::SomeOtherConcern
         end
 
         module Concern
@@ -1678,9 +1674,8 @@ class Tapioca::Compilers::SymbolTableCompilerSpec < Minitest::HooksSpec
         module ActiveModel; end
 
         module ActiveModel::Validations
-          include ::ActiveModel::Validations::HelperMethods
-
           extend ::ActiveSupport::Concern
+          include ::ActiveModel::Validations::HelperMethods
 
           mixes_in_class_methods ::ActiveModel::Validations::ClassMethods
         end

--- a/spec/tapioca/compilers/symbol_table_compiler_spec.rb
+++ b/spec/tapioca/compilers/symbol_table_compiler_spec.rb
@@ -2050,6 +2050,9 @@ class Tapioca::Compilers::SymbolTableCompilerSpec < Minitest::HooksSpec
           def many_kinds_of_args(*a, b, c, d:, e: 42, **f, &blk)
           end
 
+          sig { returns(T.proc.params(x: String).void) }
+          attr_reader :some_attribute
+
           class << self
             extend(T::Sig)
 
@@ -2235,6 +2238,9 @@ class Tapioca::Compilers::SymbolTableCompilerSpec < Minitest::HooksSpec
 
           sig { params(a: Integer, b: Integer, c: Integer, d: Integer, e: Integer, f: Integer, blk: T.proc.void).void }
           def many_kinds_of_args(*a, b, c, d:, e: T.unsafe(nil), **f, &blk); end
+
+          sig { returns(T.proc.params(x: String).void) }
+          def some_attribute; end
 
           class << self
             sig { void }

--- a/spec/tapioca/rbi_spec.rb
+++ b/spec/tapioca/rbi_spec.rb
@@ -431,8 +431,8 @@ module Tapioca
           rbi << RBI::Class.new("S2")
           rbi << RBI::Method.new("m1")
           rbi << RBI::Method.new("m2", is_singleton: true)
-          rbi << RBI::Include.new("I")
           rbi << RBI::Extend.new("E")
+          rbi << RBI::Include.new("I")
           rbi << RBI::MixesInClassMethods.new("MICM")
           rbi << RBI::Helper.new("h")
           rbi << RBI::TStructConst.new("SC", "Type")
@@ -444,9 +444,8 @@ module Tapioca
           rbi.sort_nodes!
 
           assert_equal(<<~RBI, rbi.string)
-            include I
-
             extend E
+            include I
 
             h!
 
@@ -523,8 +522,8 @@ module Tapioca
           rbi << RBI::Class.new("S2")
           rbi << RBI::Method.new("m1")
           rbi << RBI::Method.new("m2", is_singleton: true)
-          rbi << RBI::Include.new("I")
           rbi << RBI::Extend.new("E")
+          rbi << RBI::Include.new("I")
           rbi << RBI::MixesInClassMethods.new("MICM")
           rbi << RBI::Helper.new("h")
           rbi << RBI::TStructConst.new("SC", "Type")
@@ -536,9 +535,8 @@ module Tapioca
           rbi.sort_nodes!
 
           assert_equal(<<~RBI, rbi.string)
-            include I
-
             extend E
+            include I
 
             h!
 
@@ -572,9 +570,8 @@ module Tapioca
 
           assert_equal(<<~RBI, rbi.string)
             include I2
-            include I1
-
             extend E2
+            include I1
             extend E1
 
             mixes_in_class_methods M2
@@ -626,7 +623,6 @@ module Tapioca
           assert_equal(<<~RBI, rbi.string)
             module Scope
               include I
-
               extend E
 
               h!
@@ -683,9 +679,8 @@ module Tapioca
 
           assert_equal(<<~RBI, rbi.string)
             include I2
-            include I1
-
             extend E2
+            include I1
             extend E1
 
             h1!
@@ -806,9 +801,8 @@ module Tapioca
           assert_equal(<<~RBI, rbi.string)
             class Scope1
               include I2
-              include I1
-
               extend E2
+              include I1
               extend E1
 
               h1!
@@ -840,9 +834,8 @@ module Tapioca
 
             class Scope2
               include I2
-              include I1
-
               extend E2
+              include I1
               extend E1
 
               h1!
@@ -869,9 +862,8 @@ module Tapioca
 
               class Scope2.1
                 include I2
-                include I1
-
                 extend E2
+                include I1
                 extend E1
 
                 h1!


### PR DESCRIPTION
### Motivation

My previous PR on RBI generation (#297) broke two things:

1. Grouping the include and extend in separate groups meant I changed the [order in which they were generated](https://github.com/Shopify/tapioca/commit/2ad440590e747403012cdbba7b49c2baa0aae072#diff-3e55697f4d9bb01a769a76f008853abea864fdb0c8de83956ee0303bfddc1764L1556-R1561) and includes were always printed before extends which is actually incorrect. So the first commit (2bb2a7e) groups them together to get the right order again.

2. Both params types and return types need to be sanitized for weird types such as `<VOID>`. It was done on the [whole signature string before](https://github.com/Shopify/tapioca/commit/d2107da489c440ae655226b33d8fee10a7051688#diff-6c17c60032864d0164ef50591234ad8238992fb3dad7d6ac33158f333ea61190L680-L684) and I forgot to do it on parameters types. The second commit (86b2982) fixes this and adds a related test.

With these fixes we can generate the RBIs for Shopify's core without any error! 🎉 

### Tests

See included tests.

