### PR TITLE
Generate RBIs with documentation by default

### DIFF
--- a/sorbet/tapioca/config.yml
+++ b/sorbet/tapioca/config.yml
@@ -1,2 +1,3 @@
 ---
 exclude: []
+doc: true


### PR DESCRIPTION
### Motivation

So I'll stop forgetting to pass `--doc` when I regenerate the RBIs.

### Tests

No functional changes.

