### PR TITLE
Handle identity_cache aliases

### DIFF
--- a/lib/tapioca.rb
+++ b/lib/tapioca.rb
@@ -18,4 +18,5 @@ module Tapioca
 end
 
 require "tapioca/compilers/dsl/base"
+require "tapioca/active_record_column_type_helper"
 require "tapioca/version"

--- a/lib/tapioca/column_type_helper.rb
+++ b/lib/tapioca/column_type_helper.rb
@@ -1,0 +1,98 @@
+# typed: strict
+# frozen_string_literal: true
+
+module ColumnTypeHelper
+  extend T::Sig
+
+  private
+
+  sig do
+    params(
+      constant: T.class_of(ActiveRecord::Base),
+      column_name: String
+    ).returns([String, String])
+  end
+  def type_for(constant, column_name)
+    return ["T.untyped", "T.untyped"] if do_not_generate_strong_types?(constant)
+
+    column_type = constant.attribute_types[column_name]
+
+    getter_type =
+      case column_type
+      when defined?(MoneyColumn) && MoneyColumn::ActiveRecordType
+        "::Money"
+      when ActiveRecord::Type::Integer
+        "::Integer"
+      when ActiveRecord::Type::String
+        "::String"
+      when ActiveRecord::Type::Date
+        "::Date"
+      when ActiveRecord::Type::Decimal
+        "::BigDecimal"
+      when ActiveRecord::Type::Float
+        "::Float"
+      when ActiveRecord::Type::Boolean
+        "T::Boolean"
+      when ActiveRecord::Type::DateTime, ActiveRecord::Type::Time
+        "::DateTime"
+      when ActiveRecord::AttributeMethods::TimeZoneConversion::TimeZoneConverter
+        "::ActiveSupport::TimeWithZone"
+      else
+        handle_unknown_type(column_type)
+      end
+
+    column = constant.columns_hash[column_name]
+    setter_type = getter_type
+
+    if column&.null
+      return ["T.nilable(#{getter_type})", "T.nilable(#{setter_type})"]
+    end
+
+    if column_name == constant.primary_key ||
+        column_name == "created_at" ||
+        column_name == "updated_at"
+      getter_type = "T.nilable(#{getter_type})"
+    end
+
+    [getter_type, setter_type]
+  end
+
+  sig { params(constant: Module).returns(T::Boolean) }
+  def do_not_generate_strong_types?(constant)
+    Object.const_defined?(:StrongTypeGeneration) &&
+        !(constant.singleton_class < Object.const_get(:StrongTypeGeneration))
+  end
+
+  sig { params(column_type: Object).returns(String) }
+  def handle_unknown_type(column_type)
+    return "T.untyped" unless ActiveModel::Type::Value === column_type
+
+    lookup_return_type_of_method(column_type, :deserialize) ||
+      lookup_return_type_of_method(column_type, :cast) ||
+      lookup_arg_type_of_method(column_type, :serialize) ||
+      "T.untyped"
+  end
+
+  sig { params(column_type: ActiveModel::Type::Value, method: Symbol).returns(T.nilable(String)) }
+  def lookup_return_type_of_method(column_type, method)
+    signature = T::Private::Methods.signature_for_method(column_type.method(method))
+    return unless signature
+
+    return_type = signature.return_type
+    return if return_type == T::Private::Types::Void || return_type == T::Private::Types::NotTyped
+
+    return_type.to_s
+  end
+
+  sig { params(column_type: ActiveModel::Type::Value, method: Symbol).returns(T.nilable(String)) }
+  def lookup_arg_type_of_method(column_type, method)
+    signature = T::Private::Methods.signature_for_method(column_type.method(method))
+    return unless signature
+
+    # Arg types is an array [name, type] entries, so we desctructure the type of
+    # first argument to get the first argument type
+    _, first_argument_type = signature.arg_types.first
+
+    first_argument_type.to_s
+  end
+end

--- a/lib/tapioca/compilers/dsl/active_record_columns.rb
+++ b/lib/tapioca/compilers/dsl/active_record_columns.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "parlour"
+require "tapioca/column_type_helper"
 
 begin
   require "active_record"
