### PR TITLE
Add typing for find_by!

### DIFF
--- a/lib/tapioca/compilers/dsl/active_record_relations.rb
+++ b/lib/tapioca/compilers/dsl/active_record_relations.rb
@@ -532,7 +532,7 @@ module Tapioca
                   ],
                   return_type: "T::Boolean"
                 )
-              when :find, :find_by!
+              when :find
                 create_common_method(
                   "find",
                   parameters: [
@@ -547,6 +547,14 @@ module Tapioca
                     create_rest_param("args", type: "T.untyped"),
                   ],
                   return_type: "T.nilable(#{constant_name})"
+                )
+              when :find_by!
+                create_common_method(
+                  "find_by!",
+                  parameters: [
+                    create_rest_param("args", type: "T.untyped"),
+                  ],
+                  return_type: constant_name
                 )
               when :first, :last, :take
                 create_common_method(

--- a/spec/tapioca/compilers/dsl/active_record_relations_spec.rb
+++ b/spec/tapioca/compilers/dsl/active_record_relations_spec.rb
@@ -93,6 +93,9 @@ class Tapioca::Compilers::Dsl::ActiveRecordRelationsSpec < DslSpec
             sig { params(args: T.untyped).returns(T.nilable(::Post)) }
             def find_by(*args); end
 
+            sig { params(args: T.untyped).returns(::Post) }
+            def find_by!(*args); end
+
             sig { params(attributes: T.untyped, block: T.nilable(T.proc.params(object: ::Post).void)).returns(::Post) }
             def find_or_create_by(attributes, &block); end
 

--- a/spec/tapioca/compilers/dsl/active_record_relations_spec.rb
+++ b/spec/tapioca/compilers/dsl/active_record_relations_spec.rb
@@ -90,9 +90,6 @@ class Tapioca::Compilers::Dsl::ActiveRecordRelationsSpec < DslSpec
             sig { params(args: T.untyped).returns(T.untyped) }
             def find(*args); end
 
-            sig { params(args: T.untyped).returns(T.untyped) }
-            def find(*args); end
-
             sig { params(args: T.untyped).returns(T.nilable(::Post)) }
             def find_by(*args); end
 


### PR DESCRIPTION
### Motivation
Bug fix for v0.6.0
It appears that we're generating the signature for `find` twice while missing the signature for `find_by!`, was probably accidentally left on one line during the refactoring.

### Implementation
- Deleted the duplicate `find` signature in the spec expectation
- Moved the `find_by!` to its only condition and generated the correct type for it

### Tests
Included

