### PR TITLE
Update AASM DSL generator

### DIFF
--- a/lib/tapioca/dsl/compilers/aasm.rb
+++ b/lib/tapioca/dsl/compilers/aasm.rb
@@ -105,7 +105,8 @@ module Tapioca
                   event.create_method(
                     method,
                     parameters: [
-                      create_block_param("block", type: "T.proc.bind(#{name_of(constant)}).void"),
+                      create_opt_param("symbol", type: "T.nilable(Symbol)", default: "nil"),
+                      create_block_param("block", type: "T.nilable(T.proc.bind(#{name_of(constant)}).void)"),
                     ]
                   )
                 end

--- a/spec/tapioca/dsl/compilers/aasm_spec.rb
+++ b/spec/tapioca/dsl/compilers/aasm_spec.rb
@@ -98,32 +98,32 @@ module Tapioca
                     def event(name, options = nil, &block); end
 
                     class PrivateAASMEvent < AASM::Core::Event
-                      sig { params(block: T.proc.bind(StateMachine).void).returns(T.untyped) }
-                      def after(&block); end
+                      sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
+                      def after(symbol = nil, &block); end
 
-                      sig { params(block: T.proc.bind(StateMachine).void).returns(T.untyped) }
-                      def after_commit(&block); end
+                      sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
+                      def after_commit(symbol = nil, &block); end
 
-                      sig { params(block: T.proc.bind(StateMachine).void).returns(T.untyped) }
-                      def after_transaction(&block); end
+                      sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
+                      def after_transaction(symbol = nil, &block); end
 
-                      sig { params(block: T.proc.bind(StateMachine).void).returns(T.untyped) }
-                      def before(&block); end
+                      sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
+                      def before(symbol = nil, &block); end
 
-                      sig { params(block: T.proc.bind(StateMachine).void).returns(T.untyped) }
-                      def before_success(&block); end
+                      sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
+                      def before_success(symbol = nil, &block); end
 
-                      sig { params(block: T.proc.bind(StateMachine).void).returns(T.untyped) }
-                      def before_transaction(&block); end
+                      sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
+                      def before_transaction(symbol = nil, &block); end
 
-                      sig { params(block: T.proc.bind(StateMachine).void).returns(T.untyped) }
-                      def ensure(&block); end
+                      sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
+                      def ensure(symbol = nil, &block); end
 
-                      sig { params(block: T.proc.bind(StateMachine).void).returns(T.untyped) }
-                      def error(&block); end
+                      sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
+                      def error(symbol = nil, &block); end
 
-                      sig { params(block: T.proc.bind(StateMachine).void).returns(T.untyped) }
-                      def success(&block); end
+                      sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
+                      def success(symbol = nil, &block); end
                     end
                   end
 


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->

Hello! I encountered some type errors in a project related to the AASM gem.  More specifically, it appears the DSL generator for AASM only supports one form of their lifecycle callbacks.

```ruby
class Foo
  include AASM
  
  aasm do
    state :state1
    state :state2

    event :do_something do
      transitions from: :state1, to: :state2

      after :some_method
    end

    def some_method
    end
  end
end
```

The above code would produce a typeerror along the lines of `after requires a block parameter, but no block was passed https://srb.help/7021`.  However, [this is in fact valid usage](https://github.com/aasm/aasm#callbacks) of the `after` hook.  Similar to `ActiveRecord` callbacks, they accept either a block or a symbol corresponding to a method name.

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->

This PR updates the generated `sig`s for AASM lifecycle hooks from this:

```ruby
sig { params(block: T.proc.bind(StateMachine).void).returns(T.untyped)  }
```

To this:

```ruby
sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }  }
```

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->

I updated the relevant test.