### PR TITLE
Ignore vendor folder by default

### DIFF
--- a/lib/tapioca/cli.rb
+++ b/lib/tapioca/cli.rb
@@ -115,6 +115,7 @@ module Tapioca
         <<~CONTENT
           --dir
           .
+          --ignore=vendor
         CONTENT
       end
     end

--- a/spec/tapioca/cli/init_spec.rb
+++ b/spec/tapioca/cli/init_spec.rb
@@ -20,6 +20,7 @@ module Tapioca
         assert_equal(<<~CONTENTS, File.read(repo_path / "sorbet/config"))
           --dir
           .
+          --ignore=vendor
         CONTENTS
         assert_path_exists(repo_path / "sorbet/tapioca/require.rb")
         assert_equal(<<~CONTENTS, File.read(repo_path / "sorbet/tapioca/require.rb"))


### PR DESCRIPTION
### Motivation

There is some practices to install gems in `vendor/bundle`.
During type checking or tools around sorbet like `spoom` this line presented in each projects that I work in.

### Implementation

Generate a sorbet config with ignore vendor directive
