### PR TITLE
All tests should use `spec_helper` for unified setup

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,6 +13,7 @@ require "tapioca/helpers/test/content"
 require "tapioca/helpers/test/template"
 require "tapioca/helpers/test/isolation"
 require "dsl_spec_helper"
+require "spec_with_project"
 
 Minitest::Reporters.use!(Minitest::Reporters::SpecReporter.new(color: true))
 

--- a/spec/spec_with_project.rb
+++ b/spec/spec_with_project.rb
@@ -1,23 +1,7 @@
 # typed: strict
 # frozen_string_literal: true
 
-require "sorbet-runtime"
-
-require "minitest/autorun"
-require "minitest/hooks/default"
-require "minitest/reporters"
-
 require "helpers/mock_project"
-
-Minitest::Reporters.use!(Minitest::Reporters::SpecReporter.new(color: true))
-
-module Minitest
-  class Test
-    extend T::Sig
-
-    Minitest::Test.make_my_diffs_pretty!
-  end
-end
 
 module Tapioca
   class SpecWithProject < Minitest::HooksSpec

--- a/spec/tapioca/cli/check_shims_spec.rb
+++ b/spec/tapioca/cli/check_shims_spec.rb
@@ -1,7 +1,7 @@
 # typed: true
 # frozen_string_literal: true
 
-require "spec_with_project"
+require "spec_helper"
 
 module Tapioca
   class CleanShimsTest < SpecWithProject

--- a/spec/tapioca/cli/config_spec.rb
+++ b/spec/tapioca/cli/config_spec.rb
@@ -1,7 +1,7 @@
 # typed: true
 # frozen_string_literal: true
 
-require "spec_with_project"
+require "spec_helper"
 
 module Tapioca
   class ConfigTest < SpecWithProject

--- a/spec/tapioca/cli/dsl_spec.rb
+++ b/spec/tapioca/cli/dsl_spec.rb
@@ -1,7 +1,7 @@
 # typed: true
 # frozen_string_literal: true
 
-require "spec_with_project"
+require "spec_helper"
 
 module Tapioca
   class DslSpec < SpecWithProject

--- a/spec/tapioca/cli/gem_spec.rb
+++ b/spec/tapioca/cli/gem_spec.rb
@@ -1,7 +1,7 @@
 # typed: true
 # frozen_string_literal: true
 
-require "spec_with_project"
+require "spec_helper"
 require "tapioca/helpers/test/template"
 
 module Tapioca

--- a/spec/tapioca/cli/init_spec.rb
+++ b/spec/tapioca/cli/init_spec.rb
@@ -1,7 +1,7 @@
 # typed: strict
 # frozen_string_literal: true
 
-require "spec_with_project"
+require "spec_helper"
 require "yaml"
 
 module Tapioca

--- a/spec/tapioca/cli/require_spec.rb
+++ b/spec/tapioca/cli/require_spec.rb
@@ -1,7 +1,7 @@
 # typed: strict
 # frozen_string_literal: true
 
-require "spec_with_project"
+require "spec_helper"
 
 module Tapioca
   class RequireSpec < SpecWithProject

--- a/spec/tapioca/cli/todo_spec.rb
+++ b/spec/tapioca/cli/todo_spec.rb
@@ -1,7 +1,7 @@
 # typed: strict
 # frozen_string_literal: true
 
-require "spec_with_project"
+require "spec_helper"
 
 module Tapioca
   class TodoSpec < SpecWithProject

--- a/spec/tapioca/cli/version_spec.rb
+++ b/spec/tapioca/cli/version_spec.rb
@@ -1,7 +1,7 @@
 # typed: strict
 # frozen_string_literal: true
 
-require "spec_with_project"
+require "spec_helper"
 
 module Tapioca
   class VersionSpec < SpecWithProject

--- a/spec/tapioca/compilers/requires_compiler_spec.rb
+++ b/spec/tapioca/compilers/requires_compiler_spec.rb
@@ -1,7 +1,7 @@
 # typed: strict
 # frozen_string_literal: true
 
-require "spec_with_project"
+require "spec_helper"
 require "tapioca/compilers/requires_compiler"
 
 module Tapioca

--- a/spec/tapioca/gemfile_spec.rb
+++ b/spec/tapioca/gemfile_spec.rb
@@ -1,8 +1,7 @@
 # typed: strict
 # frozen_string_literal: true
 
-require "spec_with_project"
-require "tapioca/internal"
+require "spec_helper"
 
 module Tapioca
   class GemfileSpec < SpecWithProject


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
Some tests were doing their own setup inside `spec_with_project` but that meant that any Minitest configuration would have to be duplicated.

However, `spec_with_project` just defines a `Minitest::Spec` subclass, so it can easily be required from `spec_helper` as part of the setup for all tests.

This fixes a problem with CLI tests that were just relying on requiring `spec_with_project` not respecting the line number filter for the runner, since the configuration of Minitest was different there.

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
- Remove any Minitest setup code from `spec_with_project`
- Require `spec_with_project` in `spec_helper`
- Replace all requires of `spec_with_project` with `spec_helper`

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->
No new tests
