### PR TITLE
Do not print trailing spaces with empty comments

### DIFF
--- a/lib/tapioca/rbi/printer.rb
+++ b/lib/tapioca/rbi/printer.rb
@@ -118,7 +118,10 @@ module Tapioca
 
       sig { override.params(v: Printer).void }
       def accept_printer(v)
-        v.printl("# #{text.strip}")
+        text = self.text.strip
+        v.printt("#")
+        v.print(" #{text}") unless text.empty?
+        v.printn
       end
     end
 

--- a/spec/tapioca/rbi/printer_spec.rb
+++ b/spec/tapioca/rbi/printer_spec.rb
@@ -455,6 +455,22 @@ module Tapioca
           RBI
         end
 
+        it("builds empty comments") do
+          tree = RBI::Tree.new(comments: [
+            RBI::Comment.new("typed: true"),
+            RBI::Comment.new(""),
+            RBI::Comment.new("Some intro comment"),
+            RBI::Comment.new("Some other comment"),
+          ])
+
+          assert_equal(<<~RBI, tree.string)
+            # typed: true
+            #
+            # Some intro comment
+            # Some other comment
+          RBI
+        end
+
         it("prints params inline comments") do
           comments = [RBI::Comment.new("comment")]
 


### PR DESCRIPTION
### Motivation

Avoid printing a trailing space on empty comments lines

Be the following sequence of comments:

```rb
tree = RBI::Tree.new(comments: [
  RBI::Comment.new("typed: true"),
  RBI::Comment.new(""),
  RBI::Comment.new("Some comment")
])
```

Before this PR, the rendering included a trailing space on the second line:

```rb
# typed: true
# <-- trailing space
# Some comment
```

With this PR, no trailing space is rendered:

```rb
# typed: true
#<-- no trailing space
# Some comment
```

This plays better with cops.

### Tests

See automated tests.