### PR TITLE
Remove stale gem rbis on generate

### DIFF
--- a/lib/tapioca/generators/gem.rb
+++ b/lib/tapioca/generators/gem.rb
@@ -55,6 +55,11 @@ module Tapioca
         require_gem_file
 
         gem_queue = gems_to_generate(@gem_names).reject { |gem| @gem_excludes.include?(gem.name) }
+        anything_done = [
+          perform_removals,
+          gem_queue.any?,
+        ].any?
+
         Executor.new(gem_queue, number_of_workers: @number_of_workers).run_in_parallel do |gem|
           shell.indent do
             compile_gem_rbi(gem)
@@ -62,8 +67,12 @@ module Tapioca
           end
         end
 
-        say("All operations performed in working directory.", [:green, :bold])
-        say("Please review changes and commit them.", [:green, :bold])
+        if anything_done
+          say("All operations performed in working directory.", [:green, :bold])
+          say("Please review changes and commit them.", [:green, :bold])
+        else
+          say("No operations performed, all RBIs are up-to-date.", [:green, :bold])
+        end
       end
 
       sig { params(should_verify: T::Boolean).void }


### PR DESCRIPTION
Closes #520

### Motivation

If gems are removed from the Gemfile, we need to delete the corresponding RBI in `generate` too, similar to what we do in `sync`.

### Implementation

I re-used the same strategy in sync. The commits in order:
1. Start removing stale gem RBIs in generate
2. Add rails-dom-testing and erubi to require.rb. Our RBIs were a bit stale and re-generating without these requires caused type errors
3. Re-generate RBIs

### Tests

See included tests.