### PR TITLE
Bump Ruby version to 3.0.2

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -3,7 +3,7 @@ name: tapioca
 type: ruby
 
 up:
-  - ruby: 3.0.1
+  - ruby: 3.0.2
   - bundler
 
 env:


### PR DESCRIPTION
### Motivation

Some tests are breaking locally because of whitequark parser warnings.

### Implementation

Bump Ruby 3.0.2 to avoid the warnings and have tests pass locally.
