### PR TITLE
Improve RequiresCompiler performance

### DIFF
--- a/lib/tapioca/compilers/requires_compiler.rb
+++ b/lib/tapioca/compilers/requires_compiler.rb
@@ -2,7 +2,6 @@
 # frozen_string_literal: true
 
 require "spoom"
-require "set"
 
 module Tapioca
   module Compilers
@@ -18,11 +17,9 @@ module Tapioca
       def compile
         config = Spoom::Sorbet::Config.parse_file(@sorbet_path)
         files = collect_files(config)
-        names_in_project = Set.new(files.map { |file| File.basename(file, ".rb") })
+        names_in_project = files.map { |file| [File.basename(file, ".rb"), true] }.to_h
         files.flat_map do |file|
-          collect_requires(file).reject do |req|
-            names_in_project.include?(req)
-          end
+          collect_requires(file).reject { |req| names_in_project[req] }
         end.sort.uniq.map do |name|
           "require \"#{name}\"\n"
         end.join


### PR DESCRIPTION


### Motivation

When trying tapioca on a large codebase I noticed that the `require` subcommand would run for a very long time (more than 40 minutes).  When I profiled to investigate I found that almost all of time was spent running `File.basename` in a tight loop.

Looking closer, I found that most of [these calls](https://github.com/Shopify/tapioca/blob/fc1445a84a2f2287ae1c380140fb469d4ffc3a2f/lib/tapioca/compilers/requires_compiler.rb#L90) were redundant since `RequiresCompiler#name_in_project?` always receives the same `files` argument, so in all but the first call it is spending most of its time repeating previously done work.

### Implementation

I've inlined the helper method `RequiresCompiler#name_in_project?` and converted it to a set to speed up the large number of inclusion checks to be performed.  In the application I'm testing with this brings the total runtime of `tapioca require` from 40 minutes to 20 seconds.

### Tests

I believe this does not change behavior and is well covered by existing tests.  If you disagree I'm happy to add a test or benchmark of some kind.