### PR TITLE
Use root/absolute namespace in compiled RBI

### DIFF
--- a/lib/tapioca/compilers/symbol_table_compiler.rb
+++ b/lib/tapioca/compilers/symbol_table_compiler.rb
@@ -131,7 +131,7 @@ module Tapioca
 
       sig { params(event: Gem::SymbolFound).void }
       def on_symbol(event)
-        symbol = event.symbol
+        symbol = event.symbol.delete_prefix("::")
         return if symbol_in_payload?(symbol) && !@bootstrap_symbols.include?(symbol)
 
         constant = constantize(symbol)

--- a/lib/tapioca/sorbet_ext/name_patch.rb
+++ b/lib/tapioca/sorbet_ext/name_patch.rb
@@ -1,9 +1,9 @@
 # typed: true
 # frozen_string_literal: true
 
-# We need sorbet to compile this signature before applying the patch
-# to avoid an infinite loop.
-::Tapioca::Reflection.qualified_name_of(String)
+# We need sorbet to compile the signature for `qualified_name_of` before applying
+# the patch to avoid an infinite loop.
+T::Utils.signature_for_method(::Tapioca::Reflection.method(:qualified_name_of))
 
 module T
   module Types

--- a/lib/tapioca/sorbet_ext/name_patch.rb
+++ b/lib/tapioca/sorbet_ext/name_patch.rb
@@ -1,12 +1,18 @@
 # typed: true
 # frozen_string_literal: true
 
+# We need sorbet to compile this signature before applying the patch
+# to avoid an infinite loop.
+::Tapioca::Reflection.qualified_name_of(String)
+
 module T
   module Types
     class Simple
       module NamePatch
         def name
-          @name ||= ::Tapioca::Reflection.name_of(@raw_type).freeze
+          # Sorbet memoizes this method into the `@name` instance variable but
+          # doing so means that types get memoized before this patch is applied
+          ::Tapioca::Reflection.qualified_name_of(@raw_type)
         end
       end
 

--- a/spec/tapioca/compilers/symbol_table_compiler_spec.rb
+++ b/spec/tapioca/compilers/symbol_table_compiler_spec.rb
@@ -112,7 +112,7 @@ class Tapioca::Compilers::SymbolTableCompilerSpec < Minitest::HooksSpec
         end
 
         Bar::Arr = T.let(T.unsafe(nil), Array)
-        Bar::Foo = T.type_alias { T.any(String, Symbol) }
+        Bar::Foo = T.type_alias { T.any(::String, ::Symbol) }
 
         module Base
           include ::T::Props
@@ -273,7 +273,7 @@ class Tapioca::Compilers::SymbolTableCompilerSpec < Minitest::HooksSpec
         module Bar; end
         module Bar::A; end
         class Bar::A::B; end
-        Bar::A::Foo = T.type_alias { T.any(Bar::A, Bar::A::B, String, Symbol) }
+        Bar::A::Foo = T.type_alias { T.any(::Bar::A, ::Bar::A::B, ::String, ::Symbol) }
       RBI
 
       assert_equal(output, compile)
@@ -2399,13 +2399,13 @@ class Tapioca::Compilers::SymbolTableCompilerSpec < Minitest::HooksSpec
         class Foo
           final!
 
-          sig(:final) { params(a: Integer, b: String).returns(Integer) }
+          sig(:final) { params(a: ::Integer, b: ::String).returns(::Integer) }
           def bar(a, b:); end
 
           sig(:final) { void }
           def foo; end
 
-          sig(:final) { returns(T.proc.params(x: String).void) }
+          sig(:final) { returns(T.proc.params(x: ::String).void) }
           def some_attribute; end
 
           class << self
@@ -2598,9 +2598,9 @@ class Tapioca::Compilers::SymbolTableCompilerSpec < Minitest::HooksSpec
         end
 
         class Bar < ::T::Struct
-          prop :bar, String
-          const :baz, T::Hash[String, T.untyped]
-          const :foo, Integer
+          prop :bar, ::String
+          const :baz, T::Hash[::String, T.untyped]
+          const :foo, ::Integer
           prop :quux, T.untyped, default: T.unsafe(nil)
 
           class << self
