### PR TITLE
Fix ActiveJob generator

### DIFF
--- a/manual/generator_activejob.md
+++ b/manual/generator_activejob.md
@@ -7,6 +7,7 @@ For example, with the following `ActiveJob` subclass:
 
 ~~~rb
 class NotifyUserJob < ActiveJob::Base
+  sig { params(user: User).returns(Mail) }
   def perform(user)
     # ...
   end
@@ -19,10 +20,10 @@ this generator will produce the RBI file `notify_user_job.rbi` with the followin
 # notify_user_job.rbi
 # typed: true
 class NotifyUserJob
-  sig { params(user: T.untyped).returns(NotifyUserJob) }
+  sig { params(user: User).returns(T.any(NotifyUserJob, FalseClass)) }
   def self.perform_later(user); end
 
-  sig { params(user: T.untyped).returns(NotifyUserJob) }
+  sig { params(user: User).returns(Mail) }
   def self.perform_now(user); end
 end
 ~~~

--- a/spec/tapioca/compilers/dsl/active_job_spec.rb
+++ b/spec/tapioca/compilers/dsl/active_job_spec.rb
@@ -62,10 +62,10 @@ class Tapioca::Compilers::Dsl::ActiveJobSpec < DslSpec
       expected = <<~RBI
         # typed: strong
         class NotifyJob
-          sig { params(user_id: T.untyped).returns(NotifyJob) }
+          sig { params(user_id: T.untyped).returns(T.any(NotifyJob, FalseClass)) }
           def self.perform_later(user_id); end
 
-          sig { params(user_id: T.untyped).returns(NotifyJob) }
+          sig { params(user_id: T.untyped).returns(T.untyped) }
           def self.perform_now(user_id); end
         end
       RBI
@@ -87,10 +87,10 @@ class Tapioca::Compilers::Dsl::ActiveJobSpec < DslSpec
       expected = <<~RBI
         # typed: strong
         class NotifyJob
-          sig { params(user_id: Integer).returns(NotifyJob) }
+          sig { params(user_id: Integer).returns(T.any(NotifyJob, FalseClass)) }
           def self.perform_later(user_id); end
 
-          sig { params(user_id: Integer).returns(NotifyJob) }
+          sig { params(user_id: Integer).void }
           def self.perform_now(user_id); end
         end
       RBI


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->

For Active Job classes, we were generating the signatures wrong in two ways:

1. `perform_later` returns an instance of the job class, or [`false` if the job couldn't be enqueued](https://github.com/rails/rails/blob/5aaaa1630ae9a71b3c3ecc4dc46074d678c08d67/activejob/lib/active_job/enqueuing.rb#L68).
2. `perform_now` returns the return value of `perform` immediately. It does not return an instance of the job class.

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->

Make relevant updates.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->
Updated existing tests.
