### PR TITLE
Add ability to query Sorbet features

### DIFF
--- a/lib/tapioca/compilers/dsl/active_support_concern.rb
+++ b/lib/tapioca/compilers/dsl/active_support_concern.rb
@@ -1,11 +1,15 @@
 # typed: strict
 # frozen_string_literal: true
 
+require "tapioca/compilers/sorbet"
+
 begin
   require "active_support"
 rescue LoadError
   return
 end
+
+return unless Tapioca::Compilers::Sorbet.supports?(:mixes_in_class_methods_multiple_args)
 
 module Tapioca
   module Compilers

--- a/spec/tapioca/compilers/sorbet_spec.rb
+++ b/spec/tapioca/compilers/sorbet_spec.rb
@@ -4,17 +4,6 @@
 require "spec_helper"
 
 class Tapioca::Compilers::SorbetSpec < Minitest::Spec
-  sig { params(path: T.nilable(String), block: T.proc.params(custom_path: T.nilable(String)).void).void }
-  def with_custom_sorbet_exe_path(path, &block)
-    sorbet_exe_env_value = ENV[Tapioca::Compilers::Sorbet::EXE_PATH_ENV_VAR]
-    begin
-      ENV[Tapioca::Compilers::Sorbet::EXE_PATH_ENV_VAR] = path
-      block.call(path)
-    ensure
-      ENV[Tapioca::Compilers::Sorbet::EXE_PATH_ENV_VAR] = sorbet_exe_env_value
-    end
-  end
-
   it("returns the value of TAPIOCA_SORBET_EXE if set") do
     with_custom_sorbet_exe_path("bin/custom-sorbet-static") do |custom_path|
       assert_equal(Tapioca::Compilers::Sorbet.sorbet_path, custom_path)
@@ -32,6 +21,37 @@ class Tapioca::Compilers::SorbetSpec < Minitest::Spec
     default_path = Tapioca::Compilers::Sorbet::SORBET.to_s.shellescape
     with_custom_sorbet_exe_path(nil) do
       assert_equal(Tapioca::Compilers::Sorbet.sorbet_path, default_path)
+    end
+  end
+
+  it("returns false for feature check for old versions of Sorbet") do
+    version = Gem::Version.new("0.5.5000")
+
+    refute(Tapioca::Compilers::Sorbet.supports?(:mixes_in_class_methods_multiple_args, version: version))
+  end
+
+  it("returns true for feature check for new versions of Sorbet") do
+    version = Gem::Version.new("0.5.7000")
+
+    assert(Tapioca::Compilers::Sorbet.supports?(:mixes_in_class_methods_multiple_args, version: version))
+  end
+
+  it("raises for an unknown feature check") do
+    assert_raises do
+      Tapioca::Compilers::Sorbet.supports?(:unknown_feature_name)
+    end
+  end
+
+  private
+
+  sig { params(path: T.nilable(String), block: T.proc.params(custom_path: T.nilable(String)).void).void }
+  def with_custom_sorbet_exe_path(path, &block)
+    sorbet_exe_env_value = ENV[Tapioca::Compilers::Sorbet::EXE_PATH_ENV_VAR]
+    begin
+      ENV[Tapioca::Compilers::Sorbet::EXE_PATH_ENV_VAR] = path
+      block.call(path)
+    ensure
+      ENV[Tapioca::Compilers::Sorbet::EXE_PATH_ENV_VAR] = sorbet_exe_env_value
     end
   end
 end


### PR DESCRIPTION


### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
We sometimes want to generate different code depending on which version of Sorbet is in play. For that we need to check which version of Sorbet we are working against.

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
In order to achieve this, we've added a query method for "features" for Sorbet that does a minimum version check against the version of Sorbet that Tapioca is running against. That allows features to turn themselves on or off based on feature detection.

The first use of this query is in the ActiveSupport::Concern generator, so that we don't end up generating `mixes_in_class_methods` calls with multiple parameters on older versions of Sorbet.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->
Added tests for the new method.
