### PR TITLE
Add an extension of PrivateRelation for "where chain"

### DIFF
--- a/lib/tapioca/compilers/dsl/active_record_relations.rb
+++ b/lib/tapioca/compilers/dsl/active_record_relations.rb
@@ -465,13 +465,6 @@ module Tapioca
           def create_relation_methods
             create_relation_method("all")
             create_relation_method(
-              "not",
-              parameters: [
-                create_param("opts", type: "T.untyped"),
-                create_rest_param("rest", type: "T.untyped"),
-              ]
-            )
-            create_relation_method(
               "where",
               parameters: [
                 create_rest_param("args", type: "T.untyped"),

--- a/lib/tapioca/compilers/dsl/active_record_relations.rb
+++ b/lib/tapioca/compilers/dsl/active_record_relations.rb
@@ -297,6 +297,15 @@ module Tapioca
           def create_relation_where_chain_methods(klass)
             WHERE_CHAIN_QUERY_METHODS.each do |method_name|
               case method_name
+              when :not
+                klass.create_method(
+                  method_name.to_s,
+                  parameters: [
+                    create_param("opts", type: "T.untyped"),
+                    create_rest_param("rest", type: "T.untyped"),
+                  ],
+                  return_type: RelationClassName
+                )
               when :missing
                 klass.create_method(
                   method_name.to_s,
@@ -337,6 +346,15 @@ module Tapioca
           def create_association_relation_where_chain_methods(klass)
             WHERE_CHAIN_QUERY_METHODS.each do |method_name|
               case method_name
+              when :not
+                klass.create_method(
+                  method_name.to_s,
+                  parameters: [
+                    create_param("opts", type: "T.untyped"),
+                    create_rest_param("rest", type: "T.untyped"),
+                  ],
+                  return_type: AssociationRelationClassName
+                )
               when :missing
                 klass.create_method(
                   method_name.to_s,

--- a/lib/tapioca/compilers/dsl/active_record_relations.rb
+++ b/lib/tapioca/compilers/dsl/active_record_relations.rb
@@ -228,7 +228,7 @@ module Tapioca
               .grep_v(/=$/) # end with "=""
               .grep_v(/(?<!uniq)!$/) # end with "!" except for "uniq!"
           end, T::Array[Symbol])
-          QUERY_WHERE_CHAIN_METHODS = T.let(
+          WHERE_CHAIN_QUERY_METHODS = T.let(
             ActiveRecord::QueryMethods::WhereChain.instance_methods(false),
             T::Array[Symbol]
           )
@@ -295,7 +295,7 @@ module Tapioca
 
           sig { params(klass: RBI::Scope).void }
           def create_relation_where_chain_methods(klass)
-            QUERY_WHERE_CHAIN_METHODS.each do |method_name|
+            WHERE_CHAIN_QUERY_METHODS.each do |method_name|
               case method_name
               when :missing
                 klass.create_method(
@@ -335,7 +335,7 @@ module Tapioca
 
           sig { params(klass: RBI::Scope).void }
           def create_association_relation_where_chain_methods(klass)
-            QUERY_WHERE_CHAIN_METHODS.each do |method_name|
+            WHERE_CHAIN_QUERY_METHODS.each do |method_name|
               case method_name
               when :missing
                 klass.create_method(

--- a/lib/tapioca/compilers/dsl/helper/active_record_constants.rb
+++ b/lib/tapioca/compilers/dsl/helper/active_record_constants.rb
@@ -16,6 +16,7 @@ module Tapioca
           CommonRelationMethodsModuleName = T.let("CommonRelationMethods", String)
 
           RelationClassName = T.let("PrivateRelation", String)
+          RelationWhereChainClassName = T.let("PrivateWhereChainRelation", String)
           AssociationRelationClassName = T.let("PrivateAssociationRelation", String)
           AssociationsCollectionProxyClassName = T.let("PrivateCollectionProxy", String)
         end

--- a/lib/tapioca/compilers/dsl/helper/active_record_constants.rb
+++ b/lib/tapioca/compilers/dsl/helper/active_record_constants.rb
@@ -18,6 +18,7 @@ module Tapioca
           RelationClassName = T.let("PrivateRelation", String)
           RelationWhereChainClassName = T.let("PrivateWhereChainRelation", String)
           AssociationRelationClassName = T.let("PrivateAssociationRelation", String)
+          AssociationRelationWhereChainClassName = T.let("PrivateAssociationWhereChainRelation", String)
           AssociationsCollectionProxyClassName = T.let("PrivateCollectionProxy", String)
         end
       end

--- a/lib/tapioca/compilers/dsl/helper/active_record_constants.rb
+++ b/lib/tapioca/compilers/dsl/helper/active_record_constants.rb
@@ -16,9 +16,9 @@ module Tapioca
           CommonRelationMethodsModuleName = T.let("CommonRelationMethods", String)
 
           RelationClassName = T.let("PrivateRelation", String)
-          RelationWhereChainClassName = T.let("PrivateWhereChainRelation", String)
+          RelationWhereChainClassName = T.let("PrivateRelationWhereChain", String)
           AssociationRelationClassName = T.let("PrivateAssociationRelation", String)
-          AssociationRelationWhereChainClassName = T.let("PrivateAssociationWhereChainRelation", String)
+          AssociationRelationWhereChainClassName = T.let("PrivateAssociationRelationWhereChain", String)
           AssociationsCollectionProxyClassName = T.let("PrivateCollectionProxy", String)
         end
       end

--- a/spec/tapioca/compilers/dsl/active_record_relations_spec.rb
+++ b/spec/tapioca/compilers/dsl/active_record_relations_spec.rb
@@ -326,7 +326,7 @@ class Tapioca::Compilers::Dsl::ActiveRecordRelationsSpec < DslSpec
             sig { params(attributes: T::Array[Hash], returning: T.nilable(T.any(T::Array[Symbol], FalseClass)), unique_by: T.nilable(T.any(T::Array[Symbol], Symbol))).returns(ActiveRecord::Result) }
             def upsert_all(attributes, returning: nil, unique_by: nil); end
 
-            sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
+            sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationWhereChainRelation) }
             def where(*args, &blk); end
           end
 
@@ -454,6 +454,11 @@ class Tapioca::Compilers::Dsl::ActiveRecordRelationsSpec < DslSpec
             def to_ary; end
 
             Elem = type_member(fixed: ::Post)
+          end
+
+          class PrivateAssociationWhereChainRelation < PrivateAssociationRelation
+            sig { params(args: T.untyped).returns(PrivateAssociationRelation) }
+            def missing(*args); end
           end
 
           class PrivateCollectionProxy < ::ActiveRecord::Associations::CollectionProxy

--- a/spec/tapioca/compilers/dsl/active_record_relations_spec.rb
+++ b/spec/tapioca/compilers/dsl/active_record_relations_spec.rb
@@ -326,7 +326,7 @@ class Tapioca::Compilers::Dsl::ActiveRecordRelationsSpec < DslSpec
             sig { params(attributes: T::Array[Hash], returning: T.nilable(T.any(T::Array[Symbol], FalseClass)), unique_by: T.nilable(T.any(T::Array[Symbol], Symbol))).returns(ActiveRecord::Result) }
             def upsert_all(attributes, returning: nil, unique_by: nil); end
 
-            sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationWhereChainRelation) }
+            sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelationWhereChain) }
             def where(*args, &blk); end
           end
 
