### PR TITLE
Refactor how `SmartProperties` methods are generated

### DIFF
--- a/spec/tapioca/cli/dsl_spec.rb
+++ b/spec/tapioca/cli/dsl_spec.rb
@@ -101,11 +101,15 @@ module Tapioca
             # Please instead update this file by running `bin/tapioca dsl Post`.
 
             class Post
-              sig { returns(T.nilable(::String)) }
-              def title; end
+              include SmartPropertiesGeneratedMethods
 
-              sig { params(title: T.nilable(::String)).returns(T.nilable(::String)) }
-              def title=(title); end
+              module SmartPropertiesGeneratedMethods
+                sig { returns(T.nilable(::String)) }
+                def title; end
+
+                sig { params(title: T.nilable(::String)).returns(T.nilable(::String)) }
+                def title=(title); end
+              end
             end
           RBI
 
@@ -206,11 +210,15 @@ module Tapioca
             # Please instead update this file by running `bin/tapioca dsl Post`.
 
             class Post
-              sig { returns(T.nilable(::String)) }
-              def title; end
+              include SmartPropertiesGeneratedMethods
 
-              sig { params(title: T.nilable(::String)).returns(T.nilable(::String)) }
-              def title=(title); end
+              module SmartPropertiesGeneratedMethods
+                sig { returns(T.nilable(::String)) }
+                def title; end
+
+                sig { params(title: T.nilable(::String)).returns(T.nilable(::String)) }
+                def title=(title); end
+              end
             end
           RBI
 
@@ -222,11 +230,15 @@ module Tapioca
             # Please instead update this file by running `bin/tapioca dsl Namespace::Comment`.
 
             class Namespace::Comment
-              sig { returns(::String) }
-              def body; end
+              include SmartPropertiesGeneratedMethods
 
-              sig { params(body: ::String).returns(::String) }
-              def body=(body); end
+              module SmartPropertiesGeneratedMethods
+                sig { returns(::String) }
+                def body; end
+
+                sig { params(body: ::String).returns(::String) }
+                def body=(body); end
+              end
             end
           RBI
 
@@ -277,11 +289,15 @@ module Tapioca
             # Please instead update this file by running `bin/tapioca dsl Foo::Role`.
 
             class Foo::Role
-              sig { returns(T.nilable(::String)) }
-              def title; end
+              include SmartPropertiesGeneratedMethods
 
-              sig { params(title: T.nilable(::String)).returns(T.nilable(::String)) }
-              def title=(title); end
+              module SmartPropertiesGeneratedMethods
+                sig { returns(T.nilable(::String)) }
+                def title; end
+
+                sig { params(title: T.nilable(::String)).returns(T.nilable(::String)) }
+                def title=(title); end
+              end
             end
           RBI
 
@@ -428,11 +444,15 @@ module Tapioca
             # typed: true
 
             class Post
-              sig { returns(T.nilable(::String)) }
-              def title; end
+              include SmartPropertiesGeneratedMethods
 
-              sig { params(title: T.nilable(::String)).returns(T.nilable(::String)) }
-              def title=(title); end
+              module SmartPropertiesGeneratedMethods
+                sig { returns(T.nilable(::String)) }
+                def title; end
+
+                sig { params(title: T.nilable(::String)).returns(T.nilable(::String)) }
+                def title=(title); end
+              end
             end
           RBI
         end
@@ -663,15 +683,18 @@ module Tapioca
             class Post
               include GeneratedBar
               include GeneratedFoo
-
-              sig { returns(T.nilable(::String)) }
-              def title; end
-
-              sig { params(title: T.nilable(::String)).returns(T.nilable(::String)) }
-              def title=(title); end
+              include SmartPropertiesGeneratedMethods
 
               module GeneratedBar; end
               module GeneratedFoo; end
+
+              module SmartPropertiesGeneratedMethods
+                sig { returns(T.nilable(::String)) }
+                def title; end
+
+                sig { params(title: T.nilable(::String)).returns(T.nilable(::String)) }
+                def title=(title); end
+              end
             end
           RBI
 

--- a/spec/tapioca/compilers/dsl/smart_properties_spec.rb
+++ b/spec/tapioca/compilers/dsl/smart_properties_spec.rb
@@ -83,11 +83,15 @@ class Tapioca::Compilers::Dsl::SmartPropertiesSpec < DslSpec
         # typed: strong
 
         class Post
-          sig { returns(T.nilable(::String)) }
-          def title; end
+          include SmartPropertiesGeneratedMethods
 
-          sig { params(title: T.nilable(::String)).returns(T.nilable(::String)) }
-          def title=(title); end
+          module SmartPropertiesGeneratedMethods
+            sig { returns(T.nilable(::String)) }
+            def title; end
+
+            sig { params(title: T.nilable(::String)).returns(T.nilable(::String)) }
+            def title=(title); end
+          end
         end
       RBI
 
