### PR TITLE
Make `init` create a skeleton Tapioca config

### DIFF
--- a/lib/tapioca/cli.rb
+++ b/lib/tapioca/cli.rb
@@ -24,6 +24,7 @@ module Tapioca
     def init
       generator = Generators::Init.new(
         sorbet_config: SORBET_CONFIG_FILE,
+        tapioca_config: TAPIOCA_CONFIG_FILE,
         default_postrequire: DEFAULT_POSTREQUIRE_FILE,
         default_command: DEFAULT_COMMAND
       )

--- a/lib/tapioca/generators/init.rb
+++ b/lib/tapioca/generators/init.rb
@@ -7,13 +7,21 @@ module Tapioca
       sig do
         params(
           sorbet_config: String,
+          tapioca_config: String,
           default_postrequire: String,
           default_command: String,
           file_writer: Thor::Actions
         ).void
       end
-      def initialize(sorbet_config:, default_postrequire:, default_command:, file_writer: FileWriter.new)
+      def initialize(
+        sorbet_config:,
+        tapioca_config:,
+        default_postrequire:,
+        default_command:,
+        file_writer: FileWriter.new
+      )
         @sorbet_config = sorbet_config
+        @tapioca_config = tapioca_config
         @default_postrequire = default_postrequire
 
         super(default_command: default_command, file_writer: file_writer)
@@ -24,7 +32,8 @@ module Tapioca
 
       sig { override.void }
       def generate
-        create_config
+        create_sorbet_config
+        create_tapioca_config
         create_post_require
         if File.exist?(@default_command)
           generate_binstub!
@@ -36,11 +45,30 @@ module Tapioca
       private
 
       sig { void }
-      def create_config
+      def create_sorbet_config
         create_file(@sorbet_config, <<~CONTENT, skip: true, force: false)
           --dir
           .
         CONTENT
+      end
+
+      sig { void }
+      def create_tapioca_config
+        create_file(@tapioca_config, <<~YAML, skip: true, force: false)
+          gem:
+            # Add your `gem` command parameters here:
+            #
+            # exclude:
+            # - gem_name
+            # doc: true
+            # workers: 5
+          dsl:
+            # Add your `dsl` command parameters here:
+            #
+            # exclude:
+            # - SomeGeneratorName
+            # workers: 5
+        YAML
       end
 
       sig { void }

--- a/spec/tapioca/cli/init_spec.rb
+++ b/spec/tapioca/cli/init_spec.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "spec_with_project"
+require "yaml"
 
 module Tapioca
   class InitSpec < SpecWithProject
@@ -20,6 +21,7 @@ module Tapioca
         out, err, status = @project.tapioca("init")
 
         assert_includes(out, "create  sorbet/config")
+        assert_includes(out, "create  sorbet/tapioca/config.yml")
         assert_includes(out, "create  sorbet/tapioca/require.rb")
         assert_includes(out, "create  bin/tapioca")
 
@@ -37,6 +39,11 @@ module Tapioca
 
         assert_project_file_exist("bin/tapioca")
 
+        tapioca_config = YAML.load(@project.read("sorbet/tapioca/config.yml"))
+        assert_equal(["gem", "dsl"], tapioca_config.keys)
+        assert_nil(tapioca_config["gem"])
+        assert_nil(tapioca_config["dsl"])
+
         assert_empty(err)
         assert(status)
       end
@@ -45,10 +52,12 @@ module Tapioca
         @project.write("bin/tapioca")
         @project.write("sorbet/config")
         @project.write("sorbet/tapioca/require.rb")
+        @project.write("sorbet/tapioca/config.yml")
 
         out, err, status = @project.tapioca("init")
 
         assert_includes(out, "skip  sorbet/config")
+        assert_includes(out, "skip  sorbet/tapioca/config.yml")
         assert_includes(out, "skip  sorbet/tapioca/require.rb")
         assert_includes(out, "force  bin/tapioca")
 


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
Now that Tapioca config is documented and can easily be supported going forward, we should start generating a skeleton Tapioca config file during `tapioca init`.

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
Add and call a method to create a Tapioca config file with commented out example content.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->
Updated existing tests.

