### PR TITLE
Rename `Gem` to `GemSpec`

### DIFF
--- a/lib/tapioca/compilers/symbol_table/symbol_generator.rb
+++ b/lib/tapioca/compilers/symbol_table/symbol_generator.rb
@@ -14,7 +14,7 @@ module Tapioca
 
         attr_reader(:gem, :indent)
 
-        sig { params(gem: Gemfile::Gem, indent: Integer).void }
+        sig { params(gem: Gemfile::GemSpec, indent: Integer).void }
         def initialize(gem, indent = 0)
           @gem = gem
           @indent = indent

--- a/lib/tapioca/compilers/symbol_table_compiler.rb
+++ b/lib/tapioca/compilers/symbol_table_compiler.rb
@@ -8,7 +8,7 @@ module Tapioca
 
       sig do
         params(
-          gem: Gemfile::Gem,
+          gem: Gemfile::GemSpec,
           indent: Integer
         ).returns(String)
       end

--- a/lib/tapioca/gemfile.rb
+++ b/lib/tapioca/gemfile.rb
@@ -20,7 +20,7 @@ module Tapioca
     sig { returns(Bundler::Definition) }
     attr_reader(:definition)
 
-    sig { returns(T::Array[Gem]) }
+    sig { returns(T::Array[GemSpec]) }
     attr_reader(:dependencies)
 
     sig { returns(T::Array[String]) }
@@ -32,11 +32,11 @@ module Tapioca
       @lockfile = T.let(File.new(Bundler.default_lockfile), File)
       @definition = T.let(Bundler::Dsl.evaluate(gemfile, lockfile, {}), Bundler::Definition)
       dependencies, missing_specs = load_dependencies
-      @dependencies = T.let(dependencies, T::Array[Gem])
+      @dependencies = T.let(dependencies, T::Array[GemSpec])
       @missing_specs = T.let(missing_specs, T::Array[String])
     end
 
-    sig { params(gem_name: String).returns(T.nilable(Gem)) }
+    sig { params(gem_name: String).returns(T.nilable(GemSpec)) }
     def gem(gem_name)
       dependencies.detect { |dep| dep.name == gem_name }
     end
@@ -51,11 +51,11 @@ module Tapioca
     sig { returns(File) }
     attr_reader(:gemfile, :lockfile)
 
-    sig { returns([T::Array[Gem], T::Array[String]]) }
+    sig { returns([T::Array[GemSpec], T::Array[String]]) }
     def load_dependencies
       materialized_dependencies, missing_specs = materialize_deps
       dependencies = materialized_dependencies
-        .map { |spec| Gem.new(spec) }
+        .map { |spec| GemSpec.new(spec) }
         .reject { |gem| gem.ignore?(dir) }
         .uniq(&:rbi_file_name)
         .sort_by(&:rbi_file_name)
@@ -92,7 +92,7 @@ module Tapioca
       File.expand_path(gemfile.path + "/..")
     end
 
-    class Gem
+    class GemSpec
       extend(T::Sig)
 
       IGNORED_GEMS = T.let(["sorbet", "sorbet-static", "sorbet-runtime"].freeze, T::Array[String])

--- a/spec/tapioca/compilers/symbol_table_compiler_spec.rb
+++ b/spec/tapioca/compilers/symbol_table_compiler_spec.rb
@@ -38,7 +38,7 @@ class Tapioca::Compilers::SymbolTableCompilerSpec < Minitest::HooksSpec
       )
 
       spec = Bundler::StubSpecification.from_stub(stub)
-      gem = Tapioca::Gemfile::Gem.new(spec)
+      gem = Tapioca::Gemfile::GemSpec.new(spec)
 
       Tapioca::Compilers::SymbolTableCompiler.new.compile(gem)
     end


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->

The name `Gem` for the internal class to hold information about a gem was causing reference errors, and ended up confusing top level `Gem` with `Tapioca::Gemfile::Gem` in generated RBI files (until #472 is merged at least).

`GemSpec` is a better and more descriptive name for it than `Gem` anyway.

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
Change names.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->
Nothing to test
