### PR TITLE
Add block builders to RBI trees and scopes

### DIFF
--- a/lib/tapioca/rbi/model.rb
+++ b/lib/tapioca/rbi/model.rb
@@ -72,10 +72,17 @@ module Tapioca
       sig { returns(T::Array[Node]) }
       attr_reader :nodes
 
-      sig { params(loc: T.nilable(Loc), comments: T::Array[Comment]).void }
-      def initialize(loc: nil, comments: [])
+      sig do
+        params(
+          loc: T.nilable(Loc),
+          comments: T::Array[Comment],
+          block: T.nilable(T.proc.params(tree: Tree).void)
+        ).void
+      end
+      def initialize(loc: nil, comments: [], &block)
         super(loc: loc, comments: comments)
         @nodes = T.let([], T::Array[Node])
+        block&.call(self)
       end
 
       sig { params(node: Node).void }
@@ -112,10 +119,18 @@ module Tapioca
       sig { returns(String) }
       attr_accessor :name
 
-      sig { params(name: String, loc: T.nilable(Loc), comments: T::Array[Comment]).void }
-      def initialize(name, loc: nil, comments: [])
-        super(loc: loc, comments: comments)
+      sig do
+        params(
+          name: String,
+          loc: T.nilable(Loc),
+          comments: T::Array[Comment],
+          block: T.nilable(T.proc.params(mod: Module).void)
+        ).void
+      end
+      def initialize(name, loc: nil, comments: [], &block)
+        super(loc: loc, comments: comments) {}
         @name = name
+        block&.call(self)
       end
 
       sig { override.returns(String) }
@@ -139,13 +154,15 @@ module Tapioca
           name: String,
           superclass_name: T.nilable(String),
           loc: T.nilable(Loc),
-          comments: T::Array[Comment]
+          comments: T::Array[Comment],
+          block: T.nilable(T.proc.params(klass: Class).void)
         ).void
       end
-      def initialize(name, superclass_name: nil, loc: nil, comments: [])
-        super(loc: loc, comments: comments)
+      def initialize(name, superclass_name: nil, loc: nil, comments: [], &block)
+        super(loc: loc, comments: comments) {}
         @name = name
         @superclass_name = superclass_name
+        block&.call(self)
       end
 
       sig { override.returns(String) }
@@ -158,9 +175,16 @@ module Tapioca
     class SingletonClass < Scope
       extend T::Sig
 
-      sig { params(loc: T.nilable(Loc), comments: T::Array[Comment]).void }
-      def initialize(loc: nil, comments: [])
-        super(loc: loc, comments: comments)
+      sig do
+        params(
+          loc: T.nilable(Loc),
+          comments: T::Array[Comment],
+          block: T.nilable(T.proc.params(klass: SingletonClass).void)
+        ).void
+      end
+      def initialize(loc: nil, comments: [], &block)
+        super(loc: loc, comments: comments) {}
+        block&.call(self)
       end
 
       sig { override.returns(String) }
@@ -566,9 +590,17 @@ module Tapioca
     class TStruct < Class
       extend T::Sig
 
-      sig { params(name: String, loc: T.nilable(Loc), comments: T::Array[Comment]).void }
-      def initialize(name, loc: nil, comments: [])
-        super(name, superclass_name: "::T::Struct", loc: loc, comments: comments)
+      sig do
+        params(
+          name: String,
+          loc: T.nilable(Loc),
+          comments: T::Array[Comment],
+          block: T.nilable(T.proc.params(klass: TStruct).void)
+        ).void
+      end
+      def initialize(name, loc: nil, comments: [], &block)
+        super(name, superclass_name: "::T::Struct", loc: loc, comments: comments) {}
+        block&.call(self)
       end
     end
 
@@ -639,9 +671,17 @@ module Tapioca
     class TEnum < Class
       extend T::Sig
 
-      sig { params(name: String, loc: T.nilable(Loc), comments: T::Array[Comment]).void }
-      def initialize(name, loc: nil, comments: [])
-        super(name, superclass_name: "::T::Enum", loc: loc, comments: comments)
+      sig do
+        params(
+          name: String,
+          loc: T.nilable(Loc),
+          comments: T::Array[Comment],
+          block: T.nilable(T.proc.params(klass: TEnum).void)
+        ).void
+      end
+      def initialize(name, loc: nil, comments: [], &block)
+        super(name, superclass_name: "::T::Enum", loc: loc, comments: comments) {}
+        block&.call(self)
       end
     end
 


### PR DESCRIPTION
### Motivation

Make the creation of nested RBI trees and scopes easier.

Let's try to build this RBI string:

```rb
module Foo
  class Bar
    class Baz < Bar
      class << self; end
    end
  end
end
```

Before this PR, the only way was to save the reference of the created node to reuse it:

```rb
scope1 = RBI::Module.new("Foo")
scope2 = RBI::Class.new("Bar")
scope3 = RBI::Class.new("Baz", superclass_name: "Bar")
scope4 = RBI::SingletonClass.new

rbi = RBI::Tree.new
rbi << scope1
scope1 << scope2
scope2 << scope3
scope3 << scope4
```

With this PR, we can now use the block builder syntax:

```rb
rbi = RBI::Tree.new do |tree|
  tree << RBI::Module.new("Foo") do |mod|
    mod << RBI::Class.new("Bar") do |klass1|
      klass1 << RBI::Class.new("Baz", superclass_name: "Bar") do |klass2|
        klass2 << RBI::SingletonClass.new
      end
    end
  end
end
```

### Tests

See automated tests.