@@ -2630,25 +2630,25 @@ class Tapioca::Compilers::SymbolTableCompilerSpec < Minitest::HooksSpec
           extend ::T::Props::ClassMethods
           extend ::T::Props::Plugin::ClassMethods
 
-          prop :bar, String
-          const :baz, T.proc.params(arg0: String).void
-          const :foo, Integer
+          prop :bar, ::String
+          const :baz, T.proc.params(arg0: ::String).void
+          const :foo, ::Integer
         end
 
         class Foo
-          sig { params(a: Integer, b: String).returns(Integer) }
+          sig { params(a: ::Integer, b: ::String).returns(::Integer) }
           def bar(a, b:); end
 
           sig { type_parameters(:U).params(a: T.type_parameter(:U)).returns(T.type_parameter(:U)) }
           def baz(a); end
 
-          sig { params(a: Integer, b: String).void }
+          sig { params(a: ::Integer, b: ::String).void }
           def foo(a, b:); end
 
-          sig { params(a: Integer, b: Integer, c: Integer, d: Integer, e: Integer, f: Integer, blk: T.proc.void).void }
+          sig { params(a: ::Integer, b: ::Integer, c: ::Integer, d: ::Integer, e: ::Integer, f: ::Integer, blk: T.proc.void).void }
           def many_kinds_of_args(*a, b, c, d:, e: T.unsafe(nil), **f, &blk); end
 
-          sig { returns(T.proc.params(x: String).void) }
+          sig { returns(T.proc.params(x: ::String).void) }
           def some_attribute; end
 
           class << self
@@ -2666,8 +2666,8 @@ class Tapioca::Compilers::SymbolTableCompilerSpec < Minitest::HooksSpec
           B = type_template(:out)
           C = type_template
           D = type_member(fixed: Integer)
-          E = type_member(fixed: Integer, upper: T::Array[Numeric])
-          F = type_member(fixed: Integer, lower: T.any(Complex, T::Hash[Symbol, T::Array[Integer]]), upper: T.nilable(Numeric))
+          E = type_member(fixed: Integer, upper: T::Array[::Numeric])
+          F = type_member(fixed: Integer, lower: T.any(::Complex, T::Hash[::Symbol, T::Array[::Integer]]), upper: T.nilable(::Numeric))
 
           class << self
             extend T::Generic
@@ -2697,30 +2697,30 @@ class Tapioca::Compilers::SymbolTableCompilerSpec < Minitest::HooksSpec
           def something(foo); end
         end
 
-        Generics::SimpleGenericType::NullGenericType = T.let(T.unsafe(nil), Generics::SimpleGenericType[Integer])
+        Generics::SimpleGenericType::NullGenericType = T.let(T.unsafe(nil), Generics::SimpleGenericType[::Integer])
 
         module Quux
           interface!
 
-          sig { abstract.returns(Integer) }
+          sig { abstract.returns(::Integer) }
           def something; end
         end
 
         class Quux::Concrete
           include ::Quux
 
-          sig { returns(String) }
+          sig { returns(::String) }
           def bar; end
 
-          sig { params(baz: T::Hash[String, Object]).returns(T::Hash[String, Object]) }
+          sig { params(baz: T::Hash[::String, ::Object]).returns(T::Hash[::String, ::Object]) }
           def baz=(baz); end
 
-          sig { returns(T::Array[Integer]) }
+          sig { returns(T::Array[::Integer]) }
           def foo; end
 
           def foo=(_arg0); end
 
-          sig { override.returns(Integer) }
+          sig { override.returns(::Integer) }
           def something; end
         end
       RBI
@@ -2741,7 +2741,7 @@ class Tapioca::Compilers::SymbolTableCompilerSpec < Minitest::HooksSpec
 
       output = template(<<~RBI)
         class Foo
-          sig { params(params: {"foo" => Integer, bar: String, :"foo bar" => Class}).void }
+          sig { params(params: {"foo" => ::Integer, bar: ::String, :"foo bar" => ::Class}).void }
           def foo(params); end
         end
       RBI
@@ -2943,10 +2943,10 @@ class Tapioca::Compilers::SymbolTableCompilerSpec < Minitest::HooksSpec
 
           Elem = type_member(fixed: Integer)
 