@@ -98,6 +99,7 @@ module Tapioca
       # ~~~
       class ActiveRecordColumns < Base
         extend T::Sig
+        include ColumnTypeHelper
 
         sig { override.params(root: Parlour::RbiGenerator::Namespace, constant: T.class_of(ActiveRecord::Base)).void }
         def decorate(root, constant)
@@ -296,96 +298,6 @@ module Tapioca
             methods_to_add,
             return_type: "T::Boolean"
           )
-        end
-
-        sig do
-          params(
-            constant: T.class_of(ActiveRecord::Base),
-            column_name: String
-          ).returns([String, String])
-        end
-        def type_for(constant, column_name)
-          return ["T.untyped", "T.untyped"] if do_not_generate_strong_types?(constant)
-
-          column_type = constant.attribute_types[column_name]
-
-          getter_type =
-            case column_type
-            when defined?(MoneyColumn) && MoneyColumn::ActiveRecordType
-              "::Money"
-            when ActiveRecord::Type::Integer
-              "::Integer"
-            when ActiveRecord::Type::String
-              "::String"
-            when ActiveRecord::Type::Date
-              "::Date"
-            when ActiveRecord::Type::Decimal
-              "::BigDecimal"
-            when ActiveRecord::Type::Float
-              "::Float"
-            when ActiveRecord::Type::Boolean
-              "T::Boolean"
-            when ActiveRecord::Type::DateTime, ActiveRecord::Type::Time
-              "::DateTime"
-            when ActiveRecord::AttributeMethods::TimeZoneConversion::TimeZoneConverter
-              "::ActiveSupport::TimeWithZone"
-            else
-              handle_unknown_type(column_type)
-            end
-
-          column = constant.columns_hash[column_name]
-          setter_type = getter_type
-
-          if column&.null
-            return ["T.nilable(#{getter_type})", "T.nilable(#{setter_type})"]
-          end
-
-          if column_name == constant.primary_key ||
-              column_name == "created_at" ||
-              column_name == "updated_at"
-            getter_type = "T.nilable(#{getter_type})"
-          end
-
-          [getter_type, setter_type]
-        end
-
-        sig { params(constant: Module).returns(T::Boolean) }
-        def do_not_generate_strong_types?(constant)
-          Object.const_defined?(:StrongTypeGeneration) &&
-              !(constant.singleton_class < Object.const_get(:StrongTypeGeneration))
-        end
-
-        sig { params(column_type: Object).returns(String) }
-        def handle_unknown_type(column_type)
-          return "T.untyped" unless ActiveModel::Type::Value === column_type
-
-          lookup_return_type_of_method(column_type, :deserialize) ||
-            lookup_return_type_of_method(column_type, :cast) ||
-            lookup_arg_type_of_method(column_type, :serialize) ||
-            "T.untyped"
-        end
-
-        sig { params(column_type: ActiveModel::Type::Value, method: Symbol).returns(T.nilable(String)) }
-        def lookup_return_type_of_method(column_type, method)
-          signature = T::Private::Methods.signature_for_method(column_type.method(method))
-          return unless signature
-
-          return_type = signature.return_type
-          return if return_type == T::Private::Types::Void || return_type == T::Private::Types::NotTyped
-
-          return_type.to_s
-        end
-
-        sig { params(column_type: ActiveModel::Type::Value, method: Symbol).returns(T.nilable(String)) }
-        def lookup_arg_type_of_method(column_type, method)
-          signature = T::Private::Methods.signature_for_method(column_type.method(method))
-          return unless signature
-
-          # Arg types is an array [name, type] entries, so we desctructure the type of
-          # first argument to get the first argument type
-          _, first_argument_type = signature.arg_types.first
-
-          first_argument_type.to_s
         end
 
         sig { params(type: String).returns(String) }

--- a/lib/tapioca/compilers/dsl/active_record_columns.rb
+++ b/lib/tapioca/compilers/dsl/active_record_columns.rb
@@ -2,7 +2,6 @@
 # frozen_string_literal: true
 
 require "parlour"
