### PR TITLE
Complie requires file with double quotes instead of single quotes

### DIFF
--- a/lib/tapioca/compilers/requires_compiler.rb
+++ b/lib/tapioca/compilers/requires_compiler.rb
@@ -22,7 +22,7 @@ module Tapioca
             name_in_project?(files, req)
           end
         end.sort.uniq.map do |name|
-          "require '#{name}'\n"
+          "require \"#{name}\"\n"
         end.join
       end
 

--- a/spec/tapioca/cli_spec.rb
+++ b/spec/tapioca/cli_spec.rb
@@ -290,11 +290,11 @@ class Tapioca::CliSpec < Minitest::HooksSpec
 
         # typed: false
 
-        require 'active_support/all'
-        require 'baz'
-        require 'foo/secret'
-        require 'foo/will_fail'
-        require 'smart_properties'
+        require "active_support/all"
+        require "baz"
+        require "foo/secret"
+        require "foo/will_fail"
+        require "smart_properties"
       CONTENTS
     end
 
@@ -321,7 +321,7 @@ class Tapioca::CliSpec < Minitest::HooksSpec
 
         # typed: false
 
-        require 'foo/secret'
+        require "foo/secret"
       CONTENTS
     end
   end

--- a/spec/tapioca/compilers/requires_compiler_spec.rb
+++ b/spec/tapioca/compilers/requires_compiler_spec.rb
@@ -12,44 +12,44 @@ class Tapioca::Compilers::RequiresCompilerSpec < Minitest::HooksSpec
   it("it extracts the requires from a simple project") do
     compiler = Tapioca::Compilers::RequiresCompiler.new('spec/support/require/simple/sorbet/config')
     assert_equal(<<~REQ, compiler.compile)
-      require 'a'
-      require 'b'
-      require 'c'
-      require 'd'
-      require 'e'
-      require 'f'
-      require 'g'
-      require 'h'
-      require 'i'
-      require 'j'
+      require "a"
+      require "b"
+      require "c"
+      require "d"
+      require "e"
+      require "f"
+      require "g"
+      require "h"
+      require "i"
+      require "j"
     REQ
   end
 
   it("it extracts the requires from all the files listed in the sorbet config") do
     compiler = Tapioca::Compilers::RequiresCompiler.new('spec/support/require/multi/sorbet/config')
     assert_equal(<<~REQ, compiler.compile)
-      require 'a'
-      require 'b'
-      require 'c'
-      require 'd'
+      require "a"
+      require "b"
+      require "c"
+      require "d"
     REQ
   end
 
   it("it ignores files ignored in the sorbet config") do
     compiler = Tapioca::Compilers::RequiresCompiler.new('spec/support/require/sorbet_ignore/sorbet/config')
     assert_equal(<<~REQ, compiler.compile)
-      require 'c'
-      require 'd'
+      require "c"
+      require "d"
     REQ
   end
 
   it("it ignores files located in the project") do
     compiler = Tapioca::Compilers::RequiresCompiler.new('spec/support/require/project_ignore/sorbet/config')
     assert_equal(<<~REQ, compiler.compile)
-      require 'liba'
-      require 'libb'
-      require 'libc'
-      require 'libd'
+      require "liba"
+      require "libb"
+      require "libc"
+      require "libd"
     REQ
   end
 end


### PR DESCRIPTION
### Motivation
Ever since https://github.com/Shopify/ruby-style-guide/pull/238 the ruby style guide has enforced double quotes in all the Shopify repos that use it with their Rubocop integrations. Currently the generated "requires" file was using single quotes, making it so rubocop had to correct it any time it was regenerated.

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
I simple switched the existing string to use escaped double quotes.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->
Edited the existing tests to expect this change
