### PR TITLE
Move shared generator logic into `Base` class

### DIFF
--- a/lib/tapioca/generators.rb
+++ b/lib/tapioca/generators.rb
@@ -3,6 +3,7 @@
 
 require "thor" # TODO: Remove me when logging logic has been abstracted.
 
+require_relative "generators/base"
 require_relative "generators/dsl"
 require_relative "generators/gem"
 require_relative "generators/require"

--- a/lib/tapioca/generators/base.rb
+++ b/lib/tapioca/generators/base.rb
@@ -1,0 +1,23 @@
+# typed: strict
+# frozen_string_literal: true
+
+module Tapioca
+  module Generators
+    class Base
+      extend T::Sig
+      extend T::Helpers
+
+      include Thor::Base # TODO: Remove me when logging logic has been abstracted
+
+      abstract!
+
+      sig { params(default_command: String).void }
+      def initialize(default_command:)
+        @default_command = default_command
+      end
+
+      sig { abstract.void }
+      def generate; end
+    end
+  end
+end

--- a/lib/tapioca/generators/dsl.rb
+++ b/lib/tapioca/generators/dsl.rb
@@ -3,11 +3,7 @@
 
 module Tapioca
   module Generators
-    class Dsl
-      extend T::Sig
-
-      include Thor::Base # TODO: Remove me when logging logic has been abstracted.
-
+    class Dsl < Base
       sig do
         params(
           requested_constants: T::Array[String],
@@ -43,14 +39,16 @@ module Tapioca
         @file_header = file_header
         @compiler_path = compiler_path
         @tapioca_path = tapioca_path
-        @default_command = default_command
-        @loader = T.let(nil, T.nilable(Loader))
         @should_verify = should_verify
         @quiet = quiet
         @verbose = verbose
+
+        super(default_command: default_command)
+
+        @loader = T.let(nil, T.nilable(Loader))
       end
 
-      sig { void }
+      sig { override.void }
       def generate
         load_application(eager_load: @requested_constants.empty?)
         abort_if_pending_migrations!

--- a/lib/tapioca/generators/gem.rb
+++ b/lib/tapioca/generators/gem.rb
@@ -3,11 +3,7 @@
 
 module Tapioca
   module Generators
-    class Gem
-      extend T::Sig
-
-      include Thor::Base # TODO: Remove me when logging logic has been abstracted.
-
+    class Gem < Base
       # NOTE: This was previously _private_ which it actually wasn't, but should be extracted
       # to a module
       EMPTY_RBI_COMMENT = <<~CONTENT
@@ -42,9 +38,10 @@ module Tapioca
         @prerequire = prerequire
         @postrequire = postrequire
         @typed_overrides = typed_overrides
-        @default_command = default_command
         @outpath = outpath
         @file_header = file_header
+
+        super(default_command: default_command)
 
         @loader = T.let(nil, T.nilable(Loader))
         @bundle = T.let(nil, T.nilable(Gemfile))
@@ -52,7 +49,7 @@ module Tapioca
         @expected_rbis = T.let(nil, T.nilable(T::Hash[String, String]))
       end
 
-      sig { void }
+      sig { override.void }
       def generate
         require_gem_file
 

--- a/lib/tapioca/generators/require.rb
+++ b/lib/tapioca/generators/require.rb
@@ -3,19 +3,16 @@
 
 module Tapioca
   module Generators
-    class Require
-      extend T::Sig
-
-      include Thor::Base # TODO: Remove me when logging logic has been abstracted
-
+    class Require < Base
       sig { params(requires_path: String, sorbet_config_path: String, default_command: String).void }
       def initialize(requires_path:, sorbet_config_path:, default_command:)
         @requires_path = requires_path
         @sorbet_config_path = sorbet_config_path
-        @default_command = default_command
+
+        super(default_command: default_command)
       end
 
-      sig { void }
+      sig { override.void }
       def generate
         compiler = Compilers::RequiresCompiler.new(@sorbet_config_path)
         name = set_color(@requires_path, :yellow, :bold)

--- a/lib/tapioca/generators/todo.rb
+++ b/lib/tapioca/generators/todo.rb
@@ -3,19 +3,16 @@
 
 module Tapioca
   module Generators
-    class Todo
-      extend T::Sig
-
-      include Thor::Base # TODO: Remove me when logging logic has been abstracted.
-
+    class Todo < Base
       sig { params(todos_path: String, file_header: T::Boolean, default_command: String).void }
       def initialize(todos_path:, file_header:, default_command:)
         @todos_path = todos_path
         @file_header = file_header
-        @default_command = default_command
+
+        super(default_command: default_command)
       end
 
-      sig { void }
+      sig { override.void }
       def generate
         compiler = Compilers::TodosCompiler.new
         name = set_color(@todos_path, :yellow, :bold)


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
As part of the ongoing effort to cleanup/decouple the `Generators` in Tapioca. I've moved shared logic into a `Base` 
class. 

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
* Moved up the `T::Sig` and `Thor::Shell` includes
* Moved up the `default_command` value that is shared amongst all
  generators
* Made an abstract `generate` method to ensure that all `Generators` subclasses will follow that design


### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->
See automated tests (no changes).
