### PR TITLE
Add error message for missing `ActiveRecordAssociations`

### DIFF
--- a/spec/tapioca/compilers/dsl/active_record_associations_spec.rb
+++ b/spec/tapioca/compilers/dsl/active_record_associations_spec.rb
@@ -43,10 +43,6 @@ class Tapioca::Compilers::Dsl::ActiveRecordAssociationsSpec < DslSpec
   end
 
   describe("#decorate") do
-    after(:each) do
-      T.unsafe(self).assert_no_generated_errors
-    end
-
     before(:each) do
       require "active_record"
 
@@ -56,352 +52,433 @@ class Tapioca::Compilers::Dsl::ActiveRecordAssociationsSpec < DslSpec
       )
     end
 
-    it("generates empty RBI file if there are no associations") do
-      add_ruby_file("post.rb", <<~RUBY)
-        class Post < ActiveRecord::Base
-        end
-      RUBY
+    describe("without errors") do
+      after(:each) do
+        T.unsafe(self).assert_no_generated_errors
+      end
 
-      expected = <<~RBI
-        # typed: strong
-      RBI
+      it("generates empty RBI file if there are no associations") do
+        add_ruby_file("post.rb", <<~RUBY)
+          class Post < ActiveRecord::Base
+          end
+        RUBY
 
-      assert_equal(expected, rbi_for(:Post))
-    end
+        expected = <<~RBI
+          # typed: strong
+        RBI
 
-    it("generates RBI file for belongs_to single association") do
-      add_ruby_file("schema.rb", <<~RUBY)
-        ActiveRecord::Migration.suppress_messages do
-          ActiveRecord::Schema.define do
-            create_table :posts do |t|
-              t.references(:category, null: true)
-              t.references(:author, null: false)
+        assert_equal(expected, rbi_for(:Post))
+      end
+
+      it("generates RBI file for belongs_to single association") do
+        add_ruby_file("schema.rb", <<~RUBY)
+          ActiveRecord::Migration.suppress_messages do
+            ActiveRecord::Schema.define do
+              create_table :posts do |t|
+                t.references(:category, null: true)
+                t.references(:author, null: false)
+              end
             end
           end
-        end
-      RUBY
+        RUBY
 
-      add_ruby_file("category.rb", <<~RUBY)
-        class Category < ActiveRecord::Base
-        end
-      RUBY
-
-      add_ruby_file("user.rb", <<~RUBY)
-        class User < ActiveRecord::Base
-        end
-      RUBY
-
-      add_ruby_file("post.rb", <<~RUBY)
-        class Post < ActiveRecord::Base
-          belongs_to :category
-          belongs_to :author, class_name: "User"
-
-          accepts_nested_attributes_for :category, :author
-        end
-      RUBY
-
-      expected = <<~RBI
-        # typed: strong
-
-        class Post
-          include GeneratedAssociationMethods
-
-          module GeneratedAssociationMethods
-            sig { returns(T.nilable(::User)) }
-            def author; end
-
-            sig { params(value: T.nilable(::User)).void }
-            def author=(value); end
-
-            sig { params(attributes: T.untyped).returns(T.untyped) }
-            def author_attributes=(attributes); end
-
-            sig { params(args: T.untyped, blk: T.untyped).returns(::User) }
-            def build_author(*args, &blk); end
-
-            sig { params(args: T.untyped, blk: T.untyped).returns(::Category) }
-            def build_category(*args, &blk); end
-
-            sig { returns(T.nilable(::Category)) }
-            def category; end
-
-            sig { params(value: T.nilable(::Category)).void }
-            def category=(value); end
-
-            sig { params(attributes: T.untyped).returns(T.untyped) }
-            def category_attributes=(attributes); end
-
-            sig { params(args: T.untyped, blk: T.untyped).returns(::User) }
-            def create_author(*args, &blk); end
-
-            sig { params(args: T.untyped, blk: T.untyped).returns(::User) }
-            def create_author!(*args, &blk); end
-
-            sig { params(args: T.untyped, blk: T.untyped).returns(::Category) }
-            def create_category(*args, &blk); end
-
-            sig { params(args: T.untyped, blk: T.untyped).returns(::Category) }
-            def create_category!(*args, &blk); end
-
-            sig { returns(T.nilable(::User)) }
-            def reload_author; end
-
-            sig { returns(T.nilable(::Category)) }
-            def reload_category; end
+        add_ruby_file("category.rb", <<~RUBY)
+          class Category < ActiveRecord::Base
           end
