### PR TITLE
Fix test running with sigs

### DIFF
--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -7,6 +7,8 @@ require "shellwords"
 
 module Tapioca
   class CliSpec < Minitest::HooksSpec
+    extend T::Sig
+
     attr_reader :outdir
     attr_reader :repo_path
 


### PR DESCRIPTION
### Motivation

Fix tests when running a specific file:

```
spec/cli_spec.rb:13:in `<class:CliSpec>': undefined method `sig' for Tapioca::CliSpec:Class (NoMethodError)
```