### PR TITLE
Generate `requires_ancestor` helpers in gems RBIs

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -224,7 +224,7 @@ GEM
       thor (~> 1.0)
     rainbow (3.1.1)
     rake (13.0.6)
-    rbi (0.0.9)
+    rbi (0.0.10)
       ast
       parser
       sorbet-runtime (>= 0.5.9204)

--- a/lib/tapioca/compilers/symbol_table_compiler.rb
+++ b/lib/tapioca/compilers/symbol_table_compiler.rb
@@ -185,6 +185,7 @@ module Tapioca
         compile_methods(tree, name, constant)
         compile_module_helpers(tree, constant)
         compile_mixins(tree, constant)
+        compile_required_ancestors(tree, constant)
         compile_props(tree, constant)
         compile_enums(tree, constant)
         compile_dynamic_mixins(tree, constant)
@@ -382,6 +383,15 @@ module Tapioca
               tree << RBI::Extend.new(T.must(qname))
             end
           end
+      end
+
+      sig { params(tree: RBI::Tree, constant: Module).void }
+      def compile_required_ancestors(tree, constant)
+        ancestors = Trackers::RequiredAncestor.required_ancestors_by(constant)
+        ancestors.each do |ancestor|
+          next unless ancestor # TODO: We should have a way to warn from here
+          tree << RBI::RequiresAncestor.new(ancestor.to_s)
+        end
       end
 
       sig { params(tree: RBI::Tree, name: String, constant: Module).void }

--- a/lib/tapioca/trackers.rb
+++ b/lib/tapioca/trackers.rb
@@ -12,3 +12,4 @@
 require "tapioca/trackers/mixin"
 require "tapioca/trackers/constant_definition"
 require "tapioca/trackers/autoload"
+require "tapioca/trackers/required_ancestor"

--- a/lib/tapioca/trackers/required_ancestor.rb
+++ b/lib/tapioca/trackers/required_ancestor.rb
@@ -1,0 +1,48 @@
+# typed: true
+# frozen_string_literal: true
+
+module Tapioca
+  module Trackers
+    module RequiredAncestor
+      extend T::Sig
+
+      @required_ancestors_map = {}.compare_by_identity
+
+      sig { params(requiring: T::Helpers, block: T.proc.returns(Module)).void }
+      def self.register(requiring, block)
+        ancestors = @required_ancestors_map[requiring] ||= []
+        ancestors << block
+      end
+
+      sig { params(mod: Module).returns(T::Array[T.proc.returns(Module)]) }
+      def self.required_ancestors_blocks_by(mod)
+        @required_ancestors_map[mod] || []
+      end
+
+      sig { params(mod: Module).returns(T::Array[T.nilable(Module)]) }
+      def self.required_ancestors_by(mod)
+        blocks = required_ancestors_blocks_by(mod)
+        blocks.map do |block|
+          block.call
+        rescue NameError
+          # The ancestor required doesn't exist, let's return nil and let the compiler decide what to do.
+          nil
+        end
+      end
+    end
+  end
+end
+
+module T
+  module Helpers
+    prepend(Module.new do
+      def requires_ancestor(&block)
+        # We can't directly call the block since the ancestor might not be loaded yet.
+        # We save the block in the map and will resolve it later.
+        Tapioca::Trackers::RequiredAncestor.register(self, block)
+
+        super
+      end
+    end)
+  end
+end

--- a/sorbet/rbi/gems/rbi@0.0.10.rbi
+++ b/sorbet/rbi/gems/rbi@0.0.10.rbi
@@ -344,10 +344,12 @@ end
 class RBI::Group::Kind < ::T::Enum
   enums do
     Mixins = new
+    RequiredAncestors = new
     Helpers = new
     TypeMembers = new
     MixesInClassMethods = new
     Sends = new
+    Attrs = new
     TStructFields = new
     TEnums = new
     Inits = new
@@ -693,8 +695,8 @@ class RBI::Node
 
   def parent_tree=(_arg0); end
 
-  sig { params(out: T.any(IO, StringIO), indent: Integer, print_locs: T::Boolean).void }
-  def print(out: T.unsafe(nil), indent: T.unsafe(nil), print_locs: T.unsafe(nil)); end
+  sig { params(out: T.any(IO, StringIO), indent: Integer, print_locs: T::Boolean, max_line_length: T.nilable(Integer)).void }
+  def print(out: T.unsafe(nil), indent: T.unsafe(nil), print_locs: T.unsafe(nil), max_line_length: T.unsafe(nil)); end
 
   sig { params(v: RBI::Printer).void }
   def print_blank_line_before(v); end
@@ -702,8 +704,8 @@ class RBI::Node
   sig { params(node: RBI::Node).void }
   def replace(node); end
 
-  sig { params(indent: Integer, print_locs: T::Boolean).returns(String) }
-  def string(indent: T.unsafe(nil), print_locs: T.unsafe(nil)); end
+  sig { params(indent: Integer, print_locs: T::Boolean, max_line_length: T.nilable(Integer)).returns(String) }
+  def string(indent: T.unsafe(nil), print_locs: T.unsafe(nil), max_line_length: T.unsafe(nil)); end
 end
 
 class RBI::NodeWithComments < ::RBI::Node
@@ -805,8 +807,11 @@ class RBI::Parser
 end
 
 class RBI::Printer < ::RBI::Visitor
-  sig { params(out: T.any(IO, StringIO), indent: Integer, print_locs: T::Boolean).void }
-  def initialize(out: T.unsafe(nil), indent: T.unsafe(nil), print_locs: T.unsafe(nil)); end
+  sig { params(out: T.any(IO, StringIO), indent: Integer, print_locs: T::Boolean, max_line_length: T.nilable(Integer)).void }
+  def initialize(out: T.unsafe(nil), indent: T.unsafe(nil), print_locs: T.unsafe(nil), max_line_length: T.unsafe(nil)); end
+
+  sig { returns(Integer) }
+  def current_indent; end
 
   sig { void }
   def dedent; end
@@ -817,6 +822,9 @@ class RBI::Printer < ::RBI::Visitor
   # Printing
   sig { void }
   def indent; end
+
+  sig { returns(T.nilable(Integer)) }
+  def max_line_length; end
 
   sig { returns(T.nilable(RBI::Node)) }
   def previous_node; end
@@ -873,6 +881,25 @@ class RBI::ReqParam < ::RBI::Param
 
   sig { params(other: T.nilable(Object)).returns(T::Boolean) }
   def ==(other); end
+end
+
+class RBI::RequiresAncestor < ::RBI::NodeWithComments
+  include ::RBI::Indexable
+
+  sig { params(name: String, loc: T.nilable(RBI::Loc), comments: T::Array[RBI::Comment]).void }
+  def initialize(name, loc: T.unsafe(nil), comments: T.unsafe(nil)); end
+
+  sig { override.params(v: RBI::Printer).void }
+  def accept_printer(v); end
+
+  sig { override.returns(T::Array[String]) }
+  def index_ids; end
+
+  sig { returns(String) }
+  def name; end
+
+  sig { override.returns(String) }
+  def to_s; end
 end
 
 class RBI::RestParam < ::RBI::Param
@@ -1157,6 +1184,9 @@ class RBI::Rewriters::RemoveKnownDefinitions < ::RBI::Visitor
 
   private
 
+  sig { params(node: RBI::Node, previous: RBI::Node).returns(T::Boolean) }
+  def can_delete_node?(node, previous); end
+
   sig { params(node: RBI::Node, previous: RBI::Node).void }
   def delete_node(node, previous); end
 
@@ -1195,6 +1225,9 @@ class RBI::Rewriters::SortNodes < ::RBI::Visitor
 
   sig { params(node: RBI::Node).returns(Integer) }
   def node_rank(node); end
+
+  sig { params(node: RBI::Node).void }
+  def sort_node_names!(node); end
 end
 
 # Scopes
@@ -1332,6 +1365,17 @@ class RBI::Sig < ::RBI::Node
 
   sig { returns(T::Array[String]) }
   def type_params; end
+
+  private
+
+  sig { params(v: RBI::Printer).void }
+  def print_as_block(v); end
+
+  sig { params(v: RBI::Printer).void }
+  def print_as_line(v); end
+
+  sig { returns(T::Array[String]) }
+  def sig_modifiers; end
 end
 
 class RBI::SigBuilder < ::RBI::ASTVisitor
@@ -1654,6 +1698,9 @@ class RBI::TreeBuilder < ::RBI::ASTVisitor
 
   sig { params(node: AST::Node).returns(RBI::Param) }
   def parse_param(node); end
+
+  sig { params(node: AST::Node).returns(RBI::RequiresAncestor) }
+  def parse_requires_ancestor(node); end
 
   sig { params(node: AST::Node).returns(RBI::Scope) }
   def parse_scope(node); end

--- a/sorbet/rbi/gems/spoom@1.1.5.rbi
+++ b/sorbet/rbi/gems/spoom@1.1.5.rbi
@@ -53,6 +53,8 @@ Spoom::Cli::Coverage::DATA_DIR = T.let(T.unsafe(nil), String)
 module Spoom::Cli::Helper
   include ::Spoom::Colorize
 
+  requires_ancestor { Thor }
+
   sig { params(string: String).returns(String) }
   def blue(string); end
 


### PR DESCRIPTION
### Motivation

Closes https://github.com/Shopify/tapioca/issues/438.

### Implementation

Following the same implementation as the mixins tracker: we hook on the `requires_ancestor` method to collect the required modules.

### Tests

See automated tests.