-        end
-      RBI
+        RUBY
 
-      assert_equal(expected, rbi_for(:Post))
-    end
-
-    it("generates RBI file for polymorphic belongs_to single association") do
-      add_ruby_file("post.rb", <<~RUBY)
-        class Post < ActiveRecord::Base
-          belongs_to :category, polymorphic: true
-
-          accepts_nested_attributes_for :category
-        end
-      RUBY
-
-      expected = <<~RBI
-        # typed: strong
-
-        class Post
-          include GeneratedAssociationMethods
-
-          module GeneratedAssociationMethods
-            sig { returns(T.nilable(T.untyped)) }
-            def category; end
-
-            sig { params(value: T.nilable(T.untyped)).void }
-            def category=(value); end
-
-            sig { params(attributes: T.untyped).returns(T.untyped) }
-            def category_attributes=(attributes); end
-
-            sig { returns(T.nilable(T.untyped)) }
-            def reload_category; end
+        add_ruby_file("user.rb", <<~RUBY)
+          class User < ActiveRecord::Base
           end
-        end
-      RBI
+        RUBY
 
-      assert_equal(expected, rbi_for(:Post))
-    end
+        add_ruby_file("post.rb", <<~RUBY)
+          class Post < ActiveRecord::Base
+            belongs_to :category
+            belongs_to :author, class_name: "User"
 
-    it("generates RBI file for has_one single association") do
-      add_ruby_file("schema.rb", <<~RUBY)
-        ActiveRecord::Migration.suppress_messages do
-          ActiveRecord::Schema.define do
-            create_table :posts do |t|
+            accepts_nested_attributes_for :category, :author
+          end
+        RUBY
+
+        expected = <<~RBI
+          # typed: strong
+
+          class Post
+            include GeneratedAssociationMethods
+
+            module GeneratedAssociationMethods
+              sig { returns(T.nilable(::User)) }
+              def author; end
+
+              sig { params(value: T.nilable(::User)).void }
+              def author=(value); end
+
+              sig { params(attributes: T.untyped).returns(T.untyped) }
+              def author_attributes=(attributes); end
+
+              sig { params(args: T.untyped, blk: T.untyped).returns(::User) }
+              def build_author(*args, &blk); end
+
+              sig { params(args: T.untyped, blk: T.untyped).returns(::Category) }
+              def build_category(*args, &blk); end
+
+              sig { returns(T.nilable(::Category)) }
+              def category; end
+
+              sig { params(value: T.nilable(::Category)).void }
+              def category=(value); end
+
+              sig { params(attributes: T.untyped).returns(T.untyped) }
+              def category_attributes=(attributes); end
+
+              sig { params(args: T.untyped, blk: T.untyped).returns(::User) }
+              def create_author(*args, &blk); end
+
+              sig { params(args: T.untyped, blk: T.untyped).returns(::User) }
+              def create_author!(*args, &blk); end
+
+              sig { params(args: T.untyped, blk: T.untyped).returns(::Category) }
+              def create_category(*args, &blk); end
+
+              sig { params(args: T.untyped, blk: T.untyped).returns(::Category) }
+              def create_category!(*args, &blk); end
+
+              sig { returns(T.nilable(::User)) }
+              def reload_author; end
+
+              sig { returns(T.nilable(::Category)) }
+              def reload_category; end
             end
           end
-        end
-      RUBY
+        RBI
 
