### PR TITLE
Revert non-nil default value inference for SmartProperties

### DIFF
--- a/lib/tapioca/compilers/dsl/smart_properties.rb
+++ b/lib/tapioca/compilers/dsl/smart_properties.rb
@@ -53,10 +53,10 @@ module Tapioca
       #   sig { params(published: T.nilable(T::Boolean)).returns(T.nilable(T::Boolean)) }
       #   def published=(published); end
       #
-      #   sig { returns(T::Boolean) }
+      #   sig { returns(T.nilable(T::Boolean)) }
       #   def enabled; end
       #
-      #   sig { params(enabled: T::Boolean).returns(T::Boolean) }
+      #   sig { params(enabled: T.nilable(T::Boolean)).returns(T.nilable(T::Boolean)) }
       #   def enabled=(enabled); end
       # end
       # ~~~
@@ -124,10 +124,9 @@ module Tapioca
 
         sig { params(property: ::SmartProperties::Property).returns(String) }
         def type_for(property)
-          converter, accepter, default, required = property.to_h.fetch_values(
+          converter, accepter, required = property.to_h.fetch_values(
             :converter,
             :accepter,
-            :default,
             :required,
           )
 
@@ -148,10 +147,11 @@ module Tapioca
             "T.untyped"
           end
 
-          not_required = Proc === required || !required
-          nilable_default = Proc === default || default.nil?
-          property_nilable = type != "T.untyped" && not_required && nilable_default
-          type = "T.nilable(#{type})" if property_nilable
+          # Early return for "T.untyped", nothing more to do.
+          return type if type == "T.untyped"
+
+          might_be_optional = Proc === required || !required
+          type = "T.nilable(#{type})" if might_be_optional
 
           type
         end

--- a/manual/generator_smartproperties.md
+++ b/manual/generator_smartproperties.md
@@ -41,10 +41,10 @@ class Post
   sig { params(published: T.nilable(T::Boolean)).returns(T.nilable(T::Boolean)) }
   def published=(published); end
 
-  sig { returns(T::Boolean) }
+  sig { returns(T.nilable(T::Boolean)) }
   def enabled; end
 
-  sig { params(enabled: T::Boolean).returns(T::Boolean) }
+  sig { params(enabled: T.nilable(T::Boolean)).returns(T.nilable(T::Boolean)) }
   def enabled=(enabled); end
 end
 ~~~

--- a/spec/tapioca/compilers/dsl/smart_properties_spec.rb
+++ b/spec/tapioca/compilers/dsl/smart_properties_spec.rb
@@ -294,10 +294,10 @@ class Tapioca::Compilers::Dsl::SmartPropertiesSpec < DslSpec
         # typed: strong
 
         class Post
-          sig { returns(T::Boolean) }
+          sig { returns(T.nilable(T::Boolean)) }
           def enabled; end
 
-          sig { params(enabled: T::Boolean).returns(T::Boolean) }
+          sig { params(enabled: T.nilable(T::Boolean)).returns(T.nilable(T::Boolean)) }
           def enabled=(enabled); end
         end
       RBI
@@ -340,10 +340,10 @@ class Tapioca::Compilers::Dsl::SmartPropertiesSpec < DslSpec
         # typed: strong
 
         class Post
-          sig { returns(::String) }
+          sig { returns(T.nilable(::String)) }
           def title; end
 
-          sig { params(title: ::String).returns(::String) }
+          sig { params(title: T.nilable(::String)).returns(T.nilable(::String)) }
           def title=(title); end
         end
       RBI


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
Mostly reverts #338.

The problem with the approach we took in #338 was that even though the properties would have an initial default value, Smart Properties has no protections against those properties being assigned a `nil` value.

For example:
```ruby
class Foo
  include SmartProperties
  property :bar, default: "42"
end

foo = Foo.new
foo.bar # => "42"
foo.bar = nil
foo.bar # => nil
```

I've seen a few places in Core that explicitly check for `nil` even though the property had a default value, so I think a nilable type is safer overall.

/cc @samuelgiles 

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
Got rid of the default check for deciding on nilability. Left the other changes that simplified the code path from #338.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->
Updated tests.
