### PR TITLE
Ignore Dependabot updates in release notes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,9 +9,13 @@ updates:
       - dependency-name: "sorbet-runtime"
     reviewers:
       - "Shopify/sorbet"
+    labels:
+      - "ignore-for-release"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
     reviewers:
       - "Shopify/sorbet"
+    labels:
+      - "ignore-for-release"


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
Label Dependabot PRs with the `ignore-for-release` label to avoid it showing up in the release notes.


### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
Add the label `ignore-for-release` to Dependabot PRs.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->
See automated tests.
