### PR TITLE
Exclude anonymous or value constants from DSL generation

### DIFF
--- a/lib/tapioca/compilers/dsl_compiler.rb
+++ b/lib/tapioca/compilers/dsl_compiler.rb
@@ -49,6 +49,8 @@ module Tapioca
       end
       def run(&blk)
         constants_to_process = gather_constants(requested_constants)
+          .select { |c| Reflection.name_of(c) && Module === c } # Filter anonymous or value constants
+          .sort_by! { |c| T.must(Reflection.name_of(c)) }
 
         if constants_to_process.empty?
           report_error(<<~ERROR)
@@ -58,7 +60,7 @@ module Tapioca
         end
 
         result = Executor.new(
-          constants_to_process.sort_by { |c| c.name.to_s },
+          constants_to_process,
           number_of_workers: @number_of_workers
         ).run_in_parallel do |constant|
           rbi = rbi_for_constant(constant)

--- a/spec/support/repo/lib/job.rb
+++ b/spec/support/repo/lib/job.rb
@@ -6,3 +6,8 @@ class Job
   def perform(foo, bar)
   end
 end
+
+# This is to make sure we don't fail on anonymous constants
+Class.new do
+  include Sidekiq::Worker
+end


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
Fix #592

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
The whole idea of DSL generation revolves around being able to generate files that are named after the constants that are being decorated, so it makes sense to filter out any constants that were collected that are anonymous.

Moreover, while we enforce that the constants that we expect to be collected are supposed to be classes/modules, we never actually enforce that at runtime, in the absence of Sorbet runtime, so I've added a filter to exclude value constants from the list of collected constants as well.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->

No added tests, but I added an anonymous Sidekiq Worker class in the test repo to trigger a failure if we don't filter anonymous classes.