### PR TITLE
Load the Rails application before loading the gems

### DIFF
--- a/lib/tapioca/loader.rb
+++ b/lib/tapioca/loader.rb
@@ -9,9 +9,9 @@ module Tapioca
     def load_bundle(gemfile, initialize_file, require_file)
       require_helper(initialize_file)
 
-      gemfile.require_bundle
-
       load_rails_application
+
+      gemfile.require_bundle
 
       require_helper(require_file)
 

--- a/spec/support/gems/bar/lib/bar.rb
+++ b/spec/support/gems/bar/lib/bar.rb
@@ -9,3 +9,9 @@ module Bar
     39 + a + b + number
   end
 end
+
+# Used to check we load the Rails application before the gems
+#
+# We try to access the `Rails::Application` constant defined in the `config/application.rb` of the support repo.
+# If the application is not loaded before the gems, this call will fail.
+puts Rails::Application


### PR DESCRIPTION
### Motivation

Sometimes gems depends on things that will be loaded by the Rails application so we need to make sure we load the application before the gems.

### Tests

See automated tests.
