### PR TITLE
Improve return type of `materialize_deps`

### DIFF
--- a/lib/tapioca/gemfile.rb
+++ b/lib/tapioca/gemfile.rb
@@ -62,7 +62,7 @@ module Tapioca
       [dependencies, missing_specs]
     end
 
-    sig { returns([T::Array[::Gem::Specification], T::Array[String]]) }
+    sig { returns([T::Array[Spec], T::Array[String]]) }
     def materialize_deps
       deps = definition.locked_gems.dependencies.values
       missing_specs = T::Array[String].new


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->

The existing return type was problematic for the generated Tapioca RBI file since Tapioca gem generator drops the leading `::` anchors from constants declared in `sig`s. Thus `Gem::Specification` ends up pointing to `Tapioca::Gemfile::Gem` instead.

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->

Referring to the `Spec` alias is more correct.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->
No extra tests.