@@ -442,7 +442,7 @@ class Tapioca::Compilers::Dsl::ActiveRecordRelationsSpec < DslSpec
             sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
             def unscope(*args, &blk); end
 
-            sig { params(args: T.untyped, blk: T.untyped).returns(PrivateWhereChainRelation) }
+            sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelationWhereChain) }
             def where(*args, &blk); end
           end
 
@@ -456,7 +456,7 @@ class Tapioca::Compilers::Dsl::ActiveRecordRelationsSpec < DslSpec
             Elem = type_member(fixed: ::Post)
           end
 
-          class PrivateAssociationWhereChainRelation < PrivateAssociationRelation
+          class PrivateAssociationRelationWhereChain < PrivateAssociationRelation
             sig { params(args: T.untyped).returns(PrivateAssociationRelation) }
             def missing(*args); end
           end
@@ -517,7 +517,7 @@ class Tapioca::Compilers::Dsl::ActiveRecordRelationsSpec < DslSpec
             Elem = type_member(fixed: ::Post)
           end
 
-          class PrivateWhereChainRelation < PrivateRelation
+          class PrivateRelationWhereChain < PrivateRelation
             sig { params(args: T.untyped).returns(PrivateRelation) }
             def missing(*args); end
           end

--- a/spec/tapioca/compilers/dsl/active_record_relations_spec.rb
+++ b/spec/tapioca/compilers/dsl/active_record_relations_spec.rb
@@ -511,6 +511,11 @@ class Tapioca::Compilers::Dsl::ActiveRecordRelationsSpec < DslSpec
 
             Elem = type_member(fixed: ::Post)
           end