-require "tapioca/column_type_helper"
 
 begin
   require "active_record"
@@ -99,7 +98,6 @@ module Tapioca
       # ~~~
       class ActiveRecordColumns < Base
         extend T::Sig
-        include ColumnTypeHelper
 
         sig { override.params(root: Parlour::RbiGenerator::Namespace, constant: T.class_of(ActiveRecord::Base)).void }
         def decorate(root, constant)
@@ -166,7 +164,7 @@ module Tapioca
           ).void
         end
         def add_methods_for_attribute(klass, constant, column_name, attribute_name = column_name, methods_to_add = nil)
-          getter_type, setter_type = type_for(constant, column_name)
+          getter_type, setter_type = ActiveRecordColumnTypeHelper.new(constant).type_for(column_name)
 
           # Added by ActiveRecord::AttributeMethods::Read
           #

--- a/lib/tapioca/compilers/dsl/identity_cache.rb
+++ b/lib/tapioca/compilers/dsl/identity_cache.rb
@@ -166,11 +166,10 @@ module Tapioca
         def create_fetch_by_methods(field, klass, constant)
           field_length = field.key_fields.length
           fields_name = field.key_fields.join("_and_")
-          suffix = field.send(:fetch_method_suffix)
           is_cache_index = field.instance_variable_defined?(:@attribute_proc)
 
           # Both `cache_index` and `cache_attribute` generate aliased methods
-          create_aliased_fetch_by_methods(klass, constant, field.alias_name.to_s, field_length, suffix)
+          create_aliased_fetch_by_methods(field, klass, constant)
 
           # If the method used was `cache_index` a few extra methods are created
           if is_cache_index
@@ -219,16 +218,16 @@ module Tapioca
 
         sig do
           params(
+            field: T.untyped,
             klass: Parlour::RbiGenerator::Namespace,
             constant: T.class_of(::ActiveRecord::Base),
-            alias_name: String,
-            length: Integer,
-            suffix: String,
           ).void
         end
-        def create_aliased_fetch_by_methods(klass, constant, alias_name, length, suffix)
-          type, _ = type_for(constant, alias_name)
+        def create_aliased_fetch_by_methods(field, klass, constant)
+          type, _ = type_for(constant, field.alias_name.to_s)
           multi_type = type.delete_prefix("T.nilable(").delete_suffix(")")
