### PR TITLE
Update `Symbol(TableCompiler|Generator)` to use `RBI::File` over `String`

### DIFF
--- a/lib/tapioca/compilers/symbol_table/symbol_generator.rb
+++ b/lib/tapioca/compilers/symbol_table/symbol_generator.rb
@@ -41,12 +41,9 @@ module Tapioca
           gem.parse_yard_docs if include_doc
         end
 
-        sig { returns(RBI::Tree) }
-        def generate
-          rbi = RBI::Tree.new
-
+        sig { params(rbi: RBI::Tree).returns(RBI::Tree) }
+        def generate(rbi)
           generate_from_symbol(rbi, T.must(@symbol_queue.shift)) until @symbol_queue.empty?
-
           rbi
         end
 

--- a/lib/tapioca/compilers/symbol_table/symbol_generator.rb
+++ b/lib/tapioca/compilers/symbol_table/symbol_generator.rb
@@ -41,10 +41,9 @@ module Tapioca
           gem.parse_yard_docs if include_doc
         end
 
-        sig { params(rbi: RBI::File).returns(RBI::Tree) }
+        sig { params(rbi: RBI::File).void }
         def generate(rbi)
           generate_from_symbol(rbi.root, T.must(@symbol_queue.shift)) until @symbol_queue.empty?
-          rbi.root
         end
 
         private

--- a/lib/tapioca/compilers/symbol_table/symbol_generator.rb
+++ b/lib/tapioca/compilers/symbol_table/symbol_generator.rb
@@ -41,17 +41,13 @@ module Tapioca
           gem.parse_yard_docs if include_doc
         end
 
-        sig { returns(String) }
+        sig { returns(RBI::Tree) }
         def generate
           rbi = RBI::Tree.new
 
           generate_from_symbol(rbi, T.must(@symbol_queue.shift)) until @symbol_queue.empty?
 
-          rbi.nest_singleton_methods!
-          rbi.nest_non_public_methods!
-          rbi.group_nodes!
-          rbi.sort_nodes!
-          rbi.string
+          rbi
         end
 
         private

--- a/lib/tapioca/compilers/symbol_table/symbol_generator.rb
+++ b/lib/tapioca/compilers/symbol_table/symbol_generator.rb
@@ -41,10 +41,10 @@ module Tapioca
           gem.parse_yard_docs if include_doc
         end
 
-        sig { params(rbi: RBI::Tree).returns(RBI::Tree) }
+        sig { params(rbi: RBI::File).returns(RBI::Tree) }
         def generate(rbi)
-          generate_from_symbol(rbi, T.must(@symbol_queue.shift)) until @symbol_queue.empty?
-          rbi
+          generate_from_symbol(rbi.root, T.must(@symbol_queue.shift)) until @symbol_queue.empty?
+          rbi.root
         end
 
         private

--- a/lib/tapioca/compilers/symbol_table_compiler.rb
+++ b/lib/tapioca/compilers/symbol_table_compiler.rb
@@ -6,13 +6,12 @@ module Tapioca
     class SymbolTableCompiler
       extend(T::Sig)
 
-      sig { params(gem: Gemfile::GemSpec, indent: Integer, include_docs: T::Boolean).returns(String) }
+      sig { params(gem: Gemfile::GemSpec, indent: Integer, include_docs: T::Boolean).returns(RBI::Tree) }
       def compile(gem, indent = 0, include_docs = false)
         rbi_file = RBI::File.new(strictness: "true")
         Tapioca::Compilers::SymbolTable::SymbolGenerator
           .new(gem, indent, include_docs)
           .generate(rbi_file.root)
-          .transform_rbi
       end
     end
   end

--- a/lib/tapioca/compilers/symbol_table_compiler.rb
+++ b/lib/tapioca/compilers/symbol_table_compiler.rb
@@ -6,14 +6,7 @@ module Tapioca
     class SymbolTableCompiler
       extend(T::Sig)
 
-      sig do
-        params(
-          gem: Gemfile::GemSpec,
-          rbi: RBI::File,
-          indent: Integer,
-          include_docs: T::Boolean
-        ).returns(RBI::Tree)
-      end
+      sig { params(gem: Gemfile::GemSpec, rbi: RBI::File, indent: Integer, include_docs: T::Boolean).void }
       def compile(gem, rbi, indent = 0, include_docs = false)
         Tapioca::Compilers::SymbolTable::SymbolGenerator
           .new(gem, indent, include_docs)

--- a/lib/tapioca/compilers/symbol_table_compiler.rb
+++ b/lib/tapioca/compilers/symbol_table_compiler.rb
@@ -6,19 +6,13 @@ module Tapioca
     class SymbolTableCompiler
       extend(T::Sig)
 
-      sig do
-        params(
-          gem: Gemfile::GemSpec,
-          indent: Integer,
-          include_docs: T::Boolean
-        ).returns(RBI::Tree)
-      end
-      def compile(
-        gem,
-        indent = 0,
-        include_docs = false
-      )
-        Tapioca::Compilers::SymbolTable::SymbolGenerator.new(gem, indent, include_docs).generate
+      sig { params(gem: Gemfile::GemSpec, indent: Integer, include_docs: T::Boolean).returns(String) }
+      def compile(gem, indent = 0, include_docs = false)
+        rbi_file = RBI::File.new(strictness: "true")
+        Tapioca::Compilers::SymbolTable::SymbolGenerator
+          .new(gem, indent, include_docs)
+          .generate(rbi_file.root)
+          .transform_rbi
       end
     end
   end

--- a/lib/tapioca/compilers/symbol_table_compiler.rb
+++ b/lib/tapioca/compilers/symbol_table_compiler.rb
@@ -6,12 +6,18 @@ module Tapioca
     class SymbolTableCompiler
       extend(T::Sig)
 
-      sig { params(gem: Gemfile::GemSpec, indent: Integer, include_docs: T::Boolean).returns(RBI::Tree) }
-      def compile(gem, indent = 0, include_docs = false)
-        rbi_file = RBI::File.new(strictness: "true")
+      sig do
+        params(
+          gem: Gemfile::GemSpec,
+          rbi: RBI::File,
+          indent: Integer,
+          include_docs: T::Boolean
+        ).returns(RBI::Tree)
+      end
+      def compile(gem, rbi, indent = 0, include_docs = false)
         Tapioca::Compilers::SymbolTable::SymbolGenerator
           .new(gem, indent, include_docs)
-          .generate(rbi_file.root)
+          .generate(rbi)
       end
     end
   end

--- a/lib/tapioca/compilers/symbol_table_compiler.rb
+++ b/lib/tapioca/compilers/symbol_table_compiler.rb
@@ -11,7 +11,7 @@ module Tapioca
           gem: Gemfile::GemSpec,
           indent: Integer,
           include_docs: T::Boolean
-        ).returns(String)
+        ).returns(RBI::Tree)
       end
       def compile(
         gem,

--- a/lib/tapioca/generators/gem.rb
+++ b/lib/tapioca/generators/gem.rb
@@ -146,7 +146,8 @@ module Tapioca
         say("Compiling #{gem_name}, this may take a few seconds... ")
 
         strictness = @typed_overrides[gem.name] || "true"
-        rbi_body_content = compiler.compile(gem, 0, @doc).to_s
+        rbi = RBI::File.new(strictness: strictness)
+        rbi_body_content = compiler.compile(gem, rbi, 0, @doc).transformed_string
         content = String.new
         content << rbi_header(
           "#{@default_command} gem #{gem.name}",

--- a/lib/tapioca/generators/gem.rb
+++ b/lib/tapioca/generators/gem.rb
@@ -146,14 +146,9 @@ module Tapioca
         say("Compiling #{gem_name}, this may take a few seconds... ")
 
         strictness = @typed_overrides[gem.name] || "true"
-        rbi = RBI::File.new(strictness: strictness)
+        rbi = RBI::File.new
         compiler.compile(gem, rbi, 0, @doc)
-        rbi.transform_rbi!
-        # NOTE: This is not using the standard helper method `transformed_string`.
-        # The following test suite is based on the string output of the `RBI::Tree` rather
-        # than the, now used, `RBI::File`. The file output includes the sigils, comments, etc.
-        # We should eventually update these tests to be based on the `RBI::File`.
-        rbi_body_content = rbi.root.string
+        rbi_body_content = rbi.transformed_string
         content = String.new
         content << rbi_header(
           "#{@default_command} gem #{gem.name}",

--- a/lib/tapioca/generators/gem.rb
+++ b/lib/tapioca/generators/gem.rb
@@ -146,7 +146,7 @@ module Tapioca
         say("Compiling #{gem_name}, this may take a few seconds... ")
 
         strictness = @typed_overrides[gem.name] || "true"
-        rbi_body_content = compiler.compile(gem, 0, @doc).transform_rbi
+        rbi_body_content = compiler.compile(gem, 0, @doc)
         content = String.new
         content << rbi_header(
           "#{@default_command} gem #{gem.name}",

--- a/lib/tapioca/generators/gem.rb
+++ b/lib/tapioca/generators/gem.rb
@@ -148,7 +148,12 @@ module Tapioca
         strictness = @typed_overrides[gem.name] || "true"
         rbi = RBI::File.new(strictness: strictness)
         compiler.compile(gem, rbi, 0, @doc)
-        rbi_body_content = rbi.transformed_string
+        rbi.transform_rbi!
+        # NOTE: This is not using the standard helper method `transformed_string`.
+        # The following test suite is based on the string output of the `RBI::Tree` rather
+        # than the, now used, `RBI::File`. The file output includes the sigils, comments, etc.
+        # We should eventually update these tests to be based on the `RBI::File`.
+        rbi_body_content = rbi.root.string
         content = String.new
         content << rbi_header(
           "#{@default_command} gem #{gem.name}",

--- a/lib/tapioca/generators/gem.rb
+++ b/lib/tapioca/generators/gem.rb
@@ -146,7 +146,7 @@ module Tapioca
         say("Compiling #{gem_name}, this may take a few seconds... ")
 
         strictness = @typed_overrides[gem.name] || "true"
-        rbi_body_content = compiler.compile(gem, 0, @doc)
+        rbi_body_content = compiler.compile(gem, 0, @doc).to_s
         content = String.new
         content << rbi_header(
           "#{@default_command} gem #{gem.name}",

--- a/lib/tapioca/generators/gem.rb
+++ b/lib/tapioca/generators/gem.rb
@@ -146,7 +146,9 @@ module Tapioca
         say("Compiling #{gem_name}, this may take a few seconds... ")
 
         strictness = @typed_overrides[gem.name] || "true"
-        rbi_body_content = compiler.compile(gem, 0, @doc)
+        rbi = compiler.compile(gem, 0, @doc)
+        rbi.nest_singleton_methods!
+        rbi_body_content = transform_rbi(rbi)
         content = String.new
         content << rbi_header(
           "#{@default_command} gem #{gem.name}",
@@ -378,6 +380,15 @@ module Tapioca
         end.join("\n  - ")
 
         "  File(s) #{cause}:\n  - #{filenames}"
+      end
+
+      sig { params(rbi: RBI::Tree).returns(String) }
+      def transform_rbi(rbi)
+        rbi.nest_singleton_methods!
+        rbi.nest_non_public_methods!
+        rbi.group_nodes!
+        rbi.sort_nodes!
+        rbi.string
       end
     end
   end

--- a/lib/tapioca/generators/gem.rb
+++ b/lib/tapioca/generators/gem.rb
@@ -147,7 +147,8 @@ module Tapioca
 
         strictness = @typed_overrides[gem.name] || "true"
         rbi = RBI::File.new(strictness: strictness)
-        rbi_body_content = compiler.compile(gem, rbi, 0, @doc).transformed_string
+        compiler.compile(gem, rbi, 0, @doc)
+        rbi_body_content = rbi.transformed_string
         content = String.new
         content << rbi_header(
           "#{@default_command} gem #{gem.name}",

--- a/lib/tapioca/generators/gem.rb
+++ b/lib/tapioca/generators/gem.rb
@@ -146,9 +146,7 @@ module Tapioca
         say("Compiling #{gem_name}, this may take a few seconds... ")
 
         strictness = @typed_overrides[gem.name] || "true"
-        rbi = compiler.compile(gem, 0, @doc)
-        rbi.nest_singleton_methods!
-        rbi_body_content = transform_rbi(rbi)
+        rbi_body_content = compiler.compile(gem, 0, @doc).transform_rbi
         content = String.new
         content << rbi_header(
           "#{@default_command} gem #{gem.name}",
@@ -380,15 +378,6 @@ module Tapioca
         end.join("\n  - ")
 
         "  File(s) #{cause}:\n  - #{filenames}"
-      end
-
-      sig { params(rbi: RBI::Tree).returns(String) }
-      def transform_rbi(rbi)
-        rbi.nest_singleton_methods!
-        rbi.nest_non_public_methods!
-        rbi.group_nodes!
-        rbi.sort_nodes!
-        rbi.string
       end
     end
   end

--- a/lib/tapioca/rbi_ext/model.rb
+++ b/lib/tapioca/rbi_ext/model.rb
@@ -9,18 +9,17 @@ module RBI
 
     sig { returns(String) }
     def transformed_string
-      transform_rbi
+      rbi = transform_rbi!
+      rbi.string
     end
 
-    private
-
-    sig { returns(String) }
-    def transform_rbi
+    sig { returns(RBI::Tree) }
+    def transform_rbi!
       root.nest_singleton_methods!
       root.nest_non_public_methods!
       root.group_nodes!
       root.sort_nodes!
-      root.string
+      root
     end
   end
 

--- a/lib/tapioca/rbi_ext/model.rb
+++ b/lib/tapioca/rbi_ext/model.rb
@@ -4,6 +4,26 @@
 require "rbi"
 
 module RBI
+  class File
+    extend T::Sig
+
+    sig { returns(String) }
+    def transformed_string
+      transform_rbi
+    end
+
+    private
+
+    sig { returns(String) }
+    def transform_rbi
+      root.nest_singleton_methods!
+      root.nest_non_public_methods!
+      root.group_nodes!
+      root.sort_nodes!
+      root.string
+    end
+  end
+
   class Tree
     extend T::Sig
 
@@ -86,11 +106,6 @@ module RBI
       self << method
     end
 
-    sig { returns(String) }
-    def transformed_string
-      transform_rbi
-    end
-
     private
 
     SPECIAL_METHOD_NAMES = T.let(
@@ -117,15 +132,6 @@ module RBI
       nodes_cache[node.to_s] = node
       self << node
       node
-    end
-
-    sig { returns(String) }
-    def transform_rbi
-      nest_singleton_methods!
-      nest_non_public_methods!
-      group_nodes!
-      sort_nodes!
-      string
     end
   end
 

--- a/lib/tapioca/rbi_ext/model.rb
+++ b/lib/tapioca/rbi_ext/model.rb
@@ -10,7 +10,7 @@ module RBI
     sig { returns(String) }
     def transformed_string
       transform_rbi!
-      root.string
+      string
     end
 
     sig { void }

--- a/lib/tapioca/rbi_ext/model.rb
+++ b/lib/tapioca/rbi_ext/model.rb
@@ -9,17 +9,16 @@ module RBI
 
     sig { returns(String) }
     def transformed_string
-      rbi = transform_rbi!
-      rbi.string
+      transform_rbi!
+      root.string
     end
 
-    sig { returns(RBI::Tree) }
+    sig { void }
     def transform_rbi!
       root.nest_singleton_methods!
       root.nest_non_public_methods!
       root.group_nodes!
       root.sort_nodes!
-      root
     end
   end
 

--- a/lib/tapioca/rbi_ext/model.rb
+++ b/lib/tapioca/rbi_ext/model.rb
@@ -86,13 +86,9 @@ module RBI
       self << method
     end
 
-    sig { returns(String) }
-    def transform_rbi
-      nest_singleton_methods!
-      nest_non_public_methods!
-      group_nodes!
-      sort_nodes!
-      string
+    sig { override.returns(String) }
+    def to_s
+      transform_rbi
     end
 
     private
@@ -121,6 +117,15 @@ module RBI
       nodes_cache[node.to_s] = node
       self << node
       node
+    end
+
+    sig { returns(String) }
+    def transform_rbi
+      nest_singleton_methods!
+      nest_non_public_methods!
+      group_nodes!
+      sort_nodes!
+      string
     end
   end
 

--- a/lib/tapioca/rbi_ext/model.rb
+++ b/lib/tapioca/rbi_ext/model.rb
@@ -86,8 +86,8 @@ module RBI
       self << method
     end
 
-    sig { override.returns(String) }
-    def to_s
+    sig { returns(String) }
+    def transformed_string
       transform_rbi
     end
 

--- a/lib/tapioca/rbi_ext/model.rb
+++ b/lib/tapioca/rbi_ext/model.rb
@@ -86,6 +86,15 @@ module RBI
       self << method
     end
 
+    sig { returns(String) }
+    def transform_rbi
+      nest_singleton_methods!
+      nest_non_public_methods!
+      group_nodes!
+      sort_nodes!
+      string
+    end
+
     private
 
     SPECIAL_METHOD_NAMES = T.let(

--- a/spec/tapioca/compilers/symbol_table_compiler_spec.rb
+++ b/spec/tapioca/compilers/symbol_table_compiler_spec.rb
@@ -40,8 +40,8 @@ class Tapioca::Compilers::SymbolTableCompilerSpec < Minitest::HooksSpec
       spec = Bundler::StubSpecification.from_stub(stub)
       gem = Tapioca::Gemfile::GemSpec.new(spec)
 
-      rbi_file = Tapioca::Compilers::SymbolTableCompiler.new.compile(gem, 0, include_docs)
-      rbi_file.to_s
+      rbi = RBI::File.new(strictness: "true")
+      Tapioca::Compilers::SymbolTableCompiler.new.compile(gem, rbi, 0, include_docs).transformed_string
     end
 
     it("compiles DelegateClass") do

--- a/spec/tapioca/compilers/symbol_table_compiler_spec.rb
+++ b/spec/tapioca/compilers/symbol_table_compiler_spec.rb
@@ -40,7 +40,8 @@ class Tapioca::Compilers::SymbolTableCompilerSpec < Minitest::HooksSpec
       spec = Bundler::StubSpecification.from_stub(stub)
       gem = Tapioca::Gemfile::GemSpec.new(spec)
 
-      Tapioca::Compilers::SymbolTableCompiler.new.compile(gem, 0, include_docs)
+      rbi_file = Tapioca::Compilers::SymbolTableCompiler.new.compile(gem, 0, include_docs)
+      rbi_file.to_s
     end
 
     it("compiles DelegateClass") do

--- a/spec/tapioca/compilers/symbol_table_compiler_spec.rb
+++ b/spec/tapioca/compilers/symbol_table_compiler_spec.rb
@@ -40,7 +40,7 @@ class Tapioca::Compilers::SymbolTableCompilerSpec < Minitest::HooksSpec
       spec = Bundler::StubSpecification.from_stub(stub)
       gem = Tapioca::Gemfile::GemSpec.new(spec)
 
-      Tapioca::Compilers::SymbolTableCompiler.new.compile(gem, 0, include_docs).transform_rbi
+      Tapioca::Compilers::SymbolTableCompiler.new.compile(gem, 0, include_docs)
     end
 
     it("compiles DelegateClass") do

--- a/spec/tapioca/compilers/symbol_table_compiler_spec.rb
+++ b/spec/tapioca/compilers/symbol_table_compiler_spec.rb
@@ -41,7 +41,8 @@ class Tapioca::Compilers::SymbolTableCompilerSpec < Minitest::HooksSpec
       gem = Tapioca::Gemfile::GemSpec.new(spec)
 
       rbi = RBI::File.new(strictness: "true")
-      Tapioca::Compilers::SymbolTableCompiler.new.compile(gem, rbi, 0, include_docs).transformed_string
+      Tapioca::Compilers::SymbolTableCompiler.new.compile(gem, rbi, 0, include_docs)
+      rbi.transformed_string
     end
 
     it("compiles DelegateClass") do

--- a/spec/tapioca/compilers/symbol_table_compiler_spec.rb
+++ b/spec/tapioca/compilers/symbol_table_compiler_spec.rb
@@ -42,7 +42,12 @@ class Tapioca::Compilers::SymbolTableCompilerSpec < Minitest::HooksSpec
 
       rbi = RBI::File.new(strictness: "true")
       Tapioca::Compilers::SymbolTableCompiler.new.compile(gem, rbi, 0, include_docs)
-      rbi.transformed_string
+      rbi.transform_rbi!
+      # NOTE: This is not using the standard helper method `transformed_string`.
+      # The following test suite is based on the string output of the `RBI::Tree` rather
+      # than the, now used, `RBI::File`. The file output includes the sigils, comments, etc.
+      # We should eventually update these tests to be based on the `RBI::File`.
+      rbi.root.string
     end
 
     it("compiles DelegateClass") do

--- a/spec/tapioca/compilers/symbol_table_compiler_spec.rb
+++ b/spec/tapioca/compilers/symbol_table_compiler_spec.rb
@@ -40,12 +40,7 @@ class Tapioca::Compilers::SymbolTableCompilerSpec < Minitest::HooksSpec
       spec = Bundler::StubSpecification.from_stub(stub)
       gem = Tapioca::Gemfile::GemSpec.new(spec)
 
-      rbi = Tapioca::Compilers::SymbolTableCompiler.new.compile(gem, 0, include_docs)
-      rbi.nest_singleton_methods!
-      rbi.nest_non_public_methods!
-      rbi.group_nodes!
-      rbi.sort_nodes!
-      rbi.string
+      Tapioca::Compilers::SymbolTableCompiler.new.compile(gem, 0, include_docs).transform_rbi
     end
 
     it("compiles DelegateClass") do

--- a/spec/tapioca/compilers/symbol_table_compiler_spec.rb
+++ b/spec/tapioca/compilers/symbol_table_compiler_spec.rb
@@ -40,7 +40,12 @@ class Tapioca::Compilers::SymbolTableCompilerSpec < Minitest::HooksSpec
       spec = Bundler::StubSpecification.from_stub(stub)
       gem = Tapioca::Gemfile::GemSpec.new(spec)
 
-      Tapioca::Compilers::SymbolTableCompiler.new.compile(gem, 0, include_docs)
+      rbi = Tapioca::Compilers::SymbolTableCompiler.new.compile(gem, 0, include_docs)
+      rbi.nest_singleton_methods!
+      rbi.nest_non_public_methods!
+      rbi.group_nodes!
+      rbi.sort_nodes!
+      rbi.string
     end
 
     it("compiles DelegateClass") do


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
This was a blocker for migrating all generators to use `RBI::File`.

`SymbolGenerator` and `SymbolTableCompiler` will now generate `RBI::Tree`s as opposed to `String`s.

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
Update the `sig`s and modify the implementation so that the transformations on the `RBI::Tree` take place in the
generator rather than the compiler.

Taken from Mojan's in-progress PR (see https://github.com/Shopify/tapioca/pull/453/commits/3543e3973cea81dad744465d710952a653758ab4)

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->
See automated tests (minor updates).

