### PR TITLE
Improve default gem test

### DIFF
--- a/spec/tapioca/cli/gem_spec.rb
+++ b/spec/tapioca/cli/gem_spec.rb
@@ -562,10 +562,8 @@ module Tapioca
 
         it "must not generate RBIs for missing gem specs" do
           @project.gemfile(<<~GEMFILE, append: true)
-            gem "minitest"
-
-            platform :truffleruby do
-              gem "minitest-excludes"
+            platform :rbx do
+              gem "ruby2_keywords", "0.0.5"
             end
           GEMFILE
 
@@ -573,8 +571,8 @@ module Tapioca
 
           out, err, status = @project.tapioca("gem --all")
 
-          assert_includes(out, "completed with missing specs: minitest-excludes (2.0.1)")
-          refute_includes(out, "Compiling minitest-excludes, this may take a few seconds")
+          assert_includes(out, "completed with missing specs: ruby2_keywords (0.0.5)")
+          refute_includes(out, "Compiled ruby2_keywords")
 
           assert_empty(err)
           assert(status)
@@ -582,10 +580,8 @@ module Tapioca
 
         it "must not generate RBIs for missing gem specs on Bundler 2.2.22" do
           @project.gemfile(<<~GEMFILE, append: true)
-            gem "minitest"
-
-            platform :truffleruby do
-              gem "minitest-excludes"
+            platform :rbx do
+              gem "ruby2_keywords", "0.0.5"
             end
           GEMFILE
 
@@ -593,8 +589,8 @@ module Tapioca
 
           out, _, status = @project.tapioca("gem --all")
 
-          assert_includes(out, "completed with missing specs: minitest-excludes (2.0.1)")
-          refute_includes(out, "Compiling minitest-excludes, this may take a few seconds")
+          assert_includes(out, "completed with missing specs: ruby2_keywords (0.0.5)")
+          refute_includes(out, "Compiled ruby2_keywords")
 
           # StdErr will have some messages about incompatibilities, so we don't check for clean err
           assert(status)


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
Our default gem test and missing gem tests were brittle and, in some cases, were not working at all.

- The missing gem tests were depending on a gem with other dependencies including one of our own dependencies (i.e. `minitest`) which could end up being problematic.
- The default gem test was assuming the version of the default gem that it was testing against. However, that assumption is not always correct, since default gem versions generally change with every release of Ruby.

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
- For the missing gem test, I changed the gem to be `ruby2_keywords` which is a super small gem with no other dependencies. I also changed the platform from `truffleruby` to `rbx` since it is less likely that we will ever be tested on Rubinius than TruffleRuby.
- For the default gem test, I made it easy to change which gem we target for the test, added the ability to find the version of the default gem, tell Bundler to use that exact version and assert that RBI files get generated with that version too. Moreover, I changed the gem we test against to be `ostruct` since it does not get too many changes and we never install a non-default version of that gem in Tapioca.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->
All test changes.
