### PR TITLE
Use non-nil default value for property type inference

### DIFF
--- a/manual/generator_smartproperties.md
+++ b/manual/generator_smartproperties.md
@@ -41,10 +41,10 @@ class Post
   sig { params(published: T.nilable(T::Boolean)).returns(T.nilable(T::Boolean)) }
   def published=(published); end
 
-  ssig { returns(T.nilable(T::Boolean)) }
+  sig { returns(T::Boolean) }
   def enabled; end
 
-  sig { params(enabled: T.nilable(T::Boolean)).returns(T.nilable(T::Boolean)) }
+  sig { params(enabled: T::Boolean).returns(T::Boolean) }
   def enabled=(enabled); end
 end
 ~~~

--- a/spec/tapioca/compilers/dsl/smart_properties_spec.rb
+++ b/spec/tapioca/compilers/dsl/smart_properties_spec.rb
@@ -288,11 +288,77 @@ class Tapioca::Compilers::Dsl::SmartPropertiesSpec < DslSpec
       expected = <<~RBI
         # typed: strong
         class Post
+          sig { returns(T::Boolean) }
+          def enabled; end
+
+          sig { params(enabled: T::Boolean).returns(T::Boolean) }
+          def enabled=(enabled); end
+        end
+      RBI
+
+      assert_equal(expected, rbi_for(:Post))
+    end
+
+    it("generates RBI file for smart property that accepts boolean and has lambda as default") do
+      add_ruby_file("post.rb", <<~RUBY)
+        class Post
+          include SmartProperties
+          property :enabled, accepts: [true, false], default: -> {}
+        end
+      RUBY
+
+      expected = <<~RBI
+        # typed: strong
+        class Post
           sig { returns(T.nilable(T::Boolean)) }
           def enabled; end
 
           sig { params(enabled: T.nilable(T::Boolean)).returns(T.nilable(T::Boolean)) }
           def enabled=(enabled); end
+        end
+      RBI
+
+      assert_equal(expected, rbi_for(:Post))
+    end
+
+    it("generates RBI file for smart property that accepts String and has a non-nil default") do
+      add_ruby_file("post.rb", <<~RUBY)
+        class Post
+          include SmartProperties
+          property :title, accepts: String, default: "here"
+        end
+      RUBY
+
+      expected = <<~RBI
+        # typed: strong
+        class Post
+          sig { returns(::String) }
+          def title; end
+
+          sig { params(title: ::String).returns(::String) }
+          def title=(title); end
+        end
+      RBI
+
+      assert_equal(expected, rbi_for(:Post))
+    end
+
+    it("generates RBI file for smart property that accepts String and has a nil default") do
+      add_ruby_file("post.rb", <<~RUBY)
+        class Post
+          include SmartProperties
+          property :title, accepts: String, default: nil
+        end
+      RUBY
+
+      expected = <<~RBI
+        # typed: strong
+        class Post
+          sig { returns(T.nilable(::String)) }
+          def title; end
+
+          sig { params(title: T.nilable(::String)).returns(T.nilable(::String)) }
+          def title=(title); end
         end
       RBI
 


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
Fixes https://github.com/Shopify/sorbet-issues/issues/372

If a smart property is not required but has a default value guaranteed to not be nil, then for all intents and purposes that field will never be `nil`, so we should not mark it as a nilable type.

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
Added checks for `default` field of properties. While I was doing that, I found a better way of fetching property field via `to_h` and then fetching the desired keys.

I also inverted the logic of detecting if the type should be nilable. I think it made the code more readable.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->

Added relevant extra test cases and updated the documentation for the generator.
