### PR TITLE
Set default number of workers to one

### DIFF
--- a/lib/tapioca/cli.rb
+++ b/lib/tapioca/cli.rb
@@ -82,8 +82,7 @@ module Tapioca
     option :workers,
       aliases: ["-w"],
       type: :numeric,
-      default: nil,
-      desc: "Number of parallel workers to use when generating RBIs"
+      desc: "EXPERIMENTAL: Number of parallel workers to use when generating RBIs"
     def dsl(*constants)
       current_command = T.must(current_command_chain.first)
       config = ConfigBuilder.from_options(current_command, options)
@@ -101,6 +100,14 @@ module Tapioca
         verbose: options[:verbose],
         number_of_workers: config.workers
       )
+
+      if config.workers != 1
+        say(
+          "Using more than one worker is experimental and might produce results that are not deterministic",
+          :red
+        )
+      end
+
       Tapioca.silence_warnings do
         generator.generate
       end
@@ -139,8 +146,7 @@ module Tapioca
     option :workers,
       aliases: ["-w"],
       type: :numeric,
-      default: nil,
-      desc: "Number of parallel workers to use when generating RBIs"
+      desc: "EXPERIMENTAL: Number of parallel workers to use when generating RBIs"
     def gem(*gems)
       Tapioca.silence_warnings do
         all = options[:all]
@@ -165,6 +171,13 @@ module Tapioca
         unless gems.empty?
           raise MalformattedArgumentError, "Option '--all' must be provided without any other arguments" if all
           raise MalformattedArgumentError, "Option '--verify' must be provided without any other arguments" if verify
+        end
+
+        if config.workers != 1
+          say(
+            "Using more than one worker is experimental and might produce results that are not deterministic",
+            :red
+          )
         end
 
         if gems.empty? && !all

--- a/lib/tapioca/config.rb
+++ b/lib/tapioca/config.rb
@@ -15,7 +15,7 @@ module Tapioca
     const(:generators, T::Array[String])
     const(:file_header, T::Boolean, default: true)
     const(:doc, T::Boolean, default: false)
-    const(:workers, T.nilable(Integer), default: nil)
+    const(:workers, T.nilable(Integer), default: 1)
 
     sig { returns(Pathname) }
     def outpath

--- a/lib/tapioca/config_builder.rb
+++ b/lib/tapioca/config_builder.rb
@@ -68,7 +68,7 @@ module Tapioca
       "generators" => [],
       "file_header" => true,
       "doc" => false,
-      "workers" => nil,
+      "workers" => 1,
     }.freeze, T::Hash[String, T.untyped])
   end
 end


### PR DESCRIPTION
### Motivation

Until we can figure out a way of fixing #618, we should default to sequential RBI generation and warn users that using more than one worker can cause trouble.

### Implementation

Just changed the defaults and added a warning when using a different number of workers.

### Tests

Current tests are enough.