### PR TITLE
Remove mixin filtering

### DIFF
--- a/lib/tapioca/compilers/symbol_table/symbol_generator.rb
+++ b/lib/tapioca/compilers/symbol_table/symbol_generator.rb
@@ -375,29 +375,24 @@ module Tapioca
             Module != class_of(mod) || are_equal?(mod, singleton_class)
           end
 
-          mixin_locations = Trackers::Mixin.mixin_locations_for(constant)
-
-          add_mixins(tree, prepends.reverse, Trackers::Mixin::Type::Prepend, mixin_locations)
-          add_mixins(tree, includes.reverse, Trackers::Mixin::Type::Include, mixin_locations)
-          add_mixins(tree, extends.reverse, Trackers::Mixin::Type::Extend, mixin_locations)
+          add_mixins(tree, prepends.reverse, Trackers::Mixin::Type::Prepend)
+          add_mixins(tree, includes.reverse, Trackers::Mixin::Type::Include)
+          add_mixins(tree, extends.reverse, Trackers::Mixin::Type::Extend)
         end
 
         sig do
           params(
             tree: RBI::Tree,
             mods: T::Array[Module],
-            mixin_type: Trackers::Mixin::Type,
-            mixin_locations: T::Hash[Trackers::Mixin::Type, T::Hash[Module, T::Array[String]]]
+            mixin_type: Trackers::Mixin::Type
           ).void
         end
-        def add_mixins(tree, mods, mixin_type, mixin_locations)
+        def add_mixins(tree, mods, mixin_type)
           mods
             .select do |mod|
               name = name_of(mod)
 
-              name &&
-                !name.start_with?("T::") &&
-                mixed_in_by_gem?(mod, mixin_type, mixin_locations)
+              name && !name.start_with?("T::")
             end
             .map do |mod|
               add_to_symbol_queue(name_of(mod))

--- a/spec/tapioca/compilers/symbol_table_compiler_spec.rb
+++ b/spec/tapioca/compilers/symbol_table_compiler_spec.rb
@@ -271,6 +271,9 @@ class Tapioca::Compilers::SymbolTableCompilerSpec < Minitest::HooksSpec
       RBI
 
       compiled = compile
+        .gsub(/^\s+include ::Minitest::Expectations\s/, "")
+        .gsub(/^\s+include ::JSON::Ext::Generator::GeneratorMethods::Object\s/, "")
+        .gsub(/^\s+include ::PP::ObjectMixin\s/, "")
 
       assert_includes(compiled, basic_object_output)
       assert_includes(compiled, object_output)
@@ -395,6 +398,7 @@ class Tapioca::Compilers::SymbolTableCompilerSpec < Minitest::HooksSpec
         class Array
           include ::Foo::Bar
           include ::Enumerable
+          include ::JSON::Ext::Generator::GeneratorMethods::Array
 
           def foo_int; end
         end
@@ -408,6 +412,7 @@ class Tapioca::Compilers::SymbolTableCompilerSpec < Minitest::HooksSpec
 
         class Hash
           include ::Enumerable
+          include ::JSON::Ext::Generator::GeneratorMethods::Hash
           extend ::Foo::Bar
 
           def to_bar; end
@@ -419,7 +424,9 @@ class Tapioca::Compilers::SymbolTableCompilerSpec < Minitest::HooksSpec
 
         class String
           include ::Comparable
+          include ::JSON::Ext::Generator::GeneratorMethods::String
           include ::Foo::Bar
+          extend ::JSON::Ext::Generator::GeneratorMethods::String::Extend
 
           def to_foo(base = T.unsafe(nil)); end
         end


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
It seems mixin filtering is not mature enough yet, and the way we are filtering mixins will end up resulting in RBIs that have some critical mixins missing completely. So in order to not block the 0.6.0 release, I've decided to revert the mixin filtering instead and to focus on implementing it more completely after 0.6.0.

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
Partial revert of #569

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->
Reverting the test changes in #569 
