### PR TITLE
Check test RBI files for well-formedness

### DIFF
--- a/lib/tapioca/compilers/sorbet.rb
+++ b/lib/tapioca/compilers/sorbet.rb
@@ -23,16 +23,14 @@ module Tapioca
       class << self
         extend(T::Sig)
 
-        sig { params(args: String).returns(String) }
-        def run(*args)
-          IO.popen(
-            [
-              sorbet_path,
-              "--quiet",
-              *args,
-            ].join(" "),
-            err: "/dev/null"
-          ).read
+        sig { params(args: String, quiet: T::Boolean).returns(String) }
+        def run(*args, quiet: true)
+          cmd = [sorbet_path]
+          cmd << "--quiet" if quiet
+          cmd |= args
+
+          File.write("foo.rb", cmd.to_s)
+          IO.popen(cmd, err: quiet ? "/dev/null" : [:child, :out], &:read)
         end
 
         sig { returns(String) }

--- a/spec/dsl_spec.rb
+++ b/spec/dsl_spec.rb
@@ -91,6 +91,23 @@ class DslSpec < Minitest::Spec
     file.root.nest_non_public_methods!
     file.root.group_nodes!
     file.root.sort_nodes!
-    file.string
+    file.string.tap do |str|
+      output = Tapioca::Compilers::Sorbet.run(
+        "--no-config",
+        "--stop-after",
+        "parser",
+        "-e",
+        str,
+        quiet: false
+      )
+
+      assert($?.success?, <<~MSG) # rubocop:disable Style/SpecialGlobalVars
+        Expected generated RBI file for `#{constant_name}` with no parsing errors.
+
+        Got these parsing errors:
+
+        #{indented(output, 2)}
+      MSG
+    end
   end
 end


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
[@ryanwilsonperkin caught a problem with the RBI output in Active Record relations generator](https://github.com/Shopify/tapioca/pull/236#discussion_r724279237), which reminded me that we should be checking RBI files for well-formedness automatically in every test.

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->

After every RBI file is generated as a string, we pass it through Sorbet and just check the error-code. If there is an error, we show the Sorbet output which should help figure out the problem.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->

No automated test cases.