### PR TITLE
Load ConstantLocator earlier

### DIFF
--- a/lib/tapioca.rb
+++ b/lib/tapioca.rb
@@ -18,6 +18,7 @@ module Tapioca
 end
 
 require "tapioca/reflection"
+require "tapioca/constant_locator"
 require "tapioca/compilers/dsl/base"
 require "tapioca/helpers/active_record_column_type_helper"
 require "tapioca/version"

--- a/lib/tapioca/internal.rb
+++ b/lib/tapioca/internal.rb
@@ -3,7 +3,6 @@
 
 require "tapioca"
 require "tapioca/loader"
-require "tapioca/constant_locator"
 require "tapioca/sorbet_ext/generic_name_patch"
 require "tapioca/sorbet_ext/fixed_hash_patch"
 require "tapioca/generic_type_registry"

--- a/spec/tapioca/cli/gem_spec.rb
+++ b/spec/tapioca/cli/gem_spec.rb
@@ -157,6 +157,17 @@ module Tapioca
           OUTPUT
         end
 
+        it "must not include `rbi` definitions into `tapioca` RBI" do
+          output = execute("gem")
+
+          assert_includes(output, <<~OUTPUT)
+            Compiling tapioca, this may take a few seconds...   Done
+          OUTPUT
+
+          tapioca_rbi_file = T.must(Dir.glob("#{outdir}/tapioca@*.rbi").first)
+          refute_includes(File.read(tapioca_rbi_file), "class RBI::Module")
+        end
+
         it "must generate multiple gem RBIs" do
           output = execute("gem", ["foo", "bar"])
 


### PR DESCRIPTION
### Motivation

Fixes https://github.com/Shopify/tapioca/issues/492.

### Implementation

Require `ConstantLocator` earlier in the process so it's loaded before `rbi`.

### Tests

See included test.