-      add_ruby_file("user.rb", <<~RUBY)
-        class User
-        end
-      RUBY
+        assert_equal(expected, rbi_for(:Post))
+      end
 
-      add_ruby_file("post.rb", <<~RUBY)
-        class Post < ActiveRecord::Base
-          has_one :author, class_name: "User"
+      it("generates RBI file for polymorphic belongs_to single association") do
+        add_ruby_file("post.rb", <<~RUBY)
+          class Post < ActiveRecord::Base
+            belongs_to :category, polymorphic: true
 
-          accepts_nested_attributes_for :author
-        end
-      RUBY
-
-      expected = <<~RBI
-        # typed: strong
-
-        class Post
-          include GeneratedAssociationMethods
-
-          module GeneratedAssociationMethods
-            sig { returns(T.nilable(::User)) }
-            def author; end
-
-            sig { params(value: T.nilable(::User)).void }
-            def author=(value); end
-
-            sig { params(attributes: T.untyped).returns(T.untyped) }
-            def author_attributes=(attributes); end
-
-            sig { params(args: T.untyped, blk: T.untyped).returns(::User) }
-            def build_author(*args, &blk); end
-
-            sig { params(args: T.untyped, blk: T.untyped).returns(::User) }
-            def create_author(*args, &blk); end
-
-            sig { params(args: T.untyped, blk: T.untyped).returns(::User) }
-            def create_author!(*args, &blk); end
-
-            sig { returns(T.nilable(::User)) }
-            def reload_author; end
+            accepts_nested_attributes_for :category
           end
-        end
-      RBI
+        RUBY
 
-      assert_equal(expected, rbi_for(:Post))
-    end
+        expected = <<~RBI
+          # typed: strong
 
-    it("generates RBI file for has_many collection association") do
-      add_ruby_file("comment.rb", <<~RUBY)
-        class Comment
-        end
-      RUBY
+          class Post
+            include GeneratedAssociationMethods
 
-      add_ruby_file("post.rb", <<~RUBY)
-        class Post < ActiveRecord::Base
-          has_many :comments
+            module GeneratedAssociationMethods
+              sig { returns(T.nilable(T.untyped)) }
+              def category; end
 
-          accepts_nested_attributes_for :comments
-        end
-      RUBY
+              sig { params(value: T.nilable(T.untyped)).void }
+              def category=(value); end
 
-      expected = <<~RBI
-        # typed: strong
+              sig { params(attributes: T.untyped).returns(T.untyped) }
+              def category_attributes=(attributes); end
 
-        class Post
-          include GeneratedAssociationMethods
-
-          module GeneratedAssociationMethods
-            sig { returns(T::Array[T.untyped]) }
-            def comment_ids; end
-
-            sig { params(ids: T::Array[T.untyped]).returns(T::Array[T.untyped]) }
-            def comment_ids=(ids); end
-
-            sig { returns(::Comment::PrivateCollectionProxy) }
-            def comments; end
-
-            sig { params(value: T::Enumerable[T.untyped]).void }
-            def comments=(value); end
-
-            sig { params(attributes: T.untyped).returns(T.untyped) }
-            def comments_attributes=(attributes); end
-          end
-        end
-      RBI
-
-      assert_equal(expected, rbi_for(:Post))
-    end
-
-    it("generates RBI file for has_many :through collection association") do
-      add_ruby_file("schema.rb", <<~RUBY)
-        ActiveRecord::Migration.suppress_messages do
-          ActiveRecord::Schema.define do
-            create_table :posts do |t|
+              sig { returns(T.nilable(T.untyped)) }
+              def reload_category; end
             end
           end
-        end
-      RUBY
+        RBI
 
-      add_ruby_file("commenter.rb", <<~RUBY)
-        class Commenter < ActiveRecord::Base
-          has_many :comments
-          has_many :posts, through: :comments
-        end
-      RUBY
+        assert_equal(expected, rbi_for(:Post))
+      end
 
-      add_ruby_file("comment.rb", <<~RUBY)
-        class Comment < ActiveRecord::Base
-          belongs_to :commenter
-          belongs_to :post
-        end
-      RUBY
-
-      add_ruby_file("post.rb", <<~RUBY)
-        class Post < ActiveRecord::Base
-          has_many :comments
-          has_many :commenters, through: :comments
-
-          accepts_nested_attributes_for :commenters
-        end
-      RUBY
-
-      expected = <<~RBI
-        # typed: strong
-
-        class Post
-          include GeneratedAssociationMethods
-
-          module GeneratedAssociationMethods
-            sig { returns(T::Array[T.untyped]) }
-            def comment_ids; end
-
-            sig { params(ids: T::Array[T.untyped]).returns(T::Array[T.untyped]) }
-            def comment_ids=(ids); end
-
-            sig { returns(T::Array[T.untyped]) }
-            def commenter_ids; end
-
-            sig { params(ids: T::Array[T.untyped]).returns(T::Array[T.untyped]) }
-            def commenter_ids=(ids); end
-
-            sig { returns(::Commenter::PrivateCollectionProxy) }
-            def commenters; end
-
-            sig { params(value: T::Enumerable[::Commenter]).void }
-            def commenters=(value); end
-
-            sig { params(attributes: T.untyped).returns(T.untyped) }
-            def commenters_attributes=(attributes); end
-
-            sig { returns(::Comment::PrivateCollectionProxy) }
-            def comments; end
-
-            sig { params(value: T::Enumerable[::Comment]).void }
-            def comments=(value); end
+      it("generates RBI file for has_one single association") do
+        add_ruby_file("schema.rb", <<~RUBY)
+          ActiveRecord::Migration.suppress_messages do
+            ActiveRecord::Schema.define do
+              create_table :posts do |t|
+              end
+            end
           end
-        end
-      RBI
+        RUBY
 
-      assert_equal(expected, rbi_for(:Post))
+        add_ruby_file("user.rb", <<~RUBY)
+          class User
+          end
+        RUBY
+
+        add_ruby_file("post.rb", <<~RUBY)
+          class Post < ActiveRecord::Base
+            has_one :author, class_name: "User"
+
+            accepts_nested_attributes_for :author
+          end
+        RUBY
+
+        expected = <<~RBI
+          # typed: strong
+
+          class Post
+            include GeneratedAssociationMethods
+
+            module GeneratedAssociationMethods
+              sig { returns(T.nilable(::User)) }
+              def author; end
+
+              sig { params(value: T.nilable(::User)).void }
+              def author=(value); end
+
+              sig { params(attributes: T.untyped).returns(T.untyped) }
+              def author_attributes=(attributes); end
+
+              sig { params(args: T.untyped, blk: T.untyped).returns(::User) }
+              def build_author(*args, &blk); end
+
+              sig { params(args: T.untyped, blk: T.untyped).returns(::User) }
+              def create_author(*args, &blk); end
+
+              sig { params(args: T.untyped, blk: T.untyped).returns(::User) }
+              def create_author!(*args, &blk); end
+
+              sig { returns(T.nilable(::User)) }
+              def reload_author; end
+            end
+          end
+        RBI
+
+        assert_equal(expected, rbi_for(:Post))
+      end
+
+      it("generates RBI file for has_many collection association") do
+        add_ruby_file("comment.rb", <<~RUBY)
+          class Comment
+          end
+        RUBY
+
+        add_ruby_file("post.rb", <<~RUBY)
+          class Post < ActiveRecord::Base
+            has_many :comments
+
+            accepts_nested_attributes_for :comments
+          end
+        RUBY
+
+        expected = <<~RBI
+          # typed: strong
+
+          class Post
+            include GeneratedAssociationMethods
+
+            module GeneratedAssociationMethods
+              sig { returns(T::Array[T.untyped]) }
+              def comment_ids; end
+
+              sig { params(ids: T::Array[T.untyped]).returns(T::Array[T.untyped]) }
+              def comment_ids=(ids); end
+
+              sig { returns(::Comment::PrivateCollectionProxy) }
+              def comments; end
+
+              sig { params(value: T::Enumerable[T.untyped]).void }
+              def comments=(value); end
+
+              sig { params(attributes: T.untyped).returns(T.untyped) }
+              def comments_attributes=(attributes); end
+            end
+          end
+        RBI
+
+        assert_equal(expected, rbi_for(:Post))
+      end
+
+      it("generates RBI file for has_many :through collection association") do
+        add_ruby_file("schema.rb", <<~RUBY)
+          ActiveRecord::Migration.suppress_messages do
+            ActiveRecord::Schema.define do
+              create_table :posts do |t|
+              end
+            end
+          end
+        RUBY
+
+        add_ruby_file("commenter.rb", <<~RUBY)
+          class Commenter < ActiveRecord::Base
+            has_many :comments
+            has_many :posts, through: :comments
+          end
+        RUBY
+
+        add_ruby_file("comment.rb", <<~RUBY)
+          class Comment < ActiveRecord::Base
+            belongs_to :commenter
+            belongs_to :post
+          end
+        RUBY
+
+        add_ruby_file("post.rb", <<~RUBY)
+          class Post < ActiveRecord::Base
+            has_many :comments
+            has_many :commenters, through: :comments
+
+            accepts_nested_attributes_for :commenters
+          end
+        RUBY
+
+        expected = <<~RBI
+          # typed: strong
+
+          class Post
+            include GeneratedAssociationMethods
+
+            module GeneratedAssociationMethods
+              sig { returns(T::Array[T.untyped]) }
+              def comment_ids; end
+
+              sig { params(ids: T::Array[T.untyped]).returns(T::Array[T.untyped]) }
+              def comment_ids=(ids); end
+
+              sig { returns(T::Array[T.untyped]) }
+              def commenter_ids; end
+
+              sig { params(ids: T::Array[T.untyped]).returns(T::Array[T.untyped]) }
+              def commenter_ids=(ids); end
+
+              sig { returns(::Commenter::PrivateCollectionProxy) }
+              def commenters; end
+
+              sig { params(value: T::Enumerable[::Commenter]).void }
+              def commenters=(value); end
+
+              sig { params(attributes: T.untyped).returns(T.untyped) }
+              def commenters_attributes=(attributes); end
+
+              sig { returns(::Comment::PrivateCollectionProxy) }
+              def comments; end
+
+              sig { params(value: T::Enumerable[::Comment]).void }
+              def comments=(value); end
+            end
+          end
+        RBI
+
+        assert_equal(expected, rbi_for(:Post))
+      end
+
+      it("generates RBI file for has_and_belongs_to_many collection association") do
+        add_ruby_file("schema.rb", <<~RUBY)
+          class Commenter < ActiveRecord::Base
+            has_and_belongs_to_many :posts
+          end
+        RUBY
+
+        add_ruby_file("post.rb", <<~RUBY)
+          class Post < ActiveRecord::Base
+            has_and_belongs_to_many :commenters
+
+            accepts_nested_attributes_for :commenters
+          end
+        RUBY
+
+        expected = <<~RBI
+          # typed: strong
+
+          class Post
+            include GeneratedAssociationMethods
+
+            module GeneratedAssociationMethods
+              sig { returns(T::Array[T.untyped]) }
+              def commenter_ids; end
+
+              sig { params(ids: T::Array[T.untyped]).returns(T::Array[T.untyped]) }
+              def commenter_ids=(ids); end
+
+              sig { returns(::Commenter::PrivateCollectionProxy) }
+              def commenters; end
+
+              sig { params(value: T::Enumerable[T.untyped]).void }
+              def commenters=(value); end
+
+              sig { params(attributes: T.untyped).returns(T.untyped) }
+              def commenters_attributes=(attributes); end
+            end
+          end
+        RBI
+
+        assert_equal(expected, rbi_for(:Post))
+      end
     end
 
-    it("generates RBI file for has_and_belongs_to_many collection association") do
-      add_ruby_file("schema.rb", <<~RUBY)
-        class Commenter < ActiveRecord::Base
-          has_and_belongs_to_many :posts
-        end
-      RUBY
+    describe("with errors") do
+      it("generates RBI file for broken has_many :through collection association with errors") do
+        add_ruby_file("schema.rb", <<~RUBY)
+          ActiveRecord::Migration.suppress_messages do
+            ActiveRecord::Schema.define do
+              create_table :posts do |t|
+                t.references(:shop)
+              end
 
-      add_ruby_file("post.rb", <<~RUBY)
-        class Post < ActiveRecord::Base
-          has_and_belongs_to_many :commenters
+              create_table :shops do |t|
+              end
 
-          accepts_nested_attributes_for :commenters
-        end
-      RUBY
-
-      expected = <<~RBI
-        # typed: strong
-
-        class Post
-          include GeneratedAssociationMethods
-
-          module GeneratedAssociationMethods
-            sig { returns(T::Array[T.untyped]) }
-            def commenter_ids; end
-
-            sig { params(ids: T::Array[T.untyped]).returns(T::Array[T.untyped]) }
-            def commenter_ids=(ids); end
-
-            sig { returns(::Commenter::PrivateCollectionProxy) }
-            def commenters; end
-
-            sig { params(value: T::Enumerable[T.untyped]).void }
-            def commenters=(value); end
-
-            sig { params(attributes: T.untyped).returns(T.untyped) }
-            def commenters_attributes=(attributes); end
+              create_table :managers do |t|
+                t.references(:shop)
+              end
+            end
           end
-        end
-      RBI
+        RUBY
 
-      assert_equal(expected, rbi_for(:Post))
+        add_ruby_file("commenter.rb", <<~RUBY)
+          class Manager < ActiveRecord::Base
+            belongs_to :shop
+          end
+        RUBY
+
+        add_ruby_file("comment.rb", <<~RUBY)
+          class Shop < ActiveRecord::Base
+            has_many :managers
+          end
+        RUBY
+
+        add_ruby_file("post.rb", <<~RUBY)
+          class Post < ActiveRecord::Base
+            belongs_to :shop
+            has_one :manager, through: :shop
+          end
+        RUBY
+
+        expected = <<~RBI
+          # typed: strong
+
+          class Post
+            include GeneratedAssociationMethods
+
+            module GeneratedAssociationMethods
+              sig { params(args: T.untyped, blk: T.untyped).returns(::Shop) }
+              def build_shop(*args, &blk); end
+
+              sig { params(args: T.untyped, blk: T.untyped).returns(::Shop) }
+              def create_shop(*args, &blk); end
+
+              sig { params(args: T.untyped, blk: T.untyped).returns(::Shop) }
+              def create_shop!(*args, &blk); end
+
+              sig { returns(T.nilable(::Shop)) }
+              def reload_shop; end
+
+              sig { returns(T.nilable(::Shop)) }
+              def shop; end
+
+              sig { params(value: T.nilable(::Shop)).void }
+              def shop=(value); end
+            end
+          end
+        RBI
+
+        assert_equal(expected, rbi_for(:Post))
+
+        assert_equal(1, generated_errors.size)
+        assert_equal(<<~MSG, generated_errors.first)
+          Cannot generate association `manager` on `Post` since the source of the through association is missing.
+        MSG
+      end
     end
   end
 


### PR DESCRIPTION
See also: #238, #536, #558

### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
Based off the feedback received on #558, I've simplified it to a more concrete case which simply adds an error message for missing `ActiveRecordAssociations`. 

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
Reimplements a `SourceReflectionError` taken from @paracycle's [branch](https://github.com/Shopify/tapioca/compare/uk-add-errors-for-generators). Also, slightly reorganizes the `ActiveRecordAssociationsSpec` tests to nest ` #decorate` calls that have errors and those without.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->
See automated tests.
