### PR TITLE
In Ruby 2.6 `Symbol`s don't have `end_with?` method

### DIFF
--- a/lib/tapioca/compilers/dsl/active_record_relations.rb
+++ b/lib/tapioca/compilers/dsl/active_record_relations.rb
@@ -260,6 +260,11 @@ module Tapioca
             end
           end
 
+          sig { params(method_name: Symbol).returns(T::Boolean) }
+          def bang_method?(method_name)
+            method_name.to_s.end_with?("!")
+          end
+
           sig { void }
           def create_classes_and_includes
             model.create_extend(CommonRelationMethodsModuleName)
@@ -489,7 +494,7 @@ module Tapioca
                 ]
 
                 # Bang methods don't have the `unique_by` parameter
-                unless method_name.end_with?("!")
+                unless bang_method?(method_name)
                   parameters << create_kw_opt_param("unique_by", type: unique_by_type, default: "nil")
                 end
 
@@ -505,7 +510,7 @@ module Tapioca
                 ]
 
                 # Bang methods don't have the `unique_by` parameter
-                unless method_name.end_with?("!")
+                unless bang_method?(method_name)
                   parameters << create_kw_opt_param("unique_by", type: unique_by_type, default: "nil")
                 end
 
@@ -577,7 +582,7 @@ module Tapioca
               when :raise_record_not_found_exception!
                 # skip
               else
-                return_type = if method_name.end_with?("!")
+                return_type = if bang_method?(method_name)
                   constant_name
                 else
                   as_nilable_type(constant_name)


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
Fix #719 

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
We were calling `end_with?` on `Symbol` method names to check if the method was a bang method or not. Changed all usages to use a helper method named `bang_method?` which encapsulates the `to_s` conversion.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->
Existing tests have not been catching this since Rails 6 and above seems to be adding its own `ends_with?` method on `Symbol`. Given this, not sure how to test this reliably.