+
+          class PrivateWhereChainRelation < PrivateRelation
+            sig { params(args: T.untyped).returns(PrivateRelation) }
+            def missing(*args); end
+          end
         end
       RUBY
 

--- a/spec/tapioca/compilers/dsl/active_record_relations_spec.rb
+++ b/spec/tapioca/compilers/dsl/active_record_relations_spec.rb
@@ -269,9 +269,6 @@ class Tapioca::Compilers::Dsl::ActiveRecordRelationsSpec < DslSpec
             sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
             def none(*args, &blk); end
 
-            sig { params(opts: T.untyped, rest: T.untyped).returns(PrivateAssociationRelation) }
-            def not(opts, *rest); end
-
             sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
             def offset(*args, &blk); end
 
@@ -390,9 +387,6 @@ class Tapioca::Compilers::Dsl::ActiveRecordRelationsSpec < DslSpec
 
             sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
             def none(*args, &blk); end
-
-            sig { params(opts: T.untyped, rest: T.untyped).returns(PrivateRelation) }
-            def not(opts, *rest); end
 
             sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
             def offset(*args, &blk); end

--- a/spec/tapioca/compilers/dsl/active_record_relations_spec.rb
+++ b/spec/tapioca/compilers/dsl/active_record_relations_spec.rb
@@ -442,7 +442,7 @@ class Tapioca::Compilers::Dsl::ActiveRecordRelationsSpec < DslSpec
             sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
             def unscope(*args, &blk); end
 
-            sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
+            sig { params(args: T.untyped, blk: T.untyped).returns(PrivateWhereChainRelation) }
             def where(*args, &blk); end
           end
 

--- a/spec/tapioca/compilers/dsl/active_record_relations_spec.rb
+++ b/spec/tapioca/compilers/dsl/active_record_relations_spec.rb
@@ -459,6 +459,9 @@ class Tapioca::Compilers::Dsl::ActiveRecordRelationsSpec < DslSpec
           class PrivateAssociationRelationWhereChain < PrivateAssociationRelation
             sig { params(args: T.untyped).returns(PrivateAssociationRelation) }
             def missing(*args); end
+
+            sig { params(opts: T.untyped, rest: T.untyped).returns(PrivateAssociationRelation) }
+            def not(opts, *rest); end
           end
 
           class PrivateCollectionProxy < ::ActiveRecord::Associations::CollectionProxy
@@ -520,6 +523,9 @@ class Tapioca::Compilers::Dsl::ActiveRecordRelationsSpec < DslSpec
           class PrivateRelationWhereChain < PrivateRelation
             sig { params(args: T.untyped).returns(PrivateRelation) }
             def missing(*args); end
+
+            sig { params(opts: T.untyped, rest: T.untyped).returns(PrivateRelation) }
+            def not(opts, *rest); end
           end
         end
       RUBY


### PR DESCRIPTION

### Motivation
Fixes #574 

Rails 6.1 introduced an API for `Post.where.missing(:author)` that can
be used as syntactic sugar on top of joining and checking the associated
id is nil.

This leverages the existing QueryMethods::WhereChain class which we
haven't previously used in Tapioca.

WhereChain should be returned from `#where` and should give the ability
to do where.missing, where.not (and soon, where.associated). The result
should give back a plain PrivateRelation because
where.missing().missing() is invalid.

### Implementation
Introduced a new subclass of both `PrivateRelation` and `PrivateAssociationRelation` which appends a "WhereChain" suffix and implements `not` and `missing`, and adds the ability to pick up `associated` automatically once we update to the version of Rails that it is released in.

### Tests
Tested!

