### PR TITLE
Improve generic type variable tracking

### DIFF
--- a/lib/tapioca/compilers/symbol_table/symbol_generator.rb
+++ b/lib/tapioca/compilers/symbol_table/symbol_generator.rb
@@ -171,7 +171,7 @@ module Tapioca
         sig { params(tree: RBI::Tree, name: String, constant: Module).void }
         def compile_module(tree, name, constant)
           return unless defined_in_gem?(constant, strict: false)
-          return if Tapioca::TypeVariable === constant
+          return if Tapioca::TypeVariableModule === constant
 
           comments = documentation_comments(name)
           scope =

--- a/lib/tapioca/compilers/symbol_table/symbol_generator.rb
+++ b/lib/tapioca/compilers/symbol_table/symbol_generator.rb
@@ -288,7 +288,8 @@ module Tapioca
           # and the order they are inserted into the hash is the order they should be
           # defined in the source code.
           type_variable_declarations = type_variables.map do |type_variable|
-            type_variable_name = T.must(type_variable.name&.split("::")&.last)
+            type_variable_name = type_variable.constant_name
+            next unless type_variable_name
 
             tree << RBI::TypeMember.new(type_variable_name, type_variable.serialize)
           end

--- a/lib/tapioca/compilers/symbol_table/symbol_generator.rb
+++ b/lib/tapioca/compilers/symbol_table/symbol_generator.rb
@@ -288,7 +288,7 @@ module Tapioca
           # and the order they are inserted into the hash is the order they should be
           # defined in the source code.
           type_variable_declarations = type_variables.map do |type_variable|
-            type_variable_name = type_variable.constant_name
+            type_variable_name = type_variable.name
             next unless type_variable_name
 
             tree << RBI::TypeMember.new(type_variable_name, type_variable.serialize)

--- a/lib/tapioca/compilers/symbol_table/symbol_generator.rb
+++ b/lib/tapioca/compilers/symbol_table/symbol_generator.rb
@@ -287,10 +287,10 @@ module Tapioca
           # Each entry of `type_variables` maps a Module to a String,
           # and the order they are inserted into the hash is the order they should be
           # defined in the source code.
-          type_variable_declarations = type_variables.map do |type_variable, serialized_type_variable|
+          type_variable_declarations = type_variables.map do |type_variable|
             type_variable_name = T.must(type_variable.name&.split("::")&.last)
 
-            tree << RBI::TypeMember.new(type_variable_name, serialized_type_variable)
+            tree << RBI::TypeMember.new(type_variable_name, type_variable.serialize)
           end
 
           return if type_variable_declarations.empty?

--- a/lib/tapioca/generic_type_registry.rb
+++ b/lib/tapioca/generic_type_registry.rb
@@ -27,7 +27,7 @@ module Tapioca
 
     @type_variables = T.let(
       {}.compare_by_identity,
-      T::Hash[Module, T::Hash[TypeVariableModule, String]]
+      T::Hash[Module, T::Array[TypeVariableModule]]
     )
 
     class << self
@@ -59,7 +59,7 @@ module Tapioca
         @generic_instances[name] ||= create_generic_type(constant, name)
       end
 
-      sig { params(constant: Module).returns(T.nilable(T::Hash[TypeVariableModule, String])) }
+      sig { params(constant: Module).returns(T.nilable(T::Array[TypeVariableModule])) }
       def lookup_type_variables(constant)
         @type_variables[constant]
       end
@@ -82,7 +82,7 @@ module Tapioca
       def register_type_variable(constant, type_variable)
         type_variables = lookup_or_initialize_type_variables(constant)
 
-        type_variables[type_variable] = type_variable.serialize
+        type_variables << type_variable
       end
 
       private
@@ -150,9 +150,9 @@ module Tapioca
         end
       end
 
-      sig { params(constant: Module).returns(T::Hash[TypeVariableModule, String]) }
+      sig { params(constant: Module).returns(T::Array[TypeVariableModule]) }
       def lookup_or_initialize_type_variables(constant)
-        @type_variables[constant] ||= {}.compare_by_identity
+        @type_variables[constant] ||= []
       end
     end
   end

--- a/lib/tapioca/generic_type_registry.rb
+++ b/lib/tapioca/generic_type_registry.rb
@@ -27,7 +27,7 @@ module Tapioca
 
     @type_variables = T.let(
       {}.compare_by_identity,
-      T::Hash[Module, T::Hash[TypeVariable, String]]
+      T::Hash[Module, T::Hash[TypeVariableModule, String]]
     )
 
     class << self
@@ -59,7 +59,7 @@ module Tapioca
         @generic_instances[name] ||= create_generic_type(constant, name)
       end
 
-      sig { params(constant: Module).returns(T.nilable(T::Hash[TypeVariable, String])) }
+      sig { params(constant: Module).returns(T.nilable(T::Hash[TypeVariableModule, String])) }
       def lookup_type_variables(constant)
         @type_variables[constant]
       end
@@ -76,7 +76,7 @@ module Tapioca
       sig do
         params(
           constant: T.untyped,
-          type_variable: TypeVariable,
+          type_variable: TypeVariableModule,
         ).void
       end
       def register_type_variable(constant, type_variable)
@@ -150,7 +150,7 @@ module Tapioca
         end
       end
 
-      sig { params(constant: Module).returns(T::Hash[TypeVariable, String]) }
+      sig { params(constant: Module).returns(T::Hash[TypeVariableModule, String]) }
       def lookup_or_initialize_type_variables(constant)
         @type_variables[constant] ||= {}.compare_by_identity
       end

--- a/lib/tapioca/generic_type_registry.rb
+++ b/lib/tapioca/generic_type_registry.rb
@@ -20,7 +20,6 @@ module Tapioca
   # variable to type variable serializers. This allows us to associate type variables
   # to the constant names that represent them, easily.
   module GenericTypeRegistry
-    TypeVariable = T.type_alias { T.any(TypeMember, TypeTemplate) }
     @generic_instances = T.let(
       {},
       T::Hash[String, Module]

--- a/lib/tapioca/generic_type_registry.rb
+++ b/lib/tapioca/generic_type_registry.rb
@@ -109,6 +109,17 @@ module Tapioca
         # Let's set the `name` method to return the proper generic name
         generic_type.define_singleton_method(:name) { name }
 
+        # We need to define a `<=` method on the cloned constant, so that Sorbet
+        # can do covariance/contravariance checks on the type variables.
+        #
+        # Normally, we would be doing proper covariance/contravariance checks here, but
+        # that is not necessary, since we are not implementing a runtime type checker
+        # here. It is just enough for the checks to pass, so that we can serialize the
+        # signatures, assuming the sigs were well-formed.
+        #
+        # So we act like all subtype checks pass.
+        generic_type.define_singleton_method(:<=) { |_| true }
+
         # Return the generic type we created
         generic_type
       end

--- a/lib/tapioca/sorbet_ext/generic_name_patch.rb
+++ b/lib/tapioca/sorbet_ext/generic_name_patch.rb
@@ -23,8 +23,8 @@ module T
       def type_member(variance = :invariant, fixed: nil, lower: T.untyped, upper: BasicObject)
         # `T::Generic#type_member` just instantiates a `T::Type::TypeMember` instance and returns it.
         # We use that when registering the type member and then later return it from this method.
-        Tapioca::TypeVariable.new(
-          Tapioca::TypeVariable::Type::Member,
+        Tapioca::TypeVariableModule.new(
+          Tapioca::TypeVariableModule::Type::Member,
           variance,
           fixed,
           lower,
@@ -37,8 +37,8 @@ module T
       def type_template(variance = :invariant, fixed: nil, lower: T.untyped, upper: BasicObject)
         # `T::Generic#type_template` just instantiates a `T::Type::TypeTemplate` instance and returns it.
         # We use that when registering the type template and then later return it from this method.
-        Tapioca::TypeVariable.new(
-          Tapioca::TypeVariable::Type::Template,
+        Tapioca::TypeVariableModule.new(
+          Tapioca::TypeVariableModule::Type::Template,
           variance,
           fixed,
           lower,
@@ -60,7 +60,7 @@ module T
           # `Simple` type. We want to always make type variable types valid, so we
           # need to explicitly check that `raw_type` is a `Tapioca::TypeVariable`
           # and return `true`
-          if defined?(Tapioca::TypeVariable) && Tapioca::TypeVariable === @raw_type
+          if defined?(Tapioca::TypeVariableModule) && Tapioca::TypeVariableModule === @raw_type
             return true
           end
 
@@ -94,7 +94,7 @@ module Tapioca
   # get bound to the constant names they are assigned to by Ruby. As a result, we don't
   # need to do any matching of constants to type variables to bind their names, Ruby will
   # do that automatically for us and we get the `name` method for free from `Module`.
-  class TypeVariable < Module
+  class TypeVariableModule < Module
     extend T::Sig
 
     class Type < T::Enum

--- a/spec/tapioca/compilers/symbol_table_compiler_spec.rb
+++ b/spec/tapioca/compilers/symbol_table_compiler_spec.rb
@@ -2526,13 +2526,13 @@ class Tapioca::Compilers::SymbolTableCompilerSpec < Minitest::HooksSpec
           Template = type_template
           Elem = type_member
 
-          sig { params(foo: Generics::SimpleGenericType::Elem).void }
+          sig { params(foo: Elem).void }
           def initialize(foo); end
 
-          sig { params(foo: T::Hash[T::Array[Generics::SimpleGenericType::Template], T::Set[Generics::SimpleGenericType::Elem]]).void }
+          sig { params(foo: T::Hash[T::Array[Template], T::Set[Elem]]).void }
           def complex(foo); end
 
-          sig { params(foo: Generics::SimpleGenericType::Template).returns(Generics::SimpleGenericType::Template) }
+          sig { params(foo: Template).returns(Template) }
           def something(foo); end
         end
 
@@ -2677,7 +2677,7 @@ class Tapioca::Compilers::SymbolTableCompilerSpec < Minitest::HooksSpec
 
           Elem = type_member
 
-          const :foo, Foo::Elem
+          const :foo, Elem
 
           class << self
             def inherited(s); end
@@ -2766,11 +2766,6 @@ class Tapioca::Compilers::SymbolTableCompilerSpec < Minitest::HooksSpec
           def non_abstract_but_overriden_children
             []
           end
-
-          sig { returns(T::Array[Node[Root::Elem]]) }
-          def references_ancestor_generic_type_variable
-            []
-          end
         end
       RUBY
 
@@ -2792,9 +2787,6 @@ class Tapioca::Compilers::SymbolTableCompilerSpec < Minitest::HooksSpec
 
           sig { override.returns(T::Array[Node[Integer]]) }
           def non_abstract_but_overriden_children; end
-
-          sig { returns(T::Array[Node[Root::Elem]]) }
-          def references_ancestor_generic_type_variable; end
         end
 
         module Root
@@ -2804,16 +2796,16 @@ class Tapioca::Compilers::SymbolTableCompilerSpec < Minitest::HooksSpec
 
           Elem = type_member
 
-          sig { abstract.returns(T::Array[Node[Root::Elem]]) }
+          sig { abstract.returns(T::Array[Node[Elem]]) }
           def abstract_but_not_overridden_children; end
 
-          sig { abstract.returns(T::Array[Node[Root::Elem]]) }
+          sig { abstract.returns(T::Array[Node[Elem]]) }
           def children; end
 
-          sig { returns(T::Array[Node[Root::Elem]]) }
+          sig { returns(T::Array[Node[Elem]]) }
           def non_abstract_but_overriden_children; end
 
-          sig { returns(T::Array[Node[Root::Elem]]) }
+          sig { returns(T::Array[Node[Elem]]) }
           def non_abstract_children; end
         end
       RBI

--- a/spec/tapioca/compilers/symbol_table_compiler_spec.rb
+++ b/spec/tapioca/compilers/symbol_table_compiler_spec.rb
@@ -2526,13 +2526,13 @@ class Tapioca::Compilers::SymbolTableCompilerSpec < Minitest::HooksSpec
           Template = type_template
           Elem = type_member
 
-          sig { params(foo: Elem).void }
+          sig { params(foo: Generics::SimpleGenericType::Elem).void }
           def initialize(foo); end
 
-          sig { params(foo: T::Hash[T::Array[Template], T::Set[Elem]]).void }
+          sig { params(foo: T::Hash[T::Array[Generics::SimpleGenericType::Template], T::Set[Generics::SimpleGenericType::Elem]]).void }
           def complex(foo); end
 
-          sig { params(foo: Template).returns(Template) }
+          sig { params(foo: Generics::SimpleGenericType::Template).returns(Generics::SimpleGenericType::Template) }
           def something(foo); end
         end
 
@@ -2677,7 +2677,7 @@ class Tapioca::Compilers::SymbolTableCompilerSpec < Minitest::HooksSpec
 
           Elem = type_member
 
-          const :foo, Elem
+          const :foo, Foo::Elem
 
           class << self
             def inherited(s); end
@@ -2766,6 +2766,11 @@ class Tapioca::Compilers::SymbolTableCompilerSpec < Minitest::HooksSpec
           def non_abstract_but_overriden_children
             []
           end
+
+          sig { returns(T::Array[Node[Root::Elem]]) }
+          def references_ancestor_generic_type_variable
+            []
+          end
         end
       RUBY
 
@@ -2787,6 +2792,9 @@ class Tapioca::Compilers::SymbolTableCompilerSpec < Minitest::HooksSpec
 
           sig { override.returns(T::Array[Node[Integer]]) }
           def non_abstract_but_overriden_children; end
+
+          sig { returns(T::Array[Node[Root::Elem]]) }
+          def references_ancestor_generic_type_variable; end
         end
 
         module Root
@@ -2796,16 +2804,16 @@ class Tapioca::Compilers::SymbolTableCompilerSpec < Minitest::HooksSpec
 
           Elem = type_member
 
-          sig { abstract.returns(T::Array[Node[Elem]]) }
+          sig { abstract.returns(T::Array[Node[Root::Elem]]) }
           def abstract_but_not_overridden_children; end
 
-          sig { abstract.returns(T::Array[Node[Elem]]) }
+          sig { abstract.returns(T::Array[Node[Root::Elem]]) }
           def children; end
 
-          sig { returns(T::Array[Node[Elem]]) }
+          sig { returns(T::Array[Node[Root::Elem]]) }
           def non_abstract_but_overriden_children; end
 
-          sig { returns(T::Array[Node[Elem]]) }
+          sig { returns(T::Array[Node[Root::Elem]]) }
           def non_abstract_children; end
         end
       RBI

--- a/spec/tapioca/compilers/symbol_table_compiler_spec.rb
+++ b/spec/tapioca/compilers/symbol_table_compiler_spec.rb
@@ -2719,6 +2719,100 @@ class Tapioca::Compilers::SymbolTableCompilerSpec < Minitest::HooksSpec
       assert_equal(output, compile)
     end
 
+    it("compiles nested generic interfaces") do
+      add_ruby_file("generic.rb", <<~RUBY)
+        module Root
+          extend T::Sig
+          extend T::Generic
+          Elem = type_member
+          abstract!
+
+          sig { abstract.returns(T::Array[Node[Elem]]) }
+          def children; end
+
+          sig { abstract.returns(T::Array[Node[Elem]]) }
+          def abstract_but_not_overridden_children; end
+
+          sig { returns(T::Array[Node[Elem]]) }
+          def non_abstract_children
+            []
+          end
+
+          sig { returns(T::Array[Node[Elem]]) }
+          def non_abstract_but_overriden_children
+            []
+          end
+        end
+
+        module Node
+          extend T::Sig
+          extend T::Helpers
+          extend T::Generic
+          Elem = type_member
+        end
+
+        class OtherRoot
+          include ::Root
+          extend T::Sig
+          extend T::Generic
+          Elem = type_member(fixed: Integer)
+
+          sig { override.returns(T::Array[Node[Integer]]) }
+          def children
+            []
+          end
+
+          sig { override.returns(T::Array[Node[Integer]]) }
+          def non_abstract_but_overriden_children
+            []
+          end
+        end
+      RUBY
+
+      output = template(<<~RBI)
+        module Node
+          extend T::Generic
+
+          Elem = type_member
+        end
+
+        class OtherRoot
+          extend T::Generic
+          include ::Root
+
+          Elem = type_member(fixed: Integer)
+
+          sig { override.returns(T::Array[Node[Integer]]) }
+          def children; end
+
+          sig { override.returns(T::Array[Node[Integer]]) }
+          def non_abstract_but_overriden_children; end
+        end
+
+        module Root
+          extend T::Generic
+
+          abstract!
+
+          Elem = type_member
+
+          sig { abstract.returns(T::Array[Node[Elem]]) }
+          def abstract_but_not_overridden_children; end
+
+          sig { abstract.returns(T::Array[Node[Elem]]) }
+          def children; end
+
+          sig { returns(T::Array[Node[Elem]]) }
+          def non_abstract_but_overriden_children; end
+
+          sig { returns(T::Array[Node[Elem]]) }
+          def non_abstract_children; end
+        end
+      RBI
+
+      assert_equal(output, compile)
+    end
+
     it("compiles structs with default values") do
       add_ruby_file("foo.rb", <<~RUBY)
         class Foo < T::Struct


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
A test case submitted by @jeffcarbs in #697 surfaced the weakness of how we were doing late name binding for type variables. I was not satisfied with the changes I made on that PR, and wanted to find a better way, which is this PR that improves type variable detection immensely.

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->

There are 2 main changes made in this PR to properly run the added test:

1. We add a `<=` implementation for the generic types that we create to act like they are always covariant or contravariant. Sorbet runtime asserts co/contravariance of types in `in` and `out` positions, and fails with an error if the assertions are not satisfied. Since we are not interested in detecting these case, but more in getting the code to run, we act like everything is fine to pass these checks.
2. One of the problems we've had was how (and when) to figure out that a type variable (for example, constructed by `type_member`) is bound to a specific constant name (for example, to `Elem`). We were resorting to scanning the subconstants of a constant as we were processing it, but that made the process dependent on when we processed a certain constant and would break when there was a type variable access to a constant that was not processed yet.

   However, we know that modules are automatically bound to the name of the constant they are assigned to at the time of assignment. For example:

   ```ruby
   foo = Module.new
   foo.name # => nil
   Elem = foo
   foo.name # => "Elem"
   ```

   So, the realization is that if we make `Tapioca::TypeVariable` instances modules, then we wouldn't have to worry about this since the name binding would be done by Ruby automatically at assignment time.

   All we have to do is to make `Tapioca::TypeVariable` subclass from `Module` so that its instances are modules, and to special case that module when we are processing constants, which is exactly what this PR does.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->
Added the test contributed by @jeffcarbs 
