### PR TITLE
Add attributes accessors to RBI model

### DIFF
--- a/lib/tapioca/rbi/model.rb
+++ b/lib/tapioca/rbi/model.rb
@@ -153,6 +153,45 @@ module Tapioca
       end
     end
 
+    # Attributes
+
+    class Attr < NodeWithComments
+      extend T::Sig
+      extend T::Helpers
+
+      abstract!
+
+      sig { returns(T::Array[Symbol]) }
+      attr_reader :names
+
+      sig { returns(Visibility) }
+      attr_accessor :visibility
+
+      sig { returns(T::Array[Sig]) }
+      attr_reader :sigs
+
+      sig do
+        params(
+          name: Symbol,
+          names: Symbol,
+          visibility: Visibility,
+          sigs: T::Array[Sig],
+          loc: T.nilable(Loc),
+          comments: T::Array[Comment]
+        ).void
+      end
+      def initialize(name, *names, visibility: Visibility::Public, sigs: [], loc: nil, comments: [])
+        super(loc: loc, comments: comments)
+        @names = T.let([name, *names], T::Array[Symbol])
+        @visibility = visibility
+        @sigs = sigs
+      end
+    end
+
+    class AttrAccessor < Attr; end
+    class AttrReader < Attr; end
+    class AttrWriter < Attr; end
+
     # Methods and args
 
     class Method < NodeWithComments

--- a/lib/tapioca/rbi/printer.rb
+++ b/lib/tapioca/rbi/printer.rb
@@ -184,6 +184,43 @@ module Tapioca
       end
     end
 
+    class Attr
+      extend T::Sig
+
+      sig { override.params(v: Printer).void }
+      def accept_printer(v)
+        previous_node = v.previous_node
+        v.printn if previous_node && (!previous_node.oneline? || !oneline?)
+
+        v.visit_all(comments)
+        sigs.each { |sig| v.visit(sig) }
+        v.printl("# #{loc}") if loc && v.print_locs
+        v.printt
+        unless v.in_visibility_group || visibility == Visibility::Public
+          v.print(visibility.visibility.to_s)
+          v.print(" ")
+        end
+        case self
+        when AttrAccessor
+          v.print("attr_accessor")
+        when AttrReader
+          v.print("attr_reader")
+        when AttrWriter
+          v.print("attr_writer")
+        end
+        unless names.empty?
+          v.print(" ")
+          v.print(names.map { |name| ":#{name}" }.join(", "))
+        end
+        v.printn
+      end
+
+      sig { override.returns(T::Boolean) }
+      def oneline?
+        comments.empty? && sigs.empty?
+      end
+    end
+
     class Method
       extend T::Sig
 


### PR DESCRIPTION
### Motivation

Sorbet's RBIs support attributes definitions.

This PR adds them to the RBI model so we can actually generate them if needed (and later parse them when used in shims).

### Tests

See automated tests.

