### PR TITLE
Stop parallelizing DSL generation

### DIFF
--- a/lib/tapioca/cli.rb
+++ b/lib/tapioca/cli.rb
@@ -79,11 +79,6 @@ module Tapioca
       aliases: ["-q"],
       type: :boolean,
       desc: "Supresses file creation output"
-    option :workers,
-      aliases: ["-w"],
-      type: :numeric,
-      default: nil,
-      desc: "Number of parallel workers to use when generating RBIs"
     def dsl(*constants)
       current_command = T.must(current_command_chain.first)
       config = ConfigBuilder.from_options(current_command, options)
@@ -98,8 +93,7 @@ module Tapioca
         default_command: Config::DEFAULT_COMMAND,
         should_verify: options[:verify],
         quiet: options[:quiet],
-        verbose: options[:verbose],
-        number_of_workers: config.workers
+        verbose: options[:verbose]
       )
       Tapioca.silence_warnings do
         generator.generate

--- a/lib/tapioca/compilers/dsl_compiler.rb
+++ b/lib/tapioca/compilers/dsl_compiler.rb
@@ -22,24 +22,16 @@ module Tapioca
           requested_constants: T::Array[Module],
           requested_generators: T::Array[T.class_of(Dsl::Base)],
           excluded_generators: T::Array[T.class_of(Dsl::Base)],
-          error_handler: T.nilable(T.proc.params(error: String).void),
-          number_of_workers: T.nilable(Integer),
+          error_handler: T.nilable(T.proc.params(error: String).void)
         ).void
       end
-      def initialize(
-        requested_constants:,
-        requested_generators: [],
-        excluded_generators: [],
-        error_handler: nil,
-        number_of_workers: nil
-      )
+      def initialize(requested_constants:, requested_generators: [], excluded_generators: [], error_handler: nil)
         @generators = T.let(
           gather_generators(requested_generators, excluded_generators),
           T::Enumerable[Dsl::Base]
         )
         @requested_constants = requested_constants
         @error_handler = T.let(error_handler || $stderr.method(:puts), T.proc.params(error: String).void)
-        @number_of_workers = number_of_workers
       end
 
       sig { params(blk: T.proc.params(constant: Module, rbi: RBI::File).void).void }
@@ -53,10 +45,7 @@ module Tapioca
           ERROR
         end
 
-        Executor.new(
-          constants_to_process.sort_by { |c| c.name.to_s },
-          number_of_workers: @number_of_workers
-        ).run_in_parallel do |constant|
+        constants_to_process.sort_by { |c| c.name.to_s }.each do |constant|
           rbi = rbi_for_constant(constant)
           next if rbi.nil?
 

--- a/lib/tapioca/generators/dsl.rb
+++ b/lib/tapioca/generators/dsl.rb
@@ -17,8 +17,7 @@ module Tapioca
           file_writer: Thor::Actions,
           should_verify: T::Boolean,
           quiet: T::Boolean,
-          verbose: T::Boolean,
-          number_of_workers: T.nilable(Integer),
+          verbose: T::Boolean
         ).void
       end
       def initialize(
@@ -33,8 +32,7 @@ module Tapioca
         file_writer: FileWriter.new,
         should_verify: false,
         quiet: false,
-        verbose: false,
-        number_of_workers: nil
+        verbose: false
       )
         @requested_constants = requested_constants
         @outpath = outpath
@@ -46,7 +44,6 @@ module Tapioca
         @should_verify = should_verify
         @quiet = quiet
         @verbose = verbose
-        @number_of_workers = number_of_workers
 
         super(default_command: default_command, file_writer: file_writer)
 
@@ -76,8 +73,7 @@ module Tapioca
           excluded_generators: constantize_generators(@exclude_generators),
           error_handler: ->(error) {
             say_error(error, :bold, :red)
-          },
-          number_of_workers: @number_of_workers
+          }
         )
 
         compiler.run do |constant, contents|

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -22,7 +22,7 @@ module Tapioca
       ]
 
       exec_command << "--outdir #{outdir}" unless use_default_outdir
-      exec_command << "--workers=#{number_of_workers}" if command.start_with?("dsl") || command.start_with?("gem")
+      exec_command << "--workers=#{number_of_workers}" if command.start_with?("gem")
 
       Bundler.with_unbundled_env do
         process = IO.popen(

--- a/spec/tapioca/cli/dsl_spec.rb
+++ b/spec/tapioca/cli/dsl_spec.rb
@@ -302,16 +302,6 @@ module Tapioca
         refute_path_exists("#{outdir}/user.rbi")
       end
 
-      it "generates the correct RBIs when running in parallel" do
-        tapioca("dsl", number_of_workers: 3)
-
-        assert_path_exists("#{outdir}/baz/role.rbi")
-        assert_path_exists("#{outdir}/job.rbi")
-        assert_path_exists("#{outdir}/post.rbi")
-        assert_path_exists("#{outdir}/namespace/comment.rbi")
-        refute_path_exists("#{outdir}/user.rbi")
-      end
-
       it "generates RBI files without header" do
         tapioca("dsl --no-file-header Post")
 


### PR DESCRIPTION
Closes #572 

### Motivation

We use a local variable to track which DSL RBI files need to be deleted by the end when we finish generating DSLs [here](https://github.com/Shopify/tapioca/blob/2a6982e91a9efc4f39dd2db17726905d7247f2bc/lib/tapioca/generators/dsl.rb#L98).

Because the entire block runs in a forked process after #458, each process gets a different copy of the local and mutates it, but that cannot be easily synced between all workers. This results in accidentally removing generated files.

### Implementation

Just removed the parallelization and went back to the original implementation.

We will need an alternative way of removing stale DSL RBIs in order to parallelize generation.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->

Just reverting the functionality back.