### PR TITLE
Treat default gems properly

### DIFF
--- a/sorbet/rbi/shims/bundler.rbi
+++ b/sorbet/rbi/shims/bundler.rbi
@@ -3440,6 +3440,8 @@ end
 
 class Bundler::StubSpecification
   def self.from_stub(stub); end
+  def default_gem?; end
+  def files; end
 end
 
 class Bundler::SudoNotPermittedError

--- a/spec/tapioca/compilers/symbol_table_compiler_spec.rb
+++ b/spec/tapioca/compilers/symbol_table_compiler_spec.rb
@@ -11,11 +11,31 @@ class Tapioca::Compilers::SymbolTableCompilerSpec < Minitest::HooksSpec
   include TemplateHelper
   include IsolationHelper
 
+  class GemStub < T::Struct
+    extend T::Sig
+
+    const :name, String
+    const :version, String
+    const :platform, T.nilable(String)
+    const :full_gem_path, String
+    const :full_require_paths, T::Array[String]
+
+    sig { returns(T::Boolean) }
+    def default_gem?
+      false
+    end
+  end
+
   describe("compile") do
     sig { returns(String) }
     def compile
-      stub = Struct.new(:name, :version, :platform, :full_gem_path, :full_require_paths)
-        .new("the-dep", "1.1.2", nil, tmp_path, [tmp_path("lib")])
+      stub = GemStub.new(
+        name: "the-dep",
+        version: "1.1.2",
+        platform: nil,
+        full_gem_path: tmp_path,
+        full_require_paths: [tmp_path("lib")]
+      )
 
       spec = Bundler::StubSpecification.from_stub(stub)
       gem = Tapioca::Gemfile::Gem.new(spec)


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
If the version of a default gem specified in the `Gemfile` is the version of that default gem that is bundled with the Ruby version, then Bundler just uses the default gem from the Ruby library directory.

But Bundler still acts like the gem is installed in where it would have been, which prevents Tapioca from generating a proper RBI for the gem and we end up generating an empty gem.

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->

This PR makes sure that if a gem is marked as a default gem, we check against the files listed in its gemspec inside the Ruby library folder instead of looking inside what the gem install folder would have been.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->
No added tests.
