### PR TITLE
Fix app cache folder source gems

### DIFF
--- a/lib/tapioca/gemfile.rb
+++ b/lib/tapioca/gemfile.rb
@@ -176,7 +176,7 @@ module Tapioca
 
       sig { returns(T::Boolean) }
       def gem_in_bundle_path?
-        full_gem_path.start_with?(Bundler.bundle_path.to_s)
+        full_gem_path.start_with?(Bundler.bundle_path.to_s, Bundler.app_cache.to_s)
       end
     end
   end


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
When Bundler is configured to cache gems inside the `vendor/cache` folder in the app directory, for source gems, it creates git clones in that folder. Those gems are consumed from those git clones, so they look like they are part of the application code, as far as Tapioca is concerned.

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
By adding an explicit check for the source files coming from `Bundler.app_cache` folder, we can make sure we treat those source locations are gem sources.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->
I am afraid we don't have a good way to test these yet. But, this was tested on a real Shopify app which was using `vendor/cache` folder as default. The current install of Tapioca ended up not generating any RBI files for source gems. We debugged it with @leoncustodio to this issue and confirmed that with this patch, we were able to make Tapioca produce RBI files for those gems as well.