-          sig { override.returns(T::Array[Node[Integer]]) }
+          sig { override.returns(T::Array[Node[::Integer]]) }
           def children; end
 
-          sig { override.returns(T::Array[Node[Integer]]) }
+          sig { override.returns(T::Array[Node[::Integer]]) }
           def non_abstract_but_overriden_children; end
         end
 
@@ -2998,19 +2998,19 @@ class Tapioca::Compilers::SymbolTableCompilerSpec < Minitest::HooksSpec
 
       output = template(<<~RBI)
         class Foo < ::T::Struct
-          prop :a, T.nilable(Integer), default: T.unsafe(nil)
+          prop :a, T.nilable(::Integer), default: T.unsafe(nil)
           prop :b, T::Boolean, default: T.unsafe(nil)
           prop :c, T::Boolean, default: T.unsafe(nil)
-          prop :d, Symbol, default: T.unsafe(nil)
-          prop :e, String, default: T.unsafe(nil)
-          prop :f, Integer, default: T.unsafe(nil)
-          prop :g, Float, default: T.unsafe(nil)
-          prop :h, T::Array[String], default: T.unsafe(nil)
-          prop :i, T::Hash[String, Integer], default: T.unsafe(nil)
-          prop :k, Foo, default: T.unsafe(nil)
-          prop :l, T::Array[Foo], default: T.unsafe(nil)
-          prop :m, T::Hash[Foo, Foo], default: T.unsafe(nil)
-          prop :n, Foo, default: T.unsafe(nil)
+          prop :d, ::Symbol, default: T.unsafe(nil)
+          prop :e, ::String, default: T.unsafe(nil)
+          prop :f, ::Integer, default: T.unsafe(nil)
+          prop :g, ::Float, default: T.unsafe(nil)
+          prop :h, T::Array[::String], default: T.unsafe(nil)
+          prop :i, T::Hash[::String, ::Integer], default: T.unsafe(nil)
+          prop :k, ::Foo, default: T.unsafe(nil)
+          prop :l, T::Array[::Foo], default: T.unsafe(nil)
+          prop :m, T::Hash[::Foo, ::Foo], default: T.unsafe(nil)
+          prop :n, ::Foo, default: T.unsafe(nil)
 
           class << self
             def inherited(s); end
@@ -3164,7 +3164,7 @@ class Tapioca::Compilers::SymbolTableCompilerSpec < Minitest::HooksSpec
             sig { returns(T::Hash[T.attached_class, T::Array[T.attached_class]]) }
             def b; end
 
-            sig { returns(Foo::FooAttachedClass) }
+            sig { returns(::Foo::FooAttachedClass) }
             def c; end
           end
         end
@@ -3349,7 +3349,7 @@ class Tapioca::Compilers::SymbolTableCompilerSpec < Minitest::HooksSpec
           # Method bar
           #
           # This method does something really important
-          sig { params(a: String).void }
+          sig { params(a: ::String).void }
           def bar(a); end
 
           # Method no_sig
@@ -3383,7 +3383,7 @@ class Tapioca::Compilers::SymbolTableCompilerSpec < Minitest::HooksSpec
             # @example My example
             #   a = "hello world"
             #   a.reverse
-            sig { params(t: Integer).void }
+            sig { params(t: ::Integer).void }
             def baz(t); end
 
             # Method something
@@ -3468,7 +3468,7 @@ class Tapioca::Compilers::SymbolTableCompilerSpec < Minitest::HooksSpec
         module Namespace; end
 
         class Namespace::Foo
-          sig { params(a: String).void }
+          sig { params(a: ::String).void }
           def bar(a); end
 
           def no_sig(a); end
@@ -3479,7 +3479,7 @@ class Tapioca::Compilers::SymbolTableCompilerSpec < Minitest::HooksSpec
           def only_docs(a); end
 
           class << self
-            sig { params(t: Integer).void }
+            sig { params(t: ::Integer).void }
             def baz(t); end
 
             sig { void }

