### PR TITLE
Update CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ 2.6, 2.7, 3.0 ]
+        ruby: [ "2.6", "2.7", "3.0" ]
         bundler: [ 2.2.22, 2.2.25 ]
     name: Test Ruby ${{ matrix.ruby }}, Bundler ${{ matrix.bundler }}
     steps:
@@ -30,5 +30,5 @@ jobs:
         run: bin/docs
       - name: Run tests
         env:
-          BUNDLER_VERSION: ${{matrix.bundler}} 
+          BUNDLER_VERSION: ${{matrix.bundler}}
         run: bin/test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,15 +12,13 @@ jobs:
       fail-fast: false
       matrix:
         ruby: [ "2.6", "2.7", "3.0" ]
-        bundler: [ 2.2.22, 2.2.25 ]
-    name: Test Ruby ${{ matrix.ruby }}, Bundler ${{ matrix.bundler }}
+    name: Ruby ${{ matrix.ruby }}
     steps:
       - uses: actions/checkout@v2
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
-          bundler: ${{ matrix.bundler }}
           bundler-cache: true
       - name: Run type check
         run: bin/typecheck
@@ -29,6 +27,4 @@ jobs:
       - name: Verify documentation
         run: bin/docs
       - name: Run tests
-        env:
-          BUNDLER_VERSION: ${{matrix.bundler}}
         run: bin/test

--- a/spec/tapioca/cli/gem_spec.rb
+++ b/spec/tapioca/cli/gem_spec.rb
@@ -590,16 +590,18 @@ module Tapioca
 
         it "must generate git gem RBIs with source revision numbers" do
           @project.gemfile(<<~GEMFILE, append: true)
-            gem("ast", git: "https://github.com/whitequark/ast", ref: "e07a4f66e05ac7972643a8841e336d327ea78ae1")
+            gem("faraday", git: "https://github.com/lostisland/faraday", ref: "23e249563613971ced8f851230c46b9eeeefe931")
           GEMFILE
 
           @project.bundle_install
 
-          out, err, status = @project.tapioca("gem ast")
+          out, err, status = @project.tapioca("gem faraday")
 
-          assert_includes(out, "Compiled ast")
+          assert_includes(out, "Compiled faraday")
 
-          assert_project_file_exist("sorbet/rbi/gems/ast@2.4.1-e07a4f66e05ac7972643a8841e336d327ea78ae1.rbi")
+          assert_project_file_exist(
+            "sorbet/rbi/gems/faraday@2.0.0.alpha.pre.4-23e249563613971ced8f851230c46b9eeeefe931.rbi"
+          )
 
           assert_empty(err)
           assert(status)


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
- Fix Ruby 3.0 being resolved as 3.1 unless quoted: https://bibwild.wordpress.com/2021/12/28/github-action-setup-ruby-needs-to-quote-3-0-or-will-end-up-with-ruby-3-1/
- Remove Bundler version matrix from CI, in favour of a test that runs with Bundler 2.2.22 explicitly.

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
Read commit by commit

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->
One extra test case for Bundler 2.2.22 added.
