### PR TITLE
Fix eval'ed constants not being generated in gem RBI generation

### DIFF
--- a/lib/tapioca/constant_locator.rb
+++ b/lib/tapioca/constant_locator.rb
@@ -17,8 +17,14 @@ module Tapioca
     TracePoint.trace(:class) do |tp|
       unless tp.self.singleton_class?
         key = name_of(tp.self)
+        file = tp.path
+        if file == "(eval)"
+          file = T.must(caller_locations)
+            .drop_while { |loc| loc.path == "(eval)" }
+            .first&.path
+        end
         @class_files[key] ||= Set.new
-        @class_files[key] << tp.path
+        @class_files[key] << file
       end
     end
 

--- a/spec/tapioca/compilers/symbol_table_compiler_spec.rb
+++ b/spec/tapioca/compilers/symbol_table_compiler_spec.rb
@@ -2824,6 +2824,31 @@ class Tapioca::Compilers::SymbolTableCompilerSpec < Minitest::HooksSpec
       assert_equal(output, compile)
     end
 
+    it("handles class_env created classes and modules") do
+      add_ruby_file("container.rb", <<~RUBY)
+        class Container
+          class_eval <<~EOF
+            class FooClass
+            end
+
+            module FooModule
+            end
+
+            Bar = 42
+          EOF
+        end
+      RUBY
+
+      output = template(<<~RBI)
+        class Container; end
+        Container::Bar = T.let(T.unsafe(nil), Integer)
+        class Container::FooClass; end
+        module Container::FooModule; end
+      RBI
+
+      assert_equal(output, compile)
+    end
+
     it("includes comment documentation from sources when doc is true") do
       add_ruby_file("foo.rb", <<~RUBY)
         # frozen_string_literal: true


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
Fixes #537 

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->

For `eval`'ed classes/modules, the `path` attribute of the TracePoint object ends up being `"(eval)"`, which does not help us figure out where the class/module is being defined.

Instead, we can look back up the call stack until we find the first caller location that has a `path` that is not equal to ` (eval)"` which is where the call is ultimately being made from.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->

Added a failing test that passes after the fix.
