### PR TITLE
Remove unparser as a direct dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,7 +16,6 @@ PATH
       sorbet-static (>= 0.4.4471)
       spoom
       thor (>= 0.19.2)
-      unparser
 
 GEM
   remote: https://rubygems.org/

--- a/tapioca.gemspec
+++ b/tapioca.gemspec
@@ -30,7 +30,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency("sorbet-runtime")
   spec.add_dependency("spoom")
   spec.add_dependency("thor", ">= 0.19.2")
-  spec.add_dependency("unparser")
 
   spec.required_ruby_version = ">= 2.6"
 end


### PR DESCRIPTION
### Motivation

Dependency to `unparser` was introduced in https://github.com/Shopify/tapioca/pull/337 to get the default values of sig parameters. Since this code has been moved to the [`rbi` gem](https://github.com/Shopify/rbi) it can be removed from Tapioca's Gemspec.

cc. @mbj