### PR TITLE
Support `tapioca sync --verify`

### DIFF
--- a/lib/tapioca/cli/main.rb
+++ b/lib/tapioca/cli/main.rb
@@ -84,9 +84,13 @@ module Tapioca
       end
 
       desc "sync", "sync RBIs to Gemfile"
+      option :verify,
+        type: :boolean,
+        default: false,
+        desc: "Verifies RBIs are up-to-date"
       def sync
         Tapioca.silence_warnings do
-          generator.sync_rbis_with_gemfile
+          generator.sync_rbis_with_gemfile(should_verify: options[:verify])
         end
       end
 

--- a/lib/tapioca/generator.rb
+++ b/lib/tapioca/generator.rb
@@ -600,7 +600,7 @@ module Tapioca
     def perform_dsl_verification(dir)
       diff = verify_dsl_rbi(tmp_dir: dir)
 
-      report_diff_and_exit_if_out_of_date(diff, 'dsl')
+      report_diff_and_exit_if_out_of_date(diff, "dsl")
     ensure
       FileUtils.remove_entry(dir)
     end
@@ -631,7 +631,7 @@ module Tapioca
         diff[filename] = gem_rbi_exists?(gem_name) ? :changed : :added
       end
 
-      report_diff_and_exit_if_out_of_date(diff, 'sync')
+      report_diff_and_exit_if_out_of_date(diff, "sync")
     end
 
     sig { params(diff: T::Hash[String, Symbol], command: String).void }

--- a/lib/tapioca/generator.rb
+++ b/lib/tapioca/generator.rb
@@ -600,22 +600,7 @@ module Tapioca
     def perform_dsl_verification(dir)
       diff = verify_dsl_rbi(tmp_dir: dir)
 
-      if diff.empty?
-        say("Nothing to do, all RBIs are up-to-date.")
-      else
-        say("RBI files are out-of-date. In your development environment, please run:", :green)
-        say("  `#{Config::DEFAULT_COMMAND} dsl`", [:green, :bold])
-        say("Once it is complete, be sure to commit and push any changes", :green)
-
-        say("")
-
-        say("Reason:", [:red])
-        diff.group_by(&:last).sort.each do |cause, diff_for_cause|
-          say(build_error_for_files(cause, diff_for_cause.map(&:first)))
-        end
-
-        exit(1)
-      end
+      report_diff_and_exit_if_out_of_date(diff, 'dsl')
     ensure
       FileUtils.remove_entry(dir)
     end
@@ -646,11 +631,16 @@ module Tapioca
         diff[filename] = gem_rbi_exists?(gem_name) ? :changed : :added
       end
 
+      report_diff_and_exit_if_out_of_date(diff, 'sync')
+    end
+
+    sig { params(diff: T::Hash[String, Symbol], command: String).void }
+    def report_diff_and_exit_if_out_of_date(diff, command)
       if diff.empty?
         say("Nothing to do, all RBIs are up-to-date.")
       else
         say("RBI files are out-of-date. In your development environment, please run:", :green)
-        say("  `#{Config::DEFAULT_COMMAND} sync`", [:green, :bold])
+        say("  `#{Config::DEFAULT_COMMAND} #{command}`", [:green, :bold])
         say("Once it is complete, be sure to commit and push any changes", :green)
 
         say("")

--- a/lib/tapioca/generator.rb
+++ b/lib/tapioca/generator.rb
@@ -643,11 +643,7 @@ module Tapioca
 
       added_rbis.each do |gem_name|
         filename = expected_rbi(gem_name)
-        if gem_rbi_exists?(gem_name)
-          diff[filename] = :changed
-        else
-          diff[filename] = :added
-        end
+        diff[filename] = gem_rbi_exists?(gem_name) ? :changed : :added
       end
 
       if diff.empty?


### PR DESCRIPTION
### Motivation

`tapioca dsl` has a `--verify` flag that will "exit 1" if your DSL RBI is not up-to-date. This makes it easy to add a CI check to prevent stale RBI. We're starting to use `tapioca sync` and I found myself wanting something similar to ensure gem RBI is up-to-date.

### Implementation

Followed a similar pattern as verification for DSL.

### Tests

See added test cases
