### PR TITLE
Improve IDC generator

### DIFF
--- a/spec/tapioca/compilers/dsl/identity_cache_spec.rb
+++ b/spec/tapioca/compilers/dsl/identity_cache_spec.rb
@@ -79,22 +79,22 @@ class Tapioca::Compilers::Dsl::IdentityCacheSpec < DslSpec
           sig { params(title: T.untyped, includes: T.untyped).returns(T::Array[::Post]) }
           def self.fetch_by_title(title, includes: nil); end
 
-          sig { params(key: T.untyped).returns(T.nilable(::Integer)) }
-          def self.fetch_id_by_blog_id(key); end
+          sig { params(blog_id: T.untyped).returns(T.nilable(::Integer)) }
+          def self.fetch_id_by_blog_id(blog_id); end
 
-          sig { params(key: T.untyped).returns(T.nilable(::Integer)) }
-          def self.fetch_id_by_title(key); end
+          sig { params(title: T.untyped).returns(T.nilable(::Integer)) }
+          def self.fetch_id_by_title(title); end
 
-          sig { params(index_values: T.untyped, includes: T.untyped).returns(T::Array[::Post]) }
+          sig { params(index_values: T::Enumerable[T.untyped], includes: T.untyped).returns(T::Array[::Post]) }
           def self.fetch_multi_by_blog_id(index_values, includes: nil); end
 
-          sig { params(index_values: T.untyped, includes: T.untyped).returns(T::Array[::Post]) }
+          sig { params(index_values: T::Enumerable[T.untyped], includes: T.untyped).returns(T::Array[::Post]) }
           def self.fetch_multi_by_title(index_values, includes: nil); end
 
-          sig { params(keys: T.untyped).returns(T::Array[::Integer]) }
+          sig { params(keys: T::Enumerable[T.untyped]).returns(T::Array[::Integer]) }
           def self.fetch_multi_id_by_blog_id(keys); end
 
-          sig { params(keys: T.untyped).returns(T::Array[::Integer]) }
+          sig { params(keys: T::Enumerable[T.untyped]).returns(T::Array[::Integer]) }
           def self.fetch_multi_id_by_title(keys); end
         end
       RBI
@@ -135,22 +135,22 @@ class Tapioca::Compilers::Dsl::IdentityCacheSpec < DslSpec
           sig { params(title: T.untyped, includes: T.untyped).returns(::Post) }
           def self.fetch_by_title!(title, includes: nil); end
 
-          sig { params(key: T.untyped).returns(T.nilable(::Integer)) }
-          def self.fetch_id_by_blog_id(key); end
+          sig { params(blog_id: T.untyped).returns(T.nilable(::Integer)) }
+          def self.fetch_id_by_blog_id(blog_id); end
 
-          sig { params(key: T.untyped).returns(T.nilable(::Integer)) }
-          def self.fetch_id_by_title(key); end
+          sig { params(title: T.untyped).returns(T.nilable(::Integer)) }
+          def self.fetch_id_by_title(title); end
 
-          sig { params(index_values: T.untyped, includes: T.untyped).returns(T::Array[::Post]) }
+          sig { params(index_values: T::Enumerable[T.untyped], includes: T.untyped).returns(T::Array[::Post]) }
           def self.fetch_multi_by_blog_id(index_values, includes: nil); end
 
-          sig { params(index_values: T.untyped, includes: T.untyped).returns(T::Array[::Post]) }
+          sig { params(index_values: T::Enumerable[T.untyped], includes: T.untyped).returns(T::Array[::Post]) }
           def self.fetch_multi_by_title(index_values, includes: nil); end
 
-          sig { params(keys: T.untyped).returns(T::Array[::Integer]) }
+          sig { params(keys: T::Enumerable[T.untyped]).returns(T::Array[::Integer]) }
           def self.fetch_multi_id_by_blog_id(keys); end
 
-          sig { params(keys: T.untyped).returns(T::Array[::Integer]) }
+          sig { params(keys: T::Enumerable[T.untyped]).returns(T::Array[::Integer]) }
           def self.fetch_multi_id_by_title(keys); end
         end
       RBI
@@ -191,16 +191,16 @@ class Tapioca::Compilers::Dsl::IdentityCacheSpec < DslSpec
           sig { params(title: T.untyped, review_date: T.untyped, includes: T.untyped).returns(::Post) }
           def self.fetch_by_title_and_review_date!(title, review_date, includes: nil); end
 
-          sig { params(key: T.untyped).returns(T.nilable(::Integer)) }
-          def self.fetch_id_by_title(key); end
+          sig { params(title: T.untyped).returns(T.nilable(::Integer)) }
+          def self.fetch_id_by_title(title); end
 
-          sig { params(key_values: T.untyped).returns(T.nilable(::Integer)) }
-          def self.fetch_id_by_title_and_review_date(key_values); end
+          sig { params(title: T.untyped, review_date: T.untyped).returns(T.nilable(::Integer)) }
+          def self.fetch_id_by_title_and_review_date(title, review_date); end
 
-          sig { params(index_values: T.untyped, includes: T.untyped).returns(T::Array[::Post]) }
+          sig { params(index_values: T::Enumerable[T.untyped], includes: T.untyped).returns(T::Array[::Post]) }
           def self.fetch_multi_by_title(index_values, includes: nil); end
 
-          sig { params(keys: T.untyped).returns(T::Array[::Integer]) }
+          sig { params(keys: T::Enumerable[T.untyped]).returns(T::Array[::Integer]) }
           def self.fetch_multi_id_by_title(keys); end
         end
       RBI
@@ -354,10 +354,10 @@ class Tapioca::Compilers::Dsl::IdentityCacheSpec < DslSpec
         # typed: strong
 
         class Post
-          sig { params(key: T.untyped).returns(T.nilable(::String)) }
-          def self.fetch_author_by_id(key); end
+          sig { params(id: T.untyped).returns(T.nilable(::String)) }
+          def self.fetch_author_by_id(id); end
 
-          sig { params(keys: T.untyped).returns(T::Array[::String]) }
+          sig { params(keys: T::Enumerable[T.untyped]).returns(T::Array[::String]) }
           def self.fetch_multi_author_by_id(keys); end
         end
       RBI


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->

We are generating `fetch_enabled_by_shop_id_and_market_id(keys)` instead of `fetch_enabled_by_shop_id_and_market_id(shop_id, market_id)` for aliased IDC fields and thus
we end up having the wrong arity for these generated methods.

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->

The following changes are made to the generated method definitions:

1. `fetch_multi_by_xxx` methods get an enumerable as their `index_values` or `keys` parameter, so making that more specific.
2. It is better for `fetch_xxx` alias methods to declare their single key parameter with the name of the `key_field` instead of as just `key`.
3. `fetch_xxx_and_yyy` alias methods should declare each key value as a separate parameter, and the names of these parameters should match the `key_field` names.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->

Updated tests
