### PR TITLE
Allow DSL generators to change behaviour based on if `ActiveRecordRelations` is enabled or not

### DIFF
--- a/lib/tapioca/compilers/dsl/active_record_associations.rb
+++ b/lib/tapioca/compilers/dsl/active_record_associations.rb
@@ -329,11 +329,18 @@ module Tapioca
         end
         def relation_type_for(constant, reflection)
           validate_reflection!(reflection)
-          return "ActiveRecord::Associations::CollectionProxy" if !constant.table_exists? ||
-                                                                   polymorphic_association?(reflection)
 
-          if generator_enabled?("ActiveRecordRelations")
-            "#{qualified_name_of(reflection.klass)}::#{AssociationsCollectionProxyClassName}"
+          relations_enabled = generator_enabled?("ActiveRecordRelations")
+          polymorphic_association = !constant.table_exists? || polymorphic_association?(reflection)
+
+          if relations_enabled
+            if polymorphic_association
+              "ActiveRecord::Associations::CollectionProxy"
+            else
+              "#{qualified_name_of(reflection.klass)}::#{AssociationsCollectionProxyClassName}"
+            end
+          elsif polymorphic_association
+            "ActiveRecord::Associations::CollectionProxy[T.untyped]"
           else
             "::ActiveRecord::Associations::CollectionProxy[#{qualified_name_of(reflection.klass)}]"
           end

--- a/lib/tapioca/compilers/dsl/active_record_associations.rb
+++ b/lib/tapioca/compilers/dsl/active_record_associations.rb
@@ -332,7 +332,11 @@ module Tapioca
           return "ActiveRecord::Associations::CollectionProxy" if !constant.table_exists? ||
                                                                    polymorphic_association?(reflection)
 
-          "#{qualified_name_of(reflection.klass)}::#{AssociationsCollectionProxyClassName}"
+          if generator_enabled?("ActiveRecordRelations")
+            "#{qualified_name_of(reflection.klass)}::#{AssociationsCollectionProxyClassName}"
+          else
+            "::ActiveRecord::Associations::CollectionProxy[#{qualified_name_of(reflection.klass)}]"
+          end
         end
 
         sig do

--- a/lib/tapioca/compilers/dsl/active_record_scope.rb
+++ b/lib/tapioca/compilers/dsl/active_record_scope.rb
@@ -58,17 +58,22 @@ module Tapioca
           return if method_names.empty?
 
           root.create_path(constant) do |model|
+            relations_enabled = generator_enabled?("ActiveRecordRelations")
+
             relation_methods_module = model.create_module(RelationMethodsModuleName)
-            association_relation_methods_module = model.create_module(AssociationRelationMethodsModuleName)
+            assoc_relation_methods_mod = model.create_module(AssociationRelationMethodsModuleName) if relations_enabled
 
             method_names.each do |scope_method|
               generate_scope_method(
                 relation_methods_module,
                 scope_method.to_s,
-                RelationClassName
+                relations_enabled ? RelationClassName : "T.untyped"
               )
+
+              next unless relations_enabled
+
               generate_scope_method(
-                association_relation_methods_module,
+                assoc_relation_methods_mod,
                 scope_method.to_s,
                 AssociationRelationClassName
               )

--- a/lib/tapioca/compilers/dsl/base.rb
+++ b/lib/tapioca/compilers/dsl/base.rb
@@ -24,6 +24,19 @@ module Tapioca
         sig { returns(T::Array[String]) }
         attr_reader :errors
 
+        sig { params(name: String).returns(T.nilable(T.class_of(Tapioca::Compilers::Dsl::Base))) }
+        def self.resolve(name)
+          # Try to find built-in tapioca generator first, then globally defined generator.
+          potentials = ["Tapioca::Compilers::Dsl::#{name}", name].map do |potential_name|
+            Object.const_get(potential_name)
+          rescue NameError
+            # Skip if we can't find generator by the potential name
+            nil
+          end
+
+          potentials.compact.first
+        end
+
         sig { params(compiler: Tapioca::Compilers::DslCompiler).void }
         def initialize(compiler)
           @compiler = compiler

--- a/lib/tapioca/compilers/dsl/base.rb
+++ b/lib/tapioca/compilers/dsl/base.rb
@@ -3,6 +3,7 @@
 
 require "tapioca/rbi_ext/model"
 require "tapioca/compilers/dsl/param_helper"
+require "tapioca/compilers/dsl_compiler"
 
 module Tapioca
   module Compilers
@@ -23,8 +24,9 @@ module Tapioca
         sig { returns(T::Array[String]) }
         attr_reader :errors
 
-        sig { void }
-        def initialize
+        sig { params(compiler: Tapioca::Compilers::DslCompiler).void }
+        def initialize(compiler)
+          @compiler = compiler
           @processable_constants = T.let(Set.new(gather_constants), T::Set[Module])
           @processable_constants.compare_by_identity
           @errors = T.let([], T::Array[String])

--- a/lib/tapioca/compilers/dsl/base.rb
+++ b/lib/tapioca/compilers/dsl/base.rb
@@ -37,6 +37,11 @@ module Tapioca
           processable_constants.include?(constant)
         end
 
+        sig { params(generator_name: String).returns(T::Boolean) }
+        def generator_enabled?(generator_name)
+          @compiler.generator_enabled?(generator_name)
+        end
+
         sig do
           abstract
             .type_parameters(:T)

--- a/lib/tapioca/compilers/dsl_compiler.rb
+++ b/lib/tapioca/compilers/dsl_compiler.rb
@@ -22,7 +22,7 @@ module Tapioca
           requested_constants: T::Array[Module],
           requested_generators: T::Array[T.class_of(Dsl::Base)],
           excluded_generators: T::Array[T.class_of(Dsl::Base)],
-          error_handler: T.nilable(T.proc.params(error: String).void),
+          error_handler: T.proc.params(error: String).void,
           number_of_workers: T.nilable(Integer),
         ).void
       end
@@ -30,7 +30,7 @@ module Tapioca
         requested_constants:,
         requested_generators: [],
         excluded_generators: [],
-        error_handler: nil,
+        error_handler: $stderr.method(:puts).to_proc,
         number_of_workers: nil
       )
         @generators = T.let(
@@ -38,7 +38,7 @@ module Tapioca
           T::Enumerable[Dsl::Base]
         )
         @requested_constants = requested_constants
-        @error_handler = T.let(error_handler || $stderr.method(:puts), T.proc.params(error: String).void)
+        @error_handler = error_handler
         @number_of_workers = number_of_workers
       end
 
@@ -90,7 +90,7 @@ module Tapioca
             !excluded_generators.include?(klass)
         end.sort_by { |klass| T.must(klass.name) }
 
-        generator_klasses.map(&:new)
+        generator_klasses.map { |generator_klass| generator_klass.new(self) }
       end
 
       sig { params(requested_constants: T::Array[Module]).returns(T::Set[Module]) }

--- a/lib/tapioca/compilers/dsl_compiler.rb
+++ b/lib/tapioca/compilers/dsl_compiler.rb
@@ -78,15 +78,11 @@ module Tapioca
 
       sig { params(generator_name: String).returns(T::Boolean) }
       def generator_enabled?(generator_name)
-        # Try to find built-in tapioca generator first, then globally defined generator. The
-        # explicit `break` ensures the class is returned, not the `potential_name`.
-        generator_klass = ["Tapioca::Compilers::Dsl::#{generator_name}", generator_name].find do |potential_name|
-          break Object.const_get(potential_name)
-        rescue NameError
-          # Skip if we can't find generator by the potential name
-        end
+        generator = Dsl::Base.resolve(generator_name)
 
-        @generators.any?(generator_klass)
+        return false unless generator
+
+        @generators.any?(generator)
       end
 
       private

--- a/lib/tapioca/compilers/dsl_compiler.rb
+++ b/lib/tapioca/compilers/dsl_compiler.rb
@@ -76,6 +76,19 @@ module Tapioca
         result.compact
       end
 
+      sig { params(generator_name: String).returns(T::Boolean) }
+      def generator_enabled?(generator_name)
+        # Try to find built-in tapioca generator first, then globally defined generator. The
+        # explicit `break` ensures the class is returned, not the `potential_name`.
+        generator_klass = ["Tapioca::Compilers::Dsl::#{generator_name}", generator_name].find do |potential_name|
+          break Object.const_get(potential_name)
+        rescue NameError
+          # Skip if we can't find generator by the potential name
+        end
+
+        @generators.any?(generator_klass)
+      end
+
       private
 
       sig do

--- a/spec/dsl_spec_helper.rb
+++ b/spec/dsl_spec_helper.rb
@@ -30,7 +30,11 @@ class DslSpec < Minitest::Spec
     # Get the class under test and initialize a new instance of it
     # as the "subject"
     class_name = T.unsafe(self).target_class_name
-    Object.const_get(class_name).new
+    compiler = Tapioca::Compilers::DslCompiler.new(
+      requested_constants: [],
+      requested_generators: [Object.const_get(class_name)]
+    )
+    compiler.generators.first
   end
 
   sig { returns(Class) }

--- a/spec/dsl_spec_helper.rb
+++ b/spec/dsl_spec_helper.rb
@@ -27,14 +27,23 @@ class DslSpec < Minitest::Spec
   end
 
   subject do
-    # Get the class under test and initialize a new instance of it
-    # as the "subject"
-    class_name = T.unsafe(self).target_class_name
+    T.bind(self, DslSpec)
+    # Get the class under test and initialize a new instance of it as the "subject"
+    generator_for_names(target_class_name)
+  end
+
+  sig { params(names: String).returns(Tapioca::Compilers::Dsl::Base) }
+  def generator_for_names(*names)
+    raise "name is required" if names.empty?
+
+    classes = names.map { |class_name| Object.const_get(class_name) }
+
     compiler = Tapioca::Compilers::DslCompiler.new(
       requested_constants: [],
-      requested_generators: [Object.const_get(class_name)]
+      requested_generators: classes
     )
-    compiler.generators.first
+
+    T.must(compiler.generators.find { |generator| generator.class.name == names.first })
   end
 
   sig { returns(Class) }

--- a/spec/tapioca/compilers/dsl/active_record_associations_spec.rb
+++ b/spec/tapioca/compilers/dsl/active_record_associations_spec.rb
@@ -52,654 +52,1316 @@ class Tapioca::Compilers::Dsl::ActiveRecordAssociationsSpec < DslSpec
       )
     end
 
-    describe("without errors") do
-      after(:each) do
-        T.unsafe(self).assert_no_generated_errors
+    describe("with relations enabled") do
+      subject do
+        T.bind(self, DslSpec)
+        require "tapioca/compilers/dsl/active_record_relations"
+        generator_for_names(target_class_name, "Tapioca::Compilers::Dsl::ActiveRecordRelations")
       end
 
-      it("generates empty RBI file if there are no associations") do
-        add_ruby_file("post.rb", <<~RUBY)
-          class Post < ActiveRecord::Base
-          end
-        RUBY
+      describe("without errors") do
+        after(:each) do
+          T.unsafe(self).assert_no_generated_errors
+        end
 
-        expected = <<~RBI
-          # typed: strong
-        RBI
+        it("generates empty RBI file if there are no associations") do
+          add_ruby_file("post.rb", <<~RUBY)
+            class Post < ActiveRecord::Base
+            end
+          RUBY
 
-        assert_equal(expected, rbi_for(:Post))
-      end
+          expected = <<~RBI
+            # typed: strong
+          RBI
 
-      it("generates RBI file for belongs_to single association") do
-        add_ruby_file("schema.rb", <<~RUBY)
-          ActiveRecord::Migration.suppress_messages do
-            ActiveRecord::Schema.define do
-              create_table :posts do |t|
-                t.references(:category, null: true)
-                t.references(:author, null: false)
+          assert_equal(expected, rbi_for(:Post))
+        end
+
+        it("generates RBI file for belongs_to single association") do
+          add_ruby_file("schema.rb", <<~RUBY)
+            ActiveRecord::Migration.suppress_messages do
+              ActiveRecord::Schema.define do
+                create_table :posts do |t|
+                  t.references(:category, null: true)
+                  t.references(:author, null: false)
+                end
               end
             end
-          end
-        RUBY
+          RUBY
 
-        add_ruby_file("category.rb", <<~RUBY)
-          class Category < ActiveRecord::Base
-          end
-        RUBY
-
-        add_ruby_file("user.rb", <<~RUBY)
-          class User < ActiveRecord::Base
-          end
-        RUBY
-
-        add_ruby_file("post.rb", <<~RUBY)
-          class Post < ActiveRecord::Base
-            belongs_to :category
-            belongs_to :author, class_name: "User"
-
-            accepts_nested_attributes_for :category, :author
-          end
-        RUBY
-
-        expected = <<~RBI
-          # typed: strong
-
-          class Post
-            include GeneratedAssociationMethods
-
-            module GeneratedAssociationMethods
-              sig { returns(T.nilable(::User)) }
-              def author; end
-
-              sig { params(value: T.nilable(::User)).void }
-              def author=(value); end
-
-              sig { params(attributes: T.untyped).returns(T.untyped) }
-              def author_attributes=(attributes); end
-
-              sig { params(args: T.untyped, blk: T.untyped).returns(::User) }
-              def build_author(*args, &blk); end
-
-              sig { params(args: T.untyped, blk: T.untyped).returns(::Category) }
-              def build_category(*args, &blk); end
-
-              sig { returns(T.nilable(::Category)) }
-              def category; end
-
-              sig { params(value: T.nilable(::Category)).void }
-              def category=(value); end
-
-              sig { params(attributes: T.untyped).returns(T.untyped) }
-              def category_attributes=(attributes); end
-
-              sig { params(args: T.untyped, blk: T.untyped).returns(::User) }
-              def create_author(*args, &blk); end
-
-              sig { params(args: T.untyped, blk: T.untyped).returns(::User) }
-              def create_author!(*args, &blk); end
-
-              sig { params(args: T.untyped, blk: T.untyped).returns(::Category) }
-              def create_category(*args, &blk); end
-
-              sig { params(args: T.untyped, blk: T.untyped).returns(::Category) }
-              def create_category!(*args, &blk); end
-
-              sig { returns(T.nilable(::User)) }
-              def reload_author; end
-
-              sig { returns(T.nilable(::Category)) }
-              def reload_category; end
+          add_ruby_file("category.rb", <<~RUBY)
+            class Category < ActiveRecord::Base
             end
-          end
-        RBI
+          RUBY
 
-        assert_equal(expected, rbi_for(:Post))
-      end
-
-      it("generates RBI file for polymorphic belongs_to single association") do
-        add_ruby_file("category.rb", <<~RUBY)
-          class Category < ActiveRecord::Base
-          end
-        RUBY
-
-        add_ruby_file("post.rb", <<~RUBY)
-          class Post < ActiveRecord::Base
-            belongs_to :category, polymorphic: true
-
-            accepts_nested_attributes_for :category
-          end
-        RUBY
-
-        expected = <<~RBI
-          # typed: strong
-
-          class Post
-            include GeneratedAssociationMethods
-
-            module GeneratedAssociationMethods
-              sig { returns(T.nilable(T.untyped)) }
-              def category; end
-
-              sig { params(value: T.nilable(T.untyped)).void }
-              def category=(value); end
-
-              sig { params(attributes: T.untyped).returns(T.untyped) }
-              def category_attributes=(attributes); end
-
-              sig { returns(T.nilable(T.untyped)) }
-              def reload_category; end
+          add_ruby_file("user.rb", <<~RUBY)
+            class User < ActiveRecord::Base
             end
-          end
-        RBI
+          RUBY
 
-        assert_equal(expected, rbi_for(:Post))
-      end
+          add_ruby_file("post.rb", <<~RUBY)
+            class Post < ActiveRecord::Base
+              belongs_to :category
+              belongs_to :author, class_name: "User"
 
-      it("generates RBI file for has_one single association") do
-        add_ruby_file("schema.rb", <<~RUBY)
-          ActiveRecord::Migration.suppress_messages do
-            ActiveRecord::Schema.define do
-              create_table :posts do |t|
+              accepts_nested_attributes_for :category, :author
+            end
+          RUBY
+
+          expected = <<~RBI
+            # typed: strong
+
+            class Post
+              include GeneratedAssociationMethods
+
+              module GeneratedAssociationMethods
+                sig { returns(T.nilable(::User)) }
+                def author; end
+
+                sig { params(value: T.nilable(::User)).void }
+                def author=(value); end
+
+                sig { params(attributes: T.untyped).returns(T.untyped) }
+                def author_attributes=(attributes); end
+
+                sig { params(args: T.untyped, blk: T.untyped).returns(::User) }
+                def build_author(*args, &blk); end
+
+                sig { params(args: T.untyped, blk: T.untyped).returns(::Category) }
+                def build_category(*args, &blk); end
+
+                sig { returns(T.nilable(::Category)) }
+                def category; end
+
+                sig { params(value: T.nilable(::Category)).void }
+                def category=(value); end
+
+                sig { params(attributes: T.untyped).returns(T.untyped) }
+                def category_attributes=(attributes); end
+
+                sig { params(args: T.untyped, blk: T.untyped).returns(::User) }
+                def create_author(*args, &blk); end
+
+                sig { params(args: T.untyped, blk: T.untyped).returns(::User) }
+                def create_author!(*args, &blk); end
+
+                sig { params(args: T.untyped, blk: T.untyped).returns(::Category) }
+                def create_category(*args, &blk); end
+
+                sig { params(args: T.untyped, blk: T.untyped).returns(::Category) }
+                def create_category!(*args, &blk); end
+
+                sig { returns(T.nilable(::User)) }
+                def reload_author; end
+
+                sig { returns(T.nilable(::Category)) }
+                def reload_category; end
               end
             end
-          end
-        RUBY
+          RBI
 
-        add_ruby_file("user.rb", <<~RUBY)
-          class User
-          end
-        RUBY
+          assert_equal(expected, rbi_for(:Post))
+        end
 
-        add_ruby_file("post.rb", <<~RUBY)
-          class Post < ActiveRecord::Base
-            has_one :author, class_name: "User"
-
-            accepts_nested_attributes_for :author
-          end
-        RUBY
-
-        expected = <<~RBI
-          # typed: strong
-
-          class Post
-            include GeneratedAssociationMethods
-
-            module GeneratedAssociationMethods
-              sig { returns(T.nilable(::User)) }
-              def author; end
-
-              sig { params(value: T.nilable(::User)).void }
-              def author=(value); end
-
-              sig { params(attributes: T.untyped).returns(T.untyped) }
-              def author_attributes=(attributes); end
-
-              sig { params(args: T.untyped, blk: T.untyped).returns(::User) }
-              def build_author(*args, &blk); end
-
-              sig { params(args: T.untyped, blk: T.untyped).returns(::User) }
-              def create_author(*args, &blk); end
-
-              sig { params(args: T.untyped, blk: T.untyped).returns(::User) }
-              def create_author!(*args, &blk); end
-
-              sig { returns(T.nilable(::User)) }
-              def reload_author; end
+        it("generates RBI file for polymorphic belongs_to single association") do
+          add_ruby_file("category.rb", <<~RUBY)
+            class Category < ActiveRecord::Base
             end
-          end
-        RBI
+          RUBY
 
-        assert_equal(expected, rbi_for(:Post))
-      end
+          add_ruby_file("post.rb", <<~RUBY)
+            class Post < ActiveRecord::Base
+              belongs_to :category, polymorphic: true
 
-      it("generates RBI file for has_many collection association") do
-        add_ruby_file("schema.rb", <<~RUBY)
-          ActiveRecord::Migration.suppress_messages do
-            ActiveRecord::Schema.define do
-              create_table :posts do |t|
-              end
+              accepts_nested_attributes_for :category
+            end
+          RUBY
 
-              create_table :comments do |t|
+          expected = <<~RBI
+            # typed: strong
+
+            class Post
+              include GeneratedAssociationMethods
+
+              module GeneratedAssociationMethods
+                sig { returns(T.nilable(T.untyped)) }
+                def category; end
+
+                sig { params(value: T.nilable(T.untyped)).void }
+                def category=(value); end
+
+                sig { params(attributes: T.untyped).returns(T.untyped) }
+                def category_attributes=(attributes); end
+
+                sig { returns(T.nilable(T.untyped)) }
+                def reload_category; end
               end
             end
-          end
-        RUBY
+          RBI
 
-        add_ruby_file("comment.rb", <<~RUBY)
-          class Comment
-          end
-        RUBY
+          assert_equal(expected, rbi_for(:Post))
+        end
 
-        add_ruby_file("post.rb", <<~RUBY)
-          class Post < ActiveRecord::Base
-            has_many :comments
-
-            accepts_nested_attributes_for :comments
-          end
-        RUBY
-
-        expected = <<~RBI
-          # typed: strong
-
-          class Post
-            include GeneratedAssociationMethods
-
-            module GeneratedAssociationMethods
-              sig { returns(T::Array[T.untyped]) }
-              def comment_ids; end
-
-              sig { params(ids: T::Array[T.untyped]).returns(T::Array[T.untyped]) }
-              def comment_ids=(ids); end
-
-              sig { returns(::Comment::PrivateCollectionProxy) }
-              def comments; end
-
-              sig { params(value: T::Enumerable[::Comment]).void }
-              def comments=(value); end
-
-              sig { params(attributes: T.untyped).returns(T.untyped) }
-              def comments_attributes=(attributes); end
-            end
-          end
-        RBI
-
-        assert_equal(expected, rbi_for(:Post))
-      end
-
-      it("generates RBI file for has_many :through collection association") do
-        add_ruby_file("schema.rb", <<~RUBY)
-          ActiveRecord::Migration.suppress_messages do
-            ActiveRecord::Schema.define do
-              create_table :posts do |t|
+        it("generates RBI file for has_one single association") do
+          add_ruby_file("schema.rb", <<~RUBY)
+            ActiveRecord::Migration.suppress_messages do
+              ActiveRecord::Schema.define do
+                create_table :posts do |t|
+                end
               end
             end
-          end
-        RUBY
+          RUBY
 
-        add_ruby_file("commenter.rb", <<~RUBY)
-          class Commenter < ActiveRecord::Base
-            has_many :comments
-            has_many :posts, through: :comments
-          end
-        RUBY
-
-        add_ruby_file("comment.rb", <<~RUBY)
-          class Comment < ActiveRecord::Base
-            belongs_to :commenter
-            belongs_to :post
-          end
-        RUBY
-
-        add_ruby_file("post.rb", <<~RUBY)
-          class Post < ActiveRecord::Base
-            has_many :comments
-            has_many :commenters, through: :comments
-
-            accepts_nested_attributes_for :commenters
-          end
-        RUBY
-
-        expected = <<~RBI
-          # typed: strong
-
-          class Post
-            include GeneratedAssociationMethods
-
-            module GeneratedAssociationMethods
-              sig { returns(T::Array[T.untyped]) }
-              def comment_ids; end
-
-              sig { params(ids: T::Array[T.untyped]).returns(T::Array[T.untyped]) }
-              def comment_ids=(ids); end
-
-              sig { returns(T::Array[T.untyped]) }
-              def commenter_ids; end
-
-              sig { params(ids: T::Array[T.untyped]).returns(T::Array[T.untyped]) }
-              def commenter_ids=(ids); end
-
-              sig { returns(::Commenter::PrivateCollectionProxy) }
-              def commenters; end
-
-              sig { params(value: T::Enumerable[::Commenter]).void }
-              def commenters=(value); end
-
-              sig { params(attributes: T.untyped).returns(T.untyped) }
-              def commenters_attributes=(attributes); end
-
-              sig { returns(::Comment::PrivateCollectionProxy) }
-              def comments; end
-
-              sig { params(value: T::Enumerable[::Comment]).void }
-              def comments=(value); end
+          add_ruby_file("user.rb", <<~RUBY)
+            class User
             end
-          end
-        RBI
+          RUBY
 
-        assert_equal(expected, rbi_for(:Post))
-      end
+          add_ruby_file("post.rb", <<~RUBY)
+            class Post < ActiveRecord::Base
+              has_one :author, class_name: "User"
 
-      it("generates RBI file for has_and_belongs_to_many collection association") do
-        add_ruby_file("schema.rb", <<~RUBY)
-          ActiveRecord::Migration.suppress_messages do
-            ActiveRecord::Schema.define do
-              create_table :commenters do |t|
-              end
+              accepts_nested_attributes_for :author
+            end
+          RUBY
 
-              create_table :posts do |t|
+          expected = <<~RBI
+            # typed: strong
+
+            class Post
+              include GeneratedAssociationMethods
+
+              module GeneratedAssociationMethods
+                sig { returns(T.nilable(::User)) }
+                def author; end
+
+                sig { params(value: T.nilable(::User)).void }
+                def author=(value); end
+
+                sig { params(attributes: T.untyped).returns(T.untyped) }
+                def author_attributes=(attributes); end
+
+                sig { params(args: T.untyped, blk: T.untyped).returns(::User) }
+                def build_author(*args, &blk); end
+
+                sig { params(args: T.untyped, blk: T.untyped).returns(::User) }
+                def create_author(*args, &blk); end
+
+                sig { params(args: T.untyped, blk: T.untyped).returns(::User) }
+                def create_author!(*args, &blk); end
+
+                sig { returns(T.nilable(::User)) }
+                def reload_author; end
               end
             end
-          end
-        RUBY
+          RBI
 
-        add_ruby_file("commenter.rb", <<~RUBY)
-          class Commenter < ActiveRecord::Base
-            has_and_belongs_to_many :posts
-          end
-        RUBY
+          assert_equal(expected, rbi_for(:Post))
+        end
 
-        add_ruby_file("post.rb", <<~RUBY)
-          class Post < ActiveRecord::Base
-            has_and_belongs_to_many :commenters
+        it("generates RBI file for has_many collection association") do
+          add_ruby_file("schema.rb", <<~RUBY)
+            ActiveRecord::Migration.suppress_messages do
+              ActiveRecord::Schema.define do
+                create_table :posts do |t|
+                end
 
-            accepts_nested_attributes_for :commenters
-          end
-        RUBY
-
-        expected = <<~RBI
-          # typed: strong
-
-          class Post
-            include GeneratedAssociationMethods
-
-            module GeneratedAssociationMethods
-              sig { returns(T::Array[T.untyped]) }
-              def commenter_ids; end
-
-              sig { params(ids: T::Array[T.untyped]).returns(T::Array[T.untyped]) }
-              def commenter_ids=(ids); end
-
-              sig { returns(::Commenter::PrivateCollectionProxy) }
-              def commenters; end
-
-              sig { params(value: T::Enumerable[::Commenter]).void }
-              def commenters=(value); end
-
-              sig { params(attributes: T.untyped).returns(T.untyped) }
-              def commenters_attributes=(attributes); end
-            end
-          end
-        RBI
-
-        assert_equal(expected, rbi_for(:Post))
-      end
-
-      it("generates RBI files for models under different namespaces with associations to each other") do
-        add_ruby_file("schema.rb", <<~RUBY)
-          ActiveRecord::Migration.suppress_messages do
-            ActiveRecord::Schema.define do
-              create_table :posts do |t|
-              end
-
-              create_table :drafts do |t|
-              end
-
-              create_table :authors do |t|
-              end
-
-              create_table :comments do |t|
+                create_table :comments do |t|
+                end
               end
             end
-          end
-        RUBY
+          RUBY
 
-        add_ruby_file("models.rb", <<~RUBY)
-          module Blog
-            module Core
-              class Post < ActiveRecord::Base
+          add_ruby_file("comment.rb", <<~RUBY)
+            class Comment
+            end
+          RUBY
+
+          add_ruby_file("post.rb", <<~RUBY)
+            class Post < ActiveRecord::Base
+              has_many :comments
+
+              accepts_nested_attributes_for :comments
+            end
+          RUBY
+
+          expected = <<~RBI
+            # typed: strong
+
+            class Post
+              include GeneratedAssociationMethods
+
+              module GeneratedAssociationMethods
+                sig { returns(T::Array[T.untyped]) }
+                def comment_ids; end
+
+                sig { params(ids: T::Array[T.untyped]).returns(T::Array[T.untyped]) }
+                def comment_ids=(ids); end
+
+                sig { returns(::Comment::PrivateCollectionProxy) }
+                def comments; end
+
+                sig { params(value: T::Enumerable[::Comment]).void }
+                def comments=(value); end
+
+                sig { params(attributes: T.untyped).returns(T.untyped) }
+                def comments_attributes=(attributes); end
+              end
+            end
+          RBI
+
+          assert_equal(expected, rbi_for(:Post))
+        end
+
+        it("generates RBI file for has_many :through collection association") do
+          add_ruby_file("schema.rb", <<~RUBY)
+            ActiveRecord::Migration.suppress_messages do
+              ActiveRecord::Schema.define do
+                create_table :posts do |t|
+                end
+              end
+            end
+          RUBY
+
+          add_ruby_file("commenter.rb", <<~RUBY)
+            class Commenter < ActiveRecord::Base
+              has_many :comments
+              has_many :posts, through: :comments
+            end
+          RUBY
+
+          add_ruby_file("comment.rb", <<~RUBY)
+            class Comment < ActiveRecord::Base
+              belongs_to :commenter
+              belongs_to :post
+            end
+          RUBY
+
+          add_ruby_file("post.rb", <<~RUBY)
+            class Post < ActiveRecord::Base
+              has_many :comments
+              has_many :commenters, through: :comments
+
+              accepts_nested_attributes_for :commenters
+            end
+          RUBY
+
+          expected = <<~RBI
+            # typed: strong
+
+            class Post
+              include GeneratedAssociationMethods
+
+              module GeneratedAssociationMethods
+                sig { returns(T::Array[T.untyped]) }
+                def comment_ids; end
+
+                sig { params(ids: T::Array[T.untyped]).returns(T::Array[T.untyped]) }
+                def comment_ids=(ids); end
+
+                sig { returns(T::Array[T.untyped]) }
+                def commenter_ids; end
+
+                sig { params(ids: T::Array[T.untyped]).returns(T::Array[T.untyped]) }
+                def commenter_ids=(ids); end
+
+                sig { returns(::Commenter::PrivateCollectionProxy) }
+                def commenters; end
+
+                sig { params(value: T::Enumerable[::Commenter]).void }
+                def commenters=(value); end
+
+                sig { params(attributes: T.untyped).returns(T.untyped) }
+                def commenters_attributes=(attributes); end
+
+                sig { returns(::Comment::PrivateCollectionProxy) }
+                def comments; end
+
+                sig { params(value: T::Enumerable[::Comment]).void }
+                def comments=(value); end
+              end
+            end
+          RBI
+
+          assert_equal(expected, rbi_for(:Post))
+        end
+
+        it("generates RBI file for has_and_belongs_to_many collection association") do
+          add_ruby_file("schema.rb", <<~RUBY)
+            ActiveRecord::Migration.suppress_messages do
+              ActiveRecord::Schema.define do
+                create_table :commenters do |t|
+                end
+
+                create_table :posts do |t|
+                end
+              end
+            end
+          RUBY
+
+          add_ruby_file("commenter.rb", <<~RUBY)
+            class Commenter < ActiveRecord::Base
+              has_and_belongs_to_many :posts
+            end
+          RUBY
+
+          add_ruby_file("post.rb", <<~RUBY)
+            class Post < ActiveRecord::Base
+              has_and_belongs_to_many :commenters
+
+              accepts_nested_attributes_for :commenters
+            end
+          RUBY
+
+          expected = <<~RBI
+            # typed: strong
+
+            class Post
+              include GeneratedAssociationMethods
+
+              module GeneratedAssociationMethods
+                sig { returns(T::Array[T.untyped]) }
+                def commenter_ids; end
+
+                sig { params(ids: T::Array[T.untyped]).returns(T::Array[T.untyped]) }
+                def commenter_ids=(ids); end
+
+                sig { returns(::Commenter::PrivateCollectionProxy) }
+                def commenters; end
+
+                sig { params(value: T::Enumerable[::Commenter]).void }
+                def commenters=(value); end
+
+                sig { params(attributes: T.untyped).returns(T.untyped) }
+                def commenters_attributes=(attributes); end
+              end
+            end
+          RBI
+
+          assert_equal(expected, rbi_for(:Post))
+        end
+
+        it("generates RBI files for models under different namespaces with associations to each other") do
+          add_ruby_file("schema.rb", <<~RUBY)
+            ActiveRecord::Migration.suppress_messages do
+              ActiveRecord::Schema.define do
+                create_table :posts do |t|
+                end
+
+                create_table :drafts do |t|
+                end
+
+                create_table :authors do |t|
+                end
+
+                create_table :comments do |t|
+                end
+              end
+            end
+          RUBY
+
+          add_ruby_file("models.rb", <<~RUBY)
+            module Blog
+              module Core
+                class Post < ActiveRecord::Base
+                  belongs_to :author
+                end
+              end
+
+              class Draft < ActiveRecord::Base
                 belongs_to :author
               end
+
+              class Author < ActiveRecord::Base
+                has_many :comments
+                has_many :drafts
+              end
             end
 
-            class Draft < ActiveRecord::Base
-              belongs_to :author
+            class Comment < ActiveRecord::Base
+              belongs_to :post, class_name: "Blog::Core::Post"
             end
+          RUBY
 
-            class Author < ActiveRecord::Base
+          expected = <<~RBI
+            # typed: strong
+
+            class Blog::Core::Post
+              include GeneratedAssociationMethods
+
+              module GeneratedAssociationMethods
+                sig { returns(T.nilable(::Blog::Author)) }
+                def author; end
+
+                sig { params(value: T.nilable(::Blog::Author)).void }
+                def author=(value); end
+
+                sig { params(args: T.untyped, blk: T.untyped).returns(::Blog::Author) }
+                def build_author(*args, &blk); end
+
+                sig { params(args: T.untyped, blk: T.untyped).returns(::Blog::Author) }
+                def create_author(*args, &blk); end
+
+                sig { params(args: T.untyped, blk: T.untyped).returns(::Blog::Author) }
+                def create_author!(*args, &blk); end
+
+                sig { returns(T.nilable(::Blog::Author)) }
+                def reload_author; end
+              end
+            end
+          RBI
+
+          assert_equal(expected, rbi_for("Blog::Core::Post"))
+
+          expected = <<~RBI
+            # typed: strong
+
+            class Blog::Author
+              include GeneratedAssociationMethods
+
+              module GeneratedAssociationMethods
+                sig { returns(T::Array[T.untyped]) }
+                def comment_ids; end
+
+                sig { params(ids: T::Array[T.untyped]).returns(T::Array[T.untyped]) }
+                def comment_ids=(ids); end
+
+                sig { returns(::Comment::PrivateCollectionProxy) }
+                def comments; end
+
+                sig { params(value: T::Enumerable[::Comment]).void }
+                def comments=(value); end
+
+                sig { returns(T::Array[T.untyped]) }
+                def draft_ids; end
+
+                sig { params(ids: T::Array[T.untyped]).returns(T::Array[T.untyped]) }
+                def draft_ids=(ids); end
+
+                sig { returns(::Blog::Draft::PrivateCollectionProxy) }
+                def drafts; end
+
+                sig { params(value: T::Enumerable[::Blog::Draft]).void }
+                def drafts=(value); end
+              end
+            end
+          RBI
+
+          assert_equal(expected, rbi_for("Blog::Author"))
+
+          expected = <<~RBI
+            # typed: strong
+
+            class Comment
+              include GeneratedAssociationMethods
+
+              module GeneratedAssociationMethods
+                sig { params(args: T.untyped, blk: T.untyped).returns(::Blog::Core::Post) }
+                def build_post(*args, &blk); end
+
+                sig { params(args: T.untyped, blk: T.untyped).returns(::Blog::Core::Post) }
+                def create_post(*args, &blk); end
+
+                sig { params(args: T.untyped, blk: T.untyped).returns(::Blog::Core::Post) }
+                def create_post!(*args, &blk); end
+
+                sig { returns(T.nilable(::Blog::Core::Post)) }
+                def post; end
+
+                sig { params(value: T.nilable(::Blog::Core::Post)).void }
+                def post=(value); end
+
+                sig { returns(T.nilable(::Blog::Core::Post)) }
+                def reload_post; end
+              end
+            end
+          RBI
+
+          assert_equal(expected, rbi_for(:Comment))
+        end
+      end
+
+      describe("with errors") do
+        it("generates RBI file for broken associations") do
+          add_ruby_file("schema.rb", <<~RUBY)
+            ActiveRecord::Migration.suppress_messages do
+              ActiveRecord::Schema.define do
+                create_table :posts do |t|
+                end
+              end
+            end
+          RUBY
+
+          add_ruby_file("post.rb", <<~RUBY)
+            class Post < ActiveRecord::Base
+              has_one :author
               has_many :comments
-              has_many :drafts
+              belongs_to :blog
+              has_and_belongs_to_many :commenters
+              has_many :readers, through: :author
+              has_one :award, through: :blog
             end
-          end
+          RUBY
 
-          class Comment < ActiveRecord::Base
-            belongs_to :post, class_name: "Blog::Core::Post"
-          end
-        RUBY
+          expected = <<~RBI
+            # typed: strong
 
-        expected = <<~RBI
-          # typed: strong
+            class Post
+              include GeneratedAssociationMethods
 
-          class Blog::Core::Post
-            include GeneratedAssociationMethods
-
-            module GeneratedAssociationMethods
-              sig { returns(T.nilable(::Blog::Author)) }
-              def author; end
-
-              sig { params(value: T.nilable(::Blog::Author)).void }
-              def author=(value); end
-
-              sig { params(args: T.untyped, blk: T.untyped).returns(::Blog::Author) }
-              def build_author(*args, &blk); end
-
-              sig { params(args: T.untyped, blk: T.untyped).returns(::Blog::Author) }
-              def create_author(*args, &blk); end
-
-              sig { params(args: T.untyped, blk: T.untyped).returns(::Blog::Author) }
-              def create_author!(*args, &blk); end
-
-              sig { returns(T.nilable(::Blog::Author)) }
-              def reload_author; end
+              module GeneratedAssociationMethods; end
             end
-          end
-        RBI
+          RBI
 
-        assert_equal(expected, rbi_for("Blog::Core::Post"))
+          assert_equal(expected, rbi_for(:Post))
 
-        expected = <<~RBI
-          # typed: strong
+          assert_equal(6, generated_errors.size)
 
-          class Blog::Author
-            include GeneratedAssociationMethods
+          # rubocop:disable Layout/LineLength
+          expected_errors = [
+            "Cannot generate association `has_one :author` on `Post` since the constant `Author` does not exist.",
+            "Cannot generate association `has_many :comments` on `Post` since the constant `Comment` does not exist.",
+            "Cannot generate association `belongs_to :blog` on `Post` since the constant `Blog` does not exist.",
+            "Cannot generate association `has_and_belongs_to_many :commenters` on `Post` since the constant `Commenter` does not exist.",
+            "Cannot generate association `has_many :readers, through: :author` on `Post` since the constant `Reader` does not exist.",
+            "Cannot generate association `has_one :award, through: :blog` on `Post` since the constant `Award` does not exist.",
+          ]
+          # rubocop:enable Layout/LineLength
 
-            module GeneratedAssociationMethods
-              sig { returns(T::Array[T.untyped]) }
-              def comment_ids; end
+          assert_equal(expected_errors, generated_errors)
+        end
 
-              sig { params(ids: T::Array[T.untyped]).returns(T::Array[T.untyped]) }
-              def comment_ids=(ids); end
+        it("generates RBI file for broken has_many :through collection association") do
+          add_ruby_file("schema.rb", <<~RUBY)
+            ActiveRecord::Migration.suppress_messages do
+              ActiveRecord::Schema.define do
+                create_table :posts do |t|
+                  t.references(:shop)
+                end
 
-              sig { returns(::Comment::PrivateCollectionProxy) }
-              def comments; end
+                create_table :shops do |t|
+                end
 
-              sig { params(value: T::Enumerable[::Comment]).void }
-              def comments=(value); end
-
-              sig { returns(T::Array[T.untyped]) }
-              def draft_ids; end
-
-              sig { params(ids: T::Array[T.untyped]).returns(T::Array[T.untyped]) }
-              def draft_ids=(ids); end
-
-              sig { returns(::Blog::Draft::PrivateCollectionProxy) }
-              def drafts; end
-
-              sig { params(value: T::Enumerable[::Blog::Draft]).void }
-              def drafts=(value); end
+                create_table :managers do |t|
+                  t.references(:shop)
+                end
+              end
             end
-          end
-        RBI
+          RUBY
 
-        assert_equal(expected, rbi_for("Blog::Author"))
-
-        expected = <<~RBI
-          # typed: strong
-
-          class Comment
-            include GeneratedAssociationMethods
-
-            module GeneratedAssociationMethods
-              sig { params(args: T.untyped, blk: T.untyped).returns(::Blog::Core::Post) }
-              def build_post(*args, &blk); end
-
-              sig { params(args: T.untyped, blk: T.untyped).returns(::Blog::Core::Post) }
-              def create_post(*args, &blk); end
-
-              sig { params(args: T.untyped, blk: T.untyped).returns(::Blog::Core::Post) }
-              def create_post!(*args, &blk); end
-
-              sig { returns(T.nilable(::Blog::Core::Post)) }
-              def post; end
-
-              sig { params(value: T.nilable(::Blog::Core::Post)).void }
-              def post=(value); end
-
-              sig { returns(T.nilable(::Blog::Core::Post)) }
-              def reload_post; end
+          add_ruby_file("commenter.rb", <<~RUBY)
+            class Manager < ActiveRecord::Base
+              belongs_to :shop
             end
-          end
-        RBI
+          RUBY
 
-        assert_equal(expected, rbi_for(:Comment))
+          add_ruby_file("comment.rb", <<~RUBY)
+            class Shop < ActiveRecord::Base
+              has_many :managers
+            end
+          RUBY
+
+          add_ruby_file("post.rb", <<~RUBY)
+            class Post < ActiveRecord::Base
+              belongs_to :shop
+              has_one :manager, through: :shop
+            end
+          RUBY
+
+          expected = <<~RBI
+            # typed: strong
+
+            class Post
+              include GeneratedAssociationMethods
+
+              module GeneratedAssociationMethods
+                sig { params(args: T.untyped, blk: T.untyped).returns(::Shop) }
+                def build_shop(*args, &blk); end
+
+                sig { params(args: T.untyped, blk: T.untyped).returns(::Shop) }
+                def create_shop(*args, &blk); end
+
+                sig { params(args: T.untyped, blk: T.untyped).returns(::Shop) }
+                def create_shop!(*args, &blk); end
+
+                sig { returns(T.nilable(::Shop)) }
+                def reload_shop; end
+
+                sig { returns(T.nilable(::Shop)) }
+                def shop; end
+
+                sig { params(value: T.nilable(::Shop)).void }
+                def shop=(value); end
+              end
+            end
+          RBI
+
+          assert_equal(expected, rbi_for(:Post))
+
+          assert_equal(1, generated_errors.size)
+          assert_equal(<<~MSG.strip, generated_errors.first)
+            Cannot generate association `manager` on `Post` since the source of the through association is missing.
+          MSG
+        end
       end
     end
 
-    describe("with errors") do
-      it("generates RBI file for broken associations") do
-        add_ruby_file("schema.rb", <<~RUBY)
-          ActiveRecord::Migration.suppress_messages do
-            ActiveRecord::Schema.define do
-              create_table :posts do |t|
+    describe("without relations enabled") do
+      describe("without errors") do
+        after(:each) do
+          T.unsafe(self).assert_no_generated_errors
+        end
+
+        it("generates empty RBI file if there are no associations") do
+          add_ruby_file("post.rb", <<~RUBY)
+            class Post < ActiveRecord::Base
+            end
+          RUBY
+
+          expected = <<~RBI
+            # typed: strong
+          RBI
+
+          assert_equal(expected, rbi_for(:Post))
+        end
+
+        it("generates RBI file for belongs_to single association") do
+          add_ruby_file("schema.rb", <<~RUBY)
+            ActiveRecord::Migration.suppress_messages do
+              ActiveRecord::Schema.define do
+                create_table :posts do |t|
+                  t.references(:category, null: true)
+                  t.references(:author, null: false)
+                end
               end
             end
-          end
-        RUBY
+          RUBY
 
-        add_ruby_file("post.rb", <<~RUBY)
-          class Post < ActiveRecord::Base
-            has_one :author
-            has_many :comments
-            belongs_to :blog
-            has_and_belongs_to_many :commenters
-            has_many :readers, through: :author
-            has_one :award, through: :blog
-          end
-        RUBY
+          add_ruby_file("category.rb", <<~RUBY)
+            class Category < ActiveRecord::Base
+            end
+          RUBY
 
-        expected = <<~RBI
-          # typed: strong
+          add_ruby_file("user.rb", <<~RUBY)
+            class User < ActiveRecord::Base
+            end
+          RUBY
 
-          class Post
-            include GeneratedAssociationMethods
+          add_ruby_file("post.rb", <<~RUBY)
+            class Post < ActiveRecord::Base
+              belongs_to :category
+              belongs_to :author, class_name: "User"
 
-            module GeneratedAssociationMethods; end
-          end
-        RBI
+              accepts_nested_attributes_for :category, :author
+            end
+          RUBY
 
-        assert_equal(expected, rbi_for(:Post))
+          expected = <<~RBI
+            # typed: strong
 
-        assert_equal(6, generated_errors.size)
+            class Post
+              include GeneratedAssociationMethods
 
-        # rubocop:disable Layout/LineLength
-        expected_errors = [
-          "Cannot generate association `has_one :author` on `Post` since the constant `Author` does not exist.",
-          "Cannot generate association `has_many :comments` on `Post` since the constant `Comment` does not exist.",
-          "Cannot generate association `belongs_to :blog` on `Post` since the constant `Blog` does not exist.",
-          "Cannot generate association `has_and_belongs_to_many :commenters` on `Post` since the constant `Commenter` does not exist.",
-          "Cannot generate association `has_many :readers, through: :author` on `Post` since the constant `Reader` does not exist.",
-          "Cannot generate association `has_one :award, through: :blog` on `Post` since the constant `Award` does not exist.",
-        ]
-        # rubocop:enable Layout/LineLength
+              module GeneratedAssociationMethods
+                sig { returns(T.nilable(::User)) }
+                def author; end
 
-        assert_equal(expected_errors, generated_errors)
+                sig { params(value: T.nilable(::User)).void }
+                def author=(value); end
+
+                sig { params(attributes: T.untyped).returns(T.untyped) }
+                def author_attributes=(attributes); end
+
+                sig { params(args: T.untyped, blk: T.untyped).returns(::User) }
+                def build_author(*args, &blk); end
+
+                sig { params(args: T.untyped, blk: T.untyped).returns(::Category) }
+                def build_category(*args, &blk); end
+
+                sig { returns(T.nilable(::Category)) }
+                def category; end
+
+                sig { params(value: T.nilable(::Category)).void }
+                def category=(value); end
+
+                sig { params(attributes: T.untyped).returns(T.untyped) }
+                def category_attributes=(attributes); end
+
+                sig { params(args: T.untyped, blk: T.untyped).returns(::User) }
+                def create_author(*args, &blk); end
+
+                sig { params(args: T.untyped, blk: T.untyped).returns(::User) }
+                def create_author!(*args, &blk); end
+
+                sig { params(args: T.untyped, blk: T.untyped).returns(::Category) }
+                def create_category(*args, &blk); end
+
+                sig { params(args: T.untyped, blk: T.untyped).returns(::Category) }
+                def create_category!(*args, &blk); end
+
+                sig { returns(T.nilable(::User)) }
+                def reload_author; end
+
+                sig { returns(T.nilable(::Category)) }
+                def reload_category; end
+              end
+            end
+          RBI
+
+          assert_equal(expected, rbi_for(:Post))
+        end
+
+        it("generates RBI file for polymorphic belongs_to single association") do
+          add_ruby_file("category.rb", <<~RUBY)
+            class Category < ActiveRecord::Base
+            end
+          RUBY
+
+          add_ruby_file("post.rb", <<~RUBY)
+            class Post < ActiveRecord::Base
+              belongs_to :category, polymorphic: true
+
+              accepts_nested_attributes_for :category
+            end
+          RUBY
+
+          expected = <<~RBI
+            # typed: strong
+
+            class Post
+              include GeneratedAssociationMethods
+
+              module GeneratedAssociationMethods
+                sig { returns(T.nilable(T.untyped)) }
+                def category; end
+
+                sig { params(value: T.nilable(T.untyped)).void }
+                def category=(value); end
+
+                sig { params(attributes: T.untyped).returns(T.untyped) }
+                def category_attributes=(attributes); end
+
+                sig { returns(T.nilable(T.untyped)) }
+                def reload_category; end
+              end
+            end
+          RBI
+
+          assert_equal(expected, rbi_for(:Post))
+        end
+
+        it("generates RBI file for has_one single association") do
+          add_ruby_file("schema.rb", <<~RUBY)
+            ActiveRecord::Migration.suppress_messages do
+              ActiveRecord::Schema.define do
+                create_table :posts do |t|
+                end
+              end
+            end
+          RUBY
+
+          add_ruby_file("user.rb", <<~RUBY)
+            class User
+            end
+          RUBY
+
+          add_ruby_file("post.rb", <<~RUBY)
+            class Post < ActiveRecord::Base
+              has_one :author, class_name: "User"
+
+              accepts_nested_attributes_for :author
+            end
+          RUBY
+
+          expected = <<~RBI
+            # typed: strong
+
+            class Post
+              include GeneratedAssociationMethods
+
+              module GeneratedAssociationMethods
+                sig { returns(T.nilable(::User)) }
+                def author; end
+
+                sig { params(value: T.nilable(::User)).void }
+                def author=(value); end
+
+                sig { params(attributes: T.untyped).returns(T.untyped) }
+                def author_attributes=(attributes); end
+
+                sig { params(args: T.untyped, blk: T.untyped).returns(::User) }
+                def build_author(*args, &blk); end
+
+                sig { params(args: T.untyped, blk: T.untyped).returns(::User) }
+                def create_author(*args, &blk); end
+
+                sig { params(args: T.untyped, blk: T.untyped).returns(::User) }
+                def create_author!(*args, &blk); end
+
+                sig { returns(T.nilable(::User)) }
+                def reload_author; end
+              end
+            end
+          RBI
+
+          assert_equal(expected, rbi_for(:Post))
+        end
+
+        it("generates RBI file for has_many collection association") do
+          add_ruby_file("schema.rb", <<~RUBY)
+            ActiveRecord::Migration.suppress_messages do
+              ActiveRecord::Schema.define do
+                create_table :posts do |t|
+                end
+
+                create_table :comments do |t|
+                end
+              end
+            end
+          RUBY
+
+          add_ruby_file("comment.rb", <<~RUBY)
+            class Comment
+            end
+          RUBY
+
+          add_ruby_file("post.rb", <<~RUBY)
+            class Post < ActiveRecord::Base
+              has_many :comments
+
+              accepts_nested_attributes_for :comments
+            end
+          RUBY
+
+          expected = <<~RBI
+            # typed: strong
+
+            class Post
+              include GeneratedAssociationMethods
+
+              module GeneratedAssociationMethods
+                sig { returns(T::Array[T.untyped]) }
+                def comment_ids; end
+
+                sig { params(ids: T::Array[T.untyped]).returns(T::Array[T.untyped]) }
+                def comment_ids=(ids); end
+
+                sig { returns(::ActiveRecord::Associations::CollectionProxy[::Comment]) }
+                def comments; end
+
+                sig { params(value: T::Enumerable[::Comment]).void }
+                def comments=(value); end
+
+                sig { params(attributes: T.untyped).returns(T.untyped) }
+                def comments_attributes=(attributes); end
+              end
+            end
+          RBI
+
+          assert_equal(expected, rbi_for(:Post))
+        end
+
+        it("generates RBI file for has_many :through collection association") do
+          add_ruby_file("schema.rb", <<~RUBY)
+            ActiveRecord::Migration.suppress_messages do
+              ActiveRecord::Schema.define do
+                create_table :posts do |t|
+                end
+              end
+            end
+          RUBY
+
+          add_ruby_file("commenter.rb", <<~RUBY)
+            class Commenter < ActiveRecord::Base
+              has_many :comments
+              has_many :posts, through: :comments
+            end
+          RUBY
+
+          add_ruby_file("comment.rb", <<~RUBY)
+            class Comment < ActiveRecord::Base
+              belongs_to :commenter
+              belongs_to :post
+            end
+          RUBY
+
+          add_ruby_file("post.rb", <<~RUBY)
+            class Post < ActiveRecord::Base
+              has_many :comments
+              has_many :commenters, through: :comments
+
+              accepts_nested_attributes_for :commenters
+            end
+          RUBY
+
+          expected = <<~RBI
+            # typed: strong
+
+            class Post
+              include GeneratedAssociationMethods
+
+              module GeneratedAssociationMethods
+                sig { returns(T::Array[T.untyped]) }
+                def comment_ids; end
+
+                sig { params(ids: T::Array[T.untyped]).returns(T::Array[T.untyped]) }
+                def comment_ids=(ids); end
+
+                sig { returns(T::Array[T.untyped]) }
+                def commenter_ids; end
+
+                sig { params(ids: T::Array[T.untyped]).returns(T::Array[T.untyped]) }
+                def commenter_ids=(ids); end
+
+                sig { returns(::ActiveRecord::Associations::CollectionProxy[::Commenter]) }
+                def commenters; end
+
+                sig { params(value: T::Enumerable[::Commenter]).void }
+                def commenters=(value); end
+
+                sig { params(attributes: T.untyped).returns(T.untyped) }
+                def commenters_attributes=(attributes); end
+
+                sig { returns(::ActiveRecord::Associations::CollectionProxy[::Comment]) }
+                def comments; end
+
+                sig { params(value: T::Enumerable[::Comment]).void }
+                def comments=(value); end
+              end
+            end
+          RBI
+
+          assert_equal(expected, rbi_for(:Post))
+        end
+
+        it("generates RBI file for has_and_belongs_to_many collection association") do
+          add_ruby_file("schema.rb", <<~RUBY)
+            ActiveRecord::Migration.suppress_messages do
+              ActiveRecord::Schema.define do
+                create_table :commenters do |t|
+                end
+
+                create_table :posts do |t|
+                end
+              end
+            end
+          RUBY
+
+          add_ruby_file("commenter.rb", <<~RUBY)
+            class Commenter < ActiveRecord::Base
+              has_and_belongs_to_many :posts
+            end
+          RUBY
+
+          add_ruby_file("post.rb", <<~RUBY)
+            class Post < ActiveRecord::Base
+              has_and_belongs_to_many :commenters
+
+              accepts_nested_attributes_for :commenters
+            end
+          RUBY
+
+          expected = <<~RBI
+            # typed: strong
+
+            class Post
+              include GeneratedAssociationMethods
+
+              module GeneratedAssociationMethods
+                sig { returns(T::Array[T.untyped]) }
+                def commenter_ids; end
+
+                sig { params(ids: T::Array[T.untyped]).returns(T::Array[T.untyped]) }
+                def commenter_ids=(ids); end
+
+                sig { returns(::ActiveRecord::Associations::CollectionProxy[::Commenter]) }
+                def commenters; end
+
+                sig { params(value: T::Enumerable[::Commenter]).void }
+                def commenters=(value); end
+
+                sig { params(attributes: T.untyped).returns(T.untyped) }
+                def commenters_attributes=(attributes); end
+              end
+            end
+          RBI
+
+          assert_equal(expected, rbi_for(:Post))
+        end
+
+        it("generates RBI files for models under different namespaces with associations to each other") do
+          add_ruby_file("schema.rb", <<~RUBY)
+            ActiveRecord::Migration.suppress_messages do
+              ActiveRecord::Schema.define do
+                create_table :posts do |t|
+                end
+
+                create_table :drafts do |t|
+                end
+
+                create_table :authors do |t|
+                end
+
+                create_table :comments do |t|
+                end
+              end
+            end
+          RUBY
+
+          add_ruby_file("models.rb", <<~RUBY)
+            module Blog
+              module Core
+                class Post < ActiveRecord::Base
+                  belongs_to :author
+                end
+              end
+
+              class Draft < ActiveRecord::Base
+                belongs_to :author
+              end
+
+              class Author < ActiveRecord::Base
+                has_many :comments
+                has_many :drafts
+              end
+            end
+
+            class Comment < ActiveRecord::Base
+              belongs_to :post, class_name: "Blog::Core::Post"
+            end
+          RUBY
+
+          expected = <<~RBI
+            # typed: strong
+
+            class Blog::Core::Post
+              include GeneratedAssociationMethods
+
+              module GeneratedAssociationMethods
+                sig { returns(T.nilable(::Blog::Author)) }
+                def author; end
+
+                sig { params(value: T.nilable(::Blog::Author)).void }
+                def author=(value); end
+
+                sig { params(args: T.untyped, blk: T.untyped).returns(::Blog::Author) }
+                def build_author(*args, &blk); end
+
+                sig { params(args: T.untyped, blk: T.untyped).returns(::Blog::Author) }
+                def create_author(*args, &blk); end
+
+                sig { params(args: T.untyped, blk: T.untyped).returns(::Blog::Author) }
+                def create_author!(*args, &blk); end
+
+                sig { returns(T.nilable(::Blog::Author)) }
+                def reload_author; end
+              end
+            end
+          RBI
+
+          assert_equal(expected, rbi_for("Blog::Core::Post"))
+
+          expected = <<~RBI
+            # typed: strong
+
+            class Blog::Author
+              include GeneratedAssociationMethods
+
+              module GeneratedAssociationMethods
+                sig { returns(T::Array[T.untyped]) }
+                def comment_ids; end
+
+                sig { params(ids: T::Array[T.untyped]).returns(T::Array[T.untyped]) }
+                def comment_ids=(ids); end
+
+                sig { returns(::ActiveRecord::Associations::CollectionProxy[::Comment]) }
+                def comments; end
+
+                sig { params(value: T::Enumerable[::Comment]).void }
+                def comments=(value); end
+
+                sig { returns(T::Array[T.untyped]) }
+                def draft_ids; end
+
+                sig { params(ids: T::Array[T.untyped]).returns(T::Array[T.untyped]) }
+                def draft_ids=(ids); end
+
+                sig { returns(::ActiveRecord::Associations::CollectionProxy[::Blog::Draft]) }
+                def drafts; end
+
+                sig { params(value: T::Enumerable[::Blog::Draft]).void }
+                def drafts=(value); end
+              end
+            end
+          RBI
+
+          assert_equal(expected, rbi_for("Blog::Author"))
+
+          expected = <<~RBI
+            # typed: strong
+
+            class Comment
+              include GeneratedAssociationMethods
+
+              module GeneratedAssociationMethods
+                sig { params(args: T.untyped, blk: T.untyped).returns(::Blog::Core::Post) }
+                def build_post(*args, &blk); end
+
+                sig { params(args: T.untyped, blk: T.untyped).returns(::Blog::Core::Post) }
+                def create_post(*args, &blk); end
+
+                sig { params(args: T.untyped, blk: T.untyped).returns(::Blog::Core::Post) }
+                def create_post!(*args, &blk); end
+
+                sig { returns(T.nilable(::Blog::Core::Post)) }
+                def post; end
+
+                sig { params(value: T.nilable(::Blog::Core::Post)).void }
+                def post=(value); end
+
+                sig { returns(T.nilable(::Blog::Core::Post)) }
+                def reload_post; end
+              end
+            end
+          RBI
+
+          assert_equal(expected, rbi_for(:Comment))
+        end
       end
 
-      it("generates RBI file for broken has_many :through collection association") do
-        add_ruby_file("schema.rb", <<~RUBY)
-          ActiveRecord::Migration.suppress_messages do
-            ActiveRecord::Schema.define do
-              create_table :posts do |t|
-                t.references(:shop)
-              end
-
-              create_table :shops do |t|
-              end
-
-              create_table :managers do |t|
-                t.references(:shop)
+      describe("with errors") do
+        it("generates RBI file for broken associations") do
+          add_ruby_file("schema.rb", <<~RUBY)
+            ActiveRecord::Migration.suppress_messages do
+              ActiveRecord::Schema.define do
+                create_table :posts do |t|
+                end
               end
             end
-          end
-        RUBY
+          RUBY
 
-        add_ruby_file("commenter.rb", <<~RUBY)
-          class Manager < ActiveRecord::Base
-            belongs_to :shop
-          end
-        RUBY
-
-        add_ruby_file("comment.rb", <<~RUBY)
-          class Shop < ActiveRecord::Base
-            has_many :managers
-          end
-        RUBY
-
-        add_ruby_file("post.rb", <<~RUBY)
-          class Post < ActiveRecord::Base
-            belongs_to :shop
-            has_one :manager, through: :shop
-          end
-        RUBY
-
-        expected = <<~RBI
-          # typed: strong
-
-          class Post
-            include GeneratedAssociationMethods
-
-            module GeneratedAssociationMethods
-              sig { params(args: T.untyped, blk: T.untyped).returns(::Shop) }
-              def build_shop(*args, &blk); end
-
-              sig { params(args: T.untyped, blk: T.untyped).returns(::Shop) }
-              def create_shop(*args, &blk); end
-
-              sig { params(args: T.untyped, blk: T.untyped).returns(::Shop) }
-              def create_shop!(*args, &blk); end
-
-              sig { returns(T.nilable(::Shop)) }
-              def reload_shop; end
-
-              sig { returns(T.nilable(::Shop)) }
-              def shop; end
-
-              sig { params(value: T.nilable(::Shop)).void }
-              def shop=(value); end
+          add_ruby_file("post.rb", <<~RUBY)
+            class Post < ActiveRecord::Base
+              has_one :author
+              has_many :comments
+              belongs_to :blog
+              has_and_belongs_to_many :commenters
+              has_many :readers, through: :author
+              has_one :award, through: :blog
             end
-          end
-        RBI
+          RUBY
 
-        assert_equal(expected, rbi_for(:Post))
+          expected = <<~RBI
+            # typed: strong
 
-        assert_equal(1, generated_errors.size)
-        assert_equal(<<~MSG.strip, generated_errors.first)
-          Cannot generate association `manager` on `Post` since the source of the through association is missing.
-        MSG
+            class Post
+              include GeneratedAssociationMethods
+
+              module GeneratedAssociationMethods; end
+            end
+          RBI
+
+          assert_equal(expected, rbi_for(:Post))
+
+          assert_equal(6, generated_errors.size)
+
+          # rubocop:disable Layout/LineLength
+          expected_errors = [
+            "Cannot generate association `has_one :author` on `Post` since the constant `Author` does not exist.",
+            "Cannot generate association `has_many :comments` on `Post` since the constant `Comment` does not exist.",
+            "Cannot generate association `belongs_to :blog` on `Post` since the constant `Blog` does not exist.",
+            "Cannot generate association `has_and_belongs_to_many :commenters` on `Post` since the constant `Commenter` does not exist.",
+            "Cannot generate association `has_many :readers, through: :author` on `Post` since the constant `Reader` does not exist.",
+            "Cannot generate association `has_one :award, through: :blog` on `Post` since the constant `Award` does not exist.",
+          ]
+          # rubocop:enable Layout/LineLength
+
+          assert_equal(expected_errors, generated_errors)
+        end
+
+        it("generates RBI file for broken has_many :through collection association") do
+          add_ruby_file("schema.rb", <<~RUBY)
+            ActiveRecord::Migration.suppress_messages do
+              ActiveRecord::Schema.define do
+                create_table :posts do |t|
+                  t.references(:shop)
+                end
+
+                create_table :shops do |t|
+                end
+
+                create_table :managers do |t|
+                  t.references(:shop)
+                end
+              end
+            end
+          RUBY
+
+          add_ruby_file("commenter.rb", <<~RUBY)
+            class Manager < ActiveRecord::Base
+              belongs_to :shop
+            end
+          RUBY
+
+          add_ruby_file("comment.rb", <<~RUBY)
+            class Shop < ActiveRecord::Base
+              has_many :managers
+            end
+          RUBY
+
+          add_ruby_file("post.rb", <<~RUBY)
+            class Post < ActiveRecord::Base
+              belongs_to :shop
+              has_one :manager, through: :shop
+            end
+          RUBY
+
+          expected = <<~RBI
+            # typed: strong
+
+            class Post
+              include GeneratedAssociationMethods
+
+              module GeneratedAssociationMethods
+                sig { params(args: T.untyped, blk: T.untyped).returns(::Shop) }
+                def build_shop(*args, &blk); end
+
+                sig { params(args: T.untyped, blk: T.untyped).returns(::Shop) }
+                def create_shop(*args, &blk); end
+
+                sig { params(args: T.untyped, blk: T.untyped).returns(::Shop) }
+                def create_shop!(*args, &blk); end
+
+                sig { returns(T.nilable(::Shop)) }
+                def reload_shop; end
+
+                sig { returns(T.nilable(::Shop)) }
+                def shop; end
+
+                sig { params(value: T.nilable(::Shop)).void }
+                def shop=(value); end
+              end
+            end
+          RBI
+
+          assert_equal(expected, rbi_for(:Post))
+
+          assert_equal(1, generated_errors.size)
+          assert_equal(<<~MSG.strip, generated_errors.first)
+            Cannot generate association `manager` on `Post` since the source of the through association is missing.
+          MSG
+        end
       end
     end
   end
 
   describe("#decorate_active_storage") do
+    subject do
+      T.bind(self, DslSpec)
+      require "tapioca/compilers/dsl/active_record_relations"
+      generator_for_names(target_class_name, "Tapioca::Compilers::Dsl::ActiveRecordRelations")
+    end
+
     before(:each) do
       T.bind(self, Tapioca::Compilers::Dsl::ActiveRecordAssociationsSpec)
       add_ruby_file("application.rb", <<~RUBY)

--- a/spec/tapioca/compilers/dsl/active_record_associations_spec.rb
+++ b/spec/tapioca/compilers/dsl/active_record_associations_spec.rb
@@ -202,6 +202,46 @@ class Tapioca::Compilers::Dsl::ActiveRecordAssociationsSpec < DslSpec
           assert_equal(expected, rbi_for(:Post))
         end
 
+        it("generates RBI file for polymorphic has_many association") do
+          add_ruby_file("model.rb", <<~RUBY)
+            class Picture < ActiveRecord::Base
+              belongs_to :imageable, polymorphic: true
+            end
+
+            class Employee < ActiveRecord::Base
+              has_many :pictures, as: :imageable
+            end
+
+            class Product < ActiveRecord::Base
+              has_many :pictures, as: :imageable
+            end
+          RUBY
+
+          expected = <<~RBI
+            # typed: strong
+
+            class Employee
+              include GeneratedAssociationMethods
+
+              module GeneratedAssociationMethods
+                sig { returns(T::Array[T.untyped]) }
+                def picture_ids; end
+
+                sig { params(ids: T::Array[T.untyped]).returns(T::Array[T.untyped]) }
+                def picture_ids=(ids); end
+
+                sig { returns(ActiveRecord::Associations::CollectionProxy) }
+                def pictures; end
+
+                sig { params(value: T::Enumerable[T.untyped]).void }
+                def pictures=(value); end
+              end
+            end
+          RBI
+
+          assert_equal(expected, rbi_for(:Employee))
+        end
+
         it("generates RBI file for has_one single association") do
           add_ruby_file("schema.rb", <<~RUBY)
             ActiveRecord::Migration.suppress_messages do
@@ -848,6 +888,46 @@ class Tapioca::Compilers::Dsl::ActiveRecordAssociationsSpec < DslSpec
           RBI
 
           assert_equal(expected, rbi_for(:Post))
+        end
+
+        it("generates RBI file for polymorphic has_many association") do
+          add_ruby_file("model.rb", <<~RUBY)
+            class Picture < ActiveRecord::Base
+              belongs_to :imageable, polymorphic: true
+            end
+
+            class Employee < ActiveRecord::Base
+              has_many :pictures, as: :imageable
+            end
+
+            class Product < ActiveRecord::Base
+              has_many :pictures, as: :imageable
+            end
+          RUBY
+
+          expected = <<~RBI
+            # typed: strong
+
+            class Employee
+              include GeneratedAssociationMethods
+
+              module GeneratedAssociationMethods
+                sig { returns(T::Array[T.untyped]) }
+                def picture_ids; end
+
+                sig { params(ids: T::Array[T.untyped]).returns(T::Array[T.untyped]) }
+                def picture_ids=(ids); end
+
+                sig { returns(ActiveRecord::Associations::CollectionProxy[T.untyped]) }
+                def pictures; end
+
+                sig { params(value: T::Enumerable[T.untyped]).void }
+                def pictures=(value); end
+              end
+            end
+          RBI
+
+          assert_equal(expected, rbi_for(:Employee))
         end
 
         it("generates RBI file for has_one single association") do

--- a/spec/tapioca/compilers/dsl/active_record_scope_spec.rb
+++ b/spec/tapioca/compilers/dsl/active_record_scope_spec.rb
@@ -35,172 +35,320 @@ class Tapioca::Compilers::Dsl::ActiveRecordScopeSpec < DslSpec
       T.unsafe(self).assert_no_generated_errors
     end
 
-    it("generates an empty RBI file for ActiveRecord classes with no scope field") do
-      add_ruby_file("post.rb", <<~RUBY)
-        class Post < ActiveRecord::Base
-        end
-      RUBY
+    describe("with relations enabled") do
+      subject do
+        T.bind(self, DslSpec)
+        require "tapioca/compilers/dsl/active_record_relations"
+        generator_for_names(target_class_name, "Tapioca::Compilers::Dsl::ActiveRecordRelations")
+      end
 
-      expected = <<~RBI
-        # typed: strong
-      RBI
+      it("generates an empty RBI file for ActiveRecord classes with no scope field") do
+        add_ruby_file("post.rb", <<~RUBY)
+          class Post < ActiveRecord::Base
+          end
+        RUBY
 
-      assert_equal(expected, rbi_for(:Post))
+        expected = <<~RBI
+          # typed: strong
+        RBI
+
+        assert_equal(expected, rbi_for(:Post))
+      end
+
+      it("generates RBI file for ActiveRecord classes with a scope field") do
+        add_ruby_file("post.rb", <<~RUBY)
+          class Post < ActiveRecord::Base
+            scope :public_kind, -> { where.not(kind: 'private') }
+          end
+        RUBY
+
+        expected = <<~RBI
+          # typed: strong
+
+          class Post
+            extend GeneratedRelationMethods
+
+            module GeneratedAssociationRelationMethods
+              sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
+              def public_kind(*args, &blk); end
+            end
+
+            module GeneratedRelationMethods
+              sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
+              def public_kind(*args, &blk); end
+            end
+          end
+        RBI
+
+        assert_equal(expected, rbi_for(:Post))
+      end
+
+      it("generates RBI file for ActiveRecord classes with multiple scope fields") do
+        add_ruby_file("post.rb", <<~RUBY)
+          class Post < ActiveRecord::Base
+            scope :public_kind, -> { where.not(kind: 'private') }
+            scope :private_kind, -> { where(kind: 'private') }
+          end
+        RUBY
+
+        expected = <<~RBI
+          # typed: strong
+
+          class Post
+            extend GeneratedRelationMethods
+
+            module GeneratedAssociationRelationMethods
+              sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
+              def private_kind(*args, &blk); end
+
+              sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
+              def public_kind(*args, &blk); end
+            end
+
+            module GeneratedRelationMethods
+              sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
+              def private_kind(*args, &blk); end
+
+              sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
+              def public_kind(*args, &blk); end
+            end
+          end
+        RBI
+
+        assert_equal(expected, rbi_for(:Post))
+      end
+
+      it("generates relation includes from non-abstract parent models") do
+        add_ruby_file("post.rb", <<~RUBY)
+          class Post < ActiveRecord::Base
+            scope :post_scope, -> { where.not(kind: 'private') }
+          end
+
+          class CustomPost < Post
+            scope :custom_post_scope, -> { where.not(kind: 'private') }
+          end
+
+          class SuperCustomPost < CustomPost
+            scope :super_custom_post_scope, -> { where.not(kind: 'private') }
+          end
+        RUBY
+
+        expected = <<~RBI
+          # typed: strong
+
+          class SuperCustomPost
+            extend GeneratedRelationMethods
+
+            module GeneratedAssociationRelationMethods
+              sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
+              def custom_post_scope(*args, &blk); end
+
+              sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
+              def post_scope(*args, &blk); end
+
+              sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
+              def super_custom_post_scope(*args, &blk); end
+            end
+
+            module GeneratedRelationMethods
+              sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
+              def custom_post_scope(*args, &blk); end
+
+              sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
+              def post_scope(*args, &blk); end
+
+              sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
+              def super_custom_post_scope(*args, &blk); end
+            end
+          end
+        RBI
+
+        assert_equal(expected, rbi_for(:SuperCustomPost))
+      end
+
+      it("generates relation includes from abstract parent models") do
+        add_ruby_file("post.rb", <<~RUBY)
+          class ApplicationRecord < ActiveRecord::Base
+            self.abstract_class = true
+
+            scope :app_scope, -> { where.not(kind: 'private') }
+          end
+
+          class Post < ApplicationRecord
+            scope :post_scope, -> { where.not(kind: 'private') }
+          end
+        RUBY
+
+        expected = <<~RBI
+          # typed: strong
+
+          class Post
+            extend GeneratedRelationMethods
+
+            module GeneratedAssociationRelationMethods
+              sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
+              def app_scope(*args, &blk); end
+
+              sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
+              def post_scope(*args, &blk); end
+            end
+
+            module GeneratedRelationMethods
+              sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
+              def app_scope(*args, &blk); end
+
+              sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
+              def post_scope(*args, &blk); end
+            end
+          end
+        RBI
+
+        assert_equal(expected, rbi_for(:Post))
+      end
     end
 
-    it("generates RBI file for ActiveRecord classes with a scope field") do
-      add_ruby_file("post.rb", <<~RUBY)
-        class Post < ActiveRecord::Base
-          scope :public_kind, -> { where.not(kind: 'private') }
-        end
-      RUBY
+    describe("without relations enabled") do
+      it("generates an empty RBI file for ActiveRecord classes with no scope field") do
+        add_ruby_file("post.rb", <<~RUBY)
+          class Post < ActiveRecord::Base
+          end
+        RUBY
 
-      expected = <<~RBI
-        # typed: strong
+        expected = <<~RBI
+          # typed: strong
+        RBI
 
-        class Post
-          extend GeneratedRelationMethods
+        assert_equal(expected, rbi_for(:Post))
+      end
 
-          module GeneratedAssociationRelationMethods
-            sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
-            def public_kind(*args, &blk); end
+      it("generates RBI file for ActiveRecord classes with a scope field") do
+        add_ruby_file("post.rb", <<~RUBY)
+          class Post < ActiveRecord::Base
+            scope :public_kind, -> { where.not(kind: 'private') }
+          end
+        RUBY
+
+        expected = <<~RBI
+          # typed: strong
+
+          class Post
+            extend GeneratedRelationMethods
+
+            module GeneratedRelationMethods
+              sig { params(args: T.untyped, blk: T.untyped).returns(T.untyped) }
+              def public_kind(*args, &blk); end
+            end
+          end
+        RBI
+
+        assert_equal(expected, rbi_for(:Post))
+      end
+
+      it("generates RBI file for ActiveRecord classes with multiple scope fields") do
+        add_ruby_file("post.rb", <<~RUBY)
+          class Post < ActiveRecord::Base
+            scope :public_kind, -> { where.not(kind: 'private') }
+            scope :private_kind, -> { where(kind: 'private') }
+          end
+        RUBY
+
+        expected = <<~RBI
+          # typed: strong
+
+          class Post
+            extend GeneratedRelationMethods
+
+            module GeneratedRelationMethods
+              sig { params(args: T.untyped, blk: T.untyped).returns(T.untyped) }
+              def private_kind(*args, &blk); end
+
+              sig { params(args: T.untyped, blk: T.untyped).returns(T.untyped) }
+              def public_kind(*args, &blk); end
+            end
+          end
+        RBI
+
+        assert_equal(expected, rbi_for(:Post))
+      end
+
+      it("generates relation includes from non-abstract parent models") do
+        add_ruby_file("post.rb", <<~RUBY)
+          class Post < ActiveRecord::Base
+            scope :post_scope, -> { where.not(kind: 'private') }
           end
 
-          module GeneratedRelationMethods
-            sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
-            def public_kind(*args, &blk); end
-          end
-        end
-      RBI
-
-      assert_equal(expected, rbi_for(:Post))
-    end
-
-    it("generates RBI file for ActiveRecord classes with multiple scope fields") do
-      add_ruby_file("post.rb", <<~RUBY)
-        class Post < ActiveRecord::Base
-          scope :public_kind, -> { where.not(kind: 'private') }
-          scope :private_kind, -> { where(kind: 'private') }
-        end
-      RUBY
-
-      expected = <<~RBI
-        # typed: strong
-
-        class Post
-          extend GeneratedRelationMethods
-
-          module GeneratedAssociationRelationMethods
-            sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
-            def private_kind(*args, &blk); end
-
-            sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
-            def public_kind(*args, &blk); end
+          class CustomPost < Post
+            scope :custom_post_scope, -> { where.not(kind: 'private') }
           end
 
-          module GeneratedRelationMethods
-            sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
-            def private_kind(*args, &blk); end
-
-            sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
-            def public_kind(*args, &blk); end
+          class SuperCustomPost < CustomPost
+            scope :super_custom_post_scope, -> { where.not(kind: 'private') }
           end
-        end
-      RBI
+        RUBY
 
-      assert_equal(expected, rbi_for(:Post))
-    end
+        expected = <<~RBI
+          # typed: strong
 
-    it("generates relation includes from non-abstract parent models") do
-      add_ruby_file("post.rb", <<~RUBY)
-        class Post < ActiveRecord::Base
-          scope :post_scope, -> { where.not(kind: 'private') }
-        end
+          class SuperCustomPost
+            extend GeneratedRelationMethods
 
-        class CustomPost < Post
-          scope :custom_post_scope, -> { where.not(kind: 'private') }
-        end
+            module GeneratedRelationMethods
+              sig { params(args: T.untyped, blk: T.untyped).returns(T.untyped) }
+              def custom_post_scope(*args, &blk); end
 
-        class SuperCustomPost < CustomPost
-          scope :super_custom_post_scope, -> { where.not(kind: 'private') }
-        end
-      RUBY
+              sig { params(args: T.untyped, blk: T.untyped).returns(T.untyped) }
+              def post_scope(*args, &blk); end
 
-      expected = <<~RBI
-        # typed: strong
+              sig { params(args: T.untyped, blk: T.untyped).returns(T.untyped) }
+              def super_custom_post_scope(*args, &blk); end
+            end
+          end
+        RBI
 
-        class SuperCustomPost
-          extend GeneratedRelationMethods
+        assert_equal(expected, rbi_for(:SuperCustomPost))
+      end
 
-          module GeneratedAssociationRelationMethods
-            sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
-            def custom_post_scope(*args, &blk); end
+      it("generates relation includes from abstract parent models") do
+        add_ruby_file("post.rb", <<~RUBY)
+          class ApplicationRecord < ActiveRecord::Base
+            self.abstract_class = true
 
-            sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
-            def post_scope(*args, &blk); end
-
-            sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
-            def super_custom_post_scope(*args, &blk); end
+            scope :app_scope, -> { where.not(kind: 'private') }
           end
 
-          module GeneratedRelationMethods
-            sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
-            def custom_post_scope(*args, &blk); end
-
-            sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
-            def post_scope(*args, &blk); end
-
-            sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
-            def super_custom_post_scope(*args, &blk); end
+          class Post < ApplicationRecord
+            scope :post_scope, -> { where.not(kind: 'private') }
           end
-        end
-      RBI
+        RUBY
 
-      assert_equal(expected, rbi_for(:SuperCustomPost))
-    end
+        expected = <<~RBI
+          # typed: strong
 
-    it("generates relation includes from abstract parent models") do
-      add_ruby_file("post.rb", <<~RUBY)
-        class ApplicationRecord < ActiveRecord::Base
-          self.abstract_class = true
+          class Post
+            extend GeneratedRelationMethods
 
-          scope :app_scope, -> { where.not(kind: 'private') }
-        end
+            module GeneratedRelationMethods
+              sig { params(args: T.untyped, blk: T.untyped).returns(T.untyped) }
+              def app_scope(*args, &blk); end
 
-        class Post < ApplicationRecord
-          scope :post_scope, -> { where.not(kind: 'private') }
-        end
-      RUBY
-
-      expected = <<~RBI
-        # typed: strong
-
-        class Post
-          extend GeneratedRelationMethods
-
-          module GeneratedAssociationRelationMethods
-            sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
-            def app_scope(*args, &blk); end
-
-            sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
-            def post_scope(*args, &blk); end
+              sig { params(args: T.untyped, blk: T.untyped).returns(T.untyped) }
+              def post_scope(*args, &blk); end
+            end
           end
+        RBI
 
-          module GeneratedRelationMethods
-            sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
-            def app_scope(*args, &blk); end
-
-            sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
-            def post_scope(*args, &blk); end
-          end
-        end
-      RBI
-
-      assert_equal(expected, rbi_for(:Post))
+        assert_equal(expected, rbi_for(:Post))
+      end
     end
   end
 
   describe("#decorate_active_storage") do
+    subject do
+      T.bind(self, DslSpec)
+      require "tapioca/compilers/dsl/active_record_relations"
+      generator_for_names(target_class_name, "Tapioca::Compilers::Dsl::ActiveRecordRelations")
+    end
+
     after(:each) do
       T.unsafe(self).assert_no_generated_errors
     end


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
If we release Tapioca in its current state, we will have to deal with 1000s of type errors, all related to the new `ActiveRecordRelations` change, before we can bump the version in Core. In order to decouple the Tapioca version bump from clearing all those errors, the best way forward is to be able to disable the `ActiveRecordRelation` generator.

However, the existence of that generator has changed the behaviour of other generators as well.  Primarily, whereas `ActiveRecordAssociations` generator was generating collection association method returns as the fake generic `CollectionProxy`, it is now doing it using the internal `PrivateCollectionProxy`. Similarly, whereas `ActiveRecordScope` generator was generating `T.untyped` as the return value of scope method, it is not generating them as `PrivateRelation` or `PrivateAssociationRelation` instead.

So that behaviour of those generators have to change depending on if `ActiveRecordRelation` has been enabled or not.

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
The implementation is best followed by reading the commits one by one, but in a nutshell:

- We now pass in the `DslCompiler` instance to each generator, so that a generator can make queries about the context it is running in.
- That allows us to add a method to query if a generator with a given name is enabled or not.
- Using that power, we can change the behaviour of `ActiveRecordAssociations` and `ActiveRecordScope` accordingly.

We also had to update how DSL generator specs work internally to be able to test a similar change in behaviour as well.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->
Updated tests to exercise both relations enabled and disabled cases. Also added a few new test cases that exercise code paths that were never exercised before.
