### PR TITLE
Add support for dsl parallelization

### DIFF
--- a/lib/tapioca/cli.rb
+++ b/lib/tapioca/cli.rb
@@ -79,6 +79,11 @@ module Tapioca
       aliases: ["-q"],
       type: :boolean,
       desc: "Supresses file creation output"
+    option :workers,
+      aliases: ["-w"],
+      type: :numeric,
+      default: nil,
+      desc: "Number of parallel workers to use when generating RBIs"
     def dsl(*constants)
       current_command = T.must(current_command_chain.first)
       config = ConfigBuilder.from_options(current_command, options)
@@ -93,7 +98,8 @@ module Tapioca
         default_command: Config::DEFAULT_COMMAND,
         should_verify: options[:verify],
         quiet: options[:quiet],
-        verbose: options[:verbose]
+        verbose: options[:verbose],
+        number_of_workers: config.workers
       )
       Tapioca.silence_warnings do
         generator.generate

--- a/lib/tapioca/compilers/dsl_compiler.rb
+++ b/lib/tapioca/compilers/dsl_compiler.rb
@@ -22,16 +22,24 @@ module Tapioca
           requested_constants: T::Array[Module],
           requested_generators: T::Array[T.class_of(Dsl::Base)],
           excluded_generators: T::Array[T.class_of(Dsl::Base)],
-          error_handler: T.nilable(T.proc.params(error: String).void)
+          error_handler: T.nilable(T.proc.params(error: String).void),
+          number_of_workers: T.nilable(Integer),
         ).void
       end
-      def initialize(requested_constants:, requested_generators: [], excluded_generators: [], error_handler: nil)
+      def initialize(
+        requested_constants:,
+        requested_generators: [],
+        excluded_generators: [],
+        error_handler: nil,
+        number_of_workers: nil
+      )
         @generators = T.let(
           gather_generators(requested_generators, excluded_generators),
           T::Enumerable[Dsl::Base]
         )
         @requested_constants = requested_constants
         @error_handler = T.let(error_handler || $stderr.method(:puts), T.proc.params(error: String).void)
+        @number_of_workers = number_of_workers
       end
 
       sig { params(blk: T.proc.params(constant: Module, rbi: RBI::File).void).void }
@@ -45,7 +53,10 @@ module Tapioca
           ERROR
         end
 
-        constants_to_process.sort_by { |c| c.name.to_s }.each do |constant|
+        Executor.new(
+          constants_to_process.sort_by { |c| c.name.to_s },
+          number_of_workers: @number_of_workers
+        ).run_in_parallel do |constant|
           rbi = rbi_for_constant(constant)
           next if rbi.nil?
 

--- a/lib/tapioca/compilers/dsl_compiler.rb
+++ b/lib/tapioca/compilers/dsl_compiler.rb
@@ -44,8 +44,8 @@ module Tapioca
 
       sig do
         type_parameters(:T).params(
-          blk: T.proc.params(constant: Module, rbi: RBI::File).returns(T.nilable(T.type_parameter(:T)))
-        ).returns(T.nilable(T::Array[T.nilable(T.type_parameter(:T))]))
+          blk: T.proc.params(constant: Module, rbi: RBI::File).returns(T.type_parameter(:T))
+        ).returns(T.nilable(T::Array[T.type_parameter(:T)]))
       end
       def run(&blk)
         constants_to_process = gather_constants(requested_constants)
@@ -71,7 +71,7 @@ module Tapioca
           report_error(msg)
         end
 
-        result
+        result&.compact
       end
 
       private

--- a/lib/tapioca/compilers/dsl_compiler.rb
+++ b/lib/tapioca/compilers/dsl_compiler.rb
@@ -42,7 +42,11 @@ module Tapioca
         @number_of_workers = number_of_workers
       end
 
-      sig { params(blk: T.proc.params(constant: Module, rbi: RBI::File).void).void }
+      sig do
+        type_parameters(:T).params(
+          blk: T.proc.params(constant: Module, rbi: RBI::File).returns(T.nilable(T.type_parameter(:T)))
+        ).returns(T.nilable(T::Array[T.nilable(T.type_parameter(:T))]))
+      end
       def run(&blk)
         constants_to_process = gather_constants(requested_constants)
 
@@ -53,7 +57,7 @@ module Tapioca
           ERROR
         end
 
-        Executor.new(
+        result = Executor.new(
           constants_to_process.sort_by { |c| c.name.to_s },
           number_of_workers: @number_of_workers
         ).run_in_parallel do |constant|
@@ -66,6 +70,8 @@ module Tapioca
         generators.flat_map(&:errors).each do |msg|
           report_error(msg)
         end
+
+        result
       end
 
       private

--- a/lib/tapioca/compilers/dsl_compiler.rb
+++ b/lib/tapioca/compilers/dsl_compiler.rb
@@ -45,7 +45,7 @@ module Tapioca
       sig do
         type_parameters(:T).params(
           blk: T.proc.params(constant: Module, rbi: RBI::File).returns(T.type_parameter(:T))
-        ).returns(T.nilable(T::Array[T.type_parameter(:T)]))
+        ).returns(T::Array[T.type_parameter(:T)])
       end
       def run(&blk)
         constants_to_process = gather_constants(requested_constants)
@@ -71,7 +71,7 @@ module Tapioca
           report_error(msg)
         end
 
-        result&.compact
+        result.compact
       end
 
       private

--- a/lib/tapioca/executor.rb
+++ b/lib/tapioca/executor.rb
@@ -33,7 +33,7 @@ module Tapioca
     end
     def run_in_parallel(&block)
       # If we only have one worker selected, it's not worth forking, just run sequentially
-      return @queue.map { |item| block.call(item) }.compact if @number_of_workers == 1
+      return @queue.map { |item| block.call(item) } if @number_of_workers == 1
 
       read_pipes = []
       write_pipes = []
@@ -50,7 +50,7 @@ module Tapioca
 
         fork do
           read.close
-          result = items.map { |item| block.call(item) }.compact
+          result = items.map { |item| block.call(item) }
 
           # Pack the result as a Base64 string of the Marshal dump of the array of values returned by the block that we
           # ran in parallel

--- a/lib/tapioca/executor.rb
+++ b/lib/tapioca/executor.rb
@@ -50,7 +50,7 @@ module Tapioca
           read.close
           result = items.map { |item| block.call(item) }.compact
 
-          # We mapped the result of invoking the paralllized block into an array. In order to return the array from the
+          # We mapped the result of invoking the parallelized block into an array. In order to return the array from the
           # worker back to the main process, we encode it in Base64, append a separator in the beginning and write it to
           # the pipe. The separator helps us split the results that are coming from the multiple workers. It looks
           # something like this:

--- a/lib/tapioca/generators/dsl.rb
+++ b/lib/tapioca/generators/dsl.rb
@@ -95,11 +95,7 @@ module Tapioca
           )
         end
 
-        processed_files&.each do |filename|
-          next if filename.nil?
-
-          rbi_files_to_purge.delete(filename)
-        end
+        processed_files&.each { |filename| rbi_files_to_purge.delete(T.must(filename)) }
 
         say("")
 

--- a/lib/tapioca/generators/dsl.rb
+++ b/lib/tapioca/generators/dsl.rb
@@ -80,24 +80,27 @@ module Tapioca
           number_of_workers: @number_of_workers
         )
 
-        compiler.run do |constant, contents|
+        processed_files = compiler.run do |constant, contents|
           constant_name = T.must(Reflection.name_of(constant))
 
           if @verbose && !@quiet
             say_status(:processing, constant_name, :yellow)
           end
 
-          filename = compile_dsl_rbi(
+          compile_dsl_rbi(
             constant_name,
             contents,
             outpath: outpath,
             quiet: @should_verify || @quiet && !@verbose
           )
-
-          if filename
-            rbi_files_to_purge.delete(filename)
-          end
         end
+
+        processed_files&.each do |filename|
+          next if filename.nil?
+
+          rbi_files_to_purge.delete(filename)
+        end
+
         say("")
 
         if @should_verify

--- a/lib/tapioca/generators/dsl.rb
+++ b/lib/tapioca/generators/dsl.rb
@@ -95,7 +95,7 @@ module Tapioca
           )
         end
 
