### PR TITLE
Revert "Generate better Struct definitions"

### DIFF
--- a/lib/tapioca/compilers/symbol_table/symbol_generator.rb
+++ b/lib/tapioca/compilers/symbol_table/symbol_generator.rb
@@ -172,15 +172,8 @@ module Tapioca
 
           scope =
             if constant.is_a?(Class)
-              if constant < Struct && struct_definition?(constant)
-                members = constant.members.map(&:to_sym)
-                keyword_init = /\(keyword_init: true\)/.freeze.match?(constant.inspect)
-
-                RBI::Struct.new(name, members: members, keyword_init: keyword_init)
-              else
-                superclass = compile_superclass(constant)
-                RBI::Class.new(name, superclass_name: superclass)
-              end
+              superclass = compile_superclass(constant)
+              RBI::Class.new(name, superclass_name: superclass)
             else
               RBI::Module.new(name)
             end
@@ -300,32 +293,6 @@ module Tapioca
           return if type_variable_declarations.empty?
 
           tree << RBI::Extend.new("T::Generic")
-        end
-
-        sig { params(constant: Class).returns(T::Boolean) }
-        def struct_definition?(constant)
-          superclass = superclass_of(constant)
-          return false unless superclass
-
-          # If the superclass is anonymous, maybe this is an instance of
-          # the bad but popular `class Bar < Struct.new(:a, :b); end` usage
-          # which creates an anonymous superclass that itself inherits from
-          # `Struct`.
-          #
-          # Similarly, if the superclass name is like `Struct::XXX`, this maybe
-          # an instance of a much less popular but still valid
-          # `class Bar < Struct.new("Name", :a, :b); end` usage
-          # which creates a `Struct::Name` named superclass that itself inherits
-          # from `Struct`.
-          #
-          # In those case, we need to look at the superclass of this superclass to
-          # see if it is `Struct`.
-          superclass_name = name_of(superclass)
-          if !superclass_name || superclass_name =~ /^(::)?Struct::[^:]+$/.freeze
-            superclass = superclass_of(superclass)
-          end
-
-          are_equal?(Struct, superclass)
         end
 
         sig { params(constant: Class).returns(T.nilable(String)) }
@@ -598,7 +565,7 @@ module Tapioca
         end
 
         sig { params(constant: Module, method_name: String).returns(T::Boolean) }
-        def typed_struct_method?(constant, method_name)
+        def struct_method?(constant, method_name)
           return false unless T::Props::ClassMethods === constant
 
           constant
@@ -626,7 +593,7 @@ module Tapioca
 
           method_name = method.name.to_s
           return unless valid_method_name?(method_name)
-          return if typed_struct_method?(constant, method_name)
+          return if struct_method?(constant, method_name)
           return if method_name.start_with?("__t_props_generated_")
 
           parameters = T.let(method.parameters, T::Array[[Symbol, T.nilable(Symbol)]])
@@ -843,6 +810,7 @@ module Tapioca
           name = super(constant)
           return if name.nil?
           return unless are_equal?(constant, resolve_constant(name, inherit: true))
+          name = "Struct" if name =~ /^(::)?Struct::[^:]+$/
           name
         end
 

--- a/spec/tapioca/compilers/symbol_table_compiler_spec.rb
+++ b/spec/tapioca/compilers/symbol_table_compiler_spec.rb
@@ -814,61 +814,17 @@ class Tapioca::Compilers::SymbolTableCompilerSpec < Minitest::HooksSpec
       assert_equal(output, compile)
     end
 
-    it("compiles Structs") do
+    it("compiles Structs, Classes, and Modules") do
       add_ruby_file("structs.rb", <<~RUBY)
         class S1 < Struct.new(:foo)
         end
-
         S2 = Struct.new(:foo) do
           def foo
           end
-
-          def bar
-          end
         end
-
         S3 = Struct.new(:foo)
-
         class S4 < Struct.new("Foo", :foo)
         end
-      RUBY
-
-      output = template(<<~RBI)
-        S1 = ::Struct.new(:foo)
-
-        S2 = ::Struct.new(:foo) do
-          def bar; end
-          def foo; end
-          def foo=(_); end
-
-          class << self
-            def [](*_arg0); end
-            def inspect; end
-            def members; end
-            def new(*_arg0); end
-          end
-        end
-
-        S3 = ::Struct.new(:foo) do
-          def foo; end
-          def foo=(_); end
-
-          class << self
-            def [](*_arg0); end
-            def inspect; end
-            def members; end
-            def new(*_arg0); end
-          end
-        end
-
-        S4 = ::Struct.new(:foo)
-      RBI
-
-      assert_equal(output, compile)
-    end
-
-    it("compiles Classes, and Modules") do
-      add_ruby_file("modules.rb", <<~RUBY)
         class C1 < Class.new
         end
         C2 = Class.new do
@@ -900,6 +856,33 @@ class Tapioca::Compilers::SymbolTableCompilerSpec < Minitest::HooksSpec
         end
 
         module M3; end
+        class S1 < ::Struct; end
+
+        class S2 < ::Struct
+          def foo; end
+          def foo=(_); end
+
+          class << self
+            def [](*_arg0); end
+            def inspect; end
+            def members; end
+            def new(*_arg0); end
+          end
+        end
+
+        class S3 < ::Struct
+          def foo; end
+          def foo=(_); end
+
+          class << self
+            def [](*_arg0); end
+            def inspect; end
+            def members; end
+            def new(*_arg0); end
+          end
+        end
+
+        class S4 < ::Struct; end
       RBI
 
       assert_equal(output, compile)


### PR DESCRIPTION
Reverts Shopify/tapioca#247

It turns out that there are too many edge cases in the wild which makes this unfeasible.

The errors I have ran into:

1. AWS SDK declares an empty struct which it keeps subclassing from. It does that by declaring the struct as `Foo = Struct.new("EmptyStruct")`, thus giving it only a name but no members. However, Tapioca currently does not generate "named structs". Even if we did, the Sorbet rewriter for structs does not rewrite something like that into a class definition, so [this is plain broken](https://sorbet.run/#%23%20typed%3A%20true%0A%0ABroken%20%3D%20Struct.new%28%22name%22%29%0A%0Aclass%20Bar%20%3C%20Broken%0Aend%0A%0AStillBroken%20%3D%20Struct.new%28%22name%22%2C%20%3Afoo%29%0A%0Aclass%20Quux%20%3C%20StillBroken%0Aend%0A%0AWorks%20%3D%20Struct.new%28%3Afoo%29%0A%0Aclass%20Baz%20%3C%20Works%0Aend%0A).
2. A lot of struct definitions actually go and override the `initialize` method in the struct block in an incompatible way. But this ends up [causing errors like `Method Foo#initialize redefined without matching argument count. Expected: 2, got: 1`](https://sorbet.run/#%23%20typed%3A%20true%0A%0ABroken%20%3D%20Struct.new%28%3Afoo%2C%20%3Abar%29%20do%0A%20%20def%20initialize%28foo%29%0A%20%20%20%20super%28foo%2C%20%22default%22%29%0A%20%20end%0Aend%0A).
3. When there are more than 1 definitions of the same struct, we get `Duplicate type member Elem` errors, due to a synthetic `Elem` being created for each definition by the rewriter. (Somehow, I can't recreate this in sorbet.run, though)
4. We end up generating `Struct::Foo` definitions coming from "named struct" in multiple RBI files, one for each gem that monkey-patches `Struct`.