### PR TITLE
Add pessimistic version dependencies on our gems

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,10 +11,10 @@ PATH
     tapioca (0.5.4)
       bundler (>= 1.17.3)
       pry (>= 0.12.2)
-      rbi (>= 0.0.7)
+      rbi (~> 0.0.0, >= 0.0.8)
       sorbet-runtime (>= 0.5.9204)
       sorbet-static (>= 0.5.9204)
-      spoom (>= 1.1.4)
+      spoom (~> 1.1.0, >= 1.1.4)
       thor (>= 0.19.2)
       yard-sorbet
 

--- a/tapioca.gemspec
+++ b/tapioca.gemspec
@@ -25,10 +25,10 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency("bundler", ">= 1.17.3")
   spec.add_dependency("pry", ">= 0.12.2")
-  spec.add_dependency("rbi", ">= 0.0.7")
+  spec.add_dependency("rbi", "~> 0.0.0", ">= 0.0.8")
   spec.add_dependency("sorbet-static", ">= 0.5.9204")
   spec.add_dependency("sorbet-runtime", ">= 0.5.9204")
-  spec.add_dependency("spoom", ">= 1.1.4")
+  spec.add_dependency("spoom", "~> 1.1.0", ">= 1.1.4")
   spec.add_dependency("thor", ">= 0.19.2")
   spec.add_dependency("yard-sorbet")
 


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
Given that we are likely to break API compatibility often in RBI or Spoom, we need a way for Tapioca to not allow people to install incompatible versions of those gems. For that reason, we should add pessimistic version dependencies on those gems (as described here: https://guides.rubygems.org/patterns/#pessimistic-version-constraint), so that RBI and Spoom can bump the minor version when they make an incompatible release and Tapioca will not automatically allow end users to install those versions.

**Note:** This is PR against the `0-5-stable` branch for now. I will cherry-pick this on `main` afterwards.
