### PR TITLE
Add ActiveSupport::Concern DSL generator

### DIFF
--- a/lib/tapioca/compilers/dsl/active_support_concern.rb
+++ b/lib/tapioca/compilers/dsl/active_support_concern.rb
@@ -1,0 +1,111 @@
+# typed: strict
+# frozen_string_literal: true
+
+begin
+  require "active_support"
+rescue LoadError
+  return
+end
+
+module Tapioca
+  module Compilers
+    module Dsl
+      # `Tapioca::Compilers::Dsl::ActiveSupportConcern` generates RBI files for classes that both `extend`
+      # `ActiveSupport::Concern` and `include` another class that extends `ActiveSupport::Concern`
+      #
+      # For example for the following hierarchy:
+      #
+      # ~~~rb
+      # # concern.rb
+      # module Foo
+      #  extend ActiveSupport::Concern
+      #  module ClassMethods; end
+      # end
+      #
+      # module Bar
+      #  extend ActiveSupport::Concern
+      #  module ClassMethods; end
+      #  include Foo
+      # end
+      #
+      # class Baz
+      #  include Bar
+      # end
+      # ~~~
+      #
+      # this generator will produce the RBI file `concern.rbi` with the following content:
+      #
+      # ~~~rbi
+      # # typed: true
+      # module Bar
+      #   mixes_in_class_methods(::Foo::ClassMethods)
+      # end
+      # ~~~
+      class ActiveSupportConcern < Base
+        extend T::Sig
+
+        sig { override.params(root: Parlour::RbiGenerator::Namespace, constant: Module).void }
+        def decorate(root, constant)
+          dependencies = linearized_dependencies_of(constant)
+
+          mixed_in_class_methods = dependencies
+            .uniq # Deduplicate
+            .map do |concern| # Map to class methods module name, if exists
+              "::#{name_of(concern)}::ClassMethods" if concern.const_defined?(:ClassMethods)
+            end
+            .compact # Remove non-existent records
+
+          return if mixed_in_class_methods.empty?
+
+          root.path(constant) do |mod|
+            mixin_module_list = mixed_in_class_methods.join(", ")
+
+            mod.create_arbitrary(code: "mixes_in_class_methods(#{mixin_module_list})")
+          end
+        end
+
+        sig { override.returns(T::Enumerable[Module]) }
+        def gather_constants
+          modules = T.cast(ObjectSpace.each_object(Module), T::Enumerable[Module])
+
+          # Find all Modules that are:
+          modules.select do |mod|
+            # named (i.e. not anonymous)
+            name_of(mod) &&
+              # not singleton classes
+              !mod.singleton_class? &&
+              # extend ActiveSupport::Concern, and
+              mod.singleton_class < ActiveSupport::Concern &&
+              # have dependencies (i.e. include another concern)
+              !dependencies_of(mod).empty?
+          end
+        end
+
+        private
+
+        sig { params(type: Module).returns(T.nilable(String)) }
+        def name_of(type)
+          Module.instance_method(:name).bind(type).call
+        end
+
+        sig { params(concern: Module).returns(T::Array[Module]) }
+        def dependencies_of(concern)
+          concern.instance_variable_get(:@_dependencies)
+        end
+
+        sig { params(concern: Module).returns(T::Array[Module]) }
+        def linearized_dependencies_of(concern)
+          # Grab all the dependencies of the concern
+          dependencies = dependencies_of(concern)
+
+          # Flatten this concern's dependencies and all of their dependencies
+          dependencies.flat_map do |dependency|
+            # Linearize dependencies of the current dependency,
+            # which, itself, is a concern
+            linearized_dependencies_of(dependency) << dependency
+          end
+        end
+      end
+    end
+  end
+end

--- a/manual/generator_activesupportconcern.md
+++ b/manual/generator_activesupportconcern.md
@@ -1,0 +1,33 @@
+## ActiveSupportConcern
+
+`Tapioca::Compilers::Dsl::ActiveSupportConcern` generates RBI files for classes that both `extend`
+`ActiveSupport::Concern` and `include` another class that extends `ActiveSupport::Concern`
+
+For example for the following hierarchy:
+
+~~~rb
+# concern.rb
+module Foo
+ extend ActiveSupport::Concern
+ module ClassMethods; end
+end
+
+module Bar
+ extend ActiveSupport::Concern
+ module ClassMethods; end
+ include Foo
+end
+
+class Baz
+ include Bar
+end
+~~~
+
+this generator will produce the RBI file `concern.rbi` with the following content:
+
+~~~rbi
+# typed: true
+module Bar
+  mixes_in_class_methods(::Foo::ClassMethods)
+end
+~~~

