### PR TITLE
Improve dsl --verify failure message a bit

### DIFF
--- a/lib/tapioca/generator.rb
+++ b/lib/tapioca/generator.rb
@@ -601,9 +601,9 @@ module Tapioca
       if diff.empty?
         say("Nothing to do, all RBIs are up-to-date.")
       else
-        say("RBI files are out-of-date. In your development environment, please run:", [:green, :bold])
+        say("RBI files are out-of-date. In your development environment, please run:", :green)
         say("  `#{Config::DEFAULT_COMMAND} dsl`", [:green, :bold])
-        say("Once it is complete, be sure to commit and push any changes", [:green, :bold])
+        say("Once it is complete, be sure to commit and push any changes", :green)
 
         say("")
 

--- a/lib/tapioca/generator.rb
+++ b/lib/tapioca/generator.rb
@@ -601,8 +601,9 @@ module Tapioca
       if diff.empty?
         say("Nothing to do, all RBIs are up-to-date.")
       else
-        say("RBI files are out-of-date, please run:")
-        say("  `#{Config::DEFAULT_COMMAND} dsl`")
+        say("RBI files are out-of-date. In your development environment, please run:", [:green, :bold])
+        say("  `#{Config::DEFAULT_COMMAND} dsl`", [:green, :bold])
+        say("Once it is complete, be sure to commit and push any changes", [:green, :bold])
 
         say("")
 

--- a/spec/tapioca/cli_spec.rb
+++ b/spec/tapioca/cli_spec.rb
@@ -642,8 +642,9 @@ class Tapioca::CliSpec < Minitest::HooksSpec
             Checking for out-of-date RBIs...
 
 
-            RBI files are out-of-date, please run:
+            RBI files are out-of-date. In your development environment, please run:
               `bin/tapioca dsl`
+            Once it is complete, be sure to commit and push any changes
 
             Reason:
               File(s) added:
@@ -692,8 +693,9 @@ class Tapioca::CliSpec < Minitest::HooksSpec
             Checking for out-of-date RBIs...
 
 
-            RBI files are out-of-date, please run:
+            RBI files are out-of-date. In your development environment, please run:
               `bin/tapioca dsl`
+            Once it is complete, be sure to commit and push any changes
 
             Reason:
               File(s) changed:


### PR DESCRIPTION
### Motivation

There seems to be a bit of confusion around the workflow of a failure in the `dsl --verify` command.

### Implementation

Lay out a little clearer what people need to do with slightly more thorough messaging.

### Tests

Updated! 🎉 