### PR TITLE
RequiresCompiler: handle ruby source files with alternate encodings

### DIFF
--- a/lib/tapioca/compilers/requires_compiler.rb
+++ b/lib/tapioca/compilers/requires_compiler.rb
@@ -45,7 +45,7 @@ module Tapioca
 
       sig { params(file_path: String).returns(T::Enumerable[String]) }
       def collect_requires(file_path)
-        File.read(file_path).lines.map do |line|
+        File.binread(file_path).lines.map do |line|
           /^\s*require\s*(\(\s*)?['"](?<name>[^'"]+)['"](\s*\))?/.match(line) { |m| m["name"] }
         end.compact
       end


### PR DESCRIPTION
### Motivation

While using tapioca, I noticed that `tapioca require` fails with an encoding error if it encounters certain valid ruby source files with encodings other than UTF-8.  See [this commit](https://github.com/brasic/tapioca/commit/f38ce3f1031455872b5e1617b1ded810e10f9578) for an example.  Since `File.read` assumes UTF-8 encoding by default, its output is not safe to match against regular expressions since it may not have `valid_encoding?`.

```
irb(main):003:0> "やあ".encode("sjis").force_encoding("UTF-8").match(/require/)
(irb):3:in `match': invalid byte sequence in UTF-8 (ArgumentError)
        from (irb):3:in `match'
```

### Implementation

The simplest way to fix this is to use `File.binread` so that the regular expression operates in binary mode and drops all multibyte-aware behavior.  That's what I've done here.  It should be sufficient as long as the paths being required are always ascii-only.  A more comprehensive solution might involve parsing the `encoding:` magic string and setting the contents encoding accordingly but I don't think that is necessary.

### Tests

I've included a test which fails before this change.