### PR TITLE
Rename method to be more descriptive about what it does

### DIFF
--- a/lib/tapioca/gemfile.rb
+++ b/lib/tapioca/gemfile.rb
@@ -42,8 +42,8 @@ module Tapioca
     end
 
     sig { void }
-    def require
-      T.unsafe(runtime).setup(*groups).require(*groups)
+    def require_bundle
+      T.unsafe(runtime).require(*groups)
     end
 
     private

--- a/lib/tapioca/generator.rb
+++ b/lib/tapioca/generator.rb
@@ -273,7 +273,7 @@ module Tapioca
     def load_application(eager_load:)
       say("Loading Rails application... ")
 
-      loader.load_rails(
+      loader.load_rails_application(
         environment_load: true,
         eager_load: eager_load
       )

--- a/lib/tapioca/loader.rb
+++ b/lib/tapioca/loader.rb
@@ -11,10 +11,10 @@ module Tapioca
     def load_bundle(gemfile, initialize_file, require_file)
       require_helper(initialize_file)
 
+      gemfile.require
+
       load_rails_application
       load_rake
-
-      gemfile.require
 
       require_helper(require_file)
 

--- a/lib/tapioca/loader.rb
+++ b/lib/tapioca/loader.rb
@@ -14,7 +14,6 @@ module Tapioca
       gemfile.require
 
       load_rails_application
-      load_rake
 
       require_helper(require_file)
 
@@ -25,11 +24,8 @@ module Tapioca
     def load_rails_application(environment_load: false, eager_load: false)
       return unless File.exist?("config/application.rb")
 
-      safe_require("rails")
-
       silence_deprecations
 
-      safe_require("rails/generators/test_case")
       if environment_load
         safe_require("./config/environment")
       else
@@ -62,11 +58,6 @@ module Tapioca
       require path
     rescue LoadError
       nil
-    end
-
-    sig { void }
-    def load_rake
-      safe_require("rake")
     end
 
     sig { void }

--- a/lib/tapioca/loader.rb
+++ b/lib/tapioca/loader.rb
@@ -11,7 +11,7 @@ module Tapioca
     def load_bundle(gemfile, initialize_file, require_file)
       require_helper(initialize_file)
 
-      gemfile.require
+      gemfile.require_bundle
 
       load_rails_application
 

--- a/lib/tapioca/loader.rb
+++ b/lib/tapioca/loader.rb
@@ -11,7 +11,7 @@ module Tapioca
     def load_bundle(gemfile, initialize_file, require_file)
       require_helper(initialize_file)
 
-      load_rails
+      load_rails_application
       load_rake
 
       gemfile.require
@@ -22,7 +22,7 @@ module Tapioca
     end
 
     sig { params(environment_load: T::Boolean, eager_load: T::Boolean).void }
-    def load_rails(environment_load: false, eager_load: false)
+    def load_rails_application(environment_load: false, eager_load: false)
       return unless File.exist?("config/application.rb")
 
       safe_require("rails")


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->

Tapioca was failing during the processing of an internal gem on Core with an error about require failing for a folder path. Investigating the failure closer, it was obvious that it was related to how Zeitwerk autovivifies implicit namespaces which are not declared in the source of the gem. What Zeitwerk does for those cases is to add an autoload for the folder path corresponding to the constant name. Now, an autoload for a folder does not normally work in Ruby, but it still calls `Kernel.require` internally. Since Zeitwerk overrides `Kernel.require`, when the constant is autoloaded Zeitwerk is able to intercept these calls and create anonymous modules for those namespaces based on the folder path. Zeitwerk never delegates those calls to the actual `require` method, so nothing fails.

However, if Zeitwerk is loaded before someone does a `require "bundler/setup"` (or equivalently `Bundler.setup`), then the `Kernel.require` method that Zeitwerk has installed [gets overwritten by the original `Kernel.require` method](https://github.com/rubygems/rubygems/blob/85d20073029e573489351b10c09494e83a4ce8d3/bundler/lib/bundler/rubygems_integration.rb#L289). When this happens, Zeitwerk has registered all the necessary autoloads, so most constant loading happens properly, but if we meet an implicit namespace autoload, then `Kernel.require` does not know what to do with a folder path and fails.

It turns out, this was happening for Tapioca because we were trying to load Rails and the Rails application (which was pulling in Zeitwerk, early) before requiring the bundle.

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->

- Stop doing a `Bundler.setup` step, since we expect that to already be done by `bundle exec` or the binstub
- Do the `Bundler.require` before trying to load any part of the Rails application.
- Stop trying to manually require `"rails"` and/or `"rake"`, since those should have already been loaded in the previous step.
- Just require `config/application` to load the Rails application if we are not eager loading the whole app.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->
No extra tests, but I tested this on Core and can confirm works correctly.
