### PR TITLE
SymbolTableCompiler returns a new tree each time called

### DIFF
--- a/lib/tapioca/generators/gem.rb
+++ b/lib/tapioca/generators/gem.rb
@@ -159,7 +159,7 @@ module Tapioca
           display_heading: @file_header
         )
 
-        Compilers::SymbolTableCompiler.new(gem, include_doc: @doc).compile(rbi)
+        rbi.root = Compilers::SymbolTableCompiler.new(gem, include_doc: @doc).compile
 
         merge_with_exported_rbi(gem, rbi) if @include_exported_rbis
 

--- a/spec/tapioca/compilers/symbol_table_compiler_spec.rb
+++ b/spec/tapioca/compilers/symbol_table_compiler_spec.rb
@@ -41,7 +41,7 @@ class Tapioca::Compilers::SymbolTableCompilerSpec < Minitest::HooksSpec
       gem = Tapioca::Gemfile::GemSpec.new(spec)
 
       rbi = RBI::File.new(strictness: "true")
-      Tapioca::Compilers::SymbolTableCompiler.new(gem, include_doc: include_doc).compile(rbi)
+      rbi.root = Tapioca::Compilers::SymbolTableCompiler.new(gem, include_doc: include_doc).compile
       rbi.transform_rbi!
       # NOTE: This is not using the standard helper method `transformed_string`.
       # The following test suite is based on the string output of the `RBI::Tree` rather


### PR DESCRIPTION
### Motivation

Those methods don't need to pass around the tree since the nodes are always created at the root level.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->

