### PR TITLE
Improve autoload `Kernel` hooks so that they actually work now

### DIFF
--- a/lib/tapioca/autoload_tracker.rb
+++ b/lib/tapioca/autoload_tracker.rb
@@ -5,6 +5,8 @@ module Tapioca
   module AutoloadTracker
     extend T::Sig
 
+    NOOP_METHOD = -> (*_args, **_kwargs, &_block) {}
+
     @constant_names_registered_for_autoload = T.let([], T::Array[String])
 
     class << self
@@ -37,8 +39,8 @@ module Tapioca
         original_exit = Kernel.instance_method(:exit)
 
         begin
-          Kernel.define_method(:abort) {}
-          Kernel.define_method(:exit) {}
+          Kernel.define_method(:abort, NOOP_METHOD)
+          Kernel.define_method(:exit, NOOP_METHOD)
 
           block.call
         ensure

--- a/spec/tapioca/cli/gem_spec.rb
+++ b/spec/tapioca/cli/gem_spec.rb
@@ -802,11 +802,21 @@ module Tapioca
             RB
 
             write("lib/foo/bar.rb", <<~RB)
-              abort("Cannot continue")
+              begin
+                abort("Cannot continue")
+              rescue
+                # To make sure that we handle errors in our Kernel hooks
+                Process.exit(1)
+              end
             RB
 
             write("lib/foo/baz.rb", <<~RB)
-              exit 2
+              begin
+                exit 2
+              rescue
+                # To make sure that we handle errors in our Kernel hooks
+                Process.exit(1)
+              end
             RB
           end
 


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
Fixes #648.

Part of the previous autoload tracker PR (#642) was actually broken and the test that was exercising that code path was broken in that it wasn't catching the fact that the implementation was broken.

Since `Kernel#abort` and `Kernel.exit` both expect parameters, our override with no expected parameters was failing but the failure was being caught by the autoload process and silently swallowed. So while it looked like we were successfully preventing the process from exiting, we weren't really doing the correct thing.

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
I pulled out the noop method used for both `Kernel#abort` and `Kernel#exit` to a constant and made sure it handles any kind of parameters that could be given to it.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->
Improved the test to handle trivial errors that could happen while calling `Kernel#abort` and `Kernel#exit` during the test run and report them as test failures.
