### PR TITLE
Do not generate empty Active Job classes

### DIFF
--- a/lib/tapioca/compilers/dsl/active_job.rb
+++ b/lib/tapioca/compilers/dsl/active_job.rb
@@ -44,9 +44,9 @@ module Tapioca
 
         sig { override.params(root: Parlour::RbiGenerator::Namespace, constant: T.class_of(::ActiveJob::Base)).void }
         def decorate(root, constant)
-          root.path(constant) do |job|
-            next unless constant.instance_methods(false).include?(:perform)
+          return unless constant.instance_methods(false).include?(:perform)
 
+          root.path(constant) do |job|
             method = constant.instance_method(:perform)
             parameters = compile_method_parameters_to_parlour(method)
             return_type = compile_method_return_type_to_parlour(method)

--- a/spec/tapioca/compilers/dsl/active_job_spec.rb
+++ b/spec/tapioca/compilers/dsl/active_job_spec.rb
@@ -35,7 +35,7 @@ class Tapioca::Compilers::Dsl::ActiveJobSpec < DslSpec
   end
 
   describe("#decorate") do
-    it("generates empty RBI file if there is no perform method") do
+    it("generates an empty RBI file if there is no perform method") do
       add_ruby_file("job.rb", <<~RUBY)
         class NotifyJob < ActiveJob::Base
         end
@@ -43,8 +43,7 @@ class Tapioca::Compilers::Dsl::ActiveJobSpec < DslSpec
 
       expected = <<~RBI
         # typed: strong
-        class NotifyJob
-        end
+
       RBI
 
       assert_equal(expected, rbi_for(:NotifyJob))


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->

If an Active Job class has not implemented a `perform` method, we should not be generating an empty class definition for it in an RBI file. Instead, we should completely skip generating anything for that class.

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
Move the check outside the class declaration.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->
Updated tests.
