### PR TITLE
Make generic AR column types `T.untyped`

### DIFF
--- a/lib/tapioca/compilers/dsl/active_record_columns.rb
+++ b/lib/tapioca/compilers/dsl/active_record_columns.rb
@@ -296,7 +296,7 @@ module Tapioca
 
         sig { params(type: String).returns(String) }
         def as_nilable_type(type)
-          return type if type.start_with?("T.nilable(")
+          return type if type.start_with?("T.nilable(") || type == "T.untyped"
           "T.nilable(#{type})"
         end
       end

--- a/lib/tapioca/generic_type_registry.rb
+++ b/lib/tapioca/generic_type_registry.rb
@@ -59,6 +59,11 @@ module Tapioca
         @generic_instances[name] ||= create_generic_type(constant, name)
       end
 
+      sig { params(instance: Object).returns(T::Boolean) }
+      def generic_type_instance?(instance)
+        @generic_instances.values.any? { |generic_type| generic_type === instance }
+      end
+
       sig { params(constant: Module).returns(T.nilable(T::Array[TypeVariableModule])) }
       def lookup_type_variables(constant)
         @type_variables[constant]

--- a/lib/tapioca/helpers/active_record_column_type_helper.rb
+++ b/lib/tapioca/helpers/active_record_column_type_helper.rb
@@ -66,6 +66,7 @@ class ActiveRecordColumnTypeHelper
   sig { params(column_type: Object).returns(String) }
   def handle_unknown_type(column_type)
     return "T.untyped" unless ActiveModel::Type::Value === column_type
+    return "T.untyped" if Tapioca::GenericTypeRegistry.generic_type_instance?(column_type)
 
     lookup_return_type_of_method(column_type, :deserialize) ||
       lookup_return_type_of_method(column_type, :cast) ||

--- a/lib/tapioca/helpers/active_record_column_type_helper.rb
+++ b/lib/tapioca/helpers/active_record_column_type_helper.rb
@@ -43,13 +43,13 @@ class ActiveRecordColumnTypeHelper
     setter_type = getter_type
 
     if column&.null
-      return ["T.nilable(#{getter_type})", "T.nilable(#{setter_type})"]
+      return [as_nilable_type(getter_type), as_nilable_type(setter_type)]
     end
 
     if column_name == @constant.primary_key ||
         column_name == "created_at" ||
         column_name == "updated_at"
-      getter_type = "T.nilable(#{getter_type})"
+      getter_type = as_nilable_type(getter_type)
     end
 
     [getter_type, setter_type]
@@ -61,6 +61,15 @@ class ActiveRecordColumnTypeHelper
   def do_not_generate_strong_types?(constant)
     Object.const_defined?(:StrongTypeGeneration) &&
         !(constant.singleton_class < Object.const_get(:StrongTypeGeneration))
+  end
+
+  sig { params(type: String).returns(String) }
+  def as_nilable_type(type)
+    if type.start_with?("T.nilable(") || type == "T.untyped"
+      type
+    else
+      "T.nilable(#{type})"
+    end
   end
 
   sig { params(column_type: Object).returns(String) }

--- a/spec/tapioca/compilers/dsl/active_record_columns_spec.rb
+++ b/spec/tapioca/compilers/dsl/active_record_columns_spec.rb
@@ -813,10 +813,10 @@ class Tapioca::Compilers::Dsl::ActiveRecordColumnsSpec < DslSpec
           RUBY
 
           expected = indented(<<~RBI, 4)
-            sig { returns(T.nilable(T.untyped)) }
+            sig { returns(T.untyped) }
             def cost; end
 
-            sig { params(value: T.nilable(T.untyped)).returns(T.nilable(T.untyped)) }
+            sig { params(value: T.untyped).returns(T.untyped) }
             def cost=(value); end
           RBI
 
@@ -954,7 +954,7 @@ class Tapioca::Compilers::Dsl::ActiveRecordColumnsSpec < DslSpec
                 sig { returns(T::Boolean) }
                 def id?; end
 
-                sig { returns(T.nilable(T.untyped)) }
+                sig { returns(T.untyped) }
                 def id_before_last_save; end
 
                 sig { returns(T.untyped) }
@@ -972,7 +972,7 @@ class Tapioca::Compilers::Dsl::ActiveRecordColumnsSpec < DslSpec
                 sig { returns(T::Boolean) }
                 def id_changed?; end
 
-                sig { returns(T.nilable(T.untyped)) }
+                sig { returns(T.untyped) }
                 def id_in_database; end
 
                 sig { returns(T.nilable([T.untyped, T.untyped])) }
@@ -981,10 +981,10 @@ class Tapioca::Compilers::Dsl::ActiveRecordColumnsSpec < DslSpec
                 sig { returns(T::Boolean) }
                 def id_previously_changed?; end
 
-                sig { returns(T.nilable(T.untyped)) }
+                sig { returns(T.untyped) }
                 def id_previously_was; end
 
-                sig { returns(T.nilable(T.untyped)) }
+                sig { returns(T.untyped) }
                 def id_was; end
 
                 sig { void }


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
We seem to have cases in Shopify Core where we define a generic custom Active Record column type, where the actual attribute type ends up being the generic type variable the column type is instantiated with.

Since #701, we seem to be generating the types of those columns as the name of the type member, which obviously does not type-check. Even worse than this, before #701, we were silently generating badly typed RBI files like:
```ruby
class Model
  extend T::Sig
  include GeneratedAttributeMethods

  module GeneratedAttributeMethods
    # ...

    sig { returns(T.nilable()) }
    def details; end

    sig { params(value: T.nilable()).returns(T.nilable()) }
    def details=(value); end

    sig { returns(T::Boolean) }
    def details?; end

    sig { returns(T.nilable()) }
    def details_before_last_save; end

    sig { returns(T.untyped) }
    def details_before_type_cast; end

    sig { returns(T::Boolean) }
    def details_came_from_user?; end

    sig { returns(T.nilable([T.nilable(), T.nilable()])) }
    def details_change; end

    sig { returns(T.nilable([T.nilable(), T.nilable()])) }
    def details_change_to_be_saved; end

    sig { returns(T::Boolean) }
    def details_changed?; end

    sig { returns(T.nilable()) }
    def details_in_database; end

    sig { returns(T.nilable([T.nilable(), T.nilable()])) }
    def details_previous_change; end

    sig { returns(T::Boolean) }
    def details_previously_changed?; end

    sig { returns(T.nilable()) }
    def details_previously_was; end

    sig { returns(T.nilable()) }
    def details_was; end

    # ...
  end
end
```
(I am still not sure why these generated RBI files are not currently failing type-checking on Core, as they are obviously invalid 🤔)

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->

The implementation ignores generic custom column types by checking to see if the column type is an instance of a generic type instantiation.

I also fixed a slight nit with some column types being generated a `T.nilable(T.untyped)`.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->
Added a failing test which passes after this PR.
