### PR TITLE
Extract reflection methods into a module

### DIFF
--- a/lib/tapioca.rb
+++ b/lib/tapioca.rb
@@ -17,6 +17,7 @@ module Tapioca
   class Error < StandardError; end
 end
 
+require "tapioca/reflection"
 require "tapioca/compilers/dsl/base"
 require "tapioca/helpers/active_record_column_type_helper"
 require "tapioca/version"

--- a/lib/tapioca/compilers/dsl/action_controller_helpers.rb
+++ b/lib/tapioca/compilers/dsl/action_controller_helpers.rb
@@ -90,7 +90,7 @@ module Tapioca
               # the Action Controlller base helper methods module, so we should
               # just add that as an include and stop doing more processing.
               if helpers_module.name == "ActionController::Base::HelperMethods"
-                next helper_methods.create_include("::#{helpers_module.name}")
+                next helper_methods.create_include(T.must(qualified_name_of(helpers_module)))
               end
 
               # Find all the included helper modules and generate an include
@@ -129,7 +129,7 @@ module Tapioca
         def gather_includes(mod)
           mod.ancestors
             .reject { |ancestor| ancestor.is_a?(Class) || ancestor == mod || ancestor.name.nil? }
-            .map { |ancestor| "::#{ancestor.name}" }
+            .map { |ancestor| T.must(qualified_name_of(ancestor)) }
             .reverse
         end
       end

--- a/lib/tapioca/compilers/dsl/active_record_associations.rb
+++ b/lib/tapioca/compilers/dsl/active_record_associations.rb
@@ -243,7 +243,7 @@ module Tapioca
         def type_for(constant, reflection)
           return "T.untyped" if !constant.table_exists? || polymorphic_association?(reflection)
 
-          "::#{reflection.klass.name}"
+          T.must(qualified_name_of(reflection.klass))
         end
 
         sig do

--- a/lib/tapioca/compilers/dsl/active_support_concern.rb
+++ b/lib/tapioca/compilers/dsl/active_support_concern.rb
@@ -70,10 +70,8 @@ module Tapioca
 
         sig { override.returns(T::Enumerable[Module]) }
         def gather_constants
-          modules = T.cast(ObjectSpace.each_object(Module), T::Enumerable[Module])
-
           # Find all Modules that are:
-          modules.select do |mod|
+          all_modules.select do |mod|
             # named (i.e. not anonymous)
             name_of(mod) &&
               # not singleton classes

--- a/lib/tapioca/compilers/dsl/active_support_concern.rb
+++ b/lib/tapioca/compilers/dsl/active_support_concern.rb
@@ -55,7 +55,7 @@ module Tapioca
           mixed_in_class_methods = dependencies
             .uniq # Deduplicate
             .map do |concern| # Map to class methods module name, if exists
-              "::#{name_of(concern)}::ClassMethods" if concern.const_defined?(:ClassMethods)
+              "#{qualified_name_of(concern)}::ClassMethods" if concern.const_defined?(:ClassMethods)
             end
             .compact # Remove non-existent records
 
@@ -84,11 +84,6 @@ module Tapioca
         end
 
         private
-
-        sig { params(type: Module).returns(T.nilable(String)) }
-        def name_of(type)
-          Module.instance_method(:name).bind(type).call
-        end
 
         sig { params(concern: Module).returns(T::Array[Module]) }
         def dependencies_of(concern)

--- a/lib/tapioca/compilers/dsl/base.rb
+++ b/lib/tapioca/compilers/dsl/base.rb
@@ -10,6 +10,8 @@ module Tapioca
         extend T::Sig
         extend T::Helpers
 
+        include Reflection
+
         abstract!
 
         sig { returns(T::Set[Module]) }

--- a/lib/tapioca/compilers/dsl/base.rb
+++ b/lib/tapioca/compilers/dsl/base.rb
@@ -43,6 +43,18 @@ module Tapioca
 
         private
 
