### PR TITLE
Style fixes for `Gemfile` and `.rubocop.yml`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,7 +9,7 @@ require:
 AllCops:
   TargetRubyVersion: 2.4
   Exclude:
-  - 'vendor/**/*'
+  - "vendor/**/*"
   - "spec/support/repo/bin/tapioca"
 
 Style/CaseEquality:
@@ -17,7 +17,7 @@ Style/CaseEquality:
 
 Style/ClassAndModuleChildren:
   Exclude:
-  - spec/tapioca/**/*
+  - "spec/tapioca/**/*"
 
 Sorbet:
   Enabled: true

--- a/Gemfile
+++ b/Gemfile
@@ -4,18 +4,18 @@ source("https://rubygems.org")
 
 gemspec
 
-gem 'rubocop-shopify', require: false
+gem("minitest")
+gem("minitest-hooks")
+gem("minitest-reporters")
+gem("pry-byebug")
+gem("rubocop-shopify", require: false)
+gem("rubocop-sorbet", ">= 0.4.1")
+gem("sorbet")
+gem("yard", "~> 0.9.25")
 
 group(:deployment, :development) do
   gem("rake")
 end
-
-gem("yard", "~> 0.9.25")
-gem("pry-byebug")
-gem("minitest")
-gem("minitest-hooks")
-gem("minitest-reporters")
-gem("sorbet")
 
 group(:development, :test) do
   gem("smart_properties", ">= 1.15.0", require: false)
@@ -26,15 +26,13 @@ group(:development, :test) do
   gem("activerecord-typedstore", "~> 1.3", require: false)
   gem("sqlite3")
   gem("identity_cache", "~> 1.0", require: false)
-  gem('cityhash', git: 'https://github.com/csfrancis/cityhash.git',
-                  ref: '3cfc7d01f333c01811d5e834f1495eaa29f87c36', require: false)
+  gem("cityhash", git: "https://github.com/csfrancis/cityhash.git",
+                  ref: "3cfc7d01f333c01811d5e834f1495eaa29f87c36", require: false)
   gem("activemodel-serializers-xml", "~> 1.0", require: false)
   gem("activeresource", "~> 5.1", require: false)
-  gem("google-protobuf", "~>3.12.0", require: false)
+  gem("google-protobuf", "~> 3.12.0", require: false)
   # Fix version to 0.14.1 since it is the last version to support Ruby 2.4
   gem("shopify-money", "= 0.14.1", require: false)
-  gem("sidekiq", "~>5.0", require: false) # Version 6 dropped support for Ruby 2.4
+  gem("sidekiq", "~> 5.0", require: false) # Version 6 dropped support for Ruby 2.4
   gem("nokogiri", "1.10.10", require: false) # Lock to last supported for Ruby 2.4
 end
-
-gem "rubocop-sorbet", ">= 0.4.1"


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
While doing other work, I noticed that there was some inconsistencies in `Gemfile` and `.rubocop.yml` that were irking my OCD. 

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
Synchronize and use \" for string formatting in both files. Also, re-organized the `Gemfile` so that similarly scoped gems
were grouped together.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->
N/A
