### PR TITLE
Move `include Thor::Base` to `CliHelper`

### DIFF
--- a/lib/tapioca/generators/base.rb
+++ b/lib/tapioca/generators/base.rb
@@ -12,7 +12,6 @@ module Tapioca
       end
 
       include CliHelper
-      include Thor::Base # TODO: Remove me when logging logic has been abstracted
 
       abstract!
 

--- a/lib/tapioca/helpers/cli_helper.rb
+++ b/lib/tapioca/helpers/cli_helper.rb
@@ -8,7 +8,7 @@ module Tapioca
     extend T::Sig
     extend T::Helpers
 
-    requires_ancestor { Thor::Shell }
+    include Thor::Base
 
     sig { params(message: String, color: T.any(Symbol, T::Array[Symbol])).void }
     def say_error(message = "", *color)


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
Now that logging helpers have been moved out, I am able to move the `include Thor::Base` to a more appropriate place with those helpers.

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
Lingering `TODO` from `Generator` refactor. Now that logging helpers have been extracted to `CliHelper`, the `include Thor::Base` (which was included for those logging methods) can live with them.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->
See automated tests. (No change)
