### PR TITLE
Fix various DSL compilers matching `XPath`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,4 +35,5 @@ group(:development, :test) do
   gem("config", require: false)
   gem("aasm", require: false)
   gem("bcrypt", require: false)
+  gem("xpath", require: false)
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -282,6 +282,8 @@ GEM
     websocket-driver (0.7.4)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
+    xpath (3.2.0)
+      nokogiri (~> 1.8)
     yard (0.9.26)
     yard-sorbet (0.5.3)
       sorbet-runtime (>= 0.5)
@@ -318,6 +320,7 @@ DEPENDENCIES
   sqlite3
   state_machines
   tapioca!
+  xpath
 
 BUNDLED WITH
    2.2.32

--- a/lib/tapioca/compilers/dsl/rails_generators.rb
+++ b/lib/tapioca/compilers/dsl/rails_generators.rb
@@ -64,12 +64,12 @@ module Tapioca
 
         sig { override.returns(T::Enumerable[Module]) }
         def gather_constants
-          all_modules.select do |const|
+          all_classes.select do |const|
             name = qualified_name_of(const)
 
             name &&
               !name.match?(BUILT_IN_MATCHER) &&
-              const < ::Rails::Generators::Base
+              ::Rails::Generators::Base > const
           end
         end
 

--- a/lib/tapioca/compilers/dsl/url_helpers.rb
+++ b/lib/tapioca/compilers/dsl/url_helpers.rb
@@ -151,9 +151,14 @@ module Tapioca
 
         sig { params(mod: Module, helper: Module).returns(T::Boolean) }
         def includes_helper?(mod, helper)
-          superclass_ancestors = mod.superclass&.ancestors if Class === mod
-          superclass_ancestors ||= []
-          (mod.ancestors - superclass_ancestors).include?(helper)
+          superclass_ancestors = []
+
+          if Class === mod
+            superclass = superclass_of(mod)
+            superclass_ancestors = ancestors_of(superclass) if superclass
+          end
+
+          (ancestors_of(mod) - superclass_ancestors).any? { |ancestor| helper == ancestor }
         end
       end
     end

--- a/spec/tapioca/compilers/dsl/rails_generators_spec.rb
+++ b/spec/tapioca/compilers/dsl/rails_generators_spec.rb
@@ -34,6 +34,14 @@ class Tapioca::Compilers::Dsl::RailsGeneratorsSpec < DslSpec
       assert_equal(["AppGenerator", "NamedGenerator", "UnnamedGenerator"], gathered_constants)
     end
 
+    it("does not gather XPath") do
+      add_ruby_file("xpath.rb", <<~RUBY)
+        require "xpath"
+      RUBY
+
+      assert_empty(gathered_constants)
+    end
+
     it("ignores generator classes without a name") do
       add_ruby_file("content.rb", <<~RUBY)
         unnamed = Class.new(::Rails::Generators::Base)

--- a/spec/tapioca/compilers/dsl/url_helpers_spec.rb
+++ b/spec/tapioca/compilers/dsl/url_helpers_spec.rb
@@ -151,6 +151,22 @@ class Tapioca::Compilers::Dsl::UrlHelpersSpec < DslSpec
         "SuperClass",
       ], gathered_constants)
     end
+
+    it("does not gather XPath") do
+      add_ruby_file("xpath.rb", <<~RUBY)
+        require "xpath"
+
+        class Application < Rails::Application
+        end
+      RUBY
+
+      assert_equal([
+        "ActionDispatch::IntegrationTest",
+        "ActionView::Helpers",
+        "GeneratedPathHelpersModule",
+        "GeneratedUrlHelpersModule",
+      ], gathered_constants)
+    end
   end
 
   describe("#decorate") do


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
Fixes #676

[`XPath`](https://github.com/teamcapybara/xpath/blob/9860a6b20b31be97f6bd23a42ff6573c35f910c3/lib/xpath.rb) is a strange module that overloads a lot of the common methods that we use for type checking, especially `<` and `==`. That makes it surreptitiously match some of our DSL compilers and ends up causing problems.
 
### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
Make sure we don't rely on the `<` and `==` of types that are not under our control.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->
Add explicit tests to make sure we don't match `XPath` for the two generators that were gathering it.
