### PR TITLE
Update `Tapioca::Error` class

### DIFF
--- a/lib/tapioca.rb
+++ b/lib/tapioca.rb
@@ -13,8 +13,6 @@ module Tapioca
   ensure
     $VERBOSE = original_verbosity
   end
-
-  class Error < StandardError; end
 end
 
 require "tapioca/reflection"

--- a/lib/tapioca/error.rb
+++ b/lib/tapioca/error.rb
@@ -1,0 +1,59 @@
+# typed: strict
+# frozen_string_literal: true
+
+module Tapioca
+  class Error < StandardError
+    extend T::Sig
+
+    sig { returns(T.nilable(Class)) }
+    attr_reader :generator
+
+    sig { returns(T.nilable(String)) }
+    attr_reader :help_message
+
+    sig do
+      params(
+        msg: String,
+        generator: Class,
+        help_message: T.nilable(String),
+      ).void
+    end
+    def initialize(msg, generator, help_message = nil)
+      @generator = generator
+      @help_message = help_message
+
+      super(msg)
+    end
+
+    sig { returns(T.nilable(String)) }
+    def exception_location
+      "#{file_path}:#{line_number}"
+    end
+
+    sig { params(with_backtrace: T::Boolean).returns(String) }
+    def formatted_message(with_backtrace: false)
+      output = String.new("#{exception_location}: #{generator}\n")
+      output << "  #{help_message}\n" unless help_message.nil?
+      output << "  #{T.must(backtrace).join("\n  ")}\n" if with_backtrace
+      output
+    end
+
+    private
+
+    sig { returns(T::Array[String]) }
+    def file_info
+      full_message.split(":").take(2)
+    end
+
+    sig { returns(String) }
+    def line_number
+      T.must(file_info.last)
+    end
+
+    sig { returns(String) }
+    def file_path
+      file = T.must(file_info.first)
+      Pathname.new(file).to_s
+    end
+  end
+end

--- a/spec/tapioca/error_spec.rb
+++ b/spec/tapioca/error_spec.rb
@@ -1,0 +1,133 @@
+# typed: true
+# frozen_string_literal: true
+
+require "spec_helper"
+require "tapioca/error"
+
+module Tapioca
+  class WithoutHelp < Tapioca::Generators::Base
+    sig { override.void }
+    def generate
+      raise Tapioca::Error.new("stubbed", self.class)
+    end
+  end
+
+  class WithHelp < Tapioca::Generators::Base
+    sig { override.void }
+    def generate
+      raise Tapioca::Error.new("stubbed", self.class, "describe solution")
+    end
+  end
+
+  class ErrorSpec < ::Minitest::Spec
+    describe(:exception) do
+      describe(:without_help) do
+        before(:each) do
+          @generator_klass = Tapioca::WithoutHelp.new(default_command: "bin/tapioca dsl")
+        end
+
+        it "contains the correct message" do
+          error = assert_raises(Tapioca::Error) do
+            @generator_klass.generate
+          end
+          assert_equal(error.message, "stubbed")
+        end
+
+        it "contains the correct generator" do
+          error = assert_raises(Tapioca::Error) do
+            @generator_klass.generate
+          end
+          assert_equal(error.generator, Tapioca::WithoutHelp)
+        end
+
+        it "contains the correct exception_location" do
+          error = assert_raises(Tapioca::Error) do
+            @generator_klass.generate
+          end
+          assert_equal(error.exception_location, "#{__FILE__}:11")
+        end
+
+        it "does not contain a help_message" do
+          error = assert_raises(Tapioca::Error) do
+            @generator_klass.generate
+          end
+          assert_nil(error.help_message)
+        end
+
+        it "contains the correct formatted_message without a backtrace" do
+          error = assert_raises(Tapioca::Error) do
+            @generator_klass.generate
+          end
+          assert_equal(error.formatted_message, <<~MSG)
+            #{__FILE__}:11: Tapioca::WithoutHelp
+          MSG
+        end
+
+        it "contains the correct formatted_message with a backtrace" do
+          error = assert_raises(Tapioca::Error) do
+            @generator_klass.generate
+          end
+          # TODO: This is testing with a backtrace, determine a cleaner way of dealing with this.
+          assert_includes(error.formatted_message(with_backtrace: true), <<~MSG)
+            #{__FILE__}:11: Tapioca::WithoutHelp
+          MSG
+        end
+      end
+
+      describe(:with_help) do
+        before(:each) do
+          @generator_klass = Tapioca::WithHelp.new(default_command: "bin/tapioca dsl")
+        end
+
+        it "contains the correct message" do
+          error = assert_raises(Tapioca::Error) do
+            @generator_klass.generate
+          end
+          assert_equal(error.message, "stubbed")
+        end
+
+        it "contains the correct generator" do
+          error = assert_raises(Tapioca::Error) do
+            @generator_klass.generate
+          end
+          assert_equal(error.generator, Tapioca::WithHelp)
+        end
+
+        it "contains the correct exception_location" do
+          error = assert_raises(Tapioca::Error) do
+            @generator_klass.generate
+          end
+          assert_equal(error.exception_location, "#{__FILE__}:18")
+        end
+
+        it "contains the correct help_message" do
+          error = assert_raises(Tapioca::Error) do
+            @generator_klass.generate
+          end
+          assert_equal(error.help_message, "describe solution")
+        end
+
+        it "contains the correct formatted_message without a backtrace" do
+          error = assert_raises(Tapioca::Error) do
+            @generator_klass.generate
+          end
+          assert_equal(error.formatted_message, <<~MSG)
+            #{__FILE__}:18: Tapioca::WithHelp
+              describe solution
+          MSG
+        end
+
+        it "contains the correct formatted_message with a backtrace" do
+          error = assert_raises(Tapioca::Error) do
+            @generator_klass.generate
+          end
+          # TODO: This is testing with a backtrace, determine a cleaner way of dealing with this.
+          assert_includes(error.formatted_message(with_backtrace: true), <<~MSG)
+            #{__FILE__}:18: Tapioca::WithHelp
+              describe solution
+          MSG
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
As part of #536 and #238, we want to update the error messaging for DSL compilation in `tapioca`. This introduces an updated `Tapioca::Error` class which includes additional fields for `generator` (the Generator which errored out) as well as `help_message` guiding messaging we can provide tips in when we know what likely went wrong.

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
Moved `Tapioca::Error` from `lib/tapioca.rb` to it's own file, `lib/tapioca/error.rb`. Extended the `initializer` method to accept additional fields, `generator` and `help_message`. Added some helper methods for formatting better output (still some more work could be done here, but this is a decent starting point).

I envision this will be used as a general case for `tapioca` related error messaging. I figure that DSL compilers could subclass this class for narrower, more scoped, errors in their respective classes to keep the errors close to the code.

**Considerations**:
* I'm on the fence whether we should define `help_messages` at runtime, or have them predefined for subclasses of `Tapioca::Error`
  * Runtime provides more flexibility, while predefined may have to be more general depending where it occurs
  * Keeping it predefined does have the benefit of maintaining a straightforward `StandardError` API which may be nice
* The `formatted_message` output is still _semi_-WIP right now. There's room for improvement, however, without definitive use cases it's harder to estimate. 

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->
See automated tests.
