### PR TITLE
Fix doc generation on CI

### DIFF
--- a/lib/tapioca/compilers/dsl/identity_cache.rb
+++ b/lib/tapioca/compilers/dsl/identity_cache.rb
@@ -2,7 +2,6 @@
 # frozen_string_literal: true
 
 begin
-  require "rails/railtie"
   require "identity_cache"
 rescue LoadError
   # means IdentityCache is not installed,

--- a/spec/tapioca/compilers/dsl/identity_cache_spec.rb
+++ b/spec/tapioca/compilers/dsl/identity_cache_spec.rb
@@ -4,6 +4,10 @@
 require "spec_helper"
 
 class Tapioca::Compilers::Dsl::IdentityCacheSpec < DslSpec
+  before do
+    require "rails/railtie"
+  end
+
   describe("#initialize") do
     after(:each) do
       T.unsafe(self).assert_no_generated_errors


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
If the `config` DSL generator was loaded after `identity_cache` DSL generator, then we had a failure because `Rails::Railtie` would be loaded but there wouldn't be a properly configured application around.

The problem was because `identity_cache` was requiring `rails/railtie` explicitly, which it shouldn't do. Any proper installation of IDC should be inside of a properly configured Rails application or, alternatively, it would be loaded inside a non-Rails application which would not trigger the IDC Railtie anyway.

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
The best fix is to move the require of `rails/railtie` to IDC generator tests instead.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->
No new tests.