+        sig { returns(T::Enumerable[Class]) }
+        def all_classes
+          @all_classes = T.let(@all_classes, T.nilable(T::Enumerable[Class]))
+          @all_classes ||= T.cast(ObjectSpace.each_object(Class), T::Enumerable[Class]).each
+        end
+
+        sig { returns(T::Enumerable[Module]) }
+        def all_modules
+          @all_modules = T.let(@all_modules, T.nilable(T::Enumerable[Module]))
+          @all_modules ||= T.cast(ObjectSpace.each_object(Module), T::Enumerable[Module]).each
+        end
+
         # Get the types of each parameter from a method signature
         sig do
           params(

--- a/lib/tapioca/compilers/dsl/base.rb
+++ b/lib/tapioca/compilers/dsl/base.rb
@@ -171,7 +171,7 @@ module Tapioca
         sig { params(method_def: T.any(Method, UnboundMethod)).returns(String) }
         def compile_method_return_type_to_rbi(method_def)
           signature = T::Private::Methods.signature_for_method(method_def)
-          return_type = signature.nil? ? "T.untyped" : signature.return_type.to_s
+          return_type = signature.nil? ? "T.untyped" : name_of_type(signature.return_type)
           return_type = "void" if return_type == "<VOID>"
           # Map <NOT-TYPED> to `T.untyped`
           return_type = "T.untyped" if return_type == "<NOT-TYPED>"

--- a/lib/tapioca/compilers/dsl/sidekiq_worker.rb
+++ b/lib/tapioca/compilers/dsl/sidekiq_worker.rb
@@ -72,8 +72,7 @@ module Tapioca
 
         sig { override.returns(T::Enumerable[Module]) }
         def gather_constants
-          classes = T.cast(ObjectSpace.each_object(Class), T::Enumerable[Class])
-          classes.select { |c| c < Sidekiq::Worker }
+          all_classes.select { |c| c < Sidekiq::Worker }
         end
       end
     end

--- a/lib/tapioca/compilers/dsl/smart_properties.rb
+++ b/lib/tapioca/compilers/dsl/smart_properties.rb
@@ -88,7 +88,7 @@ module Tapioca
           classes.select do |c|
             c < ::SmartProperties
           end.reject do |c|
-            c.name.nil? || c == ::SmartProperties::Validations::Ancestor
+            name_of(c).nil? || c == ::SmartProperties::Validations::Ancestor
           end
         end
 
@@ -142,7 +142,7 @@ module Tapioca
             "T::Boolean"
           elsif Array(accepter).all? { |a| a.is_a?(Module) }
             accepters = Array(accepter)
-            types = accepters.map { |mod| name_of(mod) }.join(", ")
+            types = accepters.map { |mod| "::#{name_of(mod)}" }.join(", ")
             types = "T.any(#{types})" if accepters.size > 1
             types
           else
@@ -155,12 +155,6 @@ module Tapioca
           type = "T.nilable(#{type})" if property_nilable
 
           type
-        end
-
-        sig { params(type: Module).returns(String) }
-        def name_of(type)
-          name = Module.instance_method(:name).bind(type).call
-          name.start_with?("::") ? name : "::#{name}"
         end
       end
     end

--- a/lib/tapioca/compilers/dsl/smart_properties.rb
+++ b/lib/tapioca/compilers/dsl/smart_properties.rb
@@ -141,7 +141,7 @@ module Tapioca
             "T::Boolean"
           elsif Array(accepter).all? { |a| a.is_a?(Module) }
             accepters = Array(accepter)
-            types = accepters.map { |mod| "::#{name_of(mod)}" }.join(", ")
+            types = accepters.map { |mod| T.must(qualified_name_of(mod)) }.join(", ")
             types = "T.any(#{types})" if accepters.size > 1
             types
           else

--- a/lib/tapioca/compilers/dsl/smart_properties.rb
+++ b/lib/tapioca/compilers/dsl/smart_properties.rb
@@ -84,8 +84,7 @@ module Tapioca
 
         sig { override.returns(T::Enumerable[Module]) }
         def gather_constants
-          classes = T.cast(ObjectSpace.each_object(Class), T::Enumerable[Class])
-          classes.select do |c|
+          all_classes.select do |c|
             c < ::SmartProperties
           end.reject do |c|
             name_of(c).nil? || c == ::SmartProperties::Validations::Ancestor

--- a/lib/tapioca/compilers/dsl/state_machines.rb
+++ b/lib/tapioca/compilers/dsl/state_machines.rb
@@ -162,7 +162,7 @@ module Tapioca
 
         sig { override.returns(T::Enumerable[Module]) }
         def gather_constants
-          Object.descendants.select { |mod| mod < ::StateMachines::InstanceMethods }
+          all_classes.select { |mod| mod < ::StateMachines::InstanceMethods }
         end
 
         private

--- a/lib/tapioca/compilers/dsl/url_helpers.rb
+++ b/lib/tapioca/compilers/dsl/url_helpers.rb
@@ -111,7 +111,7 @@ module Tapioca
           Object.const_set(:GeneratedPathHelpersModule, Rails.application.routes.named_routes.path_helpers_module)
 
           constants = all_modules.select do |mod|
-            next unless Module.instance_method(:name).bind(mod).call
+            next unless name_of(mod)
 
             includes_helper?(mod, GeneratedUrlHelpersModule) ||
               includes_helper?(mod, GeneratedPathHelpersModule) ||

--- a/lib/tapioca/compilers/dsl/url_helpers.rb
+++ b/lib/tapioca/compilers/dsl/url_helpers.rb
@@ -110,8 +110,7 @@ module Tapioca
           Object.const_set(:GeneratedUrlHelpersModule, Rails.application.routes.named_routes.url_helpers_module)
           Object.const_set(:GeneratedPathHelpersModule, Rails.application.routes.named_routes.path_helpers_module)
 
-          module_enumerator = T.cast(ObjectSpace.each_object(Module), T::Enumerator[Module])
-          constants = module_enumerator.select do |mod|
+          constants = all_modules.select do |mod|
             next unless Module.instance_method(:name).bind(mod).call
 
             includes_helper?(mod, GeneratedUrlHelpersModule) ||

--- a/lib/tapioca/compilers/symbol_table/symbol_generator.rb
+++ b/lib/tapioca/compilers/symbol_table/symbol_generator.rb
@@ -673,7 +673,7 @@ module Tapioca
             sig << RBI::SigParam.new(name, type)
           end
 
-          return_type = type_of(signature.return_type)
+          return_type = name_of_type(signature.return_type)
           sig.return_type = sanitize_signature_types(return_type)
           add_to_symbol_queue(sig.return_type)
 

--- a/lib/tapioca/compilers/symbol_table/symbol_generator.rb
+++ b/lib/tapioca/compilers/symbol_table/symbol_generator.rb
@@ -833,7 +833,7 @@ module Tapioca
           # We are dealing with a ActiveSupport::Deprecation::DeprecatedConstantProxy
           # so try to get the name of the target class
           begin
-            target = Kernel.instance_method(:send).bind(constant).call(:target)
+            target = constant.__send__(:target)
           rescue NoMethodError
             return
           end

--- a/lib/tapioca/compilers/symbol_table/symbol_generator.rb
+++ b/lib/tapioca/compilers/symbol_table/symbol_generator.rb
@@ -558,9 +558,9 @@ module Tapioca
         sig { params(mod: Module).returns(T::Hash[Symbol, T::Array[Symbol]]) }
         def method_names_by_visibility(mod)
           {
-            public: Module.instance_method(:public_instance_methods).bind(mod).call,
-            protected: Module.instance_method(:protected_instance_methods).bind(mod).call,
-            private: Module.instance_method(:private_instance_methods).bind(mod).call,
+            public: public_instance_methods_of(mod),
+            protected: protected_instance_methods_of(mod),
+            private: private_instance_methods_of(mod),
           }
         end
 

--- a/lib/tapioca/constant_locator.rb
+++ b/lib/tapioca/constant_locator.rb
@@ -9,15 +9,14 @@ module Tapioca
   # correspondence between classes/modules and files, as this information isn't
   # available in the ruby runtime without extra accounting.
   module ConstantLocator
-    @class_files = {}
+    extend Reflection
 
-    NAME = Module.instance_method(:name)
-    private_constant :NAME
+    @class_files = {}
 
     # Immediately activated upon load. Observes class/module definition.
     TracePoint.trace(:class) do |tp|
       unless tp.self.singleton_class?
-        key = NAME.bind(tp.self).call
+        key = name_of(tp.self)
         @class_files[key] ||= Set.new
         @class_files[key] << tp.path
       end
@@ -26,11 +25,10 @@ module Tapioca
     # Returns the files in which this class or module was opened. Doesn't know
     # about situations where the class was opened prior to +require+ing,
     # or where metaprogramming was used via +eval+, etc.
-    def files_for(klass)
-      name = String === klass ? klass : NAME.bind(klass).call
+    def self.files_for(klass)
+      name = String === klass ? klass : name_of(klass)
       files = @class_files[name]
       files || Set.new
     end
-    module_function :files_for
   end
 end

--- a/lib/tapioca/generator.rb
+++ b/lib/tapioca/generator.rb
@@ -146,7 +146,7 @@ module Tapioca
       )
 
       compiler.run do |constant, contents|
-        constant_name = Module.instance_method(:name).bind(constant).call
+        constant_name = T.must(Reflection.name_of(constant))
 
         if verbose && !quiet
           say("Processing: ", [:yellow])

--- a/lib/tapioca/generic_type_registry.rb
+++ b/lib/tapioca/generic_type_registry.rb
@@ -50,7 +50,7 @@ module Tapioca
         # Build the name of the instantiated generic type,
         # something like `"Foo[X, Y, Z]"`
         type_list = types.map { |type| T::Utils.coerce(type).name }.join(", ")
-        name = "#{name_of(constant)}[#{type_list}]"
+        name = "#{Reflection.name_of(constant)}[#{type_list}]"
 
         # Create a generic type with an overridden `name`
         # method that returns the name we constructed above.
@@ -143,11 +143,6 @@ module Tapioca
       sig { params(constant: Module).returns(T::Hash[TypeVariable, String]) }
       def lookup_or_initialize_type_variables(constant)
         @type_variables[constant] ||= {}.compare_by_identity
-      end
-
-      sig { params(constant: Module).returns(T.nilable(String)) }
-      def name_of(constant)
-        Module.instance_method(:name).bind(constant).call
       end
     end
   end

--- a/lib/tapioca/loader.rb
+++ b/lib/tapioca/loader.rb
@@ -1,6 +1,8 @@
 # typed: strict
 # frozen_string_literal: true
 
+require "tapioca/core_ext/class"
+
 module Tapioca
   class Loader
     extend(T::Sig)
@@ -63,18 +65,9 @@ module Tapioca
 
     sig { returns(T::Array[T.untyped]) }
     def rails_engines
-      engines = []
+      return [] unless Object.const_defined?("Rails::Engine")
 
-      return engines unless Object.const_defined?("Rails::Engine")
-
-      base = Object.const_get("Rails::Engine")
-      ObjectSpace.each_object(base.singleton_class) do |k|
-        k = T.cast(k, Class)
-        next if k.singleton_class?
-        engines.unshift(k) unless k == base
-      end
-
-      engines.reject(&:abstract_railtie?)
+      Object.const_get("Rails::Engine").descendants.reject(&:abstract_railtie?)
     end
 
     sig { params(path: String).void }

--- a/lib/tapioca/rbi_ext/model.rb
+++ b/lib/tapioca/rbi_ext/model.rb
@@ -9,7 +9,7 @@ module RBI
 
     sig { params(constant: ::Module, block: T.nilable(T.proc.params(scope: Scope).void)).void }
     def create_path(constant, &block)
-      constant_name = T.let(::Module.instance_method(:name).bind(constant).call, T.nilable(String))
+      constant_name = Tapioca::Reflection.name_of(constant)
       raise "given constant does not have a name" unless constant_name
 
       instance = ::Module.const_get(constant_name)

--- a/lib/tapioca/reflection.rb
+++ b/lib/tapioca/reflection.rb
@@ -1,0 +1,93 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "tapioca/reflection/bind_call_reflection"
+require "tapioca/reflection/pre_bind_call_reflection"
+
+module Tapioca
+  module Reflection
+    extend T::Sig
+
+    CLASS_METHOD = T.let(Kernel.instance_method(:class), UnboundMethod)
+    CONSTANTS_METHOD = T.let(Module.instance_method(:constants), UnboundMethod)
+    NAME_METHOD = T.let(Module.instance_method(:name), UnboundMethod)
+    SINGLETON_CLASS_METHOD = T.let(Object.instance_method(:singleton_class), UnboundMethod)
+    ANCESTORS_METHOD = T.let(Module.instance_method(:ancestors), UnboundMethod)
+    SUPERCLASS_METHOD = T.let(Class.instance_method(:superclass), UnboundMethod)
+    OBJECT_ID_METHOD = T.let(BasicObject.instance_method(:__id__), UnboundMethod)
+    EQUAL_METHOD = T.let(BasicObject.instance_method(:equal?), UnboundMethod)
+
+    sig { params(object: BasicObject).returns(Class).checked(:never) }
+    def class_of(object)
+      CLASS_METHOD.bind(object).call
+    end
+
+    sig { params(constant: Module).returns(T::Array[Symbol]) }
+    def constants_of(constant)
+      CONSTANTS_METHOD.bind(constant).call(false)
+    end
+
+    sig { params(constant: Module).returns(T.nilable(String)) }
+    def name_of(constant)
+      NAME_METHOD.bind(constant).call
+    end
+
+    sig { params(constant: Module).returns(Class) }
+    def singleton_class_of(constant)
+      SINGLETON_CLASS_METHOD.bind(constant).call
+    end
+
+    sig { params(constant: Module).returns(T::Array[Module]) }
+    def ancestors_of(constant)
+      ANCESTORS_METHOD.bind(constant).call
+    end
+
+    sig { params(constant: Class).returns(T.nilable(Class)) }
+    def superclass_of(constant)
+      SUPERCLASS_METHOD.bind(constant).call
+    end
+
+    sig { params(object: BasicObject).returns(Integer).checked(:never) }
+    def object_id_of(object)
+      OBJECT_ID_METHOD.bind(object).call
+    end
+
+    sig { params(object: BasicObject, other: BasicObject).returns(T::Boolean).checked(:never) }
+    def are_equal?(object, other)
+      EQUAL_METHOD.bind(object).call(other)
+    end
+
+    sig { params(constant: Module).returns(T::Array[Module]) }
+    def inherited_ancestors_of(constant)
+      if Class === constant
+        ancestors_of(superclass_of(constant) || Object)
+      else
+        Module.ancestors
+      end
+    end
+
+    sig { params(constant: Module).returns(T.nilable(String)) }
+    def qualified_name_of(constant)
+      name = name_of(constant)
+      return if name.nil?
+
+      if name.start_with?("::")
+        name
+      else
+        "::#{name}"
+      end
+    end
+
+    sig { params(method: T.any(UnboundMethod, Method)).returns(T.untyped) }
+    def signature_of(method)
+      T::Private::Methods.signature_for_method(method)
+    rescue LoadError, StandardError
+      nil
+    end
+
+    sig { params(constant: Module).returns(String) }
+    def type_of(constant)
+      constant.to_s.gsub(/\bAttachedClass\b/, "T.attached_class")
+    end
+  end
+end

--- a/lib/tapioca/reflection.rb
+++ b/lib/tapioca/reflection.rb
@@ -101,9 +101,9 @@ module Tapioca
       nil
     end
 
-    sig { params(constant: Module).returns(String) }
-    def type_of(constant)
-      constant.to_s.gsub(/\bAttachedClass\b/, "T.attached_class")
+    sig { params(type: T::Types::Base).returns(String) }
+    def name_of_type(type)
+      type.to_s.gsub(/\bAttachedClass\b/, "T.attached_class")
     end
   end
 end

--- a/lib/tapioca/reflection.rb
+++ b/lib/tapioca/reflection.rb
@@ -1,12 +1,10 @@
 # typed: strict
 # frozen_string_literal: true
 
-require "tapioca/reflection/bind_call_reflection"
-require "tapioca/reflection/pre_bind_call_reflection"
-
 module Tapioca
   module Reflection
     extend T::Sig
+    extend self
 
     CLASS_METHOD = T.let(Kernel.instance_method(:class), UnboundMethod)
     CONSTANTS_METHOD = T.let(Module.instance_method(:constants), UnboundMethod)

--- a/lib/tapioca/reflection.rb
+++ b/lib/tapioca/reflection.rb
@@ -16,6 +16,9 @@ module Tapioca
     SUPERCLASS_METHOD = T.let(Class.instance_method(:superclass), UnboundMethod)
     OBJECT_ID_METHOD = T.let(BasicObject.instance_method(:__id__), UnboundMethod)
     EQUAL_METHOD = T.let(BasicObject.instance_method(:equal?), UnboundMethod)
+    PUBLIC_INSTANCE_METHODS_METHOD = T.let(Module.instance_method(:public_instance_methods), UnboundMethod)
+    PROTECTED_INSTANCE_METHODS_METHOD = T.let(Module.instance_method(:protected_instance_methods), UnboundMethod)
+    PRIVATE_INSTANCE_METHODS_METHOD = T.let(Module.instance_method(:private_instance_methods), UnboundMethod)
 
     sig { params(object: BasicObject).returns(Class).checked(:never) }
     def class_of(object)
@@ -55,6 +58,21 @@ module Tapioca
     sig { params(object: BasicObject, other: BasicObject).returns(T::Boolean).checked(:never) }
     def are_equal?(object, other)
       EQUAL_METHOD.bind(object).call(other)
+    end
+
+    sig { params(constant: Module).returns(T::Array[Symbol]) }
+    def public_instance_methods_of(constant)
+      PUBLIC_INSTANCE_METHODS_METHOD.bind(constant).call
+    end
+
+    sig { params(constant: Module).returns(T::Array[Symbol]) }
+    def protected_instance_methods_of(constant)
+      PROTECTED_INSTANCE_METHODS_METHOD.bind(constant).call
+    end
+
+    sig { params(constant: Module).returns(T::Array[Symbol]) }
+    def private_instance_methods_of(constant)
+      PRIVATE_INSTANCE_METHODS_METHOD.bind(constant).call
     end
 
     sig { params(constant: Module).returns(T::Array[Module]) }

--- a/lib/tapioca/sorbet_ext/name_patch.rb
+++ b/lib/tapioca/sorbet_ext/name_patch.rb
@@ -6,7 +6,7 @@ module T
     class Simple
       module NamePatch
         def name
-          @name ||= Module.instance_method(:name).bind(@raw_type).call.freeze
+          @name ||= ::Tapioca::Reflection.name_of(@raw_type).freeze
         end
       end
 

--- a/spec/tapioca/compilers/dsl/smart_properties_spec.rb
+++ b/spec/tapioca/compilers/dsl/smart_properties_spec.rb
@@ -28,12 +28,8 @@ class Tapioca::Compilers::Dsl::SmartPropertiesSpec < DslSpec
 
     it("ignores SmartProperty classes without a name") do
       add_ruby_file("content.rb", <<~RUBY)
-        class Post
+        post = Class.new do
           include ::SmartProperties
-
-          def self.name
-            nil
-          end
         end
       RUBY
 

--- a/spec/tapioca/reflection_spec.rb
+++ b/spec/tapioca/reflection_spec.rb
@@ -1,0 +1,106 @@
+# typed: true
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Tapioca
+  class LyingFoo < BasicObject
+    include ::Kernel
+
+    def class
+      ::String
+    end
+
+    def self.constants
+      [::Symbol, ::String]
+    end
+
+    def self.name
+      "Foo"
+    end
+
+    def self.singleton_class
+      ::String
+    end
+
+    def self.ancestors
+      [::Integer, ::String, ::Symbol]
+    end
+
+    def self.superclass
+      ::Integer
+    end
+
+    def __id__
+      1
+    end
+
+    def equal?(other)
+      other == 1
+    end
+
+    def self.public_instance_methods
+      [:foo, :bar, :baz]
+    end
+
+    def self.protected_instance_methods
+      [:foo, :bar, :baz]
+    end
+
+    def self.private_instance_methods
+      [:foo, :bar, :baz]
+    end
+  end
+
+  class ReflectionSpec < Minitest::Spec
+    describe("reflection methods") do
+      it("might return the wrong results without Reflection helpers") do
+        foo = LyingFoo.new
+
+        refute_equal([], LyingFoo.constants)
+        refute_equal("Tapioca::LyingFoo", LyingFoo.name)
+        refute_equal([Object, Kernel, BasicObject], LyingFoo.ancestors)
+        refute_equal(Object, LyingFoo.superclass)
+        assert_equal(String, LyingFoo.singleton_class)
+        assert_equal([:foo, :bar, :baz], LyingFoo.public_instance_methods)
+        assert_equal([:foo, :bar, :baz], LyingFoo.protected_instance_methods)
+        assert_equal([:foo, :bar, :baz], LyingFoo.private_instance_methods)
+
+        refute_equal(LyingFoo, foo.class)
+        assert_equal(1, foo.__id__)
+        refute(foo.equal?(foo))
+        assert(foo.equal?(1))
+      end
+
+      it("return the correct results with Reflection helpers") do
+        foo = LyingFoo.new
+
+        assert_equal([], Reflection.constants_of(LyingFoo))
+        assert_equal("Tapioca::LyingFoo", Reflection.name_of(LyingFoo))
+        assert_equal([Tapioca::LyingFoo, Kernel, BasicObject], Reflection.ancestors_of(LyingFoo))
+        assert_equal(BasicObject, Reflection.superclass_of(LyingFoo))
+        refute_equal(String, Reflection.singleton_class_of(LyingFoo))
+        refute_equal([:foo, :bar, :baz], Reflection.public_instance_methods_of(LyingFoo))
+        refute_equal([:foo, :bar, :baz], Reflection.protected_instance_methods_of(LyingFoo))
+        refute_equal([:foo, :bar, :baz], Reflection.private_instance_methods_of(LyingFoo))
+
+        assert_equal(LyingFoo, Reflection.class_of(foo))
+        refute_equal(1, Reflection.object_id_of(foo))
+        assert(Reflection.are_equal?(foo, foo))
+        refute(Reflection.are_equal?(foo, 1))
+      end
+    end
+
+    describe("#qualified_name_of") do
+      it("returns nil if the class is anonymous") do
+        klass = Class.new
+
+        assert_nil(Reflection.qualified_name_of(klass))
+      end
+
+      it("returns top level anchored name for named class") do
+        assert_equal("::Tapioca::LyingFoo", Reflection.qualified_name_of(LyingFoo))
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->

We use reflection helper methods throughout the codebase, but they kept being replicated and we ended up having lots of copies of how to grab the actual name of a constant, etc. We need a more unified central way to do that.

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
This implementation extracts said reflection helper methods into a helper module that can be mixed into a class (done for `SymbolGenerator` and `Dsl::Base`) or can have the helper methods called on the module itself.

I've also unified some other patterns wrt reflection in the codebase as well.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->
Added an extra test to validate that we get expected results for a lying class. Also some changes to existing tests.
