### PR TITLE
Drop Ruby 2.4 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ 2.4, 2.5, 2.6, 2.7 ]
+        ruby: [ 2.5, 2.6, 2.7 ]
     name: Test Ruby ${{ matrix.ruby }}
     steps:
       - uses: actions/checkout@v2

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,7 +7,7 @@ require:
  - rubocop-sorbet
 
 AllCops:
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.5
   Exclude:
   - "vendor/**/*"
   - "spec/support/repo/bin/tapioca"

--- a/tapioca.gemspec
+++ b/tapioca.gemspec
@@ -35,5 +35,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency("spoom")
   spec.add_dependency("thor", ">= 0.19.2")
 
-  spec.required_ruby_version = ">= 2.4"
+  spec.required_ruby_version = ">= 2.5"
 end


### PR DESCRIPTION
### Motivation

Support for Ruby 2.4 has ended [more than a year ago](https://www.ruby-lang.org/en/news/2020/04/05/support-of-ruby-2-4-has-ended/) we're not doing any good by keeping it alive.

Furthermore, it's now blocking active development on `tapioca`: 

![image](https://user-images.githubusercontent.com/583144/119999606-ece3f600-bf9f-11eb-9a7d-c0bed6d9bfc8.png)