### PR TITLE
Compile generic types in signatures using the correct constant

### DIFF
--- a/spec/tapioca/compilers/symbol_table_compiler_spec.rb
+++ b/spec/tapioca/compilers/symbol_table_compiler_spec.rb
@@ -2234,12 +2234,16 @@ class Tapioca::Compilers::SymbolTableCompilerSpec < Minitest::HooksSpec
             extend T::Sig
             extend T::Generic
 
+            Template = type_template
             Elem = type_member
 
             sig { params(foo: Elem).void }
             def initialize(foo)
               @foo = foo
             end
+
+            sig { params(foo: Template).void }
+            def something(foo); end
 
             NullGenericType = SimpleGenericType[Integer].new(0)
           end
@@ -2335,10 +2339,14 @@ class Tapioca::Compilers::SymbolTableCompilerSpec < Minitest::HooksSpec
         class Generics::SimpleGenericType
           extend T::Generic
 
+          Template = type_template
           Elem = type_member
 
-          sig { params(foo: T.untyped).void }
+          sig { params(foo: Elem).void }
           def initialize(foo); end
+
+          sig { params(foo: Template).void }
+          def something(foo); end
         end
 
         Generics::SimpleGenericType::NullGenericType = T.let(T.unsafe(nil), Generics::SimpleGenericType[Integer])


### PR DESCRIPTION
Closes #323

### Motivation

The current mechanism for compiling signature types is by invoking `to_s` on the specific constant used for the type. However, generics always return `T.untyped` for the `to_s`, so we need an alternative mechanism to get the actual constant name for compilation.

### Implementation

Basically, it boils down to this:
1. If the parameter is not a generic, keep the old mechanism
2. If the parameter is generic, list all constants inside the method owner and find the one for which it's value is equal the generic type. Then use the constant name for compiling

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->

I added an extra `type_template`, since those also need special care when compiling.