### PR TITLE
Add `checked` signature builder

### DIFF
--- a/lib/tapioca/rbi/model.rb
+++ b/lib/tapioca/rbi/model.rb
@@ -304,6 +304,9 @@ module Tapioca
       sig { returns(T::Array[String]) }
       attr_reader :type_params
 
+      sig { returns(T.nilable(Symbol)) }
+      attr_accessor :checked
+
       sig do
         params(
           params: T::Array[SigParam],
@@ -312,6 +315,7 @@ module Tapioca
           is_override: T::Boolean,
           is_overridable: T::Boolean,
           type_params: T::Array[String],
+          checked: T.nilable(Symbol),
           loc: T.nilable(Loc)
         ).void
       end
@@ -322,6 +326,7 @@ module Tapioca
         is_override: false,
         is_overridable: false,
         type_params: [],
+        checked: nil,
         loc: nil
       )
         super(loc: loc)
@@ -331,6 +336,7 @@ module Tapioca
         @is_override = is_override
         @is_overridable = is_overridable
         @type_params = type_params
+        @checked = checked
       end
 
       sig { params(param: SigParam).void }

--- a/lib/tapioca/rbi/printer.rb
+++ b/lib/tapioca/rbi/printer.rb
@@ -411,6 +411,9 @@ module Tapioca
         else
           v.print("void")
         end
+        if checked
+          v.print(".checked(:#{checked})")
+        end
         v.printn(" }")
       end
     end

--- a/spec/tapioca/rbi/printer_spec.rb
+++ b/spec/tapioca/rbi/printer_spec.rb
@@ -103,6 +103,7 @@ module Tapioca
           sig3 = RBI::Sig.new(is_abstract: true)
           sig3.is_override = true
           sig3.is_overridable = true
+          sig3.checked = :never
 
           sig4 = RBI::Sig.new(return_type: "T.type_parameter(:V)")
           sig4.type_params << "U"
@@ -118,7 +119,7 @@ module Tapioca
           assert_equal(<<~RBI, method.string)
             sig { void }
             sig { params(a: A, b: T.nilable(B), b: T.proc.void).returns(R) }
-            sig { abstract.override.overridable.void }
+            sig { abstract.override.overridable.void.checked(:never) }
             sig { type_parameters(:U, :V).params(a: T.type_parameter(:U)).returns(T.type_parameter(:V)) }
             def foo; end
           RBI


### PR DESCRIPTION
### Motivation

A signature accept the sig builder `checked`.

This PR adds it to the RBI model so we can generate them (and later parse them).

### Tests

See automated tests.

