### PR TITLE
Drop Ruby 2.5 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ 2.5, 2.6, 2.7 ]
+        ruby: [ 2.6, 2.7 ]
     name: Test Ruby ${{ matrix.ruby }}
     steps:
       - uses: actions/checkout@v2

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,7 +7,7 @@ require:
  - rubocop-sorbet
 
 AllCops:
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 2.6
   Exclude:
   - "vendor/**/*"
   - "spec/support/repo/bin/tapioca"

--- a/spec/support/repo/Gemfile
+++ b/spec/support/repo/Gemfile
@@ -2,8 +2,6 @@
 
 source("https://rubygems.org")
 
-nokogiri_installable = Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("2.5")
-
 gem("foo", path: "../gems/foo")
 gem("bar", path: "../gems/bar")
 gem("baz", path: "../gems/baz")
@@ -22,4 +20,4 @@ gem("activesupport")
 # Needed to test Git gems
 gem("ast", git: "https://github.com/whitequark/ast", ref: "e07a4f66e05ac7972643a8841e336d327ea78ae1")
 # Needed to test missing gems
-gem("nokogiri", ">= 1.11.1") if nokogiri_installable
+gem("nokogiri", ">= 1.11.1")

--- a/spec/tapioca/cli_spec.rb
+++ b/spec/tapioca/cli_spec.rb
@@ -811,7 +811,7 @@ class Tapioca::CliSpec < Minitest::HooksSpec
       skip "failure is to be investigated later"
       output = execute("generate")
 
-      assert_includes(output, <<~OUTPUT.strip) if ruby_version(">= 2.5")
+      assert_includes(output, <<~OUTPUT.strip)
         Requiring all gems to prepare for compiling...  Done
           completed with missing specs: mini_portile2
       OUTPUT

--- a/spec/tapioca/compilers/symbol_table_compiler_spec.rb
+++ b/spec/tapioca/compilers/symbol_table_compiler_spec.rb
@@ -864,9 +864,7 @@ class Tapioca::Compilers::SymbolTableCompilerSpec < Minitest::HooksSpec
 
           class << self
             def [](*_arg0); end
-        <% if ruby_version(">= 2.5.0") %>
             def inspect; end
-        <% end %>
             def members; end
             def new(*_arg0); end
           end
@@ -878,9 +876,7 @@ class Tapioca::Compilers::SymbolTableCompilerSpec < Minitest::HooksSpec
 
           class << self
             def [](*_arg0); end
-        <% if ruby_version(">= 2.5.0") %>
             def inspect; end
-        <% end %>
             def members; end
             def new(*_arg0); end
           end

--- a/tapioca.gemspec
+++ b/tapioca.gemspec
@@ -36,5 +36,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency("thor", ">= 0.19.2")
   spec.add_dependency("unparser")
 
-  spec.required_ruby_version = ">= 2.5"
+  spec.required_ruby_version = ">= 2.6"
 end


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->

This PR continues the work of https://github.com/Shopify/tapioca/pull/339

Support for Ruby 2.5 ended a couple of months ago and we're not doing any good by keeping it alive.