--- a/spec/tapioca/compilers/symbol_table_compiler_spec.rb
+++ b/spec/tapioca/compilers/symbol_table_compiler_spec.rb
@@ -748,10 +748,10 @@ class Tapioca::Compilers::SymbolTableCompilerSpec < Minitest::HooksSpec
           sig { params(x: T.any(::Bar, ::String)).returns(::Bar) }
           def bar(x); end
 
-          sig { params(x: Foo::Bar).returns(Foo::Bar) }
+          sig { params(x: ::Foo::Bar).returns(::Foo::Bar) }
           def local_bar(x); end
 
-          sig { params(x: Foo::String).returns(Foo::String) }
+          sig { params(x: ::Foo::String).returns(::Foo::String) }
           def local_string(x); end
 
           sig { params(x: ::String).returns(::String) }

--- a/spec/tapioca/dsl/compilers/action_controller_helpers_spec.rb
+++ b/spec/tapioca/dsl/compilers/action_controller_helpers_spec.rb
@@ -165,7 +165,7 @@ module Tapioca
                     sig { returns(T.untyped) }
                     def current_user_name; end
 
-                    sig { params(user_id: Integer).void }
+                    sig { params(user_id: ::Integer).void }
                     def notify_user(user_id); end
                   end
 
@@ -210,7 +210,7 @@ module Tapioca
                     sig { returns(T.untyped) }
                     def current_user_name; end
 
-                    sig { params(user_id: Integer).void }
+                    sig { params(user_id: ::Integer).void }
                     def notify_user(user_id); end
                   end
 
@@ -255,7 +255,7 @@ module Tapioca
                     sig { params(user: T.untyped).returns(T.untyped) }
                     def greet(user); end
 
-                    sig { params(user_id: Integer).void }
+                    sig { params(user_id: ::Integer).void }
                     def notify_user(user_id); end
                   end
 

--- a/spec/tapioca/dsl/compilers/action_mailer_spec.rb
+++ b/spec/tapioca/dsl/compilers/action_mailer_spec.rb
@@ -106,7 +106,7 @@ module Tapioca
 
                 class NotifierMailer
                   class << self
-                    sig { params(customer_id: Integer).returns(::ActionMailer::MessageDelivery) }
+                    sig { params(customer_id: ::Integer).returns(::ActionMailer::MessageDelivery) }
                     def notify_customer(customer_id); end
                   end
                 end

--- a/spec/tapioca/dsl/compilers/active_job_spec.rb
+++ b/spec/tapioca/dsl/compilers/active_job_spec.rb
@@ -66,7 +66,7 @@ module Tapioca
 
                 class NotifyJob
                   class << self
-                    sig { params(user_id: T.untyped).returns(T.any(::NotifyJob, ::FalseClass)) }
+                    sig { params(user_id: T.untyped).returns(T.any(NotifyJob, FalseClass)) }
                     def perform_later(user_id); end
 
                     sig { params(user_id: T.untyped).returns(T.untyped) }
@@ -94,10 +94,10 @@ module Tapioca
 
                 class NotifyJob
                   class << self
-                    sig { params(user_id: Integer).returns(T.any(NotifyJob, FalseClass)) }
+                    sig { params(user_id: ::Integer).returns(T.any(NotifyJob, FalseClass)) }
                     def perform_later(user_id); end
 
-                    sig { params(user_id: Integer).void }
+                    sig { params(user_id: ::Integer).void }
                     def perform_now(user_id); end
                   end
                 end

--- a/spec/tapioca/dsl/compilers/active_job_spec.rb
+++ b/spec/tapioca/dsl/compilers/active_job_spec.rb
@@ -66,7 +66,7 @@ module Tapioca
 
                 class NotifyJob
                   class << self
-                    sig { params(user_id: T.untyped).returns(T.any(NotifyJob, FalseClass)) }
+                    sig { params(user_id: T.untyped).returns(T.any(::NotifyJob, ::FalseClass)) }
                     def perform_later(user_id); end
 
                     sig { params(user_id: T.untyped).returns(T.untyped) }

--- a/spec/tapioca/dsl/compilers/active_record_columns_spec.rb
+++ b/spec/tapioca/dsl/compilers/active_record_columns_spec.rb
@@ -578,10 +578,10 @@ module Tapioca
                 RUBY
 
                 expected = indented(<<~RBI, 4)
-                  sig { returns(T.nilable(CustomType)) }
+                  sig { returns(T.nilable(::CustomType)) }
                   def cost; end
 
-                  sig { params(value: T.nilable(CustomType)).returns(T.nilable(CustomType)) }
+                  sig { params(value: T.nilable(::CustomType)).returns(T.nilable(::CustomType)) }
                   def cost=(value); end
                 RBI
 
@@ -627,10 +627,10 @@ module Tapioca
                 RUBY
 
                 expected = indented(<<~RBI, 4)
-                  sig { returns(T.nilable(T.any(CustomType, Numeric))) }
+                  sig { returns(T.nilable(T.any(::CustomType, ::Numeric))) }
                   def cost; end
 
-                  sig { params(value: T.nilable(T.any(CustomType, Numeric))).returns(T.nilable(T.any(CustomType, Numeric))) }
+                  sig { params(value: T.nilable(T.any(::CustomType, ::Numeric))).returns(T.nilable(T.any(::CustomType, ::Numeric))) }
                   def cost=(value); end
                 RBI
 
@@ -675,10 +675,10 @@ module Tapioca
                 RUBY
 
                 expected = indented(<<~RBI, 4)
-                  sig { returns(T.nilable(CustomType)) }
+                  sig { returns(T.nilable(::CustomType)) }
                   def cost; end
 
-                  sig { params(value: T.nilable(CustomType)).returns(T.nilable(CustomType)) }
+                  sig { params(value: T.nilable(::CustomType)).returns(T.nilable(::CustomType)) }
                   def cost=(value); end
                 RBI
 
@@ -720,10 +720,10 @@ module Tapioca
                 RUBY
 
                 expected = indented(<<~RUBY, 4)
-                  sig { returns(T.nilable(ValueType[Integer])) }
+                  sig { returns(T.nilable(ValueType[::Integer])) }
                   def cost; end
 
-                  sig { params(value: T.nilable(ValueType[Integer])).returns(T.nilable(ValueType[Integer])) }
+                  sig { params(value: T.nilable(ValueType[::Integer])).returns(T.nilable(ValueType[::Integer])) }
                   def cost=(value); end
                 RUBY
 

--- a/spec/tapioca/dsl/compilers/active_support_current_attributes_spec.rb
+++ b/spec/tapioca/dsl/compilers/active_support_current_attributes_spec.rb
@@ -117,7 +117,7 @@ module Tapioca
                     sig { params(value: T.untyped).returns(T.untyped) }
                     def account=(value); end
 
-                    sig { params(user_id: Integer).void }
+                    sig { params(user_id: ::Integer).void }
                     def authenticate(user_id); end
 
                     sig { returns(T.untyped) }

--- a/spec/tapioca/dsl/compilers/sidekiq_worker_spec.rb
+++ b/spec/tapioca/dsl/compilers/sidekiq_worker_spec.rb
@@ -92,13 +92,13 @@ module Tapioca
 
                 class NotifierWorker
                   class << self
-                    sig { params(customer_id: Integer).returns(String) }
+                    sig { params(customer_id: ::Integer).returns(String) }
                     def perform_async(customer_id); end
 
-                    sig { params(interval: T.any(DateTime, Time), customer_id: Integer).returns(String) }
+                    sig { params(interval: T.any(DateTime, Time), customer_id: ::Integer).returns(String) }
                     def perform_at(interval, customer_id); end
 
-                    sig { params(interval: Numeric, customer_id: Integer).returns(String) }
+                    sig { params(interval: Numeric, customer_id: ::Integer).returns(String) }
                     def perform_in(interval, customer_id); end
                   end
                 end


### PR DESCRIPTION
### Motivation

Came across a subtle bug in tapioca RBI generation where absolute namespacing get dropped (e.g. `::String` comes out of RBI as `String`). This causes issues when the referenced constant shares a name with both a global constant and one that lives somewhere inside the current namespace. See the test for an example.

### Implementation

~Unsure how to fix, just wanted to send a reproduction.~ Use `qualified_name_of` in the Simple type name patch.

### Tests

Added new tests and also needed to update existing ones.
