### PR TITLE
Serialize generic types with unspecified type variables

### DIFF
--- a/spec/tapioca/compilers/symbol_table_compiler_spec.rb
+++ b/spec/tapioca/compilers/symbol_table_compiler_spec.rb
@@ -2320,7 +2320,7 @@ class Tapioca::Compilers::SymbolTableCompilerSpec < Minitest::HooksSpec
           def initialize(foo); end
         end
 
-        Generics::SimpleGenericType::NullGenericType = T.let(T.unsafe(nil), T.untyped)
+        Generics::SimpleGenericType::NullGenericType = T.let(T.unsafe(nil), Generics::SimpleGenericType[Integer])
 
         module Quux
           interface!
@@ -2371,6 +2371,48 @@ class Tapioca::Compilers::SymbolTableCompilerSpec < Minitest::HooksSpec
           extend T::Generic
 
           sealed!
+
+          Elem = type_member
+        end
+      RBI
+
+      assert_equal(output, compile)
+    end
+
+    it("can compile generic constant types") do
+      add_ruby_file("optional.rb", <<~RUBY)
+        class Foo
+          extend T::Generic
+
+          Elem = type_member
+        end
+
+        FOO = Foo.new
+
+        class Bar
+          extend T::Generic
+
+          Key = type_member
+          Value = type_member
+        end
+
+        BAR = Bar.new
+      RUBY
+
+      output = template(<<~RBI)
+        BAR = T.let(T.unsafe(nil), Bar[T.untyped, T.untyped])
+
+        class Bar
+          extend T::Generic
+
+          Key = type_member
+          Value = type_member
+        end
+
+        FOO = T.let(T.unsafe(nil), Foo[T.untyped])
+
+        class Foo
+          extend T::Generic
 
           Elem = type_member
         end


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->

The generic serialization code is serializing generic types with unspecified type variables incorrectly. Sorbet currently allows one to type `Foo.new` even if `Foo` is a generic type that expects type variables, and treats `Foo.new` as if it was `Foo[T.untyped].new` or similar.

However, Sorbet complains about `T.let(T.unsafe(nil), Foo)` usage, with the error message saying that `Foo` is a generic class without type arguments.

Thus, if the user code has a constant definition like `FOO = Foo.new` (where `Foo` is a generic class), then the generated RBI code for it, `FOO = T.let(T.unsafe(nil), Foo)` would end up raising a type checking error.

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->

The fix is to treat generic types differently when grabbing their name. If their name does not already have the type variables, then we add `T.untyped` for each of the type variables it would expect and generate the type name like that.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->

Added an extra test to check for this specific case.
