### PR TITLE
Fix typed override `Hash` defaults

### DIFF
--- a/lib/tapioca/helpers/config_helper.rb
+++ b/lib/tapioca/helpers/config_helper.rb
@@ -68,7 +68,7 @@ module Tapioca
         .returns(Thor::CoreExt::HashWithIndifferentAccess)
     end
     def merge_options(*options)
-      options.each_with_object(Thor::CoreExt::HashWithIndifferentAccess.new) do |option, result|
+      merged = options.each_with_object({}) do |option, result|
         result.merge!(option || {}) do |_, this_val, other_val|
           if this_val.is_a?(Hash) && other_val.is_a?(Hash)
             Thor::CoreExt::HashWithIndifferentAccess.new(this_val.merge(other_val))
@@ -77,6 +77,8 @@ module Tapioca
           end
         end
       end
+
+      Thor::CoreExt::HashWithIndifferentAccess.new(merged)
     end
   end
 end


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
The new merge options was not doing the correct thing when calling `merge!` on `result`, since the result is now created as an indifferent access hash, which doesn't seem to implement the block callback for `merge!`.

This was causing the default `"activesupport" => "false"` setting to be lost.

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
We create a normal Hash and then convert it to an indifferent access hash instead.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->
No tests

