### PR TITLE
Introduce RBI::File

### DIFF
--- a/lib/tapioca/rbi/model.rb
+++ b/lib/tapioca/rbi/model.rb
@@ -114,6 +114,31 @@ module Tapioca
       end
     end
 
+    class File
+      extend T::Sig
+
+      sig { returns(Tree) }
+      attr_reader :root
+
+      sig { returns(T.nilable(String)) }
+      attr_reader :strictness
+
+      sig { returns(T::Array[Comment]) }
+      attr_accessor :comments
+
+      sig { params(strictness: T.nilable(String), comments: T::Array[Comment]).void }
+      def initialize(strictness: nil, comments: [])
+        @root = T.let(Tree.new, Tree)
+        @strictness = strictness
+        @comments = comments
+      end
+
+      sig { params(node: Node).void }
+      def <<(node)
+        @root << node
+      end
+    end
+
     # Scopes
 
     class Scope < Tree

--- a/lib/tapioca/rbi/parser.rb
+++ b/lib/tapioca/rbi/parser.rb
@@ -36,7 +36,7 @@ module Tapioca
 
       sig { params(path: String).returns(Tree) }
       def parse_file(path)
-        parse(File.read(path), file: path)
+        parse(::File.read(path), file: path)
       rescue ::Parser::SyntaxError => e
         raise Error, e.message
       end

--- a/spec/tapioca/rbi/printer_spec.rb
+++ b/spec/tapioca/rbi/printer_spec.rb
@@ -7,6 +7,26 @@ module Tapioca
   module RBI
     class PrinterSpec < Minitest::HooksSpec
       describe("build rbi") do
+        it("builds files without strictness") do
+          file = RBI::File.new
+          file.root << RBI::Module.new("Foo")
+
+          assert_equal(<<~RBI, file.string)
+            module Foo; end
+          RBI
+        end
+
+        it("builds files with strictness") do
+          file = RBI::File.new(strictness: "true")
+          file.root << RBI::Module.new("Foo")
+
+          assert_equal(<<~RBI, file.string)
+            # typed: true
+
+            module Foo; end
+          RBI
+        end
+
         it("builds modules and classes") do
           rbi = RBI::Tree.new
           rbi << RBI::Module.new("Foo")
@@ -308,6 +328,42 @@ module Tapioca
       end
 
       describe("can build RBI nodes with comments") do
+        it("builds files with comments but no strictness") do
+          comments = [
+            RBI::Comment.new("This is a"),
+            RBI::Comment.new("Multiline Comment"),
+          ]
+
+          file = RBI::File.new(comments: comments)
+          file.root << RBI::Module.new("Foo")
+
+          assert_equal(<<~RBI, file.string)
+            # This is a
+            # Multiline Comment
+
+            module Foo; end
+          RBI
+        end
+
+        it("builds files with comments and strictness") do
+          comments = [
+            RBI::Comment.new("This is a"),
+            RBI::Comment.new("Multiline Comment"),
+          ]
+
+          file = RBI::File.new(strictness: "true", comments: comments)
+          file.root << RBI::Module.new("Foo")
+
+          assert_equal(<<~RBI, file.string)
+            # typed: true
+
+            # This is a
+            # Multiline Comment
+
+            module Foo; end
+          RBI
+        end
+
         it("builds nodes with comments") do
           comments_single = [RBI::Comment.new("This is a single line comment")]
 


### PR DESCRIPTION
### Motivation

Provides a way to manipulate a full file with something less abstract than a `RBI::Tree`.
`RBI::File` also allows the user to store the strictness level to be used when printing the file.

### Tests

See automated tests.

