### PR TITLE
Ignore interpolated strings in RequiresCompiler

### DIFF
--- a/lib/tapioca/compilers/requires_compiler.rb
+++ b/lib/tapioca/compilers/requires_compiler.rb
@@ -48,6 +48,7 @@ module Tapioca
         File.read(file_path).lines.map do |line|
           /^\s*require\s*(\(\s*)?['"](?<name>[^'"]+)['"](\s*\))?/.match(line) { |m| m["name"] }
         end.compact
+          .reject { |require| require.include?('#{') } # ignore interpolation
       end
 
       sig { params(config: Spoom::Sorbet::Config, file_path: Pathname).returns(T::Boolean) }

--- a/spec/tapioca/compilers/requires_compiler_spec.rb
+++ b/spec/tapioca/compilers/requires_compiler_spec.rb
@@ -98,6 +98,29 @@ module Tapioca
           REQ
         end
 
+        it("it ignores requires with interpolation") do
+          @project.sorbet_config(<<~CONFIG)
+            .
+          CONFIG
+
+          @project.write("lib/file1.rb", <<~'RB')
+            require "a"
+            require "#{ENV["SOMETHING"]}"
+          RB
+
+          @project.write("lib/file2.rb", <<~'RB')
+            require "b"
+            require "a"
+            require "lib-#{1 + 2}"
+          RB
+
+          compiler = Tapioca::Compilers::RequiresCompiler.new(@project.absolute_path("sorbet/config"))
+          assert_equal(<<~REQ, compiler.compile)
+            require "a"
+            require "b"
+          REQ
+        end
+
         it("it ignores files ignored in the sorbet config") do
           @project.sorbet_config(<<~CONFIG)
             .


### PR DESCRIPTION
### Motivation

If a require uses an interpolated argument it should not be included in the compiled file for the following reasons:
 - The output of `collect_requires` is later filtered by `name_in_project?`, which compares require arguments with file paths.  This strategy won't work with interpolated strings.
 - The regular expression isn't smart enough to correctly handle the full semantics of interpolated strings, which allows for things like interior quotes.  That means that an instance of e.g. `require "#{ENV["SOMETHING"]}"` will be transformed into `require "#{ENV["` which is invalid syntax.

### Implementation
I considered altering the regular expression to use a negative lookahead assertion against the sequence `#{` but the regex is already fairly obscure.  It seemed simpler to add a post-processing step to remove any indicators of interpolation.

### Tests
Included