-        processed_files&.each { |filename| rbi_files_to_purge.delete(T.must(filename)) }
+        processed_files.each { |filename| rbi_files_to_purge.delete(T.must(filename)) }
 
         say("")
 

--- a/lib/tapioca/generators/dsl.rb
+++ b/lib/tapioca/generators/dsl.rb
@@ -17,7 +17,8 @@ module Tapioca
           file_writer: Thor::Actions,
           should_verify: T::Boolean,
           quiet: T::Boolean,
-          verbose: T::Boolean
+          verbose: T::Boolean,
+          number_of_workers: T.nilable(Integer),
         ).void
       end
       def initialize(
@@ -32,7 +33,8 @@ module Tapioca
         file_writer: FileWriter.new,
         should_verify: false,
         quiet: false,
-        verbose: false
+        verbose: false,
+        number_of_workers: nil
       )
         @requested_constants = requested_constants
         @outpath = outpath
@@ -44,6 +46,7 @@ module Tapioca
         @should_verify = should_verify
         @quiet = quiet
         @verbose = verbose
+        @number_of_workers = number_of_workers
 
         super(default_command: default_command, file_writer: file_writer)
 
@@ -73,7 +76,8 @@ module Tapioca
           excluded_generators: constantize_generators(@exclude_generators),
           error_handler: ->(error) {
             say_error(error, :bold, :red)
-          }
+          },
+          number_of_workers: @number_of_workers
         )
 
         compiler.run do |constant, contents|

--- a/lib/tapioca/helpers/test/isolation.rb
+++ b/lib/tapioca/helpers/test/isolation.rb
@@ -53,11 +53,14 @@ module Tapioca
               end
 
               write.puts [result].pack("m")
+              write.close
               exit!(false)
             end
 
             write.close
             result = read.read
+            read.close
+
             Process.wait2(T.must(pid))
             T.must(result).unpack1("m")
           end

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -22,7 +22,7 @@ module Tapioca
       ]
 
       exec_command << "--outdir #{outdir}" unless use_default_outdir
