### PR TITLE
Add support for bundler 2.2.25+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,13 +12,15 @@ jobs:
       fail-fast: false
       matrix:
         ruby: [ 2.6, 2.7, 3.0 ]
-    name: Test Ruby ${{ matrix.ruby }}
+        bundler: [ 2.2.22, 2.2.25 ]
+    name: Test Ruby ${{ matrix.ruby }}, Bundler ${{ matrix.bundler }}
     steps:
       - uses: actions/checkout@v2
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
+          bundler: ${{ matrix.bundler }}
           bundler-cache: true
       - name: Run type check
         run: bin/typecheck
@@ -27,4 +29,4 @@ jobs:
       - name: Verify documentation
         run: bin/docs
       - name: Run tests
-        run: bin/test
+        run: bundle _${{ matrix.bundler }}_ exec rake


### PR DESCRIPTION
### Motivation

Add support for Bundler 2.2.25 and up.
Fix https://github.com/Shopify/tapioca/issues/413

### Implementation

- Keep support for < 2.2.25 by leaving that codepath mostly unchanged.
- Use the current version of the `materialize` method for bundler versions 2.2.25 and up.
- I refactored a bit. If this makes it more confusing, let me know and I can rearrange some things. Also: naming variables is hard.

### Tests

- I added a 2.2.22 and 2.2.25 bundler versions to the test matrix, otherwise relying on the tests that were there.