--- a/manual/generators.md
+++ b/manual/generators.md
@@ -12,6 +12,7 @@ In the following section you will find all available DSL generators:
 * [ActiveRecordScope](generator_activerecordscope.md)
 * [ActiveRecordTypedStore](generator_activerecordtypedstore.md)
 * [ActiveResource](generator_activeresource.md)
+* [ActiveSupportConcern](generator_activesupportconcern.md)
 * [ActiveSupportCurrentAttributes](generator_activesupportcurrentattributes.md)
 * [FrozenRecord](generator_frozenrecord.md)
 * [IdentityCache](generator_identitycache.md)

--- a/spec/tapioca/compilers/dsl/active_support_concern_spec.rb
+++ b/spec/tapioca/compilers/dsl/active_support_concern_spec.rb
@@ -1,0 +1,308 @@
+# typed: true
+# frozen_string_literal: true
+
+require "spec_helper"
+
+class Tapioca::Compilers::Dsl::ActiveSupportConcernSpec < DslSpec
+  describe("#gather_constants") do
+    it("does not gather anonymous constants") do
+      add_ruby_file("test_case.rb", <<~RUBY)
+        module TestCase
+          module Foo
+            extend ActiveSupport::Concern
+          end
+
+          class Baz
+            constant = Module.new do
+              extend ActiveSupport::Concern
+              include Foo
+
+              def self.name
+                "TestName"
+              end
+            end
+
+            include constant
+          end
+        end
+      RUBY
+
+      assert_equal([], gathered_constants_in_namespace(:TestCase))
+    end
+
+    it("does not gather constants that don't extend ActiveSupport::Concern") do
+      add_ruby_file("test_case.rb", <<~RUBY)
+        module TestCase
+          module Foo
+            extend ActiveSupport::Concern
+          end
+
+          module Bar
+            include Foo
+          end
+
+          class Baz
+            include Bar
+          end
+        end
+      RUBY
+
+      assert_equal([], gathered_constants_in_namespace(:TestCase))
+    end
+
+    it("does not gather constants when its mixins don't extend ActiveSupport::Concern") do
+      add_ruby_file("test_case.rb", <<~RUBY)
+        module TestCase
+          module Foo
+          end
+
+          module Bar
+            extend ActiveSupport::Concern
+            include Foo
+          end
+
+          class Baz
+            include Bar
+          end
+        end
+      RUBY
+
+      assert_equal([], gathered_constants_in_namespace(:TestCase))
+    end
+
+    it("does not gather constants for directly mixed in modules") do
+      add_ruby_file("test_case.rb", <<~RUBY)
+        module TestCase
+          module Foo
+            extend ActiveSupport::Concern
+          end
+
+          class Bar
+            include Foo
+          end
+        end
+      RUBY
+
+      assert_equal([], gathered_constants_in_namespace(:TestCase))
+    end
+
+    it("gathers constants for nested AS::Concern") do
+      add_ruby_file("test_case.rb", <<~RUBY)
+        module TestCase
+          module Foo
+            extend ActiveSupport::Concern
+          end
+
+          module Bar
+            extend ActiveSupport::Concern
+            include Foo
+          end
+
+          class Baz
+            include Bar
+          end
+        end
+      RUBY
+
+      assert_equal(["TestCase::Bar"], gathered_constants_in_namespace(:TestCase))
+    end
+
+    it("gathers constants for many nested mixins") do
+      add_ruby_file("test_case.rb", <<~RUBY)
+        module TestCase
+          module Foo
+            extend ActiveSupport::Concern
+          end
+
+          module Bar
+            extend ActiveSupport::Concern
+            include Foo
+          end
+
+          module Baz
+            extend ActiveSupport::Concern
+            include Bar
+          end
+
+          module Qux
+            extend ActiveSupport::Concern
+            include Baz
+          end
+
+          class Quux
+            include Qux
+          end
+        end
+      RUBY
+
+      assert_equal(["TestCase::Bar", "TestCase::Baz", "TestCase::Qux"], gathered_constants_in_namespace(:TestCase))
+    end
+  end
+
+  describe("#decorate") do
+    it("does not generate RBI when constant does not define a ClassMethods module") do
+      add_ruby_file("test_case.rb", <<~RUBY)
+        module Foo
+          extend ActiveSupport::Concern
+        end
+
+        module Bar
+          extend ActiveSupport::Concern
+          include Foo
+        end
+
+        class Baz
+          include Bar
+        end
+      RUBY
+
+      expected = <<~RUBY
+        # typed: strong
+
+      RUBY
+
+      assert_equal(expected, rbi_for(:Bar))
+    end
+
+    it("does not generate RBI for directly mixed in modules") do
+      add_ruby_file("test_case.rb", <<~RUBY)
+        module Foo
+          extend ActiveSupport::Concern
+
+          module ClassMethods
+          end
+        end
+
+        class Bar
+          include Foo
+        end
+      RUBY
+
+      expected = <<~RUBY
+        # typed: strong
+
+      RUBY
+
+      assert_equal(expected, rbi_for(:Foo))
+    end
+
+    it("generates RBI for nested AS::Concern") do
+      add_ruby_file("test_case.rb", <<~RUBY)
+        module Foo
+          extend ActiveSupport::Concern
+
+          module ClassMethods
+          end
+        end
+
+        module Bar
+          extend ActiveSupport::Concern
+          include Foo
+
+          module ClassMethods
+          end
+        end
+
+        class Baz
+          include Bar
+        end
+      RUBY
+
+      expected = <<~RUBY
+        # typed: strong
+        module Bar
+          mixes_in_class_methods(::Foo::ClassMethods)
+        end
+      RUBY
+
+      assert_equal(expected, rbi_for(:Bar))
+      assert_equal(
+        class_method_ancestors_for(:Baz),
+        arguments_to_micm_in_effective_order(rbi_for(:Bar))
+      )
+    end
+
+    it("generates RBI for many nested mixins") do
+      add_ruby_file("test_case.rb", <<~RUBY)
+        module Foo
+          extend ActiveSupport::Concern
+
+          module ClassMethods
+          end
+        end
+
+        module Bar
+          extend ActiveSupport::Concern
+          include Foo
+
+          module ClassMethods
+          end
+        end
+
+        module Baz
+          extend ActiveSupport::Concern
+
+          module ClassMethods
+          end
+        end
+
+        module Qux
+          extend ActiveSupport::Concern
+          include Baz
+          include Bar
+
+          module ClassMethods
+          end
+        end
+
+        class Quux
+          include Qux
+        end
+      RUBY
+
+      expected_bar = <<~RUBY
+        # typed: strong
+        module Bar
+          mixes_in_class_methods(::Foo::ClassMethods)
+        end
+      RUBY
+      assert_equal(expected_bar, rbi_for(:Bar))
+
+      expected_qux = <<~RUBY
+        # typed: strong
+        module Qux
+          mixes_in_class_methods(::Baz::ClassMethods, ::Foo::ClassMethods, ::Bar::ClassMethods)
+        end
+      RUBY
+
+      assert_equal(expected_qux, rbi_for(:Qux))
+      assert_equal(
+        class_method_ancestors_for(:Quux),
+        arguments_to_micm_in_effective_order(rbi_for(:Qux))
+      )
+    end
+  end
+
+  private
+
+  def gathered_constants_in_namespace(namespace)
+    gathered_constants.select { |const| const.start_with?("#{namespace}::") }
+  end
+
+  def class_method_ancestors_for(constant_name)
+    constant = Object.const_get(constant_name)
+    constant.singleton_class.ancestors.map(&:to_s).select do |name|
+      name.end_with?("::ClassMethods")
+    end.drop(1)
+  end
+
+  def arguments_to_micm_in_effective_order(rbi)
+    rbi.scan(/\(([^)]+)\)/)
+      .flatten
+      .first
+      .gsub(/\s+/, "")
+      .split(",")
+      .reverse
+      .map { |i| i.sub(/::/, "") }
+  end
+end


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
Sorbet currently does not provide a way of indicating that a module mixes in class methods from its ancestors. Through this RBI generator we can figure out which of its ancestors contain a `ClassMethods` module and provide that information to Sorbet using `mixes_in_class_methods`.

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
In order to pull this off, we first identify all named modules in the `ObjectSpace` that are not singleton classes, that extend `ActiveSupport::Concern` and have dependencies (i.e. include other concerns).

For those modules, we iterate over their linearized dependencies and pick out all modules that define a `ClassMethods` constant.

Finally we append these `ClassMethods` modules in a `mixes_in_class_methods` call in the correct order.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->

Added new tests.
