### PR TITLE
Stop intercepting `Module#autoload` with a prepend

### DIFF
--- a/spec/tapioca/cli/gem_spec.rb
+++ b/spec/tapioca/cli/gem_spec.rb
@@ -771,6 +771,57 @@ module Tapioca
           RBI
         end
 
+        it "uses the correct autoload, even when a gem redefines it via alias-method-chain" do
+          foo = mock_gem("foo", "0.0.1") do
+            write("lib/foo.rb", <<~RB)
+              class Module
+                alias_method :autoload_without_foo, :autoload
+
+                def autoload(const, path)
+                  autoload_without_foo(const, path)
+                end
+              end
+            RB
+          end
+
+          @project.require_mock_gem(foo)
+          @project.bundle_install
+
+          _, err, status = @project.tapioca("gem foo")
+          assert_empty(err)
+          assert(status)
+        end
+
+        it "uses ignores `abort` and `exit` calls inside autoloaded files" do
+          foo = mock_gem("foo", "0.0.1") do
+            write("lib/foo.rb", <<~RB)
+              module Foo
+                autoload :Bar, __dir__ + "/foo/bar.rb"
+                autoload :Baz, __dir__ + "/foo/baz.rb"
+              end
+            RB
+
+            write("lib/foo/bar.rb", <<~RB)
+              abort("Cannot continue")
+            RB
+
+            write("lib/foo/baz.rb", <<~RB)
+              exit 2
+            RB
+          end
+
+          @project.require_mock_gem(foo)
+          # We know RDoc is problematic with respect to calling `abort` in an autoload
+          @project.require_real_gem("rdoc")
+          # Just so that we have something else we can generate for.
+          @project.require_real_gem("json")
+          @project.bundle_install
+
+          _, err, status = @project.tapioca("gem json")
+          assert_empty(err)
+          assert(status)
+        end
+
         it "generates abstract classes properly" do
           foo = mock_gem("foo", "0.0.1") do
             write("lib/foo.rb", <<~RB)

--- a/spec/tapioca/cli/gem_spec.rb
+++ b/spec/tapioca/cli/gem_spec.rb
@@ -700,7 +700,7 @@ module Tapioca
             # Top-level autoloads `FakeYard::Rake` module.
             write("lib/fake_yard.rb", <<~RB)
               module FakeYard
-                autoload :Rake, "#{absolute_path("lib/fake_yard/rake.rb")}"
+                autoload :Rake, __dir__ + "/fake_yard/rake.rb"
               end
             RB
 
@@ -711,7 +711,7 @@ module Tapioca
             write("lib/fake_yard/rake.rb", <<~RB)
               module FakeYard
                 module Rake
-                  autoload :YardocTask, "#{absolute_path("lib/fake_yard/yardoc_task.rb")}"
+                  autoload :YardocTask, __dir__ + "/yardoc_task.rb"
                 end
               end
             RB


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
After #639 was merged, we noticed there were 2 problems:

1. In projects with Bootsnap installed, we were getting into an infinite loop and exiting with a stack overflow exception. This was happening because `AutoloadTracker` used prepending a module to intercept `Kernel#autoload` but Bootsnap was using alias-method-chain. The two approaches are not exactly compatible and by the time Bootsnap is loaded, the method it was aliasing was becoming the `AutoloadTracker#autoload` method, thus an infinite loop was entered.
2. I noticed that the eager load method was sometimes exiting the process with the message: ``webrick is not found. You may need to `gem install webrick` to install webrick.``. I followed that message into [RDoc calling an `abort`](https://github.com/ruby/ruby/blob/d486286f1d8fa01356498792b368c46fe9619d09/lib/rdoc/servlet.rb#L10) if it couldn't require `webrick`. There are some other gems that do that too, so we needed a way to prevent process exits during eager load.

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->

1. Solving this problem is easy by doing alias-method-chain in Tapioca for intercepting `Module#autoload`.
2. This is implemented by temporarily redefining `Kernel#abort` and `Kernel#exit` during the eager load operation, and then redefining them back, after the operation is finished.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->

Added 2 tests to exercise the two situations. Thanks to @RyanBrushett and @Morriar for the tests.
