### PR TITLE
Adds a `verbose` flag to the `dsl` command

### DIFF
--- a/lib/tapioca/cli.rb
+++ b/lib/tapioca/cli.rb
@@ -79,9 +79,14 @@ module Tapioca
       aliases: ["-q"],
       type: :boolean,
       desc: "Supresses file creation output"
+    option :verbose,
+      aliases: ["-V"],
+      type: :boolean,
+      desc: "Verbose output for debugging purposes"
     def dsl(*constants)
       Tapioca.silence_warnings do
-        generator.build_dsl(constants, should_verify: options[:verify], quiet: options[:quiet])
+        generator.build_dsl(constants, should_verify: options[:verify], quiet: options[:quiet],
+verbose: options[:verbose])
       end
     end
 

--- a/lib/tapioca/cli.rb
+++ b/lib/tapioca/cli.rb
@@ -86,8 +86,12 @@ module Tapioca
       desc: "Supresses file creation output"
     def dsl(*constants)
       Tapioca.silence_warnings do
-        generator.build_dsl(constants, should_verify: options[:verify], quiet: options[:quiet],
-verbose: options[:verbose])
+        generator.build_dsl(
+          constants,
+          should_verify: options[:verify],
+          quiet: options[:quiet],
+          verbose: options[:verbose]
+        )
       end
     end
 

--- a/lib/tapioca/cli.rb
+++ b/lib/tapioca/cli.rb
@@ -37,6 +37,11 @@ module Tapioca
       type: :boolean,
       default: true,
       desc: "Add a \"This file is generated\" header on top of each generated RBI file"
+    class_option :verbose,
+      aliases: ["-V"],
+      type: :boolean,
+      default: false,
+      desc: "Verbose output for debugging purposes"
 
     map T.unsafe(["--version", "-v"] => :__print_version)
 
@@ -79,10 +84,6 @@ module Tapioca
       aliases: ["-q"],
       type: :boolean,
       desc: "Supresses file creation output"
-    option :verbose,
-      aliases: ["-V"],
-      type: :boolean,
-      desc: "Verbose output for debugging purposes"
     def dsl(*constants)
       Tapioca.silence_warnings do
         generator.build_dsl(constants, should_verify: options[:verify], quiet: options[:quiet],

--- a/lib/tapioca/generator.rb
+++ b/lib/tapioca/generator.rb
@@ -118,10 +118,11 @@ module Tapioca
       params(
         requested_constants: T::Array[String],
         should_verify: T::Boolean,
-        quiet: T::Boolean
+        quiet: T::Boolean,
+        verbose: T::Boolean
       ).void
     end
-    def build_dsl(requested_constants, should_verify: false, quiet: false)
+    def build_dsl(requested_constants, should_verify: false, quiet: false, verbose: false)
       load_application(eager_load: requested_constants.empty?)
       load_dsl_generators
 
@@ -147,6 +148,10 @@ module Tapioca
       compiler.run do |constant, contents|
         constant_name = Module.instance_method(:name).bind(constant).call
 
+        if verbose
+          say("Processing: ", [:yellow])
+          say(constant_name)
+        end
         filename = compile_dsl_rbi(
           constant_name,
           contents,

--- a/lib/tapioca/generator.rb
+++ b/lib/tapioca/generator.rb
@@ -148,15 +148,16 @@ module Tapioca
       compiler.run do |constant, contents|
         constant_name = Module.instance_method(:name).bind(constant).call
 
-        if verbose
+        if verbose && !quiet
           say("Processing: ", [:yellow])
           say(constant_name)
         end
+
         filename = compile_dsl_rbi(
           constant_name,
           contents,
           outpath: outpath,
-          quiet: should_verify || quiet
+          quiet: should_verify || quiet && !verbose
         )
 
         if filename

--- a/spec/tapioca/cli/dsl_spec.rb
+++ b/spec/tapioca/cli/dsl_spec.rb
@@ -204,6 +204,35 @@ module Tapioca
         CONTENTS
       end
 
+      it "generates RBI files with verbose output" do
+        output = execute("dsl", "--verbose")
+
+        assert_equal(<<~OUTPUT, output)
+          Loading Rails application... Done
+          Loading DSL generator classes... Done
+          Compiling DSL RBI files...
+
+          Processing: Baz::Role
+          Wrote: #{outdir}/baz/role.rbi
+          Processing: Job
+          Wrote: #{outdir}/job.rbi
+          Processing: Namespace::Comment
+          Wrote: #{outdir}/namespace/comment.rbi
+          Processing: Post
+          Wrote: #{outdir}/post.rbi
+
+          Done
+          All operations performed in working directory.
+          Please review changes and commit them.
+        OUTPUT
+
+        assert_path_exists("#{outdir}/baz/role.rbi")
+        assert_path_exists("#{outdir}/job.rbi")
+        assert_path_exists("#{outdir}/post.rbi")
+        assert_path_exists("#{outdir}/namespace/comment.rbi")
+        refute_path_exists("#{outdir}/user.rbi")
+      end
+
       it "can generates RBI files quietly" do
         output = execute("dsl", "--quiet")
 


### PR DESCRIPTION
Closes: https://github.com/Shopify/tapioca/issues/281

### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
Adds a `--verbose` flag to the `dsl` command. The output will now show which constant we're processing at runtime, so that if errors were to arise, we can pin point where the problem occurred.

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
Added a `verbose` option to the `dsl` command in `cli.rb`. The information is then printed based on whether or not that flag is set to true.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->
Added additional test case ensuring that output is as expected. 

