### PR TITLE
Implement support for final method signatures

### DIFF
--- a/lib/tapioca/compilers/gem/listeners/sorbet_signatures.rb
+++ b/lib/tapioca/compilers/gem/listeners/sorbet_signatures.rb
@@ -60,7 +60,19 @@ module Tapioca
               sig.is_overridable = true
             end
 
+            sig.is_final = signature_final?(signature)
+
             sig
+          end
+
+          sig { params(signature: T.untyped).returns(T::Boolean) }
+          def signature_final?(signature)
+            modules_with_final = T::Private::Methods.instance_variable_get(:@modules_with_final)
+            final_methods = modules_with_final[signature.owner.object_id]
+
+            return false unless final_methods
+
+            final_methods.include?(signature.method_name)
           end
         end
       end


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
Fixes #766.

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
Use the new `is_final` flag in `rbi` gem and set it to true for methods that have a signature marked as final.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->
Added an extra test case with final signatures.
