### PR TITLE
Generate typed store accessors in their own module

### DIFF
--- a/lib/tapioca/compilers/dsl/active_record_typed_store.rb
+++ b/lib/tapioca/compilers/dsl/active_record_typed_store.rb
@@ -34,53 +34,57 @@ module Tapioca
       # # post.rbi
       # # typed: true
       # class Post
-      #   sig { params(review_date: T.nilable(Date)).returns(T.nilable(Date)) }
-      #   def review_date=(review_date); end
+      #   include StoreAccessors
       #
-      #   sig { returns(T.nilable(Date)) }
-      #   def review_date; end
+      #   module StoreAccessors
+      #     sig { params(review_date: T.nilable(Date)).returns(T.nilable(Date)) }
+      #     def review_date=(review_date); end
       #
-      #   sig { returns(T.nilable(Date)) }
-      #   def review_date_was; end
+      #     sig { returns(T.nilable(Date)) }
+      #     def review_date; end
       #
-      #   sig { returns(T::Boolean) }
-      #   def review_date_changed?; end
+      #     sig { returns(T.nilable(Date)) }
+      #     def review_date_was; end
       #
-      #   sig { returns(T.nilable(Date)) }
-      #   def review_date_before_last_save; end
+      #     sig { returns(T::Boolean) }
+      #     def review_date_changed?; end
       #
-      #   sig { returns(T::Boolean) }
-      #   def saved_change_to_review_date?; end
+      #     sig { returns(T.nilable(Date)) }
+      #     def review_date_before_last_save; end
       #
-      #   sig { returns(T.nilable([T.nilable(Date), T.nilable(Date)])) }
-      #   def review_date_change; end
+      #     sig { returns(T::Boolean) }
+      #     def saved_change_to_review_date?; end
       #
-      #   sig { returns(T.nilable([T.nilable(Date), T.nilable(Date)])) }
-      #   def saved_change_to_review_date; end
+      #     sig { returns(T.nilable([T.nilable(Date), T.nilable(Date)])) }
+      #     def review_date_change; end
       #
-      #   sig { params(reviewd: T::Boolean).returns(T::Boolean) }
-      #   def reviewed=(reviewed); end
+      #     sig { returns(T.nilable([T.nilable(Date), T.nilable(Date)])) }
+      #     def saved_change_to_review_date; end
       #
-      #   sig { returns(T::Boolean) }
-      #   def reviewed; end
+      #     sig { params(reviewd: T::Boolean).returns(T::Boolean) }
+      #     def reviewed=(reviewed); end
       #
-      #   sig { returns(T::Boolean) }
-      #   def reviewed_was; end
+      #     sig { returns(T::Boolean) }
+      #     def reviewed; end
       #
-      #   sig { returns(T::Boolean) }
-      #   def reviewed_changed?; end
+      #     sig { returns(T::Boolean) }
+      #     def reviewed_was; end
       #
-      #   sig { returns(T::Boolean) }
-      #   def reviewed_before_last_save; end
+      #     sig { returns(T::Boolean) }
+      #     def reviewed_changed?; end
       #
-      #   sig { returns(T::Boolean) }
-      #   def saved_change_to_reviewed?; end
+      #     sig { returns(T::Boolean) }
+      #     def reviewed_before_last_save; end
       #
-      #   sig { returns(T.nilable([T::Boolean, T::Boolean])) }
-      #   def reviewed_change; end
+      #     sig { returns(T::Boolean) }
+      #     def saved_change_to_reviewed?; end
       #
-      #   sig { returns(T.nilable([T::Boolean, T::Boolean])) }
-      #   def saved_change_to_reviewed; end
+      #     sig { returns(T.nilable([T::Boolean, T::Boolean])) }
+      #     def reviewed_change; end
+      #
+      #     sig { returns(T.nilable([T::Boolean, T::Boolean])) }
+      #     def saved_change_to_reviewed; end
+      #   end
       # end
       # ~~~
       class ActiveRecordTypedStore < Base
@@ -105,7 +109,9 @@ module Tapioca
                 type = type_for(field.type_sym)
                 type = "T.nilable(#{type})" if field.null && type != "T.untyped"
 
-                generate_methods(model, field.name.to_s, type)
+                store_accessors_module = model.create_module("StoreAccessors")
+                generate_methods(store_accessors_module, field.name.to_s, type)
+                model.create_include("StoreAccessors")
               end
             end
           end

--- a/manual/generator_activerecordtypedstore.md
+++ b/manual/generator_activerecordtypedstore.md
@@ -22,52 +22,56 @@ this generator will produce the RBI file `post.rbi` with the following content:
 # post.rbi
 # typed: true
 class Post
-  sig { params(review_date: T.nilable(Date)).returns(T.nilable(Date)) }
-  def review_date=(review_date); end
+  include StoreAccessors
 
-  sig { returns(T.nilable(Date)) }
-  def review_date; end
+  module StoreAccessors
+    sig { params(review_date: T.nilable(Date)).returns(T.nilable(Date)) }
+    def review_date=(review_date); end
 
-  sig { returns(T.nilable(Date)) }
-  def review_date_was; end
+    sig { returns(T.nilable(Date)) }
+    def review_date; end
 
-  sig { returns(T::Boolean) }
-  def review_date_changed?; end
+    sig { returns(T.nilable(Date)) }
+    def review_date_was; end
 
-  sig { returns(T.nilable(Date)) }
-  def review_date_before_last_save; end
+    sig { returns(T::Boolean) }
+    def review_date_changed?; end
 
-  sig { returns(T::Boolean) }
-  def saved_change_to_review_date?; end
+    sig { returns(T.nilable(Date)) }
+    def review_date_before_last_save; end
 
-  sig { returns(T.nilable([T.nilable(Date), T.nilable(Date)])) }
-  def review_date_change; end
+    sig { returns(T::Boolean) }
+    def saved_change_to_review_date?; end
 
-  sig { returns(T.nilable([T.nilable(Date), T.nilable(Date)])) }
-  def saved_change_to_review_date; end
+    sig { returns(T.nilable([T.nilable(Date), T.nilable(Date)])) }
+    def review_date_change; end
 
-  sig { params(reviewd: T::Boolean).returns(T::Boolean) }
-  def reviewed=(reviewed); end
+    sig { returns(T.nilable([T.nilable(Date), T.nilable(Date)])) }
+    def saved_change_to_review_date; end
 
-  sig { returns(T::Boolean) }
-  def reviewed; end
+    sig { params(reviewd: T::Boolean).returns(T::Boolean) }
+    def reviewed=(reviewed); end
 
-  sig { returns(T::Boolean) }
-  def reviewed_was; end
+    sig { returns(T::Boolean) }
+    def reviewed; end
 
-  sig { returns(T::Boolean) }
-  def reviewed_changed?; end
+    sig { returns(T::Boolean) }
+    def reviewed_was; end
 
-  sig { returns(T::Boolean) }
-  def reviewed_before_last_save; end
+    sig { returns(T::Boolean) }
+    def reviewed_changed?; end
 
-  sig { returns(T::Boolean) }
-  def saved_change_to_reviewed?; end
+    sig { returns(T::Boolean) }
+    def reviewed_before_last_save; end
 
-  sig { returns(T.nilable([T::Boolean, T::Boolean])) }
-  def reviewed_change; end
+    sig { returns(T::Boolean) }
+    def saved_change_to_reviewed?; end
 
-  sig { returns(T.nilable([T::Boolean, T::Boolean])) }
-  def saved_change_to_reviewed; end
+    sig { returns(T.nilable([T::Boolean, T::Boolean])) }
+    def reviewed_change; end
+
+    sig { returns(T.nilable([T::Boolean, T::Boolean])) }
+    def saved_change_to_reviewed; end
+  end
 end
 ~~~

--- a/spec/tapioca/compilers/dsl/active_record_typed_store_spec.rb
+++ b/spec/tapioca/compilers/dsl/active_record_typed_store_spec.rb
@@ -84,59 +84,63 @@ class Tapioca::Compilers::Dsl::ActiveRecordTypedStoreSpec < DslSpec
         # typed: strong
 
         class Post
-          sig { returns(T.nilable(String)) }
-          def reviewer; end
+          include StoreAccessors
 
-          sig { params(reviewer: T.nilable(String)).returns(T.nilable(String)) }
-          def reviewer=(reviewer); end
+          module StoreAccessors
+            sig { returns(T.nilable(String)) }
+            def reviewer; end
 
-          sig { returns(T::Boolean) }
-          def reviewer?; end
+            sig { params(reviewer: T.nilable(String)).returns(T.nilable(String)) }
+            def reviewer=(reviewer); end
 
-          sig { returns(T.nilable(String)) }
-          def reviewer_before_last_save; end
+            sig { returns(T::Boolean) }
+            def reviewer?; end
 
-          sig { returns(T.nilable([T.nilable(String), T.nilable(String)])) }
-          def reviewer_change; end
+            sig { returns(T.nilable(String)) }
+            def reviewer_before_last_save; end
 
-          sig { returns(T::Boolean) }
-          def reviewer_changed?; end
+            sig { returns(T.nilable([T.nilable(String), T.nilable(String)])) }
+            def reviewer_change; end
 
-          sig { returns(T.nilable(String)) }
-          def reviewer_was; end
+            sig { returns(T::Boolean) }
+            def reviewer_changed?; end
 
-          sig { returns(T.nilable([T.nilable(String), T.nilable(String)])) }
-          def saved_change_to_reviewer; end
+            sig { returns(T.nilable(String)) }
+            def reviewer_was; end
 
-          sig { returns(T::Boolean) }
-          def saved_change_to_reviewer?; end
+            sig { returns(T.nilable([T.nilable(String), T.nilable(String)])) }
+            def saved_change_to_reviewer; end
 
-          sig { returns(T.nilable([T.nilable(String), T.nilable(String)])) }
-          def saved_change_to_title; end
+            sig { returns(T::Boolean) }
+            def saved_change_to_reviewer?; end
 
-          sig { returns(T::Boolean) }
-          def saved_change_to_title?; end
+            sig { returns(T.nilable([T.nilable(String), T.nilable(String)])) }
+            def saved_change_to_title; end
 
-          sig { returns(T.nilable(String)) }
-          def title; end
+            sig { returns(T::Boolean) }
+            def saved_change_to_title?; end
 
-          sig { params(title: T.nilable(String)).returns(T.nilable(String)) }
-          def title=(title); end
+            sig { returns(T.nilable(String)) }
+            def title; end
 
-          sig { returns(T::Boolean) }
-          def title?; end
+            sig { params(title: T.nilable(String)).returns(T.nilable(String)) }
+            def title=(title); end
 
-          sig { returns(T.nilable(String)) }
-          def title_before_last_save; end
+            sig { returns(T::Boolean) }
+            def title?; end
 
-          sig { returns(T.nilable([T.nilable(String), T.nilable(String)])) }
-          def title_change; end
+            sig { returns(T.nilable(String)) }
+            def title_before_last_save; end
 
-          sig { returns(T::Boolean) }
-          def title_changed?; end
+            sig { returns(T.nilable([T.nilable(String), T.nilable(String)])) }
+            def title_change; end
 
-          sig { returns(T.nilable(String)) }
-          def title_was; end
+            sig { returns(T::Boolean) }
+            def title_changed?; end
+
+            sig { returns(T.nilable(String)) }
+            def title_was; end
+          end
         end
       RBI
 
@@ -156,32 +160,36 @@ class Tapioca::Compilers::Dsl::ActiveRecordTypedStoreSpec < DslSpec
         # typed: strong
 
         class Post
-          sig { returns(T::Boolean) }
-          def reviewed; end
+          include StoreAccessors
 
-          sig { params(reviewed: T::Boolean).returns(T::Boolean) }
-          def reviewed=(reviewed); end
+          module StoreAccessors
+            sig { returns(T::Boolean) }
+            def reviewed; end
 
-          sig { returns(T::Boolean) }
-          def reviewed?; end
+            sig { params(reviewed: T::Boolean).returns(T::Boolean) }
+            def reviewed=(reviewed); end
 
-          sig { returns(T::Boolean) }
-          def reviewed_before_last_save; end
+            sig { returns(T::Boolean) }
+            def reviewed?; end
 
-          sig { returns(T.nilable([T::Boolean, T::Boolean])) }
-          def reviewed_change; end
+            sig { returns(T::Boolean) }
+            def reviewed_before_last_save; end
 
-          sig { returns(T::Boolean) }
-          def reviewed_changed?; end
+            sig { returns(T.nilable([T::Boolean, T::Boolean])) }
+            def reviewed_change; end
 
-          sig { returns(T::Boolean) }
-          def reviewed_was; end
+            sig { returns(T::Boolean) }
+            def reviewed_changed?; end
 
-          sig { returns(T.nilable([T::Boolean, T::Boolean])) }
-          def saved_change_to_reviewed; end
+            sig { returns(T::Boolean) }
+            def reviewed_was; end
 
-          sig { returns(T::Boolean) }
-          def saved_change_to_reviewed?; end
+            sig { returns(T.nilable([T::Boolean, T::Boolean])) }
+            def saved_change_to_reviewed; end
+
+            sig { returns(T::Boolean) }
+            def saved_change_to_reviewed?; end
+          end
         end
       RBI
 
@@ -205,66 +213,70 @@ class Tapioca::Compilers::Dsl::ActiveRecordTypedStoreSpec < DslSpec
         # typed: strong
 
         class Post
-          sig { returns(T.nilable(Date)) }
-          def review_date; end
+          include StoreAccessors
 
-          sig { params(review_date: T.nilable(Date)).returns(T.nilable(Date)) }
-          def review_date=(review_date); end
+          module StoreAccessors
+            sig { returns(T.nilable(Date)) }
+            def review_date; end
 
-          sig { returns(T::Boolean) }
-          def review_date?; end
+            sig { params(review_date: T.nilable(Date)).returns(T.nilable(Date)) }
+            def review_date=(review_date); end
 
-          sig { returns(T.nilable(Date)) }
-          def review_date_before_last_save; end
+            sig { returns(T::Boolean) }
+            def review_date?; end
 
-          sig { returns(T.nilable([T.nilable(Date), T.nilable(Date)])) }
-          def review_date_change; end
+            sig { returns(T.nilable(Date)) }
+            def review_date_before_last_save; end
 
-          sig { returns(T::Boolean) }
-          def review_date_changed?; end
+            sig { returns(T.nilable([T.nilable(Date), T.nilable(Date)])) }
+            def review_date_change; end
 
-          sig { returns(T.nilable(Date)) }
-          def review_date_was; end
+            sig { returns(T::Boolean) }
+            def review_date_changed?; end
 
-          sig { returns(T.nilable([T.nilable(Date), T.nilable(Date)])) }
-          def saved_change_to_review_date; end
+            sig { returns(T.nilable(Date)) }
+            def review_date_was; end
 
-          sig { returns(T::Boolean) }
-          def saved_change_to_review_date?; end
+            sig { returns(T.nilable([T.nilable(Date), T.nilable(Date)])) }
+            def saved_change_to_review_date; end
 
-          sig { returns(T.nilable([T.nilable(Date), T.nilable(Date)])) }
-          def saved_change_to_title_date; end
+            sig { returns(T::Boolean) }
+            def saved_change_to_review_date?; end
 
-          sig { returns(T::Boolean) }
-          def saved_change_to_title_date?; end
+            sig { returns(T.nilable([T.nilable(Date), T.nilable(Date)])) }
+            def saved_change_to_title_date; end
 
-          sig { returns(T.nilable(Date)) }
-          def title_date; end
+            sig { returns(T::Boolean) }
+            def saved_change_to_title_date?; end
 
-          sig { params(title_date: T.nilable(Date)).returns(T.nilable(Date)) }
-          def title_date=(title_date); end
+            sig { returns(T.nilable(Date)) }
+            def title_date; end
 
-          sig { returns(T::Boolean) }
-          def title_date?; end
+            sig { params(title_date: T.nilable(Date)).returns(T.nilable(Date)) }
+            def title_date=(title_date); end
 
-          sig { returns(T.nilable(Date)) }
-          def title_date_before_last_save; end
+            sig { returns(T::Boolean) }
+            def title_date?; end
 
-          sig { returns(T.nilable([T.nilable(Date), T.nilable(Date)])) }
-          def title_date_change; end
+            sig { returns(T.nilable(Date)) }
+            def title_date_before_last_save; end
 
-          sig { returns(T::Boolean) }
-          def title_date_changed?; end
+            sig { returns(T.nilable([T.nilable(Date), T.nilable(Date)])) }
+            def title_date_change; end
 
-          sig { returns(T.nilable(Date)) }
-          def title_date_was; end
+            sig { returns(T::Boolean) }
+            def title_date_changed?; end
+
+            sig { returns(T.nilable(Date)) }
+            def title_date_was; end
+          end
         end
       RBI
 
       assert_equal(rbi_for(:Post), expected)
     end
 
-    it("generates methods with DteTime type for attributes with datetime type") do
+    it("generates methods with DateTime type for attributes with datetime type") do
       add_ruby_file("post.rb", <<~RUBY)
         class Post < ActiveRecord::Base
           typed_store :metadata do |s|
@@ -277,11 +289,14 @@ class Tapioca::Compilers::Dsl::ActiveRecordTypedStoreSpec < DslSpec
         # typed: strong
 
         class Post
-          sig { returns(T.nilable(DateTime)) }
-          def review_date; end
+          include StoreAccessors
 
-          sig { params(review_date: T.nilable(DateTime)).returns(T.nilable(DateTime)) }
-          def review_date=(review_date); end
+          module StoreAccessors
+            sig { returns(T.nilable(DateTime)) }
+            def review_date; end
+
+            sig { params(review_date: T.nilable(DateTime)).returns(T.nilable(DateTime)) }
+            def review_date=(review_date); end
       RBI
 
       assert_includes(rbi_for(:Post), expected)
@@ -300,11 +315,14 @@ class Tapioca::Compilers::Dsl::ActiveRecordTypedStoreSpec < DslSpec
         # typed: strong
 
         class Post
-          sig { returns(T.nilable(Time)) }
-          def review_time; end
+          include StoreAccessors
 
-          sig { params(review_time: T.nilable(Time)).returns(T.nilable(Time)) }
-          def review_time=(review_time); end
+          module StoreAccessors
+            sig { returns(T.nilable(Time)) }
+            def review_time; end
+
+            sig { params(review_time: T.nilable(Time)).returns(T.nilable(Time)) }
+            def review_time=(review_time); end
       RBI
 
       assert_includes(rbi_for(:Post), expected)
@@ -323,11 +341,14 @@ class Tapioca::Compilers::Dsl::ActiveRecordTypedStoreSpec < DslSpec
         # typed: strong
 
         class Post
-          sig { returns(T.nilable(BigDecimal)) }
-          def rate; end
+          include StoreAccessors
 
-          sig { params(rate: T.nilable(BigDecimal)).returns(T.nilable(BigDecimal)) }
-          def rate=(rate); end
+          module StoreAccessors
+            sig { returns(T.nilable(BigDecimal)) }
+            def rate; end
+
+            sig { params(rate: T.nilable(BigDecimal)).returns(T.nilable(BigDecimal)) }
+            def rate=(rate); end
       RBI
 
       assert_includes(rbi_for(:Post), expected)
@@ -346,11 +367,14 @@ class Tapioca::Compilers::Dsl::ActiveRecordTypedStoreSpec < DslSpec
         # typed: strong
 
         class Post
-          sig { returns(T.untyped) }
-          def kind; end
+          include StoreAccessors
 
-          sig { params(kind: T.untyped).returns(T.untyped) }
-          def kind=(kind); end
+          module StoreAccessors
+            sig { returns(T.untyped) }
+            def kind; end
+
+            sig { params(kind: T.untyped).returns(T.untyped) }
+            def kind=(kind); end
       RBI
 
       assert_includes(rbi_for(:Post), expected)
@@ -369,11 +393,14 @@ class Tapioca::Compilers::Dsl::ActiveRecordTypedStoreSpec < DslSpec
         # typed: strong
 
         class Post
-          sig { returns(T.nilable(Integer)) }
-          def rate; end
+          include StoreAccessors
 
-          sig { params(rate: T.nilable(Integer)).returns(T.nilable(Integer)) }
-          def rate=(rate); end
+          module StoreAccessors
+            sig { returns(T.nilable(Integer)) }
+            def rate; end
+
+            sig { params(rate: T.nilable(Integer)).returns(T.nilable(Integer)) }
+            def rate=(rate); end
       RBI
 
       assert_includes(rbi_for(:Post), expected)
@@ -392,11 +419,14 @@ class Tapioca::Compilers::Dsl::ActiveRecordTypedStoreSpec < DslSpec
         # typed: strong
 
         class Post
-          sig { returns(T.nilable(Float)) }
-          def rate; end
+          include StoreAccessors
 
-          sig { params(rate: T.nilable(Float)).returns(T.nilable(Float)) }
-          def rate=(rate); end
+          module StoreAccessors
+            sig { returns(T.nilable(Float)) }
+            def rate; end
+
+            sig { params(rate: T.nilable(Float)).returns(T.nilable(Float)) }
+            def rate=(rate); end
       RBI
 
       assert_includes(rbi_for(:Post), expected)


### PR DESCRIPTION
### Motivation

As to better represent the real behaviour here: https://github.com/rails/rails/blob/57fe7dfce9fc751dd521ec8e175924eb1480b5d5/activerecord/lib/active_record/store.rb#L131.

One problem with the current implementation occurs when models redefine the method to change its type. The type used by Sorbet then depends on the load order (last loaded wins):

```rb
# User redefinition in the model Ruby file
class MyModel
  sig { returns(TypeB) }
  def value; end
end

# Definition in RBI as generated by Tapioca
class MyModel
  sig { returns(TypeA) }
  def value; end
end

T.reveal_type(MyModel.new.value) # TypeA, because loaded last wins
```

By using a included module we avoid this indeterministic behaviour:

```rb
# User redefinition in the model Ruby file
class MyModel
  sig { returns(TypeB) }
  def value; end
end

# Definition in RBI as generated by Tapioca
class MyModel
  include StoreAccessors

  module StoreAccessors
    sig { returns(TypeA) }
    def value; end
  end
end

T.reveal_type(MyModel.new.value) # always TypeB
```

Please note that this kind of redefinition is type unsafe (and works only because we didn't specify `override`):

```rb
sig { params(accessor: MyModel::StoreAccessor).void }
def foo(accessor)
  bar(accessor.value) # Will break at runtime if called with `MyModel`
end

sig { params(value: TypeA).void }
def bar(string)
  # Something expecting a `TypeA`
end

foo(MyModel.new) # Boom!
```

### Tests

See updated test.

cc. @rafaelfranca 