### PR TITLE
Add `MissingConstantError` messaging

### DIFF
--- a/lib/tapioca/compilers/dsl/active_record_associations.rb
+++ b/lib/tapioca/compilers/dsl/active_record_associations.rb
@@ -151,12 +151,12 @@ module Tapioca
               populate_single_assoc_getter_setter(mod, constant, association_name, reflection)
             end
           rescue SourceReflectionError
-            add_error(<<~MSG)
+            add_error(<<~MSG.strip)
               Cannot generate association `#{reflection.name}` on `#{constant}` since the source of the through association is missing.
             MSG
           rescue MissingConstantError
-            add_error(<<~MSG)
-              Cannot generate association `#{reflection.name}` on `#{constant}` since the constant `#{reflection.name.capitalize}` does not exist.
+            add_error(<<~MSG.strip)
+              Cannot generate association `#{reflection.name}` on `#{constant}` since the constant `#{reflection.class_name}` does not exist.
             MSG
           end
         end

--- a/lib/tapioca/compilers/dsl/active_record_associations.rb
+++ b/lib/tapioca/compilers/dsl/active_record_associations.rb
@@ -254,7 +254,7 @@ module Tapioca
         end
         def type_for(constant, reflection)
           return "T.untyped" if !constant.table_exists? || polymorphic_association?(reflection)
-          raise MissingConstantError unless Object.const_defined?(reflection.class_name)
+          raise MissingConstantError unless reflection.class_name.safe_constantize
 
           T.must(qualified_name_of(reflection.klass))
         end
@@ -266,6 +266,7 @@ module Tapioca
           ).returns(String)
         end
         def relation_type_for(constant, reflection)
+          raise MissingConstantError unless reflection.class_name.safe_constantize
           "ActiveRecord::Associations::CollectionProxy" if !constant.table_exists? ||
                                                             polymorphic_association?(reflection)
 

--- a/lib/tapioca/compilers/dsl/active_record_associations.rb
+++ b/lib/tapioca/compilers/dsl/active_record_associations.rb
@@ -104,6 +104,7 @@ module Tapioca
         include Helper::ActiveRecordConstants
 
         SourceReflectionError = Class.new(StandardError)
+        MissingConstantError = Class.new(StandardError)
 
         ReflectionType = T.type_alias do
           T.any(::ActiveRecord::Reflection::ThroughReflection, ::ActiveRecord::Reflection::AssociationReflection)
@@ -153,7 +154,7 @@ module Tapioca
             add_error(<<~MSG)
               Cannot generate association `#{reflection.name}` on `#{constant}` since the source of the through association is missing.
             MSG
-          rescue NameError
+          rescue MissingConstantError
             add_error(<<~MSG)
               Cannot generate association `#{reflection.name}` on `#{constant}` since the constant `#{reflection.name.capitalize}` does not exist.
             MSG
@@ -253,6 +254,7 @@ module Tapioca
         end
         def type_for(constant, reflection)
           return "T.untyped" if !constant.table_exists? || polymorphic_association?(reflection)
+          raise MissingConstantError unless Object.const_defined?(reflection.class_name)
 
           T.must(qualified_name_of(reflection.klass))
         end

--- a/lib/tapioca/compilers/dsl/active_record_associations.rb
+++ b/lib/tapioca/compilers/dsl/active_record_associations.rb
@@ -153,6 +153,10 @@ module Tapioca
             add_error(<<~MSG)
               Cannot generate association `#{reflection.name}` on `#{constant}` since the source of the through association is missing.
             MSG
+          rescue NameError
+            add_error(<<~MSG)
+              Cannot generate association `#{reflection.name}` on `#{constant}` since the constant `#{reflection.name.capitalize}` does not exist.
+            MSG
           end
         end
 

--- a/spec/tapioca/compilers/dsl/active_record_associations_spec.rb
+++ b/spec/tapioca/compilers/dsl/active_record_associations_spec.rb
@@ -407,12 +407,11 @@ class Tapioca::Compilers::Dsl::ActiveRecordAssociationsSpec < DslSpec
     end
 
     describe("with errors") do
-      it("generates RBI file for broken has_one association") do
+      it("generates RBI file for broken associations") do
         add_ruby_file("schema.rb", <<~RUBY)
           ActiveRecord::Migration.suppress_messages do
             ActiveRecord::Schema.define do
               create_table :posts do |t|
-                t.references(:author)
               end
             end
           end
@@ -421,6 +420,11 @@ class Tapioca::Compilers::Dsl::ActiveRecordAssociationsSpec < DslSpec
         add_ruby_file("post.rb", <<~RUBY)
           class Post < ActiveRecord::Base
             has_one :author
+            has_many :comments
+            belongs_to :blog
+            has_and_belongs_to_many :commenters
+            has_many :readers, through: :author
+            has_one :award, through: :blog
           end
         RUBY
 
@@ -436,10 +440,20 @@ class Tapioca::Compilers::Dsl::ActiveRecordAssociationsSpec < DslSpec
 
         assert_equal(expected, rbi_for(:Post))
 
-        assert_equal(1, generated_errors.size)
-        assert_equal(<<~MSG.strip, generated_errors.first)
-          Cannot generate association `author` on `Post` since the constant `Author` does not exist.
-        MSG
+        assert_equal(6, generated_errors.size)
+
+        # rubocop:disable Layout/LineLength
+        expected_errors = [
+          "Cannot generate association `has_one :author` on `Post` since the constant `Author` does not exist.",
+          "Cannot generate association `has_many :comments` on `Post` since the constant `Comment` does not exist.",
+          "Cannot generate association `belongs_to :blog` on `Post` since the constant `Blog` does not exist.",
+          "Cannot generate association `has_and_belongs_to_many :commenters` on `Post` since the constant `Commenter` does not exist.",
+          "Cannot generate association `has_many :readers, through: :author` on `Post` since the constant `Reader` does not exist.",
+          "Cannot generate association `has_one :award, through: :blog` on `Post` since the constant `Award` does not exist.",
+        ]
+        # rubocop:enable Layout/LineLength
+
+        assert_equal(expected_errors, generated_errors)
       end
 
       it("generates RBI file for broken has_many :through collection association") do

--- a/spec/tapioca/compilers/dsl/active_record_associations_spec.rb
+++ b/spec/tapioca/compilers/dsl/active_record_associations_spec.rb
@@ -437,7 +437,7 @@ class Tapioca::Compilers::Dsl::ActiveRecordAssociationsSpec < DslSpec
         assert_equal(expected, rbi_for(:Post))
 
         assert_equal(1, generated_errors.size)
-        assert_equal(<<~MSG, generated_errors.first)
+        assert_equal(<<~MSG.strip, generated_errors.first)
           Cannot generate association `author` on `Post` since the constant `Author` does not exist.
         MSG
       end
@@ -510,7 +510,7 @@ class Tapioca::Compilers::Dsl::ActiveRecordAssociationsSpec < DslSpec
         assert_equal(expected, rbi_for(:Post))
 
         assert_equal(1, generated_errors.size)
-        assert_equal(<<~MSG, generated_errors.first)
+        assert_equal(<<~MSG.strip, generated_errors.first)
           Cannot generate association `manager` on `Post` since the source of the through association is missing.
         MSG
       end

--- a/spec/tapioca/compilers/dsl/active_record_associations_spec.rb
+++ b/spec/tapioca/compilers/dsl/active_record_associations_spec.rb
@@ -157,6 +157,11 @@ class Tapioca::Compilers::Dsl::ActiveRecordAssociationsSpec < DslSpec
       end
 
       it("generates RBI file for polymorphic belongs_to single association") do
+        add_ruby_file("category.rb", <<~RUBY)
+          class Category < ActiveRecord::Base
+          end
+        RUBY
+
         add_ruby_file("post.rb", <<~RUBY)
           class Post < ActiveRecord::Base
             belongs_to :category, polymorphic: true


### PR DESCRIPTION
Part of: #238

### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
We want to advise the end user when associations cannot be generated due to a missing constant in the defined association.

See also: https://discourse.shopify.io/t/bin-tapioca-dsl-yields-uninitialized-constant/22411

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
Capture the raised `MissingConstantError` during `populate_association` and add a clearer error message to the error buffer.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->
See automated tests.
