### PR TITLE
Suppress call validation errors during CLI run

### DIFF
--- a/exe/tapioca
+++ b/exe/tapioca
@@ -5,6 +5,8 @@ require 'sorbet-runtime'
 
 begin
   T::Configuration.default_checked_level = :never
+  # Suppresses call validation errors
+  T::Configuration.call_validation_error_handler = ->(*) {}
   # Suppresses errors caused by T.cast, T.let, T.must, etc.
   T::Configuration.inline_type_error_handler = ->(*) {}
   # Suppresses errors caused by incorrect parameter ordering


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->

The way we modify generic types means we sometimes are not able to properly validate inline checks or call signatures. For that reason, Tapioca tries to run with most stuff turned off.

However, there is a call validation that happens inside `T::Props::Private::SetterFactory#build_setter_proc` which does not respect the `default_checked_level` value.

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->

To suppress those errors from being raised at runtime in production, we need to explicitly suppress call validation errors by setting a no-op handler.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->

No tests.
