### PR TITLE
Actually pass file location to parser

### DIFF
--- a/lib/tapioca/rbi/parser.rb
+++ b/lib/tapioca/rbi/parser.rb
@@ -36,7 +36,7 @@ module Tapioca
 
       sig { params(path: String).returns(Tree) }
       def parse_file(path)
-        parse(File.read(path), file: "-")
+        parse(File.read(path), file: path)
       rescue ::Parser::SyntaxError => e
         raise Error, e.message
       end


### PR DESCRIPTION
### Motivation

Get the real file path instead of `-` ...