### PR TITLE
Update the Bundler version used to bundle the main Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -318,4 +318,4 @@ DEPENDENCIES
   yard (~> 0.9.25)
 
 BUNDLED WITH
-   2.2.22
+   2.2.25


### PR DESCRIPTION
### Motivation

Let's use the most recent version we use in CI: https://github.com/Shopify/tapioca/blob/main/.github/workflows/ci.yml#L15