### PR TITLE
Sanitize type aliases

### DIFF
--- a/lib/tapioca/compilers/symbol_table/symbol_generator.rb
+++ b/lib/tapioca/compilers/symbol_table/symbol_generator.rb
@@ -169,7 +169,8 @@ module Tapioca
           comments = documentation_comments(name)
 
           if klass_name == "T::Private::Types::TypeAlias"
-            constant = RBI::Const.new(name, "T.type_alias { #{T.unsafe(value).aliased_type} }", comments: comments)
+            type_alias = sanitize_signature_types(T.unsafe(value).aliased_type.to_s)
+            constant = RBI::Const.new(name, "T.type_alias { #{type_alias} }", comments: comments)
             tree << constant
             return
           end

--- a/spec/tapioca/compilers/symbol_table_compiler_spec.rb
+++ b/spec/tapioca/compilers/symbol_table_compiler_spec.rb
@@ -3056,5 +3056,20 @@ class Tapioca::Compilers::SymbolTableCompilerSpec < Minitest::HooksSpec
 
       assert_equal(output, compile(false))
     end
+
+    it("properly processes void in type aliases") do
+      add_ruby_file("foo.rb", <<~RUBY)
+        module Foo
+          MyType = T.type_alias { T.proc.params(val: T.untyped).void }
+        end
+      RUBY
+
+      output = template(<<~RBI)
+        module Foo; end
+        Foo::MyType = T.type_alias { T.proc.params(val: T.untyped).void }
+      RBI
+
+      assert_equal(output, compile)
+    end
   end
 end


### PR DESCRIPTION
### Motivation

Because we weren't sanitizing type alias values, a proc type alias that returns void would be printed as `<VOID>`.
```ruby
# This code
MyType = T.type_alias { T.proc.params(val: T.untyped).void }

# Became this RBI
MyType = T.type_alias { T.proc.params(val: T.untyped).returns(<VOID>) }
```

We already handle such cases in other parts of the symbol generator, but we simply didn't do it for type aliases.

### Implementation

Use our method for sanitizing types before inserting the type alias value.

### Tests

See included tests.