### PR TITLE
Add `Gemfile.lock` for support repo

### DIFF
--- a/spec/support/repo/.gitignore
+++ b/spec/support/repo/.gitignore
@@ -1,2 +1,1 @@
-Gemfile.lock
 .bundle/

--- a/spec/support/repo/Gemfile.lock
+++ b/spec/support/repo/Gemfile.lock
@@ -1,0 +1,134 @@
+GIT
+  remote: https://github.com/whitequark/ast
+  revision: e07a4f66e05ac7972643a8841e336d327ea78ae1
+  ref: e07a4f66e05ac7972643a8841e336d327ea78ae1
+  specs:
+    ast (2.4.1)
+
+PATH
+  remote: ../../..
+  specs:
+    tapioca (0.4.23)
+      bundler (>= 1.17.3)
+      pry (>= 0.12.2)
+      rbi
+      sorbet-runtime
+      sorbet-static (>= 0.4.4471)
+      spoom
+      thor (>= 0.19.2)
+      unparser
+
+PATH
+  remote: ../gems/bar
+  specs:
+    bar (0.3.0)
+
+PATH
+  remote: ../gems/baz
+  specs:
+    baz (0.0.2)
+      smart_properties
+      zeitwerk
+
+PATH
+  remote: ../gems/foo
+  specs:
+    foo (0.0.1)
+
+PATH
+  remote: ../gems/qux
+  specs:
+    qux (0.5.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activesupport (6.1.3.2)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      tzinfo (~> 2.0)
+      zeitwerk (~> 2.3)
+    coderay (1.1.3)
+    colorize (0.8.1)
+    concurrent-ruby (1.1.9)
+    connection_pool (2.2.5)
+    diff-lcs (1.4.4)
+    extras (0.3.0)
+      forwardable-extended (~> 2.5)
+    forwardable-extended (2.6.0)
+    i18n (1.8.10)
+      concurrent-ruby (~> 1.0)
+    method_source (1.0.0)
+    mini_portile2 (2.5.3)
+    minitest (5.14.4)
+    nokogiri (1.11.7)
+      mini_portile2 (~> 2.5.0)
+      racc (~> 1.4)
+    nokogiri (1.11.7-x86_64-darwin)
+      racc (~> 1.4)
+    parser (3.0.2.0)
+      ast (~> 2.4.1)
+    pry (0.14.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    psych (4.0.1)
+    racc (1.5.2)
+    rack (2.2.3)
+    rake (13.0.6)
+    rbi (0.0.2)
+      ast
+      parser
+      rake (~> 13.0)
+      sorbet-runtime
+      unparser
+    redis (4.4.0)
+    sidekiq (6.2.1)
+      connection_pool (>= 2.2.2)
+      rack (~> 2.0)
+      redis (>= 4.2.0)
+    smart_properties (1.15.0)
+    sorbet (0.5.9001)
+      sorbet-static (= 0.5.9001)
+    sorbet-runtime (0.5.9001)
+    sorbet-static (0.5.9001-universal-darwin-14)
+    sorbet-static (0.5.9001-universal-darwin-15)
+    sorbet-static (0.5.9001-universal-darwin-16)
+    sorbet-static (0.5.9001-universal-darwin-17)
+    sorbet-static (0.5.9001-universal-darwin-18)
+    sorbet-static (0.5.9001-universal-darwin-19)
+    sorbet-static (0.5.9001-universal-darwin-20)
+    sorbet-static (0.5.9001-x86_64-linux)
+    spoom (1.1.2)
+      colorize
+      sorbet (>= 0.5.6347)
+      sorbet-runtime
+      thor (>= 0.19.2)
+    thor (1.1.0)
+    tzinfo (2.0.4)
+      concurrent-ruby (~> 1.0)
+    unparser (0.6.0)
+      diff-lcs (~> 1.3)
+      parser (>= 3.0.0)
+    zeitwerk (2.4.2)
+
+PLATFORMS
+  ruby
+  x86_64-darwin-20
+
+DEPENDENCIES
+  activesupport
+  ast!
+  bar!
+  baz!
+  extras
+  foo!
+  nokogiri
+  psych
+  qux!
+  sidekiq
+  smart_properties
+  tapioca!
+
+BUNDLED WITH
+   2.2.19


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
Our tests started failing because `smart_properties` made a new version release with breaking changes (for us, at least). We should be committing the `Gemfile.lock` file of the support repo so that versions don't move from underneath us.

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->

Add `Gemfile.lock`

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->
No added tests
