### PR TITLE
Nested generic interfaces with overrides create invalid gem RBI output

### DIFF
--- a/lib/tapioca/generic_type_registry.rb
+++ b/lib/tapioca/generic_type_registry.rb
@@ -109,6 +109,17 @@ module Tapioca
         # Let's set the `name` method to return the proper generic name
         generic_type.define_singleton_method(:name) { name }
 
+        # We need to define a `<=` method on the cloned constant, so that Sorbet
+        # can do covariance/contravariance checks on the type variables.
+        #
+        # Normally, we would be doing proper covariance/contravariance checks here, but
+        # that is not necessary, since we are not implementing a runtime type checker
+        # here. It is just enough for the checks to pass, so that we can serialize the
+        # signatures, assuming the sigs were well-formed.
+        #
+        # So we act like all subtype checks pass.
+        generic_type.define_singleton_method(:<=) { |_| true }
+
         # Return the generic type we created
         generic_type
       end

--- a/spec/tapioca/compilers/symbol_table_compiler_spec.rb
+++ b/spec/tapioca/compilers/symbol_table_compiler_spec.rb
@@ -2762,7 +2762,7 @@ class Tapioca::Compilers::SymbolTableCompilerSpec < Minitest::HooksSpec
             []
           end
 
-          sig { returns(T::Array[Node[Integer]]) }
+          sig { override.returns(T::Array[Node[Integer]]) }
           def non_abstract_but_overriden_children
             []
           end
@@ -2782,8 +2782,11 @@ class Tapioca::Compilers::SymbolTableCompilerSpec < Minitest::HooksSpec
 
           Elem = type_member(fixed: Integer)
 
-          def children(*args, &blk); end
-          def non_abstract_but_overriden_children(*args, &blk); end
+          sig { override.returns(T::Array[Node[Integer]]) }
+          def children; end
+
+          sig { override.returns(T::Array[Node[Integer]]) }
+          def non_abstract_but_overriden_children; end
         end
 
         module Root

--- a/spec/tapioca/compilers/symbol_table_compiler_spec.rb
+++ b/spec/tapioca/compilers/symbol_table_compiler_spec.rb
@@ -2725,8 +2725,7 @@ class Tapioca::Compilers::SymbolTableCompilerSpec < Minitest::HooksSpec
           extend T::Sig
           extend T::Generic
           Elem = type_member
-
-          interface!
+          abstract!
 
           sig { abstract.returns(T::Array[Node[Elem]]) }
           def children; end
@@ -2735,10 +2734,14 @@ class Tapioca::Compilers::SymbolTableCompilerSpec < Minitest::HooksSpec
           def abstract_but_not_overridden_children; end
 
           sig { returns(T::Array[Node[Elem]]) }
-          def non_abstract_children; end
+          def non_abstract_children
+            []
+          end
 
           sig { returns(T::Array[Node[Elem]]) }
-          def non_abstract_but_overriden_children; end
+          def non_abstract_but_overriden_children
+            []
+          end
         end
 
         module Node
@@ -2748,21 +2751,21 @@ class Tapioca::Compilers::SymbolTableCompilerSpec < Minitest::HooksSpec
           Elem = type_member
         end
 
-        class OtherRoot < T::Struct
+        class OtherRoot
           include ::Root
-
           extend T::Sig
           extend T::Generic
-
           Elem = type_member(fixed: Integer)
 
           sig { override.returns(T::Array[Node[Integer]]) }
           def children
-            children
+            []
           end
 
           sig { returns(T::Array[Node[Integer]]) }
-          def non_abstract_but_overriden_children; end
+          def non_abstract_but_overriden_children
+            []
+          end
         end
       RUBY
 
@@ -2773,7 +2776,7 @@ class Tapioca::Compilers::SymbolTableCompilerSpec < Minitest::HooksSpec
           Elem = type_member
         end
 
-        class OtherRoot < ::T::Struct
+        class OtherRoot
           extend T::Generic
           include ::Root
 
@@ -2781,16 +2784,12 @@ class Tapioca::Compilers::SymbolTableCompilerSpec < Minitest::HooksSpec
 
           def children(*args, &blk); end
           def non_abstract_but_overriden_children(*args, &blk); end
-
-          class << self
-            def inherited(s); end
-          end
         end
 
         module Root
           extend T::Generic
 
-          interface!
+          abstract!
 
           Elem = type_member
 


### PR DESCRIPTION
### Motivation

We introduced the use of nested generic interfaces in an internal gem which is causing tapioca to produce invalid RBI.

### Implementation

Not sure how to fix, this PR is just adding a reproduction via test case. Open to suggestions or someone just adding a commit here that fixes it.

_Edit by @paracycle_: The fix was to delay the computation of generic type names and to not cache them. The problem with missing type names was because of an early run of the super method signature in `Root#children` when the signature for `OtherRoot#children` was being evaluated. However, at that point, the type member for `Root` has not been bound to its name `"Elem"` yet, so the name that was constructed very early in generic type creation was incomplete.

By delaying the generic type name construction to as late as possible and never caching it, we can allow the `Root#children` method signature to evaluate the name for `Node[Elem]` after the type member has been bound to its name.

### Tests

See included test