@@ -106,11 +110,15 @@ class Tapioca::Compilers::Dsl::SmartPropertiesSpec < DslSpec
         # typed: strong
 
         module Viewable
-          sig { returns(T.nilable(::String)) }
-          def title; end
+          include SmartPropertiesGeneratedMethods
 
-          sig { params(title: T.nilable(::String)).returns(T.nilable(::String)) }
-          def title=(title); end
+          module SmartPropertiesGeneratedMethods
+            sig { returns(T.nilable(::String)) }
+            def title; end
+
+            sig { params(title: T.nilable(::String)).returns(T.nilable(::String)) }
+            def title=(title); end
+          end
         end
       RBI
 
@@ -129,11 +137,15 @@ class Tapioca::Compilers::Dsl::SmartPropertiesSpec < DslSpec
         # typed: strong
 
         class Post
-          sig { returns(::String) }
-          def description; end
+          include SmartPropertiesGeneratedMethods
 
-          sig { params(description: ::String).returns(::String) }
-          def description=(description); end
+          module SmartPropertiesGeneratedMethods
+            sig { returns(::String) }
+            def description; end
+
+            sig { params(description: ::String).returns(::String) }
+            def description=(description); end
+          end
         end
       RBI
 
@@ -152,11 +164,15 @@ class Tapioca::Compilers::Dsl::SmartPropertiesSpec < DslSpec
         # typed: strong
 
         class Post
-          sig { returns(T.untyped) }
-          def title; end
+          include SmartPropertiesGeneratedMethods
 
-          sig { params(title: T.untyped).returns(T.untyped) }
-          def title=(title); end
+          module SmartPropertiesGeneratedMethods
+            sig { returns(T.untyped) }
+            def title; end
+
+            sig { params(title: T.untyped).returns(T.untyped) }
+            def title=(title); end
+          end
         end
       RBI
 
@@ -175,11 +191,15 @@ class Tapioca::Compilers::Dsl::SmartPropertiesSpec < DslSpec
         # typed: strong
 
         class Post
-          sig { returns(T.nilable(T::Array[T.untyped])) }
-          def categories; end
+          include SmartPropertiesGeneratedMethods
 
-          sig { params(categories: T.nilable(T::Array[T.untyped])).returns(T.nilable(T::Array[T.untyped])) }
-          def categories=(categories); end
+          module SmartPropertiesGeneratedMethods
+            sig { returns(T.nilable(T::Array[T.untyped])) }
+            def categories; end
+
+            sig { params(categories: T.nilable(T::Array[T.untyped])).returns(T.nilable(T::Array[T.untyped])) }
+            def categories=(categories); end
+          end
         end
       RBI
 
@@ -198,11 +218,15 @@ class Tapioca::Compilers::Dsl::SmartPropertiesSpec < DslSpec
         # typed: strong
 
         class Post
-          sig { returns(T.nilable(T::Boolean)) }
-          def published; end
+          include SmartPropertiesGeneratedMethods
 
-          sig { params(published: T.nilable(T::Boolean)).returns(T.nilable(T::Boolean)) }
-          def published=(published); end
+          module SmartPropertiesGeneratedMethods
+            sig { returns(T.nilable(T::Boolean)) }
+            def published; end
+
+            sig { params(published: T.nilable(T::Boolean)).returns(T.nilable(T::Boolean)) }
+            def published=(published); end
+          end
         end
       RBI
 
@@ -221,11 +245,15 @@ class Tapioca::Compilers::Dsl::SmartPropertiesSpec < DslSpec
         # typed: strong
 
         class Post
-          sig { returns(T.nilable(T.any(::String, ::Integer))) }
-          def status; end
+          include SmartPropertiesGeneratedMethods
 
-          sig { params(status: T.nilable(T.any(::String, ::Integer))).returns(T.nilable(T.any(::String, ::Integer))) }
-          def status=(status); end
+          module SmartPropertiesGeneratedMethods
+            sig { returns(T.nilable(T.any(::String, ::Integer))) }
+            def status; end
+
+            sig { params(status: T.nilable(T.any(::String, ::Integer))).returns(T.nilable(T.any(::String, ::Integer))) }
+            def status=(status); end
+          end
         end
       RBI
 
@@ -244,11 +272,15 @@ class Tapioca::Compilers::Dsl::SmartPropertiesSpec < DslSpec
         # typed: strong
 
         class Post
-          sig { returns(T.untyped) }
-          def status; end
+          include SmartPropertiesGeneratedMethods
 
-          sig { params(status: T.untyped).returns(T.untyped) }
-          def status=(status); end
+          module SmartPropertiesGeneratedMethods
+            sig { returns(T.untyped) }
+            def status; end
+
+            sig { params(status: T.untyped).returns(T.untyped) }
+            def status=(status); end
+          end
         end
       RBI
 
@@ -267,11 +299,15 @@ class Tapioca::Compilers::Dsl::SmartPropertiesSpec < DslSpec
         # typed: strong
 
         class Post
-          sig { returns(T.nilable(::Integer)) }
-          def status; end
+          include SmartPropertiesGeneratedMethods
 
-          sig { params(status: T.nilable(::Integer)).returns(T.nilable(::Integer)) }
-          def status=(status); end
+          module SmartPropertiesGeneratedMethods
+            sig { returns(T.nilable(::Integer)) }
+            def status; end
+
+            sig { params(status: T.nilable(::Integer)).returns(T.nilable(::Integer)) }
+            def status=(status); end
+          end
         end
       RBI
 
@@ -290,11 +326,15 @@ class Tapioca::Compilers::Dsl::SmartPropertiesSpec < DslSpec
         # typed: strong
 
         class Post
-          sig { returns(T.untyped) }
-          def status; end
+          include SmartPropertiesGeneratedMethods
 
-          sig { params(status: T.untyped).returns(T.untyped) }
-          def status=(status); end
+          module SmartPropertiesGeneratedMethods
+            sig { returns(T.untyped) }
+            def status; end
+
+            sig { params(status: T.untyped).returns(T.untyped) }
+            def status=(status); end
+          end
         end
       RBI
 
@@ -313,11 +353,15 @@ class Tapioca::Compilers::Dsl::SmartPropertiesSpec < DslSpec
         # typed: strong
 
         class Post
-          sig { returns(T.nilable(::Integer)) }
-          def reader_for_status; end
+          include SmartPropertiesGeneratedMethods
 
-          sig { params(status: T.nilable(::Integer)).returns(T.nilable(::Integer)) }
-          def status=(status); end
+          module SmartPropertiesGeneratedMethods
+            sig { returns(T.nilable(::Integer)) }
+            def reader_for_status; end
+
+            sig { params(status: T.nilable(::Integer)).returns(T.nilable(::Integer)) }
+            def status=(status); end
+          end
         end
       RBI
 
@@ -336,11 +380,15 @@ class Tapioca::Compilers::Dsl::SmartPropertiesSpec < DslSpec
         # typed: strong
 
         class Post
-          sig { returns(T.nilable(T::Boolean)) }
-          def enabled; end
+          include SmartPropertiesGeneratedMethods
 
-          sig { params(enabled: T.nilable(T::Boolean)).returns(T.nilable(T::Boolean)) }
-          def enabled=(enabled); end
+          module SmartPropertiesGeneratedMethods
+            sig { returns(T.nilable(T::Boolean)) }
+            def enabled; end
+
+            sig { params(enabled: T.nilable(T::Boolean)).returns(T.nilable(T::Boolean)) }
+            def enabled=(enabled); end
+          end
         end
       RBI
 
@@ -359,11 +407,15 @@ class Tapioca::Compilers::Dsl::SmartPropertiesSpec < DslSpec
         # typed: strong
 
         class Post
-          sig { returns(T.nilable(T::Boolean)) }
-          def enabled; end
+          include SmartPropertiesGeneratedMethods
 
-          sig { params(enabled: T.nilable(T::Boolean)).returns(T.nilable(T::Boolean)) }
-          def enabled=(enabled); end
+          module SmartPropertiesGeneratedMethods
+            sig { returns(T.nilable(T::Boolean)) }
+            def enabled; end
+
+            sig { params(enabled: T.nilable(T::Boolean)).returns(T.nilable(T::Boolean)) }
+            def enabled=(enabled); end
+          end
         end
       RBI
 
@@ -382,11 +434,15 @@ class Tapioca::Compilers::Dsl::SmartPropertiesSpec < DslSpec
         # typed: strong
 
         class Post
-          sig { returns(T.nilable(::String)) }
-          def title; end
+          include SmartPropertiesGeneratedMethods
 
-          sig { params(title: T.nilable(::String)).returns(T.nilable(::String)) }
-          def title=(title); end
+          module SmartPropertiesGeneratedMethods
+            sig { returns(T.nilable(::String)) }
+            def title; end
+
+            sig { params(title: T.nilable(::String)).returns(T.nilable(::String)) }
+            def title=(title); end
+          end
         end
       RBI
 
@@ -405,11 +461,15 @@ class Tapioca::Compilers::Dsl::SmartPropertiesSpec < DslSpec
         # typed: strong
 
         class Post
-          sig { returns(T.nilable(::String)) }
-          def title; end
+          include SmartPropertiesGeneratedMethods
 
