### PR TITLE
Disambiguate Struct definitions from Struct subclasses

### DIFF
--- a/lib/tapioca/compilers/symbol_table/symbol_generator.rb
+++ b/lib/tapioca/compilers/symbol_table/symbol_generator.rb
@@ -304,6 +304,19 @@ module Tapioca
 
         sig { params(constant: Class).returns(T::Boolean) }
         def struct_definition?(constant)
+          # Make sure this is constant defined by `Struct.new` and not just
+          # by subclassing `Struct`.
+          #
+          # class Foo < Struct
+          # end
+          #
+          # ends up not defining a struct definition, but subclasses `Struct`
+          # instead. Only instances of `Foo` will be struct definitions themselves.
+          #
+          # What separates just subclassing `Struct` and a struct definition is
+          # the existence of the `members` method on the constant.
+          return false unless constant.methods.include?(:members)
+
           superclass = superclass_of(constant)
           return false unless superclass
 

--- a/spec/tapioca/compilers/symbol_table_compiler_spec.rb
+++ b/spec/tapioca/compilers/symbol_table_compiler_spec.rb
@@ -831,9 +831,13 @@ class Tapioca::Compilers::SymbolTableCompilerSpec < Minitest::HooksSpec
 
         class S4 < Struct.new("Foo", :foo)
         end
+
+        class NotAStructDefinition < Struct
+        end
       RUBY
 
       output = template(<<~RBI)
+        class NotAStructDefinition < ::Struct; end
         S1 = ::Struct.new(:foo)
 
         S2 = ::Struct.new(:foo) do


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->

Struct definition is currently failing for classes defined like:
```ruby
class Foo < Struct
end
```

which end up not defining a struct definition, but subclassing `Struct` instead. Only instances of `Foo` will be struct definitions themselves. Thus, Tapioca fails when trying to call `Foo.members`, since the method does not exist on `Foo`.

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->

What separates just subclassing `Struct` and a struct definition is the existence of the `members` method on the constant.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->

Expanded existing tests to check for this case.
