### PR TITLE
Mixins accept multiple names

### DIFF
--- a/lib/tapioca/rbi/model.rb
+++ b/lib/tapioca/rbi/model.rb
@@ -247,13 +247,13 @@ module Tapioca
 
       abstract!
 
-      sig { returns(String) }
-      attr_reader :name
+      sig { returns(T::Array[String]) }
+      attr_reader :names
 
-      sig { params(name: String, loc: T.nilable(Loc), comments: T::Array[Comment]).void }
-      def initialize(name, loc: nil, comments: [])
+      sig { params(name: String, names: String, loc: T.nilable(Loc), comments: T::Array[Comment]).void }
+      def initialize(name, *names, loc: nil, comments: [])
         super(loc: loc, comments: comments)
-        @name = name
+        @names = T.let([name, *names], T::Array[String])
       end
     end
 

--- a/lib/tapioca/rbi/printer.rb
+++ b/lib/tapioca/rbi/printer.rb
@@ -366,7 +366,7 @@ module Tapioca
         when MixesInClassMethods
           v.printt("mixes_in_class_methods")
         end
-        v.printn(" #{name}")
+        v.printn(" #{names.join(', ')}")
       end
     end
 

--- a/spec/tapioca/rbi/printer_spec.rb
+++ b/spec/tapioca/rbi/printer_spec.rb
@@ -127,12 +127,12 @@ module Tapioca
         it("builds mixins") do
           scope = RBI::Class.new("Foo")
           scope << RBI::Include.new("A")
-          scope << RBI::Extend.new("A")
+          scope << RBI::Extend.new("A", "B")
 
           assert_equal(<<~RBI, scope.string)
             class Foo
               include A
-              extend A
+              extend A, B
             end
           RBI
         end


### PR DESCRIPTION
### Motivation

Includes and extends can take multiple names:

```rb
class Foo
  include A, B
  extend A, B
end
```

This PR reflect this on the RBI model and printer.

### Tests

See automated tests.