+          length = field.key_fields.length
+          suffix = field.send(:fetch_method_suffix)
 
           if length == 1
             klass.create_method(

--- a/lib/tapioca/compilers/dsl/identity_cache.rb
+++ b/lib/tapioca/compilers/dsl/identity_cache.rb
@@ -2,7 +2,6 @@
 # frozen_string_literal: true
 
 require "parlour"
-require "tapioca/column_type_helper"
 
 begin
   require "rails/railtie"
@@ -65,7 +64,6 @@ module Tapioca
       # ~~~
       class IdentityCache < Base
         extend T::Sig
-        include ColumnTypeHelper
 
         COLLECTION_TYPE = T.let(
           ->(type) { "T::Array[::#{type}]" },
@@ -233,7 +231,7 @@ module Tapioca
           ).void
         end
         def create_aliased_fetch_by_methods(field, klass, constant)
-          type, _ = type_for(constant, field.alias_name.to_s)
+          type, _ = ActiveRecordColumnTypeHelper.new(constant).type_for(field.alias_name.to_s)
           multi_type = type.delete_prefix("T.nilable(").delete_suffix(")")
           length = field.key_fields.length
           suffix = field.send(:fetch_method_suffix)

--- a/lib/tapioca/compilers/dsl/identity_cache.rb
+++ b/lib/tapioca/compilers/dsl/identity_cache.rb
@@ -164,46 +164,88 @@ module Tapioca
         def create_fetch_by_methods(field, klass, constant)
           field_length = field.key_fields.length
           fields_name = field.key_fields.join("_and_")
+          suffix = field.send(:fetch_method_suffix)
+          is_cache_index = field.instance_variable_defined?(:@attribute_proc)
 
-          parameters = field.key_fields.map do |arg|
-            Parlour::RbiGenerator::Parameter.new(arg.to_s, type: "T.untyped")
+          # Both `cache_index` and `cache_attribute` generate aliased methods
+          create_aliased_fetch_by_methods(klass, field_length, suffix)
+
+          # If the method used was `cache_index` a few extra methods are created
+          if is_cache_index
+            name = "fetch_by_#{fields_name}"
+            parameters = field.key_fields.map do |arg|
+              Parlour::RbiGenerator::Parameter.new(arg.to_s, type: "T.untyped")
+            end
+            parameters << Parlour::RbiGenerator::Parameter.new("includes:", default: "nil", type: "T.untyped")
+
+            if field.unique
+              klass.create_method(
+                "#{name}!",
+                class_method: true,
+                parameters: parameters,
+                return_type: "::#{constant}"
+              )
+
+              klass.create_method(
+                name,
+                class_method: true,
+                parameters: parameters,
+                return_type: "T.nilable(::#{constant})"
+              )
+            else
+              klass.create_method(
+                name,
+                class_method: true,
+                parameters: parameters,
+                return_type: COLLECTION_TYPE.call(constant)
+              )
+            end
+
+            if field_length == 1
+              klass.create_method(
+                "fetch_multi_by_#{fields_name}",
+                class_method: true,
+                parameters: [
+                  Parlour::RbiGenerator::Parameter.new("index_values", type: "T.untyped"),
+                  Parlour::RbiGenerator::Parameter.new("includes:", default: "nil", type: "T.untyped"),
+                ],
+                return_type: COLLECTION_TYPE.call(constant)
+              )
+            end
           end
-          parameters << Parlour::RbiGenerator::Parameter.new("includes:", default: "nil", type: "T.untyped")
+        end
 
-          name = "fetch_by_#{fields_name}"
-          if field.unique
+        sig do
+          params(
+            klass: Parlour::RbiGenerator::Namespace,
+            length: Integer,
+            suffix: String,
+          ).void
+        end
+        def create_aliased_fetch_by_methods(klass, length, suffix)
+          single_return_type = suffix.start_with?("id") ? "T.nilable(::Integer)" : "T.untyped"
+          multi_return_type = suffix.start_with?("id") ? "T::Array[::Integer]" : "T.untyped"
+
+          if length == 1
             klass.create_method(
-              "#{name}!",
+              "fetch_#{suffix}",
               class_method: true,
-              parameters: parameters,
-              return_type: "::#{constant}"
+              parameters: [Parlour::RbiGenerator::Parameter.new("key", type: "T.untyped")],
+              return_type: single_return_type
             )
 
             klass.create_method(
-              name,
+              "fetch_multi_#{suffix}",
               class_method: true,
-              parameters: parameters,
-              return_type: "T.nilable(::#{constant})"
+              parameters: [Parlour::RbiGenerator::Parameter.new("keys", type: "T.untyped")],
+              return_type: multi_return_type
             )
           else
             klass.create_method(
-              name,
+              "fetch_#{suffix}",
               class_method: true,
-              parameters: parameters,
-              return_type: COLLECTION_TYPE.call(constant)
-            )
-          end
-
-          if field_length == 1
-            name = "fetch_multi_by_#{fields_name}"
-            klass.create_method(
-              name,
-              class_method: true,
-              parameters: [
-                Parlour::RbiGenerator::Parameter.new("index_values", type: "T.untyped"),
-                Parlour::RbiGenerator::Parameter.new("includes:", default: "nil", type: "T.untyped"),
-              ],
-              return_type: COLLECTION_TYPE.call(constant)
+              parameters: [Parlour::RbiGenerator::Parameter.new("key_values", type: "T.untyped")],
+              return_type: single_return_type
             )
           end
         end

--- a/spec/tapioca/compilers/dsl/identity_cache_spec.rb
+++ b/spec/tapioca/compilers/dsl/identity_cache_spec.rb
@@ -58,11 +58,23 @@ class Tapioca::Compilers::Dsl::IdentityCacheSpec < DslSpec
           sig { params(title: T.untyped, includes: T.untyped).returns(T::Array[::Post]) }
           def self.fetch_by_title(title, includes: nil); end
 
+          sig { params(key: T.untyped).returns(T.nilable(::Integer)) }
+          def self.fetch_id_by_blog_id(key); end
+
+          sig { params(key: T.untyped).returns(T.nilable(::Integer)) }
+          def self.fetch_id_by_title(key); end
+
           sig { params(index_values: T.untyped, includes: T.untyped).returns(T::Array[::Post]) }
           def self.fetch_multi_by_blog_id(index_values, includes: nil); end
 
           sig { params(index_values: T.untyped, includes: T.untyped).returns(T::Array[::Post]) }
           def self.fetch_multi_by_title(index_values, includes: nil); end
+
+          sig { params(keys: T.untyped).returns(T::Array[::Integer]) }
+          def self.fetch_multi_id_by_blog_id(keys); end
+
+          sig { params(keys: T.untyped).returns(T::Array[::Integer]) }
+          def self.fetch_multi_id_by_title(keys); end
         end
       RBI
 
@@ -90,11 +102,23 @@ class Tapioca::Compilers::Dsl::IdentityCacheSpec < DslSpec
           sig { params(title: T.untyped, includes: T.untyped).returns(::Post) }
           def self.fetch_by_title!(title, includes: nil); end
 
+          sig { params(key: T.untyped).returns(T.nilable(::Integer)) }
+          def self.fetch_id_by_blog_id(key); end
+
+          sig { params(key: T.untyped).returns(T.nilable(::Integer)) }
+          def self.fetch_id_by_title(key); end
+
           sig { params(index_values: T.untyped, includes: T.untyped).returns(T::Array[::Post]) }
           def self.fetch_multi_by_blog_id(index_values, includes: nil); end
 
           sig { params(index_values: T.untyped, includes: T.untyped).returns(T::Array[::Post]) }
           def self.fetch_multi_by_title(index_values, includes: nil); end
+
+          sig { params(keys: T.untyped).returns(T::Array[::Integer]) }
+          def self.fetch_multi_id_by_blog_id(keys); end
+
+          sig { params(keys: T.untyped).returns(T::Array[::Integer]) }
+          def self.fetch_multi_id_by_title(keys); end
         end
       RBI
 
@@ -122,8 +146,17 @@ class Tapioca::Compilers::Dsl::IdentityCacheSpec < DslSpec
           sig { params(title: T.untyped, review_date: T.untyped, includes: T.untyped).returns(::Post) }
           def self.fetch_by_title_and_review_date!(title, review_date, includes: nil); end
 
+          sig { params(key: T.untyped).returns(T.nilable(::Integer)) }
+          def self.fetch_id_by_title(key); end
+
+          sig { params(key_values: T.untyped).returns(T.nilable(::Integer)) }
+          def self.fetch_id_by_title_and_review_date(key_values); end
+
           sig { params(index_values: T.untyped, includes: T.untyped).returns(T::Array[::Post]) }
           def self.fetch_multi_by_title(index_values, includes: nil); end
+
+          sig { params(keys: T.untyped).returns(T::Array[::Integer]) }
+          def self.fetch_multi_id_by_title(keys); end
         end
       RBI
 
@@ -205,6 +238,29 @@ class Tapioca::Compilers::Dsl::IdentityCacheSpec < DslSpec
         class Post
           sig { returns(T.untyped) }
           def fetch_user; end
+        end
+      RBI
+
+      assert_equal(expected, rbi_for(:Post))
+    end
+
+    it("takes cache aliases into account when generating methods") do
+      add_ruby_file("post.rb", <<~RUBY)
+        class Post < ActiveRecord::Base
+          include IdentityCache
+
+          cache_attribute :author, by: :id
+        end
+      RUBY
+
+      expected = <<~RBI
+        # typed: strong
+        class Post
+          sig { params(key: T.untyped).returns(T.untyped) }
+          def self.fetch_author_by_id(key); end
+
+          sig { params(keys: T.untyped).returns(T.untyped) }
+          def self.fetch_multi_author_by_id(keys); end
         end
       RBI
 

--- a/spec/tapioca/compilers/dsl/identity_cache_spec.rb
+++ b/spec/tapioca/compilers/dsl/identity_cache_spec.rb
@@ -40,7 +40,27 @@ class Tapioca::Compilers::Dsl::IdentityCacheSpec < DslSpec
   end
 
   describe("#decorate") do
+    before(:each) do
+      require "active_record"
+
+      ::ActiveRecord::Base.establish_connection(
+        adapter: "sqlite3",
+        database: ":memory:"
+      )
+    end
+
     it("generates RBI file for classes with multiple cache_indexes") do
+      add_ruby_file("schema.rb", <<~RUBY)
+        ActiveRecord::Migration.suppress_messages do
+          ActiveRecord::Schema.define do
+            create_table :posts do |t|
+              t.integer :blog_id
+              t.string :title
+            end
+          end
+        end
+      RUBY
+
       add_ruby_file("post.rb", <<~RUBY)
         class Post < ActiveRecord::Base
           include IdentityCache
@@ -82,6 +102,17 @@ class Tapioca::Compilers::Dsl::IdentityCacheSpec < DslSpec
     end
 
     it("generates multiple methods for singled cache_index with unique field") do
+      add_ruby_file("schema.rb", <<~RUBY)
+        ActiveRecord::Migration.suppress_messages do
+          ActiveRecord::Schema.define do
+            create_table :posts do |t|
+              t.integer :blog_id
+              t.string :title
+            end
+          end
+        end
+      RUBY
+
       add_ruby_file("post.rb", <<~RUBY)
         class Post < ActiveRecord::Base
           include IdentityCache
@@ -126,6 +157,17 @@ class Tapioca::Compilers::Dsl::IdentityCacheSpec < DslSpec
     end
 
     it("generates methods for combined cache_indexes") do
+      add_ruby_file("schema.rb", <<~RUBY)
+        ActiveRecord::Migration.suppress_messages do
+          ActiveRecord::Schema.define do
+            create_table :posts do |t|
+              t.string :title
+              t.datetime :review_date
+            end
+          end
+        end
+      RUBY
+
       add_ruby_file("post.rb", <<~RUBY)
         class Post < ActiveRecord::Base
           include IdentityCache
@@ -164,6 +206,19 @@ class Tapioca::Compilers::Dsl::IdentityCacheSpec < DslSpec
     end
 
     it("generates methods for classes with cache_has_manys index") do
+      add_ruby_file("schema.rb", <<~RUBY)
+        ActiveRecord::Migration.suppress_messages do
+          ActiveRecord::Schema.define do
+            create_table :posts do |t|
+            end
+
+            create_table :users do |t|
+              t.belongs_to :post
+            end
+          end
+        end
+      RUBY
+
       add_ruby_file("user.rb", <<~RUBY)
         class User < ActiveRecord::Base
         end
@@ -192,6 +247,19 @@ class Tapioca::Compilers::Dsl::IdentityCacheSpec < DslSpec
     end
 
     it("generates methods for classes with cache_has_one index") do
+      add_ruby_file("schema.rb", <<~RUBY)
+        ActiveRecord::Migration.suppress_messages do
+          ActiveRecord::Schema.define do
+            create_table :posts do |t|
+            end
+
+            create_table :users do |t|
+              t.belongs_to :post
+            end
+          end
+        end
+      RUBY
+
       add_ruby_file("user.rb", <<~RUBY)
         class User < ActiveRecord::Base
         end
@@ -220,6 +288,19 @@ class Tapioca::Compilers::Dsl::IdentityCacheSpec < DslSpec
     end
 
     it("generates methods for classes with cache_belongs_to index on a polymorphic relation") do
+      add_ruby_file("schema.rb", <<~RUBY)
+        ActiveRecord::Migration.suppress_messages do
+          ActiveRecord::Schema.define do
+            create_table :posts do |t|
+              t.belongs_to :user
+            end
+
+            create_table :users do |t|
+            end
+          end
+        end
+      RUBY
+
       add_ruby_file("user.rb", <<~RUBY)
         class User < ActiveRecord::Base
         end
@@ -245,6 +326,16 @@ class Tapioca::Compilers::Dsl::IdentityCacheSpec < DslSpec
     end
 
     it("takes cache aliases into account when generating methods") do
+      add_ruby_file("schema.rb", <<~RUBY)
+        ActiveRecord::Migration.suppress_messages do
+          ActiveRecord::Schema.define do
+            create_table :posts do |t|
+              t.string :author
+            end
+          end
+        end
+      RUBY
+
       add_ruby_file("post.rb", <<~RUBY)
         class Post < ActiveRecord::Base
           include IdentityCache
@@ -256,10 +347,10 @@ class Tapioca::Compilers::Dsl::IdentityCacheSpec < DslSpec
       expected = <<~RBI
         # typed: strong
         class Post
-          sig { params(key: T.untyped).returns(T.untyped) }
+          sig { params(key: T.untyped).returns(T.nilable(::String)) }
           def self.fetch_author_by_id(key); end
 
-          sig { params(keys: T.untyped).returns(T.untyped) }
+          sig { params(keys: T.untyped).returns(T::Array[::String]) }
           def self.fetch_multi_author_by_id(keys); end
         end
       RBI
@@ -268,6 +359,19 @@ class Tapioca::Compilers::Dsl::IdentityCacheSpec < DslSpec
     end
 
     it("generates methods for classes with cache_belongs_to index and a simple belong_to") do
+      add_ruby_file("schema.rb", <<~RUBY)
+        ActiveRecord::Migration.suppress_messages do
+          ActiveRecord::Schema.define do
+            create_table :posts do |t|
+              t.belongs_to :user
+            end
+
+            create_table :users do |t|
+            end
+          end
+        end
+      RUBY
+
       add_ruby_file("user.rb", <<~RUBY)
         class User < ActiveRecord::Base
         end


### PR DESCRIPTION
Closes #322 

### Motivation

Identity cache provides two mechanisms for caching: `cache_index` and `cache_attribute`.

When invoking [cache_index](https://github.com/Shopify/identity_cache/blob/01e90ed9fffe960ff96e9e54eaa7a03fa47a4d85/lib/identity_cache/with_primary_index.rb#L55), it invokes `cache_attribute_by_alias` which will create the alias methods for `cache_index` that we are not currently generating. After that, `cache_index` generates other methods of its own, which are not created by `cache_attribute`.

When invoking [cache_attribute](https://github.com/Shopify/identity_cache/blob/771b0f98324274c8fd79bf2d2094ca9545f3af45/lib/identity_cache/configuration_dsl.rb#L124), it only invokes `cache_attribute_by_alias` and generates the methods with aliases. These [methods](https://github.com/Shopify/identity_cache/blob/771b0f98324274c8fd79bf2d2094ca9545f3af45/lib/identity_cache/cached/attribute_by_one.rb#L16) do not have the `include` argument.

The signatures are different (the alias methods do not have the `include` argument), but they all add entries to the cache variables that keep track of attributes.

### TL;DR

- Both `cache_index` and `cache_attribute` generate the alias methods which do not contain the `include` argument
- `cache_index` generates extra methods (with the `include` argument), which should not be added to the RBI for `cache_attribute`

The challenge is telling which method call create the cached attribute.

### Implementation

I added a new method to create the alias methods and added a few checks to the existing `create_fetch_by_methods`.

I couldn't think of an easy way of knowing if the cached attribute came from `cache_index` or from `cache_attribute`, so I added safe guards to not generate the methods in the RBIs if the `constant` does not actually respond to them. Please, let me know if you have a better suggestion on how to identify these.

### Tests

See included tests.