### PR TITLE
Remove parenthesis around `describe` titles

### DIFF
--- a/spec/tapioca/cli/dsl_spec.rb
+++ b/spec/tapioca/cli/dsl_spec.rb
@@ -5,7 +5,7 @@ require "spec_with_project"
 
 module Tapioca
   class DslSpec < SpecWithProject
-    describe("#cli::dsl") do
+    describe "#cli::dsl" do
       before(:all) do
         @project.write("config/application.rb", <<~RB)
           module Rails
@@ -30,7 +30,7 @@ module Tapioca
         RB
       end
 
-      describe("generate") do
+      describe "generate" do
         before(:all) do
           @project.require_real_gem("smart_properties", "1.15.0")
           @project.require_real_gem("sidekiq", "6.2.1")
@@ -986,7 +986,7 @@ module Tapioca
         end
       end
 
-      describe("verify") do
+      describe "verify" do
         before(:all) do
           @project.require_real_gem("smart_properties", "1.15.0")
           @project.require_real_gem("sidekiq", "6.2.1")

--- a/spec/tapioca/cli/gem_spec.rb
+++ b/spec/tapioca/cli/gem_spec.rb
@@ -86,7 +86,7 @@ module Tapioca
       end
     RBI
 
-    describe("#cli::gem") do
+    describe "#cli::gem" do
       before(:all) do
         @project.bundle_install
       end
@@ -116,7 +116,7 @@ module Tapioca
         assert_success_status(result)
       end
 
-      describe("flags") do
+      describe "flags" do
         it "must show an error if --all is supplied with arguments" do
           result = @project.tapioca("gem --all foo")
 
@@ -151,7 +151,7 @@ module Tapioca
         end
       end
 
-      describe("generate") do
+      describe "generate" do
         before(:all) do
           @project.tapioca("init")
         end
@@ -888,7 +888,7 @@ module Tapioca
         end
       end
 
-      describe("sync") do
+      describe "sync" do
         before(:all) do
           @project.require_mock_gem(mock_gem("foo", "0.0.1"))
           @project.require_mock_gem(mock_gem("bar", "0.3.0"))
@@ -1037,7 +1037,7 @@ module Tapioca
         end
       end
 
-      describe("verify") do
+      describe "verify" do
         before(:all) do
           @project.require_mock_gem(mock_gem("foo", "0.0.1"))
           @project.require_mock_gem(mock_gem("bar", "0.3.0"))

--- a/spec/tapioca/cli/init_spec.rb
+++ b/spec/tapioca/cli/init_spec.rb
@@ -6,7 +6,7 @@ require "yaml"
 
 module Tapioca
   class InitSpec < SpecWithProject
-    describe("#cli::init") do
+    describe "#cli::init" do
       before(:all) do
         project.bundle_install
       end

--- a/spec/tapioca/cli/require_spec.rb
+++ b/spec/tapioca/cli/require_spec.rb
@@ -5,7 +5,7 @@ require "spec_with_project"
 
 module Tapioca
   class RequireSpec < SpecWithProject
-    describe("#cli::require") do
+    describe "#cli::require" do
       before(:all) do
         project.bundle_install
         project.tapioca("init")

--- a/spec/tapioca/cli/todo_spec.rb
+++ b/spec/tapioca/cli/todo_spec.rb
@@ -5,7 +5,7 @@ require "spec_with_project"
 
 module Tapioca
   class TodoSpec < SpecWithProject
-    describe("#cli::todo") do
+    describe "#cli::todo" do
       before(:all) do
         project.bundle_install
         project.tapioca("init")

--- a/spec/tapioca/cli/version_spec.rb
+++ b/spec/tapioca/cli/version_spec.rb
@@ -5,7 +5,7 @@ require "spec_with_project"
 
 module Tapioca
   class VersionSpec < SpecWithProject
-    describe("#cli::version") do
+    describe "#cli::version" do
       before(:all) do
         project.bundle_install
       end

--- a/spec/tapioca/compilers/dsl/aasm_spec.rb
+++ b/spec/tapioca/compilers/dsl/aasm_spec.rb
@@ -4,7 +4,7 @@
 require "spec_helper"
 
 class Tapioca::Compilers::Dsl::AASMSpec < DslSpec
-  describe("#initialize") do
+  describe "#initialize" do
     after do
       T.unsafe(self).assert_no_generated_errors
     end
@@ -25,7 +25,7 @@ class Tapioca::Compilers::Dsl::AASMSpec < DslSpec
     end
   end
 
-  describe("#decorate") do
+  describe "#decorate" do
     after do
       T.unsafe(self).assert_no_generated_errors
     end

--- a/spec/tapioca/compilers/dsl/action_controller_helpers_spec.rb
+++ b/spec/tapioca/compilers/dsl/action_controller_helpers_spec.rb
@@ -4,7 +4,7 @@
 require "spec_helper"
 
 class Tapioca::Compilers::Dsl::ActionControllerHelpersSpec < DslSpec
-  describe("#initialize") do
+  describe "#initialize" do
     after do
       T.unsafe(self).assert_no_generated_errors
     end
@@ -72,7 +72,7 @@ class Tapioca::Compilers::Dsl::ActionControllerHelpersSpec < DslSpec
     end
   end
 
-  describe("#decorate") do
+  describe "#decorate" do
     after do
       T.unsafe(self).assert_no_generated_errors
     end

--- a/spec/tapioca/compilers/dsl/action_mailer_spec.rb
+++ b/spec/tapioca/compilers/dsl/action_mailer_spec.rb
@@ -4,7 +4,7 @@
 require "spec_helper"
 
 class Tapioca::Compilers::Dsl::ActionMailerSpec < DslSpec
-  describe("#initialize") do
+  describe "#initialize" do
     after do
       T.unsafe(self).assert_no_generated_errors
     end
@@ -51,7 +51,7 @@ class Tapioca::Compilers::Dsl::ActionMailerSpec < DslSpec
     end
   end
 
-  describe("#decorate") do
+  describe "#decorate" do
     after do
       T.unsafe(self).assert_no_generated_errors
     end

--- a/spec/tapioca/compilers/dsl/active_job_spec.rb
+++ b/spec/tapioca/compilers/dsl/active_job_spec.rb
@@ -4,7 +4,7 @@
 require "spec_helper"
 
 class Tapioca::Compilers::Dsl::ActiveJobSpec < DslSpec
-  describe("#initialize") do
+  describe "#initialize" do
     after do
       T.unsafe(self).assert_no_generated_errors
     end
@@ -38,7 +38,7 @@ class Tapioca::Compilers::Dsl::ActiveJobSpec < DslSpec
     end
   end
 
-  describe("#decorate") do
+  describe "#decorate" do
     after do
       T.unsafe(self).assert_no_generated_errors
     end

--- a/spec/tapioca/compilers/dsl/active_model_attributes_spec.rb
+++ b/spec/tapioca/compilers/dsl/active_model_attributes_spec.rb
@@ -4,7 +4,7 @@
 require "spec_helper"
 
 class Tapioca::Compilers::Dsl::ActiveModelAttributesSpec < DslSpec
-  describe("#initialize") do
+  describe "#initialize" do
     after do
       T.unsafe(self).assert_no_generated_errors
     end
@@ -37,7 +37,7 @@ class Tapioca::Compilers::Dsl::ActiveModelAttributesSpec < DslSpec
     end
   end
 
-  describe("#decorate") do
+  describe "#decorate" do
     after do
       T.unsafe(self).assert_no_generated_errors
     end

--- a/spec/tapioca/compilers/dsl/active_model_secure_password_spec.rb
+++ b/spec/tapioca/compilers/dsl/active_model_secure_password_spec.rb
@@ -4,7 +4,7 @@
 require "spec_helper"
 
 class Tapioca::Compilers::Dsl::ActiveModelSecurePasswordSpec < DslSpec
-  describe("#initialize") do
+  describe "#initialize" do
     it "gathers no constants if there are no classes using ActiveModel::SecurePassword" do
       assert_empty(gathered_constants)
     end
@@ -29,7 +29,7 @@ class Tapioca::Compilers::Dsl::ActiveModelSecurePasswordSpec < DslSpec
     end
   end
 
-  describe("#decorate") do
+  describe "#decorate" do
     it "generates empty RBI file if there are no calls to has_secure_password" do
       add_ruby_file("user.rb", <<~RUBY)
         class User

--- a/spec/tapioca/compilers/dsl/active_record_associations_spec.rb
+++ b/spec/tapioca/compilers/dsl/active_record_associations_spec.rb
@@ -4,7 +4,7 @@
 require "spec_helper"
 
 class Tapioca::Compilers::Dsl::ActiveRecordAssociationsSpec < DslSpec
-  describe("#initialize") do
+  describe "#initialize" do
     after do
       T.unsafe(self).assert_no_generated_errors
     end
@@ -42,7 +42,7 @@ class Tapioca::Compilers::Dsl::ActiveRecordAssociationsSpec < DslSpec
     end
   end
 
-  describe("#decorate") do
+  describe "#decorate" do
     before do
       require "active_record"
 
@@ -52,14 +52,14 @@ class Tapioca::Compilers::Dsl::ActiveRecordAssociationsSpec < DslSpec
       )
     end
 
-    describe("with relations enabled") do
+    describe "with relations enabled" do
       subject do
         T.bind(self, DslSpec)
         require "tapioca/compilers/dsl/active_record_relations"
         generator_for_names(target_class_name, "Tapioca::Compilers::Dsl::ActiveRecordRelations")
       end
 
-      describe("without errors") do
+      describe "without errors" do
         after do
           T.unsafe(self).assert_no_generated_errors
         end
@@ -621,7 +621,7 @@ class Tapioca::Compilers::Dsl::ActiveRecordAssociationsSpec < DslSpec
         end
       end
 
-      describe("with errors") do
+      describe "with errors" do
         it "generates RBI file for broken associations" do
           add_ruby_file("schema.rb", <<~RUBY)
             ActiveRecord::Migration.suppress_messages do
@@ -746,8 +746,8 @@ class Tapioca::Compilers::Dsl::ActiveRecordAssociationsSpec < DslSpec
       end
     end
 
-    describe("without relations enabled") do
-      describe("without errors") do
+    describe "without relations enabled" do
+      describe "without errors" do
         after do
           T.unsafe(self).assert_no_generated_errors
         end
@@ -1309,7 +1309,7 @@ class Tapioca::Compilers::Dsl::ActiveRecordAssociationsSpec < DslSpec
         end
       end
 
-      describe("with errors") do
+      describe "with errors" do
         it "generates RBI file for broken associations" do
           add_ruby_file("schema.rb", <<~RUBY)
             ActiveRecord::Migration.suppress_messages do
@@ -1435,7 +1435,7 @@ class Tapioca::Compilers::Dsl::ActiveRecordAssociationsSpec < DslSpec
     end
   end
 
-  describe("#decorate_active_storage") do
+  describe "#decorate_active_storage" do
     subject do
       T.bind(self, DslSpec)
       require "tapioca/compilers/dsl/active_record_relations"

--- a/spec/tapioca/compilers/dsl/active_record_columns_spec.rb
+++ b/spec/tapioca/compilers/dsl/active_record_columns_spec.rb
@@ -4,8 +4,8 @@
 require "spec_helper"
 
 class Tapioca::Compilers::Dsl::ActiveRecordColumnsSpec < DslSpec
-  describe("Tapioca::Compilers::Dsl::ActiveRecordColumns") do
-    describe("#initialize") do
+  describe "Tapioca::Compilers::Dsl::ActiveRecordColumns" do
+    describe "#initialize" do
       after do
         T.unsafe(self).assert_no_generated_errors
       end
@@ -40,7 +40,7 @@ class Tapioca::Compilers::Dsl::ActiveRecordColumnsSpec < DslSpec
       end
     end
 
-    describe("#decorate") do
+    describe "#decorate" do
       before do
         require "active_record"
 
@@ -50,7 +50,7 @@ class Tapioca::Compilers::Dsl::ActiveRecordColumnsSpec < DslSpec
         )
       end
 
-      describe("by default") do
+      describe "by default" do
         after do
           T.unsafe(self).assert_no_generated_errors
         end
@@ -824,7 +824,7 @@ class Tapioca::Compilers::Dsl::ActiveRecordColumnsSpec < DslSpec
         end
       end
 
-      describe("when StrongTypeGeneration is defined") do
+      describe "when StrongTypeGeneration is defined" do
         after do
           T.unsafe(self).assert_no_generated_errors
         end

--- a/spec/tapioca/compilers/dsl/active_record_enum_spec.rb
+++ b/spec/tapioca/compilers/dsl/active_record_enum_spec.rb
@@ -4,7 +4,7 @@
 require "spec_helper"
 
 class Tapioca::Compilers::Dsl::ActiveRecordEnumSpec < DslSpec
-  describe("#initialize") do
+  describe "#initialize" do
     after do
       T.unsafe(self).assert_no_generated_errors
     end
@@ -30,7 +30,7 @@ class Tapioca::Compilers::Dsl::ActiveRecordEnumSpec < DslSpec
     end
   end
 
-  describe("#decorate") do
+  describe "#decorate" do
     after do
       T.unsafe(self).assert_no_generated_errors
     end

--- a/spec/tapioca/compilers/dsl/active_record_fixtures_spec.rb
+++ b/spec/tapioca/compilers/dsl/active_record_fixtures_spec.rb
@@ -4,7 +4,7 @@
 require "spec_helper"
 
 class Tapioca::Compilers::Dsl::ActiveRecordFixturesSpec < DslSpec
-  describe("#initialize") do
+  describe "#initialize" do
     after do
       T.unsafe(self).assert_no_generated_errors
     end
@@ -22,7 +22,7 @@ class Tapioca::Compilers::Dsl::ActiveRecordFixturesSpec < DslSpec
     end
   end
 
-  describe("#decorate") do
+  describe "#decorate" do
     before do
       require "active_record"
       require "rails"

--- a/spec/tapioca/compilers/dsl/active_record_relations_spec.rb
+++ b/spec/tapioca/compilers/dsl/active_record_relations_spec.rb
@@ -6,7 +6,7 @@ require "spec_helper"
 class Tapioca::Compilers::Dsl::ActiveRecordRelationsSpec < DslSpec
   include Tapioca::SorbetHelper
 
-  describe("#initialize") do
+  describe "#initialize" do
     it "gathers no constants if there are no ActiveRecord classes" do
       assert_empty(gathered_constants)
     end
@@ -28,7 +28,7 @@ class Tapioca::Compilers::Dsl::ActiveRecordRelationsSpec < DslSpec
     end
   end
 
-  describe("#decorate") do
+  describe "#decorate" do
     it "generates proper relation classes and modules" do
       add_ruby_file("post.rb", <<~RUBY)
         class Post < ActiveRecord::Base

--- a/spec/tapioca/compilers/dsl/active_record_scope_spec.rb
+++ b/spec/tapioca/compilers/dsl/active_record_scope_spec.rb
@@ -4,7 +4,7 @@
 require "spec_helper"
 
 class Tapioca::Compilers::Dsl::ActiveRecordScopeSpec < DslSpec
-  describe("#initialize") do
+  describe "#initialize" do
     after do
       T.unsafe(self).assert_no_generated_errors
     end
@@ -30,12 +30,12 @@ class Tapioca::Compilers::Dsl::ActiveRecordScopeSpec < DslSpec
     end
   end
 
-  describe("#decorate") do
+  describe "#decorate" do
     after do
       T.unsafe(self).assert_no_generated_errors
     end
 
-    describe("with relations enabled") do
+    describe "with relations enabled" do
       subject do
         T.bind(self, DslSpec)
         require "tapioca/compilers/dsl/active_record_relations"
@@ -207,7 +207,7 @@ class Tapioca::Compilers::Dsl::ActiveRecordScopeSpec < DslSpec
       end
     end
 
-    describe("without relations enabled") do
+    describe "without relations enabled" do
       it "generates an empty RBI file for ActiveRecord classes with no scope field" do
         add_ruby_file("post.rb", <<~RUBY)
           class Post < ActiveRecord::Base
@@ -342,7 +342,7 @@ class Tapioca::Compilers::Dsl::ActiveRecordScopeSpec < DslSpec
     end
   end
 
-  describe("#decorate_active_storage") do
+  describe "#decorate_active_storage" do
     subject do
       T.bind(self, DslSpec)
       require "tapioca/compilers/dsl/active_record_relations"

--- a/spec/tapioca/compilers/dsl/active_record_typed_store_spec.rb
+++ b/spec/tapioca/compilers/dsl/active_record_typed_store_spec.rb
@@ -10,7 +10,7 @@ class Tapioca::Compilers::Dsl::ActiveRecordTypedStoreSpec < DslSpec
     RUBY
   end
 
-  describe("#initialize") do
+  describe "#initialize" do
     after do
       T.unsafe(self).assert_no_generated_errors
     end
@@ -41,7 +41,7 @@ class Tapioca::Compilers::Dsl::ActiveRecordTypedStoreSpec < DslSpec
     end
   end
 
-  describe("#decorate") do
+  describe "#decorate" do
     after do
       T.unsafe(self).assert_no_generated_errors
     end

--- a/spec/tapioca/compilers/dsl/active_resource_spec.rb
+++ b/spec/tapioca/compilers/dsl/active_resource_spec.rb
@@ -4,7 +4,7 @@
 require "spec_helper"
 
 class Tapioca::Compilers::Dsl::ActiveResourceSpec < DslSpec
-  describe("#initialize") do
+  describe "#initialize" do
     after do
       T.unsafe(self).assert_no_generated_errors
     end
@@ -29,7 +29,7 @@ class Tapioca::Compilers::Dsl::ActiveResourceSpec < DslSpec
     end
   end
 
-  describe("#decorate") do
+  describe "#decorate" do
     after do
       T.unsafe(self).assert_no_generated_errors
     end

--- a/spec/tapioca/compilers/dsl/active_storage_spec.rb
+++ b/spec/tapioca/compilers/dsl/active_storage_spec.rb
@@ -15,7 +15,7 @@ class Tapioca::Compilers::Dsl::ActiveStorageSpec < DslSpec
     RUBY
   end
 
-  describe("#initialize") do
+  describe "#initialize" do
     after do
       T.unsafe(self).assert_no_generated_errors
     end
@@ -41,7 +41,7 @@ class Tapioca::Compilers::Dsl::ActiveStorageSpec < DslSpec
     end
   end
 
-  describe("#decorate") do
+  describe "#decorate" do
     after do
       T.unsafe(self).assert_no_generated_errors
     end

--- a/spec/tapioca/compilers/dsl/active_support_concern_spec.rb
+++ b/spec/tapioca/compilers/dsl/active_support_concern_spec.rb
@@ -4,7 +4,7 @@
 require "spec_helper"
 
 class Tapioca::Compilers::Dsl::ActiveSupportConcernSpec < DslSpec
-  describe("#gather_constants") do
+  describe "#gather_constants" do
     after do
       T.unsafe(self).assert_no_generated_errors
     end
@@ -146,7 +146,7 @@ class Tapioca::Compilers::Dsl::ActiveSupportConcernSpec < DslSpec
     end
   end
 
-  describe("#decorate") do
+  describe "#decorate" do
     after do
       T.unsafe(self).assert_no_generated_errors
     end

--- a/spec/tapioca/compilers/dsl/active_support_current_attributes_spec.rb
+++ b/spec/tapioca/compilers/dsl/active_support_current_attributes_spec.rb
@@ -4,7 +4,7 @@
 require "spec_helper"
 
 class Tapioca::Compilers::Dsl::ActiveSupportCurrentAttributesSpec < DslSpec
-  describe("#initialize") do
+  describe "#initialize" do
     after do
       T.unsafe(self).assert_no_generated_errors
     end
@@ -26,7 +26,7 @@ class Tapioca::Compilers::Dsl::ActiveSupportCurrentAttributesSpec < DslSpec
     end
   end
 
-  describe("#decorate") do
+  describe "#decorate" do
     after do
       T.unsafe(self).assert_no_generated_errors
     end

--- a/spec/tapioca/compilers/dsl/config_spec.rb
+++ b/spec/tapioca/compilers/dsl/config_spec.rb
@@ -8,7 +8,7 @@ class Tapioca::Compilers::Dsl::ConfigSpec < DslSpec
     Object.send(:remove_const, :Rails)
   end
 
-  describe("#gather_constants") do
+  describe "#gather_constants" do
     after do
       T.unsafe(self).assert_no_generated_errors
     end
@@ -27,7 +27,7 @@ class Tapioca::Compilers::Dsl::ConfigSpec < DslSpec
     end
   end
 
-  describe("#decorate") do
+  describe "#decorate" do
     after do
       T.unsafe(self).assert_no_generated_errors
     end

--- a/spec/tapioca/compilers/dsl/frozen_record_spec.rb
+++ b/spec/tapioca/compilers/dsl/frozen_record_spec.rb
@@ -9,7 +9,7 @@ class Tapioca::Compilers::Dsl::FrozenRecordSpec < DslSpec
     require "tapioca/compilers/dsl/extensions/frozen_record"
   end
 
-  describe("#initialize") do
+  describe "#initialize" do
     after do
       T.unsafe(self).assert_no_generated_errors
     end
@@ -31,7 +31,7 @@ class Tapioca::Compilers::Dsl::FrozenRecordSpec < DslSpec
     end
   end
 
-  describe("#decorate") do
+  describe "#decorate" do
     after do
       T.unsafe(self).assert_no_generated_errors
     end

--- a/spec/tapioca/compilers/dsl/identity_cache_spec.rb
+++ b/spec/tapioca/compilers/dsl/identity_cache_spec.rb
@@ -8,7 +8,7 @@ class Tapioca::Compilers::Dsl::IdentityCacheSpec < DslSpec
     require "rails/railtie"
   end
 
-  describe("#initialize") do
+  describe "#initialize" do
     after do
       T.unsafe(self).assert_no_generated_errors
     end
@@ -47,7 +47,7 @@ class Tapioca::Compilers::Dsl::IdentityCacheSpec < DslSpec
     end
   end
 
-  describe("#decorate") do
+  describe "#decorate" do
     after do
       T.unsafe(self).assert_no_generated_errors
     end

--- a/spec/tapioca/compilers/dsl/mixed_in_class_attributes_spec.rb
+++ b/spec/tapioca/compilers/dsl/mixed_in_class_attributes_spec.rb
@@ -9,7 +9,7 @@ class Tapioca::Compilers::Dsl::MixedInClassAttributesSpec < DslSpec
     require "active_support/concern"
   end
 
-  describe("#gather_constants") do
+  describe "#gather_constants" do
     after do
       T.unsafe(self).assert_no_generated_errors
     end
@@ -45,7 +45,7 @@ class Tapioca::Compilers::Dsl::MixedInClassAttributesSpec < DslSpec
     end
   end
 
-  describe("#decorate") do
+  describe "#decorate" do
     after do
       T.unsafe(self).assert_no_generated_errors
     end

--- a/spec/tapioca/compilers/dsl/protobuf_spec.rb
+++ b/spec/tapioca/compilers/dsl/protobuf_spec.rb
@@ -4,7 +4,7 @@
 require "spec_helper"
 
 class Tapioca::Compilers::Dsl::ProtobufSpec < DslSpec
-  describe("#gather_constants") do
+  describe "#gather_constants" do
     after do
       T.unsafe(self).assert_no_generated_errors
     end
@@ -38,7 +38,7 @@ class Tapioca::Compilers::Dsl::ProtobufSpec < DslSpec
     end
   end
 
-  describe("#decorate") do
+  describe "#decorate" do
     after do
       T.unsafe(self).assert_no_generated_errors
     end

--- a/spec/tapioca/compilers/dsl/rails_generators_spec.rb
+++ b/spec/tapioca/compilers/dsl/rails_generators_spec.rb
@@ -4,7 +4,7 @@
 require "spec_helper"
 
 class Tapioca::Compilers::Dsl::RailsGeneratorsSpec < DslSpec
-  describe("#initialize") do
+  describe "#initialize" do
     after do
       T.unsafe(self).assert_no_generated_errors
     end
@@ -53,7 +53,7 @@ class Tapioca::Compilers::Dsl::RailsGeneratorsSpec < DslSpec
     end
   end
 
-  describe("#decorate") do
+  describe "#decorate" do
     after do
       T.unsafe(self).assert_no_generated_errors
     end

--- a/spec/tapioca/compilers/dsl/sidekiq_worker_spec.rb
+++ b/spec/tapioca/compilers/dsl/sidekiq_worker_spec.rb
@@ -4,7 +4,7 @@
 require "spec_helper"
 
 class Tapioca::Compilers::Dsl::SidekiqWorkerSpec < DslSpec
-  describe("#initialize") do
+  describe "#initialize" do
     after do
       T.unsafe(self).assert_no_generated_errors
     end
@@ -30,7 +30,7 @@ class Tapioca::Compilers::Dsl::SidekiqWorkerSpec < DslSpec
     end
   end
 
-  describe("#decorate") do
+  describe "#decorate" do
     after do
       T.unsafe(self).assert_no_generated_errors
     end

--- a/spec/tapioca/compilers/dsl/smart_properties_spec.rb
+++ b/spec/tapioca/compilers/dsl/smart_properties_spec.rb
@@ -4,7 +4,7 @@
 require "spec_helper"
 
 class Tapioca::Compilers::Dsl::SmartPropertiesSpec < DslSpec
-  describe("#initialize") do
+  describe "#initialize" do
     after do
       T.unsafe(self).assert_no_generated_errors
     end
@@ -52,7 +52,7 @@ class Tapioca::Compilers::Dsl::SmartPropertiesSpec < DslSpec
     end
   end
 
-  describe("#decorate") do
+  describe "#decorate" do
     after do
       T.unsafe(self).assert_no_generated_errors
     end

--- a/spec/tapioca/compilers/dsl/state_machines_spec.rb
+++ b/spec/tapioca/compilers/dsl/state_machines_spec.rb
@@ -4,7 +4,7 @@
 require "spec_helper"
 
 class Tapioca::Compilers::Dsl::StateMachinesSpec < DslSpec
-  describe("#initialize") do
+  describe "#initialize" do
     after do
       T.unsafe(self).assert_no_generated_errors
     end
@@ -31,7 +31,7 @@ class Tapioca::Compilers::Dsl::StateMachinesSpec < DslSpec
     end
   end
 
-  describe("#decorate") do
+  describe "#decorate" do
     after do
       T.unsafe(self).assert_no_generated_errors
     end

--- a/spec/tapioca/compilers/dsl/url_helpers_spec.rb
+++ b/spec/tapioca/compilers/dsl/url_helpers_spec.rb
@@ -4,7 +4,7 @@
 require "spec_helper"
 
 class Tapioca::Compilers::Dsl::UrlHelpersSpec < DslSpec
-  describe("#initialize") do
+  describe "#initialize" do
     after do
       T.unsafe(self).assert_no_generated_errors
     end
@@ -169,7 +169,7 @@ class Tapioca::Compilers::Dsl::UrlHelpersSpec < DslSpec
     end
   end
 
-  describe("#decorate") do
+  describe "#decorate" do
     after do
       T.unsafe(self).assert_no_generated_errors
     end

--- a/spec/tapioca/compilers/requires_compiler_spec.rb
+++ b/spec/tapioca/compilers/requires_compiler_spec.rb
@@ -7,7 +7,7 @@ require "tapioca/compilers/requires_compiler"
 module Tapioca
   module Compilers
     class RequiresCompilerSpec < Tapioca::SpecWithProject
-      describe("#compilers::requires") do
+      describe "#compilers::requires" do
         after do
           @project.remove("lib/")
           @project.remove("test/")

--- a/spec/tapioca/compilers/symbol_table_compiler_spec.rb
+++ b/spec/tapioca/compilers/symbol_table_compiler_spec.rb
@@ -26,7 +26,7 @@ class Tapioca::Compilers::SymbolTableCompilerSpec < Minitest::HooksSpec
     end
   end
 
-  describe("compile") do
+  describe "compile" do
     sig { params(include_doc: T::Boolean).returns(String) }
     def compile(include_doc: false)
       stub = GemStub.new(

--- a/spec/tapioca/gemfile_spec.rb
+++ b/spec/tapioca/gemfile_spec.rb
@@ -8,7 +8,7 @@ module Tapioca
   class GemfileSpec < SpecWithProject
     extend T::Sig
 
-    describe("gem can export RBI files") do
+    describe "gem can export RBI files" do
       it "export_rbi_files? returns false if the gem does not export RBI files" do
         foo_gem = mock_gem("foo", "0.0.1")
         foo_spec = make_spec(foo_gem)

--- a/spec/tapioca/rbi_builder_spec.rb
+++ b/spec/tapioca/rbi_builder_spec.rb
@@ -5,7 +5,7 @@ require "spec_helper"
 
 module RBI
   class BuilderSpec < Minitest::HooksSpec
-    describe("provides a simple interface to build trees") do
+    describe "provides a simple interface to build trees" do
       it "builds RBI nodes" do
         rbi = RBI::Tree.new
         rbi.create_class("A")

--- a/spec/tapioca/reflection_spec.rb
+++ b/spec/tapioca/reflection_spec.rb
@@ -57,7 +57,7 @@ module Tapioca
   end
 
   class ReflectionSpec < Minitest::Spec
-    describe("reflection methods") do
+    describe "reflection methods" do
       it "might return the wrong results without Reflection helpers" do
         foo = LyingFoo.new
 
@@ -100,7 +100,7 @@ module Tapioca
       end
     end
 
-    describe("#qualified_name_of") do
+    describe "#qualified_name_of" do
       it "returns nil if the class is anonymous" do
         klass = Class.new
 


### PR DESCRIPTION
Another less controversial change extracted from #729.