### PR TITLE
Add a command to clean shim files automatically

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,7 +11,7 @@ PATH
     tapioca (0.5.4)
       bundler (>= 1.17.3)
       pry (>= 0.12.2)
-      rbi (~> 0.0.0, >= 0.0.8)
+      rbi (~> 0.0.0, >= 0.0.9)
       sorbet-runtime (>= 0.5.9204)
       sorbet-static (>= 0.5.9204)
       spoom (~> 1.1.0, >= 1.1.4)
@@ -217,7 +217,7 @@ GEM
       thor (~> 1.0)
     rainbow (3.0.0)
     rake (13.0.6)
-    rbi (0.0.8)
+    rbi (0.0.9)
       ast
       parser
       sorbet-runtime (>= 0.5.9204)

--- a/lib/tapioca/config.rb
+++ b/lib/tapioca/config.rb
@@ -36,6 +36,7 @@ module Tapioca
     DEFAULT_RBIDIR = T.let("#{SORBET_PATH}/rbi", String)
     DEFAULT_DSLDIR = T.let("#{DEFAULT_RBIDIR}/dsl", String)
     DEFAULT_GEMDIR = T.let("#{DEFAULT_RBIDIR}/gems", String)
+    DEFAULT_SHIMDIR = T.let("#{DEFAULT_RBIDIR}/shims", String)
     DEFAULT_TODOSPATH = T.let("#{DEFAULT_RBIDIR}/todo.rbi", String)
 
     DEFAULT_OVERRIDES = T.let({

--- a/spec/tapioca/cli/clean_shims_spec.rb
+++ b/spec/tapioca/cli/clean_shims_spec.rb
@@ -1,0 +1,266 @@
+# typed: true
+# frozen_string_literal: true
+
+require "spec_with_project"
+
+module Tapioca
+  class CleanShimsTest < SpecWithProject
+    describe "tapioca clean-shims" do
+      before(:all) do
+        @project.bundle_install
+      end
+
+      after do
+        @project.remove("sorbet/rbi")
+      end
+
+      it "does nothing when there is no duplicate to clean" do
+        @project.write("sorbet/rbi/gems/foo@1.0.0.rbi", <<~RBI)
+          class Foo
+            attr_reader :foo
+          end
+        RBI
+
+        @project.write("sorbet/rbi/shims/foo.rbi", <<~RBI)
+          class Foo
+            attr_reader :bar
+          end
+        RBI
+
+        out, _, status = @project.tapioca("clean-shims")
+
+        assert_equal(<<~OUT, out)
+          Loading gem RBIs from sorbet/rbi/gems...  Done
+          Loading dsl RBIs from sorbet/rbi/dsl...  Done
+          Cleaning shim RBIs from sorbet/rbi/shims... Done (nothing to do)
+        OUT
+
+        assert(status)
+
+        assert_project_file_equal("sorbet/rbi/shims/foo.rbi", <<~RBI)
+          class Foo
+            attr_reader :bar
+          end
+        RBI
+      end
+
+      it "cleans unecessary shims" do
+        @project.write("sorbet/rbi/gems/foo@1.0.0.rbi", <<~RBI)
+          class Foo
+            attr_reader :foo
+          end
+        RBI
+
+        @project.write("sorbet/rbi/gems/bar@2.0.0.rbi", <<~RBI)
+          module Bar
+            def bar; end
+          end
+        RBI
+
+        @project.write("sorbet/rbi/shims/foo.rbi", <<~RBI)
+          class Foo
+            attr_reader :foo
+          end
+        RBI
+
+        @project.write("sorbet/rbi/shims/bar.rbi", <<~RBI)
+          module Bar
+            def foo; end
+            def bar; end
+          end
+        RBI
+
+        @project.write("sorbet/rbi/shims/baz.rbi", <<~RBI)
+          BAZ = 42
+        RBI
+
+        out, _, status = @project.tapioca("clean-shims")
+
+        assert_equal(<<~OUT, out)
+          Loading gem RBIs from sorbet/rbi/gems...  Done
+          Loading dsl RBIs from sorbet/rbi/dsl...  Done
+          Cleaning shim RBIs from sorbet/rbi/shims...
+            Deleted ::Bar#bar() at sorbet/rbi/shims/bar.rbi:3:2-3:14 (duplicate from sorbet/rbi/gems/bar@2.0.0.rbi:2:2-2:14)
+            Deleted ::Foo.attr_reader(:foo) at sorbet/rbi/shims/foo.rbi:2:2-2:18 (duplicate from sorbet/rbi/gems/foo@1.0.0.rbi:2:2-2:18)
+            Deleted ::Foo at sorbet/rbi/shims/foo.rbi:1:0-3:3 (duplicate from sorbet/rbi/gems/foo@1.0.0.rbi:1:0-3:3)
+            Deleted empty file sorbet/rbi/shims/foo.rbi
+          Done
+        OUT
+
+        assert(status)
+
+        refute_project_file_exist("sorbet/rbi/shims/foo.rbi")
+
+        assert_project_file_equal("sorbet/rbi/shims/bar.rbi", <<~RBI)
+          module Bar
+            def foo; end
+          end
+        RBI
+
+        assert_project_file_equal("sorbet/rbi/shims/baz.rbi", <<~RBI)
+          BAZ = 42
+        RBI
+      end
+
+      it "preserves missing sigs" do
+        @project.write("sorbet/rbi/gems/foo@1.0.0.rbi", <<~RBI)
+          class Foo
+            def foo; end
+            def bar; end
+          end
+        RBI
+
+        @project.write("sorbet/rbi/shims/foo.rbi", <<~RBI)
+          class Foo
+            sig { void }
+            def foo; end
+
+            def bar; end
+          end
+        RBI
+
+        out, _, status = @project.tapioca("clean-shims")
+
+        assert_equal(<<~OUT, out)
+          Loading gem RBIs from sorbet/rbi/gems...  Done
+          Loading dsl RBIs from sorbet/rbi/dsl...  Done
+          Cleaning shim RBIs from sorbet/rbi/shims...
+            Deleted ::Foo#bar() at sorbet/rbi/shims/foo.rbi:5:2-5:14 (duplicate from sorbet/rbi/gems/foo@1.0.0.rbi:3:2-3:14)
+          Done
+        OUT
+
+        assert(status)
+
+        assert_project_file_equal("sorbet/rbi/shims/foo.rbi", <<~RBI)
+          class Foo
+            sig { void }
+            def foo; end
+          end
+        RBI
+      end
+
+      it "preserves nodes with multiple definitions" do
+        @project.write("sorbet/rbi/gems/foo@1.0.0.rbi", <<~RBI)
+          class Foo
+            attr_reader :foo
+          end
+        RBI
+
+        @project.write("sorbet/rbi/shims/foo.rbi", <<~RBI)
+          class Foo
+            attr_reader :foo, :bar
+          end
+        RBI
+
+        out, _, status = @project.tapioca("clean-shims")
+
+        assert_equal(<<~OUT, out)
+          Loading gem RBIs from sorbet/rbi/gems...  Done
+          Loading dsl RBIs from sorbet/rbi/dsl...  Done
+          Cleaning shim RBIs from sorbet/rbi/shims... Done (nothing to do)
+        OUT
+
+        assert(status)
+
+        assert_project_file_equal("sorbet/rbi/shims/foo.rbi", <<~RBI)
+          class Foo
+            attr_reader :foo, :bar
+          end
+        RBI
+      end
+
+      it "cleans shims with custom rbi dirs" do
+        @project.write("rbi/gem/foo@1.0.0.rbi", <<~RBI)
+          class Foo
+            def foo; end
+          end
+        RBI
+
+        @project.write("rbi/dsl/foo.rbi", <<~RBI)
+          class Foo
+            def bar; end
+          end
+        RBI
+
+        @project.write("rbi/shim/foo.rbi", <<~RBI)
+          class Foo
+            def foo; end
+            def bar; end
+          end
+        RBI
+
+        out, _, status = @project.tapioca(
+          "clean-shims --gem-rbis-path=rbi/gem --dsl-rbis-path=rbi/dsl --shim-rbis-path=rbi/shim"
+        )
+
+        assert_equal(<<~OUT, out)
+          Loading gem RBIs from rbi/gem...  Done
+          Loading dsl RBIs from rbi/dsl...  Done
+          Cleaning shim RBIs from rbi/shim...
+            Deleted ::Foo#foo() at rbi/shim/foo.rbi:2:2-2:14 (duplicate from rbi/gem/foo@1.0.0.rbi:2:2-2:14)
+            Deleted ::Foo#bar() at rbi/shim/foo.rbi:3:2-3:14 (duplicate from rbi/dsl/foo.rbi:2:2-2:14)
+            Deleted ::Foo at rbi/shim/foo.rbi:1:0-4:3 (duplicate from rbi/gem/foo@1.0.0.rbi:1:0-3:3)
+            Deleted empty file rbi/shim/foo.rbi
+          Done
+        OUT
+
+        assert(status)
+        refute_project_file_exist("custom/shims/foo.rbi")
+        @project.remove("rbi")
+      end
+
+      it "cleans only specified shims" do
+        @project.write("sorbet/rbi/gems/foo@1.0.0.rbi", <<~RBI)
+          class Foo
+            def foo; end
+            def bar; end
+            def baz; end
+          end
+        RBI
+
+        @project.write("sorbet/rbi/shims/a.rbi", <<~RBI)
+          class Foo
+            def foo; end
+          end
+        RBI
+
+        @project.write("sorbet/rbi/shims/b.rbi", <<~RBI)
+          class Foo
+            def bar; end
+          end
+        RBI
+
+        @project.write("sorbet/rbi/shims/c.rbi", <<~RBI)
+          class Foo
+            def baz; end
+          end
+        RBI
+
+        out, _, status = @project.tapioca("clean-shims sorbet/rbi/shims/a.rbi sorbet/rbi/shims/b.rbi")
+
+        assert_equal(<<~OUT, out)
+          Loading gem RBIs from sorbet/rbi/gems...  Done
+          Loading dsl RBIs from sorbet/rbi/dsl...  Done
+          Cleaning shim RBIs...
+            Deleted ::Foo#foo() at sorbet/rbi/shims/a.rbi:2:2-2:14 (duplicate from sorbet/rbi/gems/foo@1.0.0.rbi:2:2-2:14)
+            Deleted ::Foo at sorbet/rbi/shims/a.rbi:1:0-3:3 (duplicate from sorbet/rbi/gems/foo@1.0.0.rbi:1:0-5:3)
+            Deleted empty file sorbet/rbi/shims/a.rbi
+            Deleted ::Foo#bar() at sorbet/rbi/shims/b.rbi:2:2-2:14 (duplicate from sorbet/rbi/gems/foo@1.0.0.rbi:3:2-3:14)
+            Deleted ::Foo at sorbet/rbi/shims/b.rbi:1:0-3:3 (duplicate from sorbet/rbi/gems/foo@1.0.0.rbi:1:0-5:3)
+            Deleted empty file sorbet/rbi/shims/b.rbi
+          Done
+        OUT
+
+        assert(status)
+        refute_project_file_exist("sorbet/rbi/shims/a.rbi")
+        refute_project_file_exist("sorbet/rbi/shims/b.rbi")
+
+        assert_project_file_equal("sorbet/rbi/shims/c.rbi", <<~RBI)
+          class Foo
+            def baz; end
+          end
+        RBI
+      end
+    end
+  end
+end

--- a/tapioca.gemspec
+++ b/tapioca.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency("bundler", ">= 1.17.3")
   spec.add_dependency("pry", ">= 0.12.2")
-  spec.add_dependency("rbi", "~> 0.0.0", ">= 0.0.8")
+  spec.add_dependency("rbi", "~> 0.0.0", ">= 0.0.9")
   spec.add_dependency("sorbet-static", ">= 0.5.9204")
   spec.add_dependency("sorbet-runtime", ">= 0.5.9204")
   spec.add_dependency("spoom", "~> 1.1.0", ">= 1.1.4")


### PR DESCRIPTION
### Motivation

As we get more precise content generated from the `gem` and `dsl` commands, we can expect that some shim definition are not useful anymore.

This PR adds a `clean-shims` command that remove the definitions that are no longer required from the shim RBI files.

Closes #435:

### Implementation

This work is mostly based on the [`RemoveKnownDefinitions tree rewriter`](https://github.com/Shopify/rbi/pull/100):

1. We parse the gem RBIs and index their content
2. We parse the DSL RBIs and index their content
3. We parse the shim RBIs then for each definition in the shims
   * If the definition is present in the index we remove it from the tree
   * Then, if a scope is already present in the index and is empty in the shim, we remove it from the tree
   * Then, if a file is empty we delete it

Some considerations about what we remove and what we keep:
* We preserve methods that have the same names but different parameters like `def foo; end` vs. `def foo(x); end`. In those cases, there is most likely something the developer wanted that was not generated properly in the RBI generated (and it might have been set as `typed: false`).
* We preserve nodes that have a signature in the shims but not in the generated RBIs (or a different signature in the generated RBIs).
* We also preserve different attribute accessors such as `attr_reader :foo` vs. `attr_accessor :foo, :bar`.
* We discard nodes that have a different comment between the generated RBIs and the shim as to be sure to remove nodes like this one:

   ```
   # TODO remove this once Tapioca is fixed
   class SomethingThatWasMissingInTheGeneratedRBIs; end
   ```

Please note that for project with _a lot_ of gem/dsl RBI files this command might take some time to complete since we would need to parse a lot of content.

### Example

Be the following project:

```rb
# sorbet/rbi/gems/foo@1.0.0.rbi
class Foo
  attr_reader :foo
end

# sorbet/rbi/gems/bar@2.0.0.rbi
module Bar
  def bar; end
end

# sorbet/rbi/shims/foo.rbi
class Foo
  def foo; end
end

# sorbet/rbi/shims/bar.rbi
module Bar
  def foo; end
  def bar; end
end
```

And run `tapioca clean-shims`:

```
$ tapioca clean-shims

Loading gem RBIs from sorbet/rbi/gems...  Done
Loading dsl RBIs from sorbet/rbi/dsl...  Done
Cleaning shim RBIs from sorbet/rbi/shims...
  Deleted ::Bar#bar() at sorbet/rbi/shims/bar.rbi:3:2-3:14 (duplicate from sorbet/rbi/gems/bar@2.0.0.rbi:2:2-2:14)
  Deleted ::Foo#foo() at sorbet/rbi/shims/foo.rbi:2:2-2:18 (duplicate from sorbet/rbi/gems/foo@1.0.0.rbi:2:2-2:18)
  Deleted ::Foo at sorbet/rbi/shims/foo.rbi:1:0-3:3 (duplicate from sorbet/rbi/gems/foo@1.0.0.rbi:1:0-3:3)
  Deleted empty file sorbet/rbi/shims/foo.rbi
Done
```

This will have deleted the `foo.rbi` shim and cleaned the `bar.rbi` one:

```rbi
# sorbet/rbi/shims/bar.rbi
module Bar
  def foo; end
end
```

### Tests

See automate tests.

