### PR TITLE
Update minimum supported Ruby versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ 2.4, 2.5, 2.6, 2.7 ]
+        ruby: [ 2.6, 2.7, 3.0 ]
     name: Test Ruby ${{ matrix.ruby }}
     steps:
       - uses: actions/checkout@v2

--- a/Gemfile
+++ b/Gemfile
@@ -30,7 +30,7 @@ group(:development, :test) do
                   ref: '3cfc7d01f333c01811d5e834f1495eaa29f87c36', require: false)
   gem("activemodel-serializers-xml", "~> 1.0", require: false)
   gem("activeresource", "~> 5.1", require: false)
-  gem("google-protobuf", "~>3.12.0", require: false)
+  gem("google-protobuf", "~> 3.15", require: false)
   # Fix version to 0.14.1 since it is the last version to support Ruby 2.4
   gem("shopify-money", "= 0.14.1", require: false)
   gem("sidekiq", "~>5.0", require: false) # Version 6 dropped support for Ruby 2.4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,7 +90,7 @@ GEM
       activemodel
     globalid (0.4.2)
       activesupport (>= 4.2.0)
-    google-protobuf (3.12.2)
+    google-protobuf (3.16.0)
     highline (2.0.3)
     i18n (1.8.2)
       concurrent-ruby (~> 1.0)
@@ -231,7 +231,7 @@ DEPENDENCIES
   activeresource (~> 5.1)
   cityhash!
   frozen_record (>= 0.17)
-  google-protobuf (~> 3.12.0)
+  google-protobuf (~> 3.15)
   identity_cache (~> 1.0)
   minitest
   minitest-hooks
@@ -252,4 +252,4 @@ DEPENDENCIES
   yard (~> 0.9.25)
 
 BUNDLED WITH
-   2.2.6
+   2.2.15

--- a/tapioca.gemspec
+++ b/tapioca.gemspec
@@ -35,5 +35,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency("spoom")
   spec.add_dependency("thor", ">= 0.19.2")
 
-  spec.required_ruby_version = ">= 2.4"
+  spec.required_ruby_version = ">= 2.6"
 end


### PR DESCRIPTION
Signed-off-by: Cory Hutchison <cory.hutchison@shopify.com>

### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
Ruby 2.4 support has ended as of Apr 5, 2020. As well, Ruby 2.5 support
has ended as of the end of March 2021. So this PR removes support for
those two versions and updates the related CI pipelines to test against
the currently supported versions:

2.6, 2.7 and 3.0


### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
Update `tapioca.gemspec` to specify a minimum Ruby version of `>= 2.6` and update the GitHub workflow.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->
No specific changes to tests required.

