### PR TITLE
Filter out Sorbet modules and modules that would be mixed in by other modules from dynamic extends

### DIFF
--- a/lib/tapioca/compilers/dynamic_mixin_compiler.rb
+++ b/lib/tapioca/compilers/dynamic_mixin_compiler.rb
@@ -174,11 +174,16 @@ class DynamicMixinCompiler
 
   sig { params(tree: RBI::Tree).returns([T::Array[Module], T::Array[Module]]) }
   def compile_mixes_in_class_methods(tree)
-    includes = dynamic_includes.select { |mod| (name = name_of(mod)) && !filtered_mixin?(name) }
-    includes.each do |mod|
+    includes = dynamic_includes.map do |mod|
       qname = qualified_name_of(mod)
-      tree << RBI::Include.new(T.must(qname))
-    end
+
+      next if qname.nil? || qname.empty?
+      next if filtered_mixin?(qname)
+
+      tree << RBI::Include.new(qname)
+
+      mod
+    end.compact
 
     # If we can generate multiple mixes_in_class_methods, then we want to use all dynamic extends that are not the
     # constant itself
@@ -187,7 +192,10 @@ class DynamicMixinCompiler
 
     mixed_in_class_methods.each do |mod|
       qualified_name = qualified_name_of(mod)
+
       next if qualified_name.nil? || qualified_name.empty?
+      next if filtered_mixin?(qualified_name)
+
       tree << RBI::MixesInClassMethods.new(qualified_name)
     end
 
@@ -196,10 +204,10 @@ class DynamicMixinCompiler
     [[], []] # silence errors
   end
 
-  sig { params(mixin_name: String).returns(T::Boolean) }
-  def filtered_mixin?(mixin_name)
+  sig { params(qualified_mixin_name: String).returns(T::Boolean) }
+  def filtered_mixin?(qualified_mixin_name)
     # filter T:: namespace mixins that aren't T::Props
     # T::Props and subconstants have semantic value
-    mixin_name.start_with?("T::") && !mixin_name.start_with?("T::Props")
+    qualified_mixin_name.start_with?("::T::") && !qualified_mixin_name.start_with?("::T::Props")
   end
 end

--- a/spec/tapioca/compilers/symbol_table_compiler_spec.rb
+++ b/spec/tapioca/compilers/symbol_table_compiler_spec.rb
@@ -85,6 +85,19 @@ class Tapioca::Compilers::SymbolTableCompilerSpec < Minitest::HooksSpec
           Arr = T.let([1,2,3], T::Array[Integer])
           Foo = ::T.type_alias { T.any(String, Symbol) }
         end
+
+        module Base
+          include T::Props
+          extend T::Helpers
+
+          module Signatures
+            include T::Props::ClassMethods
+            include T::Sig
+            include T::Helpers
+          end
+
+          mixes_in_class_methods Signatures
+        end
       RUBY
 
       output = template(<<~RBI)
@@ -100,6 +113,17 @@ class Tapioca::Compilers::SymbolTableCompilerSpec < Minitest::HooksSpec
 
         Bar::Arr = T.let(T.unsafe(nil), Array)
         Bar::Foo = T.type_alias { T.any(String, Symbol) }
+
+        module Base
+          include ::T::Props
+          extend ::T::Props::ClassMethods
+
+          mixes_in_class_methods ::Base::Signatures
+        end
+
+        module Base::Signatures
+          include ::T::Props::ClassMethods
+        end
       RBI
 
       assert_equal(output, compile)


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
We had a report of a case where Tapioca was generating:
```
mixes_in_class_methods(T::Sig)
mixed_in_class_methods(T::Helpers)
```
for some module in a gem RBI file. 

The cause was because there was a module like:
```ruby
module Base
  include T::Props
  extend T::Helpers

  module Signatures
    include T::Props::ClassMethods
    include T::Sig
    include T::Helpers
  end

  mixes_in_class_methods Signatures
end
```
in that codebase.

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
The problem was two-fold:
1. Tapioca was discovering that the include of `Base` would add `Signatures`, `T::Props::ClassMethods`, `T::Sig` and `T::Helpers` on the singleton class. So it tried to generate a `mixes_in_class_methods` for each of those dynamic extends. However, the last 3 of those modules are pulled in by virtue of pulling in `Signatures`, so we really should be filtering those out. So, from the list of dynamic extends, we now filter out all modules that are in the ancestor list of another dynamically extended module. As implemented, this has quadratic cost (it checks each module against the ancestors of all other modules in the list), but I guess the number of dynamic extends in most modules will be less than a handful, so this should be acceptable.
2. Tapioca was also happily generating `mixes_in_class_methods` definitions for `T::Sig`, et al, which it shouldn't, so it now filters those out, just the same as what it does for dynamic includes.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->
Added the reported failing case as a test.
