### PR TITLE
Replace usage of `T::Private::Methods.signature_for_method` with public equivalent

### DIFF
--- a/lib/tapioca/compilers/dsl/base.rb
+++ b/lib/tapioca/compilers/dsl/base.rb
@@ -132,7 +132,7 @@ module Tapioca
 
         sig { params(method_def: T.any(Method, UnboundMethod)).returns(T::Array[RBI::TypedParam]) }
         def compile_method_parameters_to_rbi(method_def)
-          signature = T::Private::Methods.signature_for_method(method_def)
+          signature = signature_of(method_def)
           method_def = signature.nil? ? method_def : signature.method
           method_types = parameters_types_from_signature(method_def, signature)
 
@@ -168,7 +168,7 @@ module Tapioca
 
         sig { params(method_def: T.any(Method, UnboundMethod)).returns(String) }
         def compile_method_return_type_to_rbi(method_def)
-          signature = T::Private::Methods.signature_for_method(method_def)
+          signature = signature_of(method_def)
           return_type = signature.nil? ? "T.untyped" : name_of_type(signature.return_type)
           return_type = "void" if return_type == "<VOID>"
           # Map <NOT-TYPED> to `T.untyped`

--- a/lib/tapioca/compilers/dsl/helpers/active_record_column_type_helper.rb
+++ b/lib/tapioca/compilers/dsl/helpers/active_record_column_type_helper.rb
@@ -89,7 +89,7 @@ module Tapioca
 
           sig { params(column_type: ActiveModel::Type::Value, method: Symbol).returns(T.nilable(String)) }
           def lookup_return_type_of_method(column_type, method)
-            signature = T::Private::Methods.signature_for_method(column_type.method(method))
+            signature = Reflection.signature_of(column_type.method(method))
             return unless signature
 
             return_type = signature.return_type
@@ -100,7 +100,7 @@ module Tapioca
 
           sig { params(column_type: ActiveModel::Type::Value, method: Symbol).returns(T.nilable(String)) }
           def lookup_arg_type_of_method(column_type, method)
-            signature = T::Private::Methods.signature_for_method(column_type.method(method))
+            signature = Reflection.signature_of(column_type.method(method))
             return unless signature
 
             # Arg types is an array [name, type] entries, so we desctructure the type of

--- a/lib/tapioca/reflection.rb
+++ b/lib/tapioca/reflection.rb
@@ -111,7 +111,7 @@ module Tapioca
 
     sig { params(method: T.any(UnboundMethod, Method)).returns(T.untyped) }
     def signature_of(method)
-      T::Private::Methods.signature_for_method(method)
+      T::Utils.signature_for_method(method)
     rescue LoadError, StandardError
       nil
     end


### PR DESCRIPTION
### Motivation

I noticed tapioca was using `T::Private::Methods.signature_for_method` which is a "private" module (private in quotes because it's not actually private, just named to try to discourage use). https://github.com/sorbet/sorbet/pull/4041 introduced a utility method that just calls that private method so this PR updates to use that.

### Implementation

- Replace usages of `T::Private::Methods.signature_for_method` with `Reflection.signature_of` where possible
- In `Reflection.signature_of`, switch to using `T::Utils.signature_for_method`

### Tests

No tests since there should be no behavior change.
