### PR TITLE
Make all `ActiveModel` attribute types nilable

### DIFF
--- a/lib/tapioca/compilers/dsl/active_model_attributes.rb
+++ b/lib/tapioca/compilers/dsl/active_model_attributes.rb
@@ -29,10 +29,10 @@ module Tapioca
       #
       # class Shop
       #
-      #   sig { returns(::String) }
+      #   sig { returns(T.nilable(::String)) }
       #   def name; end
       #
-      #   sig { params(name: ::String).returns(::String) }
+      #   sig { params(name: T.nilable(::String)).returns(T.nilable(::String)) }
       #   def name=(name); end
       # end
       # ~~~
@@ -89,7 +89,7 @@ module Tapioca
 
         sig { params(attribute_type_value: ::ActiveModel::Type::Value).returns(::String) }
         def type_for(attribute_type_value)
-          case attribute_type_value
+          type = case attribute_type_value
           when ActiveModel::Type::Boolean
             "T::Boolean"
           when ActiveModel::Type::Date
@@ -105,8 +105,11 @@ module Tapioca
           when ActiveModel::Type::String
             "::String"
           else
-            "T.untyped"
+            # we don't want untyped to be wrapped by T.nilable, so just return early
+            return "T.untyped"
           end
+
+          "T.nilable(#{type})"
         end
 
         sig { params(klass: RBI::Scope, method: String, type: String).void }

--- a/manual/generator_activemodelattributes.md
+++ b/manual/generator_activemodelattributes.md
@@ -19,10 +19,10 @@ this generator will produce an RBI file with the following content:
 
 class Shop
 
-  sig { returns(::String) }
+  sig { returns(T.nilable(::String)) }
   def name; end
 
-  sig { params(name: ::String).returns(::String) }
+  sig { params(name: T.nilable(::String)).returns(T.nilable(::String)) }
   def name=(name); end
 end
 ~~~

--- a/spec/tapioca/compilers/dsl/active_model_attributes_spec.rb
+++ b/spec/tapioca/compilers/dsl/active_model_attributes_spec.rb
@@ -114,34 +114,34 @@ class Tapioca::Compilers::Dsl::ActiveModelAttributesSpec < DslSpec
         # typed: strong
 
         class Shop
-          sig { returns(::DateTime) }
+          sig { returns(T.nilable(::DateTime)) }
           def created_at; end
 
-          sig { params(value: ::DateTime).returns(::DateTime) }
+          sig { params(value: T.nilable(::DateTime)).returns(T.nilable(::DateTime)) }
           def created_at=(value); end
 
-          sig { returns(::Integer) }
+          sig { returns(T.nilable(::Integer)) }
           def id; end
 
-          sig { params(value: ::Integer).returns(::Integer) }
+          sig { params(value: T.nilable(::Integer)).returns(T.nilable(::Integer)) }
           def id=(value); end
 
-          sig { returns(::Float) }
+          sig { returns(T.nilable(::Float)) }
           def latitude; end
 
-          sig { params(value: ::Float).returns(::Float) }
+          sig { params(value: T.nilable(::Float)).returns(T.nilable(::Float)) }
           def latitude=(value); end
 
-          sig { returns(::String) }
+          sig { returns(T.nilable(::String)) }
           def name; end
 
-          sig { params(value: ::String).returns(::String) }
+          sig { params(value: T.nilable(::String)).returns(T.nilable(::String)) }
           def name=(value); end
 
-          sig { returns(T::Boolean) }
+          sig { returns(T.nilable(T::Boolean)) }
           def test_shop; end
 
-          sig { params(value: T::Boolean).returns(T::Boolean) }
+          sig { params(value: T.nilable(T::Boolean)).returns(T.nilable(T::Boolean)) }
           def test_shop=(value); end
         end
       RBI


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->

ActiveModel provides no protections against someone assigning a `nil` value to an attribute and will return `nil` as the value of those attributes, even if they have a default value defined.

The most type-safe thing to do is to make all types nilable.

/cc @adrianna-chang-shopify 

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
Make all types in `ActiveModelAttributes` nilable except `T.untyped`.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->
Updated existing tests