-          sig { params(title: T.nilable(::String)).returns(T.nilable(::String)) }
-          def title=(title); end
+          module SmartPropertiesGeneratedMethods
+            sig { returns(T.nilable(::String)) }
+            def title; end
+
+            sig { params(title: T.nilable(::String)).returns(T.nilable(::String)) }
+            def title=(title); end
+          end
         end
       RBI
 
@@ -428,11 +488,62 @@ class Tapioca::Compilers::Dsl::SmartPropertiesSpec < DslSpec
         # typed: strong
 
         class Post
-          sig { returns(T.untyped) }
-          def title; end
+          include SmartPropertiesGeneratedMethods
 
-          sig { params(title: T.untyped).returns(T.untyped) }
-          def title=(title); end
+          module SmartPropertiesGeneratedMethods
+            sig { returns(T.untyped) }
+            def title; end
+
+            sig { params(title: T.untyped).returns(T.untyped) }
+            def title=(title); end
+          end
+        end
+      RBI
+
+      assert_equal(expected, rbi_for(:Post))
+    end
+
+    it("generates smart properties that have been overriden") do
+      add_ruby_file("post.rb", <<~RUBY)
+        class Post
+          include SmartProperties
+          property :title, accepts: String
+          property :body, accepts: String
+
+          protected :body
+
+          def body
+            "body"
+          end
+
+          def title
+            "title"
+          end
+
+          def title=
+          end
+        end
+      RUBY
+
+      expected = <<~RBI
+        # typed: strong
+
+        class Post
+          include SmartPropertiesGeneratedMethods
+
+          module SmartPropertiesGeneratedMethods
+            sig { returns(T.nilable(::String)) }
+            def body; end
+
+            sig { params(body: T.nilable(::String)).returns(T.nilable(::String)) }
+            def body=(body); end
+
+            sig { returns(T.nilable(::String)) }
+            def title; end
+
+            sig { params(title: T.nilable(::String)).returns(T.nilable(::String)) }
+            def title=(title); end
+          end
         end
       RBI
 
@@ -460,11 +571,15 @@ class Tapioca::Compilers::Dsl::SmartPropertiesSpec < DslSpec
         # typed: strong
 
         class Post
-          sig { returns(T.nilable(::Post::TrackingInfoInput)) }
-          def title; end
+          include SmartPropertiesGeneratedMethods
 
-          sig { params(title: T.nilable(::Post::TrackingInfoInput)).returns(T.nilable(::Post::TrackingInfoInput)) }
-          def title=(title); end
+          module SmartPropertiesGeneratedMethods
+            sig { returns(T.nilable(::Post::TrackingInfoInput)) }
+            def title; end
+
+            sig { params(title: T.nilable(::Post::TrackingInfoInput)).returns(T.nilable(::Post::TrackingInfoInput)) }
+            def title=(title); end
+          end
         end
       RBI
 
@@ -474,23 +589,27 @@ class Tapioca::Compilers::Dsl::SmartPropertiesSpec < DslSpec
         # typed: strong
 
         class Post::TrackingInfoInput
-          sig { returns(T.nilable(::String)) }
-          def carrier_id; end
+          include SmartPropertiesGeneratedMethods
 
-          sig { params(carrier_id: T.nilable(::String)).returns(T.nilable(::String)) }
-          def carrier_id=(carrier_id); end
+          module SmartPropertiesGeneratedMethods
+            sig { returns(T.nilable(::String)) }
+            def carrier_id; end
 
-          sig { returns(::String) }
-          def number; end
+            sig { params(carrier_id: T.nilable(::String)).returns(T.nilable(::String)) }
+            def carrier_id=(carrier_id); end
 
-          sig { params(number: ::String).returns(::String) }
-          def number=(number); end
+            sig { returns(::String) }
+            def number; end
 
-          sig { returns(T.nilable(::String)) }
-          def url; end
+            sig { params(number: ::String).returns(::String) }
+            def number=(number); end
 
-          sig { params(url: T.nilable(::String)).returns(T.nilable(::String)) }
-          def url=(url); end
+            sig { returns(T.nilable(::String)) }
+            def url; end
+
+            sig { params(url: T.nilable(::String)).returns(T.nilable(::String)) }
+            def url=(url); end
+          end
         end
       RBI
 


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
We were generating `SmartProperties` methods on the constant definition itself, but this is not how things are implemented in Smart Properties and it makes it hard to decide which method to generate.

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
By generating Smart Properties defined methods in an inner module, we model the actual operation of what really happens at runtime better. Moreover, we don't need to keep doing checks to see if the method was overridden in the constant itself, to decide if we should generate the method or not.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->
Updated existing tests and add an extra test for overridden methods.
