### PR TITLE
Never generate `T.nilable(T.untyped)` in DSL generators

### DIFF
--- a/lib/tapioca/compilers/dsl/active_model_attributes.rb
+++ b/lib/tapioca/compilers/dsl/active_model_attributes.rb
@@ -109,7 +109,7 @@ module Tapioca
             return "T.untyped"
           end
 
-          "T.nilable(#{type})"
+          as_nilable_type(type)
         end
 
         sig { params(klass: RBI::Scope, method: String, type: String).void }

--- a/lib/tapioca/compilers/dsl/active_record_associations.rb
+++ b/lib/tapioca/compilers/dsl/active_record_associations.rb
@@ -184,7 +184,7 @@ module Tapioca
         end
         def populate_single_assoc_getter_setter(klass, constant, association_name, reflection)
           association_class = type_for(constant, reflection)
-          association_type = "T.nilable(#{association_class})"
+          association_type = as_nilable_type(association_class)
 
           klass.create_method(
             association_name.to_s,

--- a/lib/tapioca/compilers/dsl/active_record_columns.rb
+++ b/lib/tapioca/compilers/dsl/active_record_columns.rb
@@ -293,12 +293,6 @@ module Tapioca
             return_type: "T::Boolean"
           )
         end
-
-        sig { params(type: String).returns(String) }
-        def as_nilable_type(type)
-          return type if type.start_with?("T.nilable(") || type == "T.untyped"
-          "T.nilable(#{type})"
-        end
       end
     end
   end

--- a/lib/tapioca/compilers/dsl/active_record_relations.rb
+++ b/lib/tapioca/compilers/dsl/active_record_relations.rb
@@ -251,6 +251,15 @@ module Tapioca
           sig { returns(String) }
           attr_reader :constant_name
 
+          sig { params(type: String).returns(String) }
+          def as_nilable_type(type)
+            if type.start_with?("T.nilable(", "::T.nilable(") || type == "T.untyped" || type == "::T.untyped"
+              type
+            else
+              "T.nilable(#{type})"
+            end
+          end
+
           sig { void }
           def create_classes_and_includes
             model.create_extend(CommonRelationMethodsModuleName)
@@ -547,7 +556,7 @@ module Tapioca
                   parameters: [
                     create_rest_param("args", type: "T.untyped"),
                   ],
-                  return_type: "T.nilable(#{constant_name})"
+                  return_type: as_nilable_type(constant_name)
                 )
               when :find_by!
                 create_common_method(
@@ -571,7 +580,7 @@ module Tapioca
                 return_type = if method_name.end_with?("!")
                   constant_name
                 else
-                  "T.nilable(#{constant_name})"
+                  as_nilable_type(constant_name)
                 end
 
                 create_common_method(

--- a/lib/tapioca/compilers/dsl/active_record_typed_store.rb
+++ b/lib/tapioca/compilers/dsl/active_record_typed_store.rb
@@ -107,7 +107,7 @@ module Tapioca
               store_data.accessors.each do |accessor|
                 field = store_data.fields[accessor]
                 type = type_for(field.type_sym)
-                type = "T.nilable(#{type})" if field.null && type != "T.untyped"
+                type = as_nilable_type(type) if field.null
 
                 store_accessors_module = model.create_module("StoreAccessors")
                 generate_methods(store_accessors_module, field.name.to_s, type)

--- a/lib/tapioca/compilers/dsl/base.rb
+++ b/lib/tapioca/compilers/dsl/base.rb
@@ -176,6 +176,15 @@ module Tapioca
           return_type
         end
 
+        sig { params(type: String).returns(String) }
+        def as_nilable_type(type)
+          if type.start_with?("T.nilable(", "::T.nilable(") || type == "T.untyped" || type == "::T.untyped"
+            type
+          else
+            "T.nilable(#{type})"
+          end
+        end
+
         sig { params(name: String).returns(T::Boolean) }
         def valid_parameter_name?(name)
           name.match?(/^[[[:alnum:]]_]+$/)

--- a/lib/tapioca/compilers/dsl/identity_cache.rb
+++ b/lib/tapioca/compilers/dsl/identity_cache.rb
@@ -116,7 +116,7 @@ module Tapioca
           if returns_collection
             COLLECTION_TYPE.call(cache_type)
           else
-            "T.nilable(::#{cache_type})"
+            as_nilable_type(T.must(qualified_name_of(cache_type)))
           end
         rescue ArgumentError
           "T.untyped"
@@ -175,18 +175,20 @@ module Tapioca
           parameters << create_kw_opt_param("includes", default: "nil", type: "T.untyped")
 
           if field.unique
+            type = T.must(qualified_name_of(constant))
+
             klass.create_method(
               "#{name}!",
               class_method: true,
               parameters: parameters,
-              return_type: "::#{constant}"
+              return_type: type
             )
 
             klass.create_method(
               name,
               class_method: true,
               parameters: parameters,
-              return_type: "T.nilable(::#{constant})"
+              return_type: as_nilable_type(type)
             )
           else
             klass.create_method(

--- a/lib/tapioca/compilers/dsl/rails_generators.rb
+++ b/lib/tapioca/compilers/dsl/rails_generators.rb
@@ -111,7 +111,7 @@ module Tapioca
           if arg.required || arg.default
             type
           else
-            "T.nilable(#{type})"
+            as_nilable_type(type)
           end
         end
       end

--- a/lib/tapioca/compilers/dsl/smart_properties.rb
+++ b/lib/tapioca/compilers/dsl/smart_properties.rb
@@ -143,11 +143,8 @@ module Tapioca
             "T.untyped"
           end
 
-          # Early return for "T.untyped", nothing more to do.
-          return type if type == "T.untyped"
-
           might_be_optional = Proc === required || !required
-          type = "T.nilable(#{type})" if might_be_optional
+          type = as_nilable_type(type) if might_be_optional
 
           type
         end

--- a/spec/tapioca/compilers/dsl/active_record_associations_spec.rb
+++ b/spec/tapioca/compilers/dsl/active_record_associations_spec.rb
@@ -184,16 +184,16 @@ class Tapioca::Compilers::Dsl::ActiveRecordAssociationsSpec < DslSpec
               include GeneratedAssociationMethods
 
               module GeneratedAssociationMethods
-                sig { returns(T.nilable(T.untyped)) }
+                sig { returns(T.untyped) }
                 def category; end
 
-                sig { params(value: T.nilable(T.untyped)).void }
+                sig { params(value: T.untyped).void }
                 def category=(value); end
 
                 sig { params(attributes: T.untyped).returns(T.untyped) }
                 def category_attributes=(attributes); end
 
-                sig { returns(T.nilable(T.untyped)) }
+                sig { returns(T.untyped) }
                 def reload_category; end
               end
             end
@@ -872,16 +872,16 @@ class Tapioca::Compilers::Dsl::ActiveRecordAssociationsSpec < DslSpec
               include GeneratedAssociationMethods
 
               module GeneratedAssociationMethods
-                sig { returns(T.nilable(T.untyped)) }
+                sig { returns(T.untyped) }
                 def category; end
 
-                sig { params(value: T.nilable(T.untyped)).void }
+                sig { params(value: T.untyped).void }
                 def category=(value); end
 
                 sig { params(attributes: T.untyped).returns(T.untyped) }
                 def category_attributes=(attributes); end
 
-                sig { returns(T.nilable(T.untyped)) }
+                sig { returns(T.untyped) }
                 def reload_category; end
               end
             end
@@ -1500,22 +1500,22 @@ class Tapioca::Compilers::Dsl::ActiveRecordAssociationsSpec < DslSpec
             sig { params(args: T.untyped, blk: T.untyped).returns(T.untyped) }
             def create_photo_blob!(*args, &blk); end
 
-            sig { returns(T.nilable(T.untyped)) }
+            sig { returns(T.untyped) }
             def photo_attachment; end
 
-            sig { params(value: T.nilable(T.untyped)).void }
+            sig { params(value: T.untyped).void }
             def photo_attachment=(value); end
 
-            sig { returns(T.nilable(T.untyped)) }
+            sig { returns(T.untyped) }
             def photo_blob; end
 
-            sig { params(value: T.nilable(T.untyped)).void }
+            sig { params(value: T.untyped).void }
             def photo_blob=(value); end
 
-            sig { returns(T.nilable(T.untyped)) }
+            sig { returns(T.untyped) }
             def reload_photo_attachment; end
 
-            sig { returns(T.nilable(T.untyped)) }
+            sig { returns(T.untyped) }
             def reload_photo_blob; end
           end
         end


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
Fixes #755 

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
Move `as_nilable_type` to the DSL base class and change all usages of `T.nilable` wrapping on bare unknown types use that utility method instead.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->
Updated tests to conform to the new reality.
