### PR TITLE
Add `gems` as an alias to the `gem` command

### DIFF
--- a/lib/tapioca/cli.rb
+++ b/lib/tapioca/cli.rb
@@ -255,7 +255,7 @@ module Tapioca
       exit(0)
     end
 
-    map T.unsafe(["--version", "-v"] => :__print_version)
+    map ["--version", "-v"] => :__print_version
 
     desc "--version, -v", "show version"
     def __print_version

--- a/lib/tapioca/cli.rb
+++ b/lib/tapioca/cli.rb
@@ -220,6 +220,7 @@ module Tapioca
         end
       end
     end
+    map "gems" => :gem
 
     desc "check-shims", "check duplicated definitions in shim RBIs"
     option :gem_rbi_dir, type: :string, desc: "Path to gem RBIs", default: DEFAULT_GEM_DIR

--- a/spec/tapioca/cli/gem_spec.rb
+++ b/spec/tapioca/cli/gem_spec.rb
@@ -95,6 +95,27 @@ module Tapioca
         @project.reset_bundler_version
       end
 
+      it "must support 'gems' as an alias to the command" do
+        foo = mock_gem("foo", "0.0.1") do
+          write("lib/foo.rb", FOO_RB)
+        end
+
+        @project.require_mock_gem(foo)
+        @project.bundle_install
+
+        out, err, status = @project.tapioca("gems foo")
+
+        assert_includes(out, <<~OUT)
+          Compiled foo
+                create  sorbet/rbi/gems/foo@0.0.1.rbi
+        OUT
+
+        assert_project_file_equal("sorbet/rbi/gems/foo@0.0.1.rbi", FOO_RBI)
+
+        assert_empty(err)
+        assert(status)
+      end
+
       describe("flags") do
         it "must show an error if --all is supplied with arguments" do
           out, err, status = @project.tapioca("gem --all foo")


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
I keep typing `bin/tapioca gems foo bar baz` especially when I am about to generate gem RBIs for multiple gems, so I thought that it would be nice to add `gems` as an alias to the `gem` command.

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
Use built-in Thor command alias mapping.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->
Add a test to verify that the alias works as intended.
