### PR TITLE
Add helper method underscore

### DIFF
--- a/lib/tapioca/core_ext/string.rb
+++ b/lib/tapioca/core_ext/string.rb
@@ -1,0 +1,18 @@
+# typed: strict
+# frozen_string_literal: true
+
+class String
+  extend T::Sig
+
+  sig { returns(String) }
+  def underscore
+    return self unless /[A-Z-]|::/.match?(self)
+
+    word = to_s.gsub("::", "/")
+    word.gsub!(/([A-Z\d]+)([A-Z][a-z])/, '\1_\2')
+    word.gsub!(/([a-z\d])([A-Z])/, '\1_\2')
+    word.tr!("-", "_")
+    word.downcase!
+    word
+  end
+end

--- a/lib/tapioca/generator.rb
+++ b/lib/tapioca/generator.rb
@@ -3,6 +3,7 @@
 
 require 'pathname'
 require 'thor'
+require "tapioca/core_ext/string"
 
 module Tapioca
   class Generator < ::Thor::Shell::Color
@@ -285,7 +286,7 @@ module Tapioca
     def constantize(constant_names)
       constant_map = constant_names.map do |name|
         begin
-          [name, name.constantize]
+          [name, Object.const_get(name)]
         rescue NameError
           [name, nil]
         end

--- a/spec/dsl_spec.rb
+++ b/spec/dsl_spec.rb
@@ -6,6 +6,7 @@ require "minitest/spec"
 require "content_helper"
 require "template_helper"
 require "isolation_helper"
+require "tapioca/core_ext/string"
 
 class DslSpec < Minitest::Spec
   extend T::Sig
@@ -45,18 +46,7 @@ class DslSpec < Minitest::Spec
 
   sig { returns(String) }
   def target_class_file
-    underscore(target_class_name)
-  end
-
-  sig { params(camel_cased_word: String).returns(String) }
-  def underscore(camel_cased_word)
-    return camel_cased_word unless /[A-Z-]|::/.match?(camel_cased_word)
-    word = camel_cased_word.to_s.gsub("::", "/")
-    word.gsub!(/([A-Z\d]+)([A-Z][a-z])/, '\1_\2')
-    word.gsub!(/([a-z\d])([A-Z])/, '\1_\2')
-    word.tr!("-", "_")
-    word.downcase!
-    word
+    target_class_name.underscore
   end
 
   sig { params(str: String, indent: Integer).returns(String) }


### PR DESCRIPTION
Closes #286

### Motivation

We can't depend on active_support being available, so I moved our spec implementation of `underscore` into a helper method so that we can use it in projects that do not include active_support.

I considered adding it as a core extension to string, but I'm not a fan of that approach as it could potentially lead to mistakes. For example, a project including Tapioca could use `underscore` in `String` during development and it would work fine, but then would break outside of a development environment, where Tapioca is not included. This is why I made it a class method.

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->

Move the implementation of `underscore` into a helper class method inside `Generator`. Please, let me know if we have a better place for utilities such as this one.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->

This is a refactor. Existing tests already cover it.