### PR TITLE
Fix Dependabot labels

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,6 @@ updates:
     labels:
       - "dependencies"
       - "ruby"
-      - "ignore-for-release"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
@@ -19,4 +18,3 @@ updates:
     labels:
       - "dependencies"
       - "gh-actions"
-      - "ignore-for-release"


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
The `dependencies` label is already ignored from release notes, so removed the `ignore-for-release` label.

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
Delete the `ignore-for-release` label from dependabot workflow.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->
See automated tests.

