### PR TITLE
Start testing on Ruby 3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ 2.6, 2.7 ]
+        ruby: [ 2.6, 2.7, 3.0 ]
     name: Test Ruby ${{ matrix.ruby }}
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->

Now that we've dropped support for [Ruby 2.4](https://github.com/Shopify/tapioca/pull/339), [2.5](https://github.com/Shopify/tapioca/pull/351) and [updated all dependencies](https://github.com/Shopify/tapioca/pull/352) to latest versions, we can start testing the library on Ruby 3.

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->

Add Ruby 3.0 to build matrix

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->

No new tests.