### PR TITLE
Clean up File IO in generators

### DIFF
--- a/lib/tapioca/cli.rb
+++ b/lib/tapioca/cli.rb
@@ -5,8 +5,6 @@ require "thor"
 
 module Tapioca
   class Cli < Thor
-    include(Thor::Actions)
-
     class_option :outdir,
       aliases: ["--out", "-o"],
       banner: "directory",
@@ -30,7 +28,6 @@ module Tapioca
     desc "init", "initializes folder structure"
     def init
       generator = Generators::Init.new(
-        file_writer: self,
         sorbet_config: Config::SORBET_CONFIG,
         default_postrequire: Config::DEFAULT_POSTREQUIRE,
         default_command: Config::DEFAULT_COMMAND

--- a/lib/tapioca/generators/base.rb
+++ b/lib/tapioca/generators/base.rb
@@ -10,6 +10,10 @@ module Tapioca
       extend T::Sig
       extend T::Helpers
 
+      class FileWriter < Thor
+        include Thor::Actions
+      end
+
       # TODO: Remove me when logging logic has been abstracted
       include Thor::Base
 
@@ -17,6 +21,7 @@ module Tapioca
 
       sig { params(default_command: String).void }
       def initialize(default_command:)
+        @file_writer = T.let(FileWriter.new, FileWriter)
         @default_command = default_command
       end
 
@@ -37,6 +42,17 @@ module Tapioca
 
         $stderr.print(buffer)
         $stderr.flush
+      end
+
+      sig do
+        params(
+          path: T.any(String, Pathname),
+          content: String,
+          skip: T::Boolean
+        ).void
+      end
+      def create_file(path, content, skip: false)
+        @file_writer.create_file(path, skip: skip) { content }
       end
     end
   end

--- a/lib/tapioca/generators/base.rb
+++ b/lib/tapioca/generators/base.rb
@@ -48,11 +48,12 @@ module Tapioca
         params(
           path: T.any(String, Pathname),
           content: String,
-          skip: T::Boolean
+          skip: T::Boolean,
+          verbose: T::Boolean
         ).void
       end
-      def create_file(path, content, skip: false)
-        @file_writer.create_file(path, skip: skip) { content }
+      def create_file(path, content, skip: false, verbose: true)
+        @file_writer.create_file(path, skip: skip, verbose: verbose) { content }
       end
     end
   end

--- a/lib/tapioca/generators/dsl.rb
+++ b/lib/tapioca/generators/dsl.rb
@@ -222,13 +222,7 @@ module Tapioca
         )
         out << contents
 
-        FileUtils.mkdir_p(File.dirname(filename))
-        File.write(filename, out)
-
-        unless quiet
-          say("Wrote: ", [:green])
-          say(filename)
-        end
+        create_file(filename, out, verbose: !quiet)
 
         filename
       end

--- a/lib/tapioca/generators/gem.rb
+++ b/lib/tapioca/generators/gem.rb
@@ -162,7 +162,7 @@ module Tapioca
           content << rbi_body_content
           say("Done", :green)
         end
-        File.write(filename.to_s, content)
+        create_file(filename, content)
 
         T.unsafe(Pathname).glob((@outpath / "#{gem.name}@*.rbi").to_s) do |file|
           remove(file) unless file.basename.to_s == gem.rbi_file_name

--- a/lib/tapioca/generators/init.rb
+++ b/lib/tapioca/generators/init.rb
@@ -4,16 +4,19 @@
 module Tapioca
   module Generators
     class Init < Base
+      class FileWriter < Thor
+        include Thor::Actions
+      end
+
       sig do
         params(
-          file_writer: Thor::Actions,
           sorbet_config: String,
           default_postrequire: String,
           default_command: String
         ).void
       end
-      def initialize(file_writer:, sorbet_config:, default_postrequire:, default_command:)
-        @file_writer = file_writer
+      def initialize(sorbet_config:, default_postrequire:, default_command:)
+        @file_writer = T.let(FileWriter.new, FileWriter)
         @sorbet_config = sorbet_config
         @default_postrequire = default_postrequire
 

--- a/lib/tapioca/generators/init.rb
+++ b/lib/tapioca/generators/init.rb
@@ -4,10 +4,6 @@
 module Tapioca
   module Generators
     class Init < Base
-      class FileWriter < Thor
-        include Thor::Actions
-      end
-
       sig do
         params(
           sorbet_config: String,
@@ -16,7 +12,6 @@ module Tapioca
         ).void
       end
       def initialize(sorbet_config:, default_postrequire:, default_command:)
-        @file_writer = T.let(FileWriter.new, FileWriter)
         @sorbet_config = sorbet_config
         @default_postrequire = default_postrequire
 
@@ -41,24 +36,20 @@ module Tapioca
 
       sig { void }
       def create_config
-        @file_writer.create_file(@sorbet_config, skip: true) do
-          <<~CONTENT
-            --dir
-            .
-          CONTENT
-        end
+        create_file(@sorbet_config, <<~CONTENT, skip: true)
+          --dir
+          .
+        CONTENT
       end
 
       sig { void }
       def create_post_require
-        @file_writer.create_file(@default_postrequire, skip: true) do
-          <<~CONTENT
-            # typed: true
-            # frozen_string_literal: true
+        create_file(@default_postrequire, <<~CONTENT, skip: true)
+          # typed: true
+          # frozen_string_literal: true
 
-            # Add your extra requires here (`#{@default_command} require` can be used to boostrap this list)
-          CONTENT
-        end
+          # Add your extra requires here (`#{@default_command} require` can be used to boostrap this list)
+        CONTENT
       end
 
       sig { void }

--- a/lib/tapioca/generators/todo.rb
+++ b/lib/tapioca/generators/todo.rb
@@ -15,8 +15,7 @@ module Tapioca
       sig { override.void }
       def generate
         compiler = Compilers::TodosCompiler.new
-        name = set_color(@todos_path, :yellow, :bold)
-        say("Compiling #{name}, this may take a few seconds... ")
+        say("Finding all unresolved constants, this may take a few seconds... ")
 
         # Clean all existing unresolved constants before regenerating the list
         # so Sorbet won't grab them as already resolved.
@@ -37,13 +36,12 @@ module Tapioca
         content << rbi_string
         content << "\n"
 
-        outdir = File.dirname(@todos_path)
-        FileUtils.mkdir_p(outdir)
-        File.write(@todos_path, content)
-
         say("Done", :green)
+        say("\n")
+        create_file(@todos_path, content)
 
-        say("All unresolved constants have been written to #{name}.", [:green, :bold])
+        name = set_color(@todos_path, :yellow, :bold)
+        say("\nAll unresolved constants have been written to #{name}.", [:green, :bold])
         say("Please review changes and commit them.", [:green, :bold])
       end
 

--- a/spec/tapioca/cli/dsl_spec.rb
+++ b/spec/tapioca/cli/dsl_spec.rb
@@ -33,7 +33,7 @@ module Tapioca
           Loading DSL generator classes... Done
           Compiling DSL RBI files...
 
-          Wrote: #{outdir}/post.rbi
+                create  #{outdir}/post.rbi
 
           Done
           All operations performed in working directory.
@@ -126,10 +126,10 @@ module Tapioca
           Loading DSL generator classes... Done
           Compiling DSL RBI files...
 
-          Wrote: #{outdir}/baz/role.rbi
-          Wrote: #{outdir}/job.rbi
-          Wrote: #{outdir}/namespace/comment.rbi
-          Wrote: #{outdir}/post.rbi
+                create  #{outdir}/baz/role.rbi
+                create  #{outdir}/job.rbi
+                create  #{outdir}/namespace/comment.rbi
+                create  #{outdir}/post.rbi
 
           Done
           All operations performed in working directory.
@@ -225,13 +225,13 @@ module Tapioca
           Compiling DSL RBI files...
 
           Processing: Baz::Role
-          Wrote: sorbet/rbi/dsl/baz/role.rbi
+                create  sorbet/rbi/dsl/baz/role.rbi
           Processing: Job
-          Wrote: sorbet/rbi/dsl/job.rbi
+                create  sorbet/rbi/dsl/job.rbi
           Processing: Namespace::Comment
-          Wrote: sorbet/rbi/dsl/namespace/comment.rbi
+                create  sorbet/rbi/dsl/namespace/comment.rbi
           Processing: Post
-          Wrote: sorbet/rbi/dsl/post.rbi
+                create  sorbet/rbi/dsl/post.rbi
 
           Done
           All operations performed in working directory.
@@ -254,13 +254,13 @@ module Tapioca
           Compiling DSL RBI files...
 
           Processing: Baz::Role
-          Wrote: #{outdir}/baz/role.rbi
+                create  #{outdir}/baz/role.rbi
           Processing: Job
-          Wrote: #{outdir}/job.rbi
+                create  #{outdir}/job.rbi
           Processing: Namespace::Comment
-          Wrote: #{outdir}/namespace/comment.rbi
+                create  #{outdir}/namespace/comment.rbi
           Processing: Post
-          Wrote: #{outdir}/post.rbi
+                create  #{outdir}/post.rbi
 
           Done
           All operations performed in working directory.
@@ -330,10 +330,10 @@ module Tapioca
           Loading DSL generator classes... Done
           Compiling DSL RBI files...
 
-          Wrote: #{outdir}/baz/role.rbi
-          Wrote: #{outdir}/job.rbi
-          Wrote: #{outdir}/namespace/comment.rbi
-          Wrote: #{outdir}/post.rbi
+                create  #{outdir}/baz/role.rbi
+                create  #{outdir}/job.rbi
+                create  #{outdir}/namespace/comment.rbi
+                create  #{outdir}/post.rbi
 
           Removing stale RBI files...
           -- Removing: #{outdir}/does_not_exist.rbi
@@ -366,7 +366,7 @@ module Tapioca
           Loading DSL generator classes... Done
           Compiling DSL RBI files...
 
-          Wrote: #{outdir}/post.rbi
+                create  #{outdir}/post.rbi
 
           Removing stale RBI files...
           -- Removing: #{outdir}/user.rbi
@@ -391,7 +391,7 @@ module Tapioca
           Loading DSL generator classes... Done
           Compiling DSL RBI files...
 
-          Wrote: #{outdir}/job.rbi
+                create  #{outdir}/job.rbi
 
           Done
           All operations performed in working directory.
@@ -431,9 +431,9 @@ module Tapioca
           Loading DSL generator classes... Done
           Compiling DSL RBI files...
 
-          Wrote: #{outdir}/baz/role.rbi
-          Wrote: #{outdir}/namespace/comment.rbi
-          Wrote: #{outdir}/post.rbi
+                create  #{outdir}/baz/role.rbi
+                create  #{outdir}/namespace/comment.rbi
+                create  #{outdir}/post.rbi
 
           Done
           All operations performed in working directory.

--- a/spec/tapioca/cli/todo_spec.rb
+++ b/spec/tapioca/cli/todo_spec.rb
@@ -14,7 +14,7 @@ module Tapioca
         output = execute("todo")
 
         assert_equal(<<~OUTPUT, output)
-          Compiling sorbet/rbi/todo.rbi, this may take a few seconds... Nothing to do
+          Finding all unresolved constants, this may take a few seconds... Nothing to do
         OUTPUT
 
         refute_path_exists(repo_path / "sorbet/rbi/todo.rbi")
@@ -37,7 +37,10 @@ module Tapioca
         File.delete(repo_path / "file.rb")
 
         assert_equal(<<~CONTENTS, output)
-          Compiling sorbet/rbi/todo.rbi, this may take a few seconds... Done
+          Finding all unresolved constants, this may take a few seconds... Done
+
+                create  sorbet/rbi/todo.rbi
+
           All unresolved constants have been written to sorbet/rbi/todo.rbi.
           Please review changes and commit them.
         CONTENTS
@@ -67,7 +70,10 @@ module Tapioca
         File.delete(repo_path / "file.rb")
 
         assert_equal(<<~CONTENTS, output)
-          Compiling sorbet/rbi/todo.rbi, this may take a few seconds... Done
+          Finding all unresolved constants, this may take a few seconds... Done
+
+                create  sorbet/rbi/todo.rbi
+
           All unresolved constants have been written to sorbet/rbi/todo.rbi.
           Please review changes and commit them.
         CONTENTS
@@ -98,7 +104,7 @@ module Tapioca
         output = execute("todo")
 
         assert_equal(<<~OUTPUT, output)
-          Compiling sorbet/rbi/todo.rbi, this may take a few seconds... Nothing to do
+          Finding all unresolved constants, this may take a few seconds... Nothing to do
         OUTPUT
 
         refute_path_exists(repo_path / "sorbet/rbi/todo.rbi")


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
We were currently using two different approaches to writing files in generators. `File.write` and `Thor::Action.create_file`. We want to unify this to be consistent for all generators.

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
Make a `create_file` method in the `Base` generator, and update references/tests for the updated line output.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->
See automated tests (minor changes).
