### PR TITLE
Proposal: gem generation plugin

### DIFF
--- a/lib/tapioca.rb
+++ b/lib/tapioca.rb
@@ -14,7 +14,7 @@ module Tapioca
   def self.silence_warnings(&blk)
     original_verbosity = $VERBOSE
     $VERBOSE = nil
-    Gem::DefaultUserInteraction.use_ui(Gem::SilentUI.new) do
+    ::Gem::DefaultUserInteraction.use_ui(::Gem::SilentUI.new) do
       blk.call
     end
   ensure

--- a/lib/tapioca/gem/plugins/base.rb
+++ b/lib/tapioca/gem/plugins/base.rb
@@ -1,0 +1,33 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "pathname"
+
+module Tapioca
+  module Gem
+    module Plugins
+      class Base
+        extend T::Sig
+        extend T::Helpers
+
+        abstract!
+
+        sig { params(cls: RBI::Class).void }
+        def decorate_class(cls)
+        end
+
+        sig { params(mod: RBI::Module).void }
+        def decorate_module(mod)
+        end
+
+        sig { params(const: RBI::Const).void }
+        def decorate_const(const)
+        end
+
+        sig { params(meth: RBI::Method).void }
+        def decorate_method(meth)
+        end
+      end
+    end
+  end
+end

--- a/lib/tapioca/gem/plugins/yard_doc.rb
+++ b/lib/tapioca/gem/plugins/yard_doc.rb
@@ -1,0 +1,62 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "pathname"
+
+module Tapioca
+  module Gem
+    module Plugins
+      class YardDoc < Base
+        extend T::Sig
+
+        IGNORED_COMMENTS = T.let([
+          ":doc:",
+          ":nodoc:",
+          "typed:",
+          "frozen_string_literal:",
+          "encoding:",
+          "warn_indent:",
+          "shareable_constant_value:",
+          "rubocop:",
+        ], T::Array[String])
+
+        sig { override.params(mod: RBI::Module).void }
+        def decorate_module(mod)
+          mod.comments = documentation_comments(mod.fully_qualified_name)
+        end
+
+        sig { override.params(cls: RBI::Class).void }
+        def decorate_class(cls)
+          cls.comments = documentation_comments(cls.fully_qualified_name)
+        end
+
+        sig { params(const: RBI::Const).void }
+        def decorate_const(const)
+          const.comments = documentation_comments(const.fully_qualified_name)
+        end
+
+        sig { override.params(meth: RBI::Method).void }
+        def decorate_method(meth)
+          meth.comments = documentation_comments(meth.fully_qualified_name)
+        end
+
+        private
+
+        sig { params(name: String).returns(T::Array[RBI::Comment]) }
+        def documentation_comments(name)
+          name = name.sub(/^::/, "") # RBI namespaces are rooted on `::` while Yard expect them without this prefix
+
+          yard_docs = YARD::Registry.at(name)
+          return [] unless yard_docs
+
+          docstring = yard_docs.docstring
+          return [] if /(copyright|license)/i.match?(docstring)
+
+          docstring.lines
+            .reject { |line| IGNORED_COMMENTS.any? { |comment| line.include?(comment) } }
+            .map! { |line| RBI::Comment.new(line) }
+        end
+      end
+    end
+  end
+end

--- a/lib/tapioca/helpers/sorbet_helper.rb
+++ b/lib/tapioca/helpers/sorbet_helper.rb
@@ -9,8 +9,8 @@ module Tapioca
     extend T::Sig
 
     SORBET_GEM_SPEC = T.let(
-      Gem::Specification.find_by_name("sorbet-static"),
-      Gem::Specification
+      ::Gem::Specification.find_by_name("sorbet-static"),
+      ::Gem::Specification
     )
 
     SORBET_BIN = T.let(
@@ -22,8 +22,8 @@ module Tapioca
 
     FEATURE_REQUIREMENTS = T.let({
       # First tag that includes https://github.com/sorbet/sorbet/pull/4706
-      to_ary_nil_support: Gem::Requirement.new(">= 0.5.9220"),
-    }.freeze, T::Hash[Symbol, Gem::Requirement])
+      to_ary_nil_support: ::Gem::Requirement.new(">= 0.5.9220"),
+    }.freeze, T::Hash[Symbol, ::Gem::Requirement])
 
     sig { params(args: String).returns(String) }
     def sorbet(*args)
@@ -44,7 +44,7 @@ module Tapioca
       sorbet_path.to_s.shellescape
     end
 
-    sig { params(feature: Symbol, version: T.nilable(Gem::Version)).returns(T::Boolean) }
+    sig { params(feature: Symbol, version: T.nilable(::Gem::Version)).returns(T::Boolean) }
     def sorbet_supports?(feature, version: nil)
       version = SORBET_GEM_SPEC.version unless version
       requirement = FEATURE_REQUIREMENTS[feature]

--- a/lib/tapioca/helpers/test/isolation.rb
+++ b/lib/tapioca/helpers/test/isolation.rb
@@ -100,7 +100,7 @@ module Tapioca
                   load_path_args << File.expand_path(p)
                 end
 
-                child = IO.popen([env, Gem.ruby, *load_path_args, $PROGRAM_NAME, *ORIG_ARGV, test_opts])
+                child = IO.popen([env, ::Gem.ruby, *load_path_args, $PROGRAM_NAME, *ORIG_ARGV, test_opts])
 
                 begin
                   Process.wait(child.pid)

--- a/lib/tapioca/helpers/test/template.rb
+++ b/lib/tapioca/helpers/test/template.rb
@@ -15,7 +15,7 @@ module Tapioca
 
         sig { params(selector: String).returns(T::Boolean) }
         def ruby_version(selector)
-          Gem::Requirement.new(selector).satisfied_by?(Gem::Version.new(RUBY_VERSION))
+          ::Gem::Requirement.new(selector).satisfied_by?(::Gem::Version.new(RUBY_VERSION))
         end
 
         sig { params(src: String).returns(String) }

--- a/lib/tapioca/rbi_ext/model.rb
+++ b/lib/tapioca/rbi_ext/model.rb
@@ -157,6 +157,20 @@ module RBI
     end
   end
 
+  class Method
+    extend T::Sig
+
+    # TODO: upstream this change
+    sig { returns(String) }
+    def fully_qualified_name
+      if is_singleton
+        "#{parent_scope&.fully_qualified_name}.#{name}"
+      else
+        "#{parent_scope&.fully_qualified_name}##{name}"
+      end
+    end
+  end
+
   class TypedParam < T::Struct
     const :param, RBI::Param
     const :type, String

--- a/spec/helpers/mock_project.rb
+++ b/spec/helpers/mock_project.rb
@@ -76,7 +76,7 @@ module Tapioca
       opts = {}
       opts[:chdir] = path
       Bundler.with_unbundled_env do
-        Gem.install("bundler", bundler_version)
+        ::Gem.install("bundler", bundler_version)
         out, err, status = Open3.capture3(["bundle", "_#{bundler_version}_", "install"].join(" "), opts)
         ExecResult.new(out: out, err: err, status: T.must(status.success?))
       end

--- a/spec/tapioca/cli/gem_spec.rb
+++ b/spec/tapioca/cli/gem_spec.rb
@@ -197,7 +197,7 @@ module Tapioca
           gem_top_level_constant = "class OpenStruct"
 
           # `default_stubs` is a private method on Ruby 2.6
-          gem_spec = Gem::Specification.send(:default_stubs, "*.gemspec").find do |spec|
+          gem_spec = ::Gem::Specification.send(:default_stubs, "*.gemspec").find do |spec|
             spec.name == gem_name && spec.default_gem?
           end
           assert(gem_spec, "Cannot find default '#{gem_name}' gem")


### PR DESCRIPTION
### Motivation

The `symbol_table_compiler` is a hairy ball that could be divided into smaller chunks.

This PR proposes to extract plugins that would decorate the nodes that are produced `symbol_table_compiler`.

As an example I extracted the `yard_doc` plugin since it was the less coupled part. We can also do it for `requires_ancestor`, `signatures`, `dynamic_mixins`, `enums`, `props` etc.

What do you think?