### PR TITLE
The `doc` option should not have a default value

### DIFF
--- a/lib/tapioca/cli.rb
+++ b/lib/tapioca/cli.rb
@@ -129,7 +129,6 @@ module Tapioca
       desc: "Verifies RBIs are up-to-date"
     option :doc,
       type: :boolean,
-      default: false,
       desc: "Include YARD documentation from sources when generating RBIs. Warning: this might be slow"
     def gem(*gems)
       Tapioca.silence_warnings do


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->

The actual base default value of our flags is set in the `ConfigBuilder` class. Any value passed to the command line flags (even if it is a default value) will override all the values in the default and in the config.

The upshot is that, since we had the default value of `false` for the `doc` option, a `doc: true` addition to the config file had no effect since the `false` coming from options would always override the config one.

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->

Remove the default value.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->

No tests.
