### PR TITLE
Bump Thor requirement

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,7 +15,7 @@ PATH
       sorbet-runtime (>= 0.5.9204)
       sorbet-static (>= 0.5.9204)
       spoom (~> 1.1.0, >= 1.1.4)
-      thor (>= 0.19.2)
+      thor (>= 1.2.0)
       yard-sorbet
 
 GEM

--- a/tapioca.gemspec
+++ b/tapioca.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency("sorbet-static", ">= 0.5.9204")
   spec.add_dependency("sorbet-runtime", ">= 0.5.9204")
   spec.add_dependency("spoom", "~> 1.1.0", ">= 1.1.4")
-  spec.add_dependency("thor", ">= 0.19.2")
+  spec.add_dependency("thor", ">= 1.2.0")
   spec.add_dependency("yard-sorbet")
 
   spec.required_ruby_version = ">= 2.6"


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
We previously bumped our Thor dependency but neglected to update our runtime dependency requirement that is now on Thor version 1.2.0 or greater (since `say_error` was added in that version).