-      exec_command << "--workers=#{number_of_workers}" if command.start_with?("gem")
+      exec_command << "--workers=#{number_of_workers}" if command.start_with?("dsl") || command.start_with?("gem")
 
       Bundler.with_unbundled_env do
         process = IO.popen(

--- a/spec/executor_spec.rb
+++ b/spec/executor_spec.rb
@@ -38,5 +38,13 @@ module Tapioca
         refute_equal(parent_pid, Process.pid)
       end
     end
+
+    it "can return a value from the parallelized block" do
+      queue = @queue.dup
+      executor = Executor.new(@queue, number_of_workers: 4)
+      result = executor.run_in_parallel { |number| number }
+
+      assert_equal(queue, T.must(result).sort)
+    end
   end
 end

--- a/spec/executor_spec.rb
+++ b/spec/executor_spec.rb
@@ -44,7 +44,7 @@ module Tapioca
       executor = Executor.new(@queue, number_of_workers: 4)
       result = executor.run_in_parallel { |number| number }
 
-      assert_equal(queue, T.must(result).sort)
+      assert_equal(queue, result.sort)
     end
   end
 end

--- a/spec/tapioca/cli/dsl_spec.rb
+++ b/spec/tapioca/cli/dsl_spec.rb
@@ -302,6 +302,16 @@ module Tapioca
         refute_path_exists("#{outdir}/user.rbi")
       end
 
+      it "generates the correct RBIs when running in parallel" do
+        tapioca("dsl", number_of_workers: 3)
+
+        assert_path_exists("#{outdir}/baz/role.rbi")
+        assert_path_exists("#{outdir}/job.rbi")
+        assert_path_exists("#{outdir}/post.rbi")
+        assert_path_exists("#{outdir}/namespace/comment.rbi")
+        refute_path_exists("#{outdir}/user.rbi")
+      end
+
       it "generates RBI files without header" do
         tapioca("dsl --no-file-header Post")
 

--- a/spec/tapioca/cli/dsl_spec.rb
+++ b/spec/tapioca/cli/dsl_spec.rb
@@ -390,7 +390,7 @@ module Tapioca
         FileUtils.touch("#{outdir}/to_be_deleted/baz.rbi")
         FileUtils.touch("#{outdir}/does_not_exist.rbi")
 
-        tapioca("dsl", number_of_workers: 4)
+        tapioca("dsl", number_of_workers: 2)
 
         refute_path_exists("#{outdir}/does_not_exist.rbi")
         refute_path_exists("#{outdir}/to_be_deleted/foo.rbi")

--- a/spec/tapioca/cli/dsl_spec.rb
+++ b/spec/tapioca/cli/dsl_spec.rb
@@ -375,6 +375,7 @@ module Tapioca
       end
 
       it "removes stale RBIs properly when running in parallel" do
+        # Files that shouldn't be deleted
         FileUtils.mkdir_p("#{outdir}/baz")
         FileUtils.mkdir_p("#{outdir}/namespace")
 
@@ -383,7 +384,17 @@ module Tapioca
         FileUtils.touch("#{outdir}/post.rbi")
         FileUtils.touch("#{outdir}/namespace/comment.rbi")
 
+        # Files that should be deleted
+        FileUtils.mkdir_p("#{outdir}/to_be_deleted")
+        FileUtils.touch("#{outdir}/to_be_deleted/foo.rbi")
+        FileUtils.touch("#{outdir}/to_be_deleted/baz.rbi")
+        FileUtils.touch("#{outdir}/does_not_exist.rbi")
+
         tapioca("dsl", number_of_workers: 4)
+
+        refute_path_exists("#{outdir}/does_not_exist.rbi")
+        refute_path_exists("#{outdir}/to_be_deleted/foo.rbi")
+        refute_path_exists("#{outdir}/to_be_deleted/baz.rbi")
 
         assert_path_exists("#{outdir}/baz/role.rbi")
         assert_path_exists("#{outdir}/job.rbi")

--- a/spec/tapioca/cli/dsl_spec.rb
+++ b/spec/tapioca/cli/dsl_spec.rb
@@ -374,6 +374,24 @@ module Tapioca
         refute_path_exists("#{outdir}/user.rbi")
       end
 
+      it "removes stale RBIs properly when running in parallel" do
+        FileUtils.mkdir_p("#{outdir}/baz")
+        FileUtils.mkdir_p("#{outdir}/namespace")
+
+        FileUtils.touch("#{outdir}/baz/role.rbi")
+        FileUtils.touch("#{outdir}/job.rbi")
+        FileUtils.touch("#{outdir}/post.rbi")
+        FileUtils.touch("#{outdir}/namespace/comment.rbi")
+
+        tapioca("dsl", number_of_workers: 4)
+
+        assert_path_exists("#{outdir}/baz/role.rbi")
+        assert_path_exists("#{outdir}/job.rbi")
+        assert_path_exists("#{outdir}/post.rbi")
+        assert_path_exists("#{outdir}/namespace/comment.rbi")
+        refute_path_exists("#{outdir}/user.rbi")
+      end
+
       it "removes stale RBI files of requested constants" do
         FileUtils.touch("#{outdir}/user.rbi")
 


### PR DESCRIPTION
Closes #577 

### Motivation

In order to run the `dsl` generator in parallel, we need some way of keeping track of which files we should not purge.

### Implementation

By commit:
1. Allow the parallelized block by executor to return a value. That value is serialize using `Marshal` and written/read through a pipe so that the workers can return something from the block. The executor then returns an array of all of the values that were returned by each iteration in the block
2. Revert the commit that removed parallelization from DSL #573
3. Make the changes to return the filenames from the parallelized block, so that we can have the right information and purge them later

### Tests

See included tests.