### PR TITLE
CollectionProxy is generic, requires type argument

### DIFF
--- a/lib/tapioca/compilers/dsl/active_record_associations.rb
+++ b/lib/tapioca/compilers/dsl/active_record_associations.rb
@@ -335,7 +335,7 @@ module Tapioca
 
           if relations_enabled
             if polymorphic_association
-              "ActiveRecord::Associations::CollectionProxy"
+              "ActiveRecord::Associations::CollectionProxy[T.untyped]"
             else
               "#{qualified_name_of(reflection.klass)}::#{AssociationsCollectionProxyClassName}"
             end

--- a/spec/tapioca/compilers/dsl/active_record_associations_spec.rb
+++ b/spec/tapioca/compilers/dsl/active_record_associations_spec.rb
@@ -230,7 +230,7 @@ class Tapioca::Compilers::Dsl::ActiveRecordAssociationsSpec < DslSpec
                 sig { params(ids: T::Array[T.untyped]).returns(T::Array[T.untyped]) }
                 def picture_ids=(ids); end
 
-                sig { returns(ActiveRecord::Associations::CollectionProxy) }
+                sig { returns(ActiveRecord::Associations::CollectionProxy[T.untyped]) }
                 def pictures; end
 
                 sig { params(value: T::Enumerable[T.untyped]).void }


### PR DESCRIPTION
### Motivation
Fix issue with the generated types introduced in v0.6.0 for polymorphic has_many relations

While integrating this new release into a service, we noticed the following error message:

```
Malformed type declaration. Generic class without type arguments ActiveRecord::Associations::CollectionProxy
```

This was happening because we are opting in to the new relations typing, and we had a polymorphic has_many relationship which triggered this particular condition.

### Implementation
`CollectionProxy` is generic so it requires an argument to be passed. I updated the test to reflect this and then the code to match.

Updates the previous implementation from https://github.com/Shopify/tapioca/commit/217a1d025e351378180478ec3c25ad45c2a1e7c7

### Tests
Yep! There was an existing test but it asserted on incorrect behaviour, and has now been fixed.

