### PR TITLE
Properly load reflections for namespaced has_many relations

### DIFF
--- a/lib/tapioca/compilers/dsl/active_record_associations.rb
+++ b/lib/tapioca/compilers/dsl/active_record_associations.rb
@@ -328,9 +328,9 @@ module Tapioca
           ).returns(String)
         end
         def relation_type_for(constant, reflection)
-          raise MissingConstantError unless reflection.class_name.safe_constantize
-          "ActiveRecord::Associations::CollectionProxy" if !constant.table_exists? ||
-                                                            polymorphic_association?(reflection)
+          validate_reflection!(reflection)
+          return "ActiveRecord::Associations::CollectionProxy" if !constant.table_exists? ||
+                                                                   polymorphic_association?(reflection)
 
           "#{qualified_name_of(reflection.klass)}::#{AssociationsCollectionProxyClassName}"
         end

--- a/spec/tapioca/compilers/dsl/active_record_associations_spec.rb
+++ b/spec/tapioca/compilers/dsl/active_record_associations_spec.rb
@@ -417,6 +417,9 @@ class Tapioca::Compilers::Dsl::ActiveRecordAssociationsSpec < DslSpec
               create_table :posts do |t|
               end
 
+              create_table :drafts do |t|
+              end
+
               create_table :authors do |t|
               end
 
@@ -434,8 +437,13 @@ class Tapioca::Compilers::Dsl::ActiveRecordAssociationsSpec < DslSpec
               end
             end
 
+            class Draft < ActiveRecord::Base
+              belongs_to :author
+            end
+
             class Author < ActiveRecord::Base
               has_many :comments
+              has_many :drafts
             end
           end
 
@@ -492,6 +500,18 @@ class Tapioca::Compilers::Dsl::ActiveRecordAssociationsSpec < DslSpec
 
               sig { params(value: T::Enumerable[::Comment]).void }
               def comments=(value); end
+
+              sig { returns(T::Array[T.untyped]) }
+              def draft_ids; end
+
+              sig { params(ids: T::Array[T.untyped]).returns(T::Array[T.untyped]) }
+              def draft_ids=(ids); end
+
+              sig { returns(::Blog::Draft::PrivateCollectionProxy) }
+              def drafts; end
+
+              sig { params(value: T::Enumerable[::Blog::Draft]).void }
+              def drafts=(value); end
             end
           end
         RBI

--- a/spec/tapioca/compilers/dsl/active_record_associations_spec.rb
+++ b/spec/tapioca/compilers/dsl/active_record_associations_spec.rb
@@ -253,6 +253,18 @@ class Tapioca::Compilers::Dsl::ActiveRecordAssociationsSpec < DslSpec
       end
 
       it("generates RBI file for has_many collection association") do
+        add_ruby_file("schema.rb", <<~RUBY)
+          ActiveRecord::Migration.suppress_messages do
+            ActiveRecord::Schema.define do
+              create_table :posts do |t|
+              end
+
+              create_table :comments do |t|
+              end
+            end
+          end
+        RUBY
+
         add_ruby_file("comment.rb", <<~RUBY)
           class Comment
           end
@@ -282,7 +294,7 @@ class Tapioca::Compilers::Dsl::ActiveRecordAssociationsSpec < DslSpec
               sig { returns(::Comment::PrivateCollectionProxy) }
               def comments; end
 
-              sig { params(value: T::Enumerable[T.untyped]).void }
+              sig { params(value: T::Enumerable[::Comment]).void }
               def comments=(value); end
 
               sig { params(attributes: T.untyped).returns(T.untyped) }
@@ -369,6 +381,18 @@ class Tapioca::Compilers::Dsl::ActiveRecordAssociationsSpec < DslSpec
 
       it("generates RBI file for has_and_belongs_to_many collection association") do
         add_ruby_file("schema.rb", <<~RUBY)
+          ActiveRecord::Migration.suppress_messages do
+            ActiveRecord::Schema.define do
+              create_table :commenters do |t|
+              end
+
+              create_table :posts do |t|
+              end
+            end
+          end
+        RUBY
+
+        add_ruby_file("commenter.rb", <<~RUBY)
           class Commenter < ActiveRecord::Base
             has_and_belongs_to_many :posts
           end
@@ -398,7 +422,7 @@ class Tapioca::Compilers::Dsl::ActiveRecordAssociationsSpec < DslSpec
               sig { returns(::Commenter::PrivateCollectionProxy) }
               def commenters; end
 
-              sig { params(value: T::Enumerable[T.untyped]).void }
+              sig { params(value: T::Enumerable[::Commenter]).void }
               def commenters=(value); end
 
               sig { params(attributes: T.untyped).returns(T.untyped) }
@@ -759,6 +783,15 @@ class Tapioca::Compilers::Dsl::ActiveRecordAssociationsSpec < DslSpec
     end
 
     it("generates RBI file for has_many_attached ActiveStorage association") do
+      add_ruby_file("schema.rb", <<~RUBY)
+        ActiveRecord::Migration.suppress_messages do
+          ActiveRecord::Schema.define do
+            create_table :posts do |t|
+            end
+          end
+        end
+      RUBY
+
       add_ruby_file("post.rb", <<~RUBY)
         class Post < ActiveRecord::Base
           has_many_attached :photos
@@ -781,7 +814,7 @@ class Tapioca::Compilers::Dsl::ActiveRecordAssociationsSpec < DslSpec
             sig { returns(::ActiveStorage::Attachment::PrivateCollectionProxy) }
             def photos_attachments; end
 
-            sig { params(value: T::Enumerable[T.untyped]).void }
+            sig { params(value: T::Enumerable[::ActiveStorage::Attachment]).void }
             def photos_attachments=(value); end
 
             sig { returns(T::Array[T.untyped]) }
@@ -793,7 +826,7 @@ class Tapioca::Compilers::Dsl::ActiveRecordAssociationsSpec < DslSpec
             sig { returns(::ActiveStorage::Blob::PrivateCollectionProxy) }
             def photos_blobs; end
 
-            sig { params(value: T::Enumerable[T.untyped]).void }
+            sig { params(value: T::Enumerable[::ActiveStorage::Blob]).void }
             def photos_blobs=(value); end
           end
         end


### PR DESCRIPTION
### Motivation
This follows up https://github.com/Shopify/tapioca/pull/634 to properly load reflections for namespaced has_many relations (vs just has_one relations).

### Implementation
It's a pretty straightforward port of the logic from #634.

### Tests
Updated the test suite to cover the new functionality.

