### PR TITLE
Expose DSL compiler test helper as a reusable unit

### DIFF
--- a/lib/tapioca/helpers/test/dsl_compiler.rb
+++ b/lib/tapioca/helpers/test/dsl_compiler.rb
@@ -1,0 +1,122 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "tapioca/helpers/test/content"
+require "tapioca/helpers/test/isolation"
+require "tapioca/helpers/test/template"
+
+module Tapioca
+  module Helpers
+    module Test
+      module DslCompiler
+        extend T::Sig
+        extend T::Helpers
+
+        include Isolation
+        include Content
+        include Template
+
+        requires_ancestor { Kernel }
+
+        sig { params(compiler_class: T.class_of(Tapioca::Compilers::Dsl::Base)).void }
+        def use_dsl_compiler(compiler_class)
+          @context = T.let(CompilerContext.new(compiler_class), T.nilable(CompilerContext))
+        end
+
+        sig { params(compiler_classes: T.class_of(Tapioca::Compilers::Dsl::Base)).void }
+        def activate_other_dsl_compilers(*compiler_classes)
+          context.activate_other_dsl_compilers(compiler_classes)
+        end
+
+        sig { params(constant_name: T.any(Symbol, String)).returns(String) }
+        def rbi_for(constant_name)
+          context.rbi_for(constant_name)
+        end
+
+        sig { returns(T::Array[String]) }
+        def gathered_constants
+          context.gathered_constants
+        end
+
+        sig { returns(T::Array[String]) }
+        def generated_errors
+          context.errors
+        end
+
+        sig { returns(CompilerContext) }
+        def context
+          raise "Please call `use_dsl_compiler` before" unless @context
+          @context
+        end
+
+        class CompilerContext
+          extend T::Sig
+
+          sig { returns(T.class_of(Tapioca::Compilers::Dsl::Base)) }
+          attr_reader :compiler_class
+
+          sig { returns(T::Array[T.class_of(Tapioca::Compilers::Dsl::Base)]) }
+          attr_reader :other_compiler_classes
+
+          sig { params(compiler_class: T.class_of(Tapioca::Compilers::Dsl::Base)).void }
+          def initialize(compiler_class)
+            @compiler_class = compiler_class
+            @other_compiler_classes = T.let([], T::Array[T.class_of(Tapioca::Compilers::Dsl::Base)])
+            @compiler = T.let(nil, T.nilable(Tapioca::Compilers::Dsl::Base))
+            @pipeline = T.let(nil, T.nilable(Tapioca::Compilers::DslCompiler))
+          end
+
+          sig { params(compiler_classes: T::Array[T.class_of(Tapioca::Compilers::Dsl::Base)]).void }
+          def activate_other_dsl_compilers(compiler_classes)
+            @other_compiler_classes = compiler_classes
+          end
+
+          sig { returns(T::Array[T.class_of(Tapioca::Compilers::Dsl::Base)]) }
+          def activated_compiler_classes
+            [compiler_class, *other_compiler_classes]
+          end
+
+          sig { returns(T::Array[String]) }
+          def gathered_constants
+            compiler.processable_constants.map(&:name).compact.sort
+          end
+
+          sig { params(constant_name: T.any(Symbol, String)).returns(String) }
+          def rbi_for(constant_name)
+            # Make sure this is a constant that we can handle.
+            unless gathered_constants.include?(constant_name.to_s)
+              raise "`#{constant_name}` is not processable by the `#{compiler_class}` generator."
+            end
+
+            file = RBI::File.new(strictness: "strong")
+            constant = Object.const_get(constant_name)
+
+            compiler.decorate(file.root, constant)
+
+            file.transformed_string
+          end
+
+          sig { returns(T::Array[String]) }
+          def errors
+            compiler.errors
+          end
+
+          private
+
+          sig { returns(Tapioca::Compilers::Dsl::Base) }
+          def compiler
+            @compiler ||= T.must(pipeline.generators.grep(compiler_class).first)
+          end
+
+          sig { returns(Tapioca::Compilers::DslCompiler) }
+          def pipeline
+            @pipeline ||= Tapioca::Compilers::DslCompiler.new(
+              requested_constants: [],
+              requested_generators: activated_compiler_classes
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/tapioca/helpers/test/template.rb
+++ b/lib/tapioca/helpers/test/template.rb
@@ -7,8 +7,11 @@ module Tapioca
   module Helpers
     module Test
       module Template
-        include Kernel
         extend T::Sig
+        extend T::Helpers
+
+        requires_ancestor { Kernel }
+
         ERB_SUPPORTS_KVARGS = T.let(
           ::ERB.instance_method(:initialize).parameters.assoc(:key), T.nilable([Symbol, Symbol])
         )
@@ -27,6 +30,14 @@ module Tapioca
           end
 
           erb.result(binding)
+        end
+
+        sig { params(str: String, indent: Integer).returns(String) }
+        def indented(str, indent)
+          str.lines.map! do |line|
+            next line if line.chomp.empty?
+            (" " * indent) + line
+          end.join
         end
       end
     end

--- a/spec/dsl_spec_helper.rb
+++ b/spec/dsl_spec_helper.rb
@@ -13,10 +13,17 @@ class DslSpec < Minitest::Spec
     # Require the file that the target class should be loaded from
     require(self.class.target_class_file)
     use_dsl_compiler(self.class.target_class)
+    @expecting_errors = false
   end
 
   after do
+    assert_empty(generated_errors) unless @expecting_errors
     generated_errors.clear
+  end
+
+  sig { returns(T.nilable(T::Boolean)) }
+  def expect_dsl_compiler_errors!
+    @expecting_errors = T.let(true, T.nilable(T::Boolean))
   end
 
   sig { returns(Class) }
@@ -58,10 +65,5 @@ class DslSpec < Minitest::Spec
     word.tr!("-", "_")
     word.downcase!
     word
-  end
-
-  sig { void }
-  def assert_no_generated_errors
-    T.unsafe(self).assert_empty(generated_errors)
   end
 end

--- a/spec/dsl_spec_helper.rb
+++ b/spec/dsl_spec_helper.rb
@@ -3,72 +3,53 @@
 
 require "sorbet-runtime"
 require "minitest/spec"
-require "tapioca/helpers/test/content"
-require "tapioca/helpers/test/template"
-require "tapioca/helpers/test/isolation"
+require "tapioca/helpers/test/dsl_compiler"
 
 class DslSpec < Minitest::Spec
   extend T::Sig
-  include Kernel
-  include Tapioca::Helpers::Test::Content
-  include Tapioca::Helpers::Test::Template
-  include Tapioca::Helpers::Test::Isolation
+  include Tapioca::Helpers::Test::DslCompiler
 
-  sig { void }
-  def after_setup
+  before do
     # Require the file that the target class should be loaded from
-    require(T.unsafe(self).target_class_file)
+    require(self.class.target_class_file)
+    use_dsl_compiler(self.class.target_class)
   end
 
-  sig { void }
-  def teardown
-    super
-    T.unsafe(self).subject.errors.clear
-  end
-
-  subject do
-    T.bind(self, DslSpec)
-    # Get the class under test and initialize a new instance of it as the "subject"
-    generator_for_names(target_class_name)
-  end
-
-  sig { params(names: String).returns(Tapioca::Compilers::Dsl::Base) }
-  def generator_for_names(*names)
-    raise "name is required" if names.empty?
-
-    classes = names.map { |class_name| Object.const_get(class_name) }
-
-    compiler = Tapioca::Compilers::DslCompiler.new(
-      requested_constants: [],
-      requested_generators: classes
-    )
-
-    T.must(compiler.generators.find { |generator| generator.class.name == names.first })
+  after do
+    generated_errors.clear
   end
 
   sig { returns(Class) }
-  def spec_test_class
-    # Find the spec test class
-    klass = T.unsafe(self).class
+  def self.spec_test_class
     # It should be the one that directly inherits from DslSpec
-    klass = klass.superclass while klass.superclass != DslSpec
-    klass
+    class_ancestors = T.cast(ancestors.grep(Class), T::Array[Class])
+
+    klass = class_ancestors
+      .take_while { |ancestor| ancestor != DslSpec }
+      .last
+
+    T.must(klass)
   end
 
   sig { returns(String) }
-  def target_class_name
+  def self.target_class_name
     # Get the name of the class under test from the name of the
     # test class
     T.must(spec_test_class.name).gsub(/Spec$/, "")
   end
 
+  sig { returns(T.class_of(Tapioca::Compilers::Dsl::Base)) }
+  def self.target_class
+    Object.const_get(target_class_name)
+  end
+
   sig { returns(String) }
-  def target_class_file
+  def self.target_class_file
     underscore(target_class_name)
   end
 
   sig { params(class_name: String).returns(String) }
-  def underscore(class_name)
+  def self.underscore(class_name)
     return class_name unless /[A-Z-]|::/.match?(class_name)
 
     word = class_name.to_s.gsub("::", "/")
@@ -77,44 +58,6 @@ class DslSpec < Minitest::Spec
     word.tr!("-", "_")
     word.downcase!
     word
-  end
-
-  sig { params(str: String, indent: Integer).returns(String) }
-  def indented(str, indent)
-    str.lines.map! do |line|
-      next line if line.chomp.empty?
-      (" " * indent) + line
-    end.join
-  end
-
-  sig { returns(T::Array[String]) }
-  def gathered_constants
-    T.unsafe(self).subject.processable_constants.map(&:name).sort
-  end
-
-  sig do
-    params(
-      constant_name: T.any(Symbol, String)
-    ).returns(String)
-  end
-  def rbi_for(constant_name)
-    # Make sure this is a constant that we can handle.
-    assert_includes(gathered_constants, constant_name.to_s, <<~MSG)
-      `#{constant_name}` is not processable by the `#{target_class_name}` generator.
-    MSG
-
-    file = RBI::File.new(strictness: "strong")
-
-    constant = Object.const_get(constant_name)
-
-    T.unsafe(self).subject.decorate(file.root, constant)
-
-    file.transformed_string
-  end
-
-  sig { returns(T::Array[String]) }
-  def generated_errors
-    T.unsafe(self).subject.errors
   end
 
   sig { void }

--- a/spec/tapioca/compilers/dsl/aasm_spec.rb
+++ b/spec/tapioca/compilers/dsl/aasm_spec.rb
@@ -6,10 +6,6 @@ require "spec_helper"
 class Tapioca::Compilers::Dsl::AASMSpec < DslSpec
   describe "Tapioca::Compilers::Dsl::AASM" do
     describe "initialize" do
-      after do
-        T.unsafe(self).assert_no_generated_errors
-      end
-
       it "gathers no constants if there are no classes that include AASM" do
         assert_empty(gathered_constants)
       end
@@ -27,10 +23,6 @@ class Tapioca::Compilers::Dsl::AASMSpec < DslSpec
     end
 
     describe "decorate" do
-      after do
-        T.unsafe(self).assert_no_generated_errors
-      end
-
       it "generates empty RBI when AASM is included but no AASM call has been made" do
         add_ruby_file("content.rb", <<~RUBY)
           class StateMachine

--- a/spec/tapioca/compilers/dsl/action_controller_helpers_spec.rb
+++ b/spec/tapioca/compilers/dsl/action_controller_helpers_spec.rb
@@ -6,10 +6,6 @@ require "spec_helper"
 class Tapioca::Compilers::Dsl::ActionControllerHelpersSpec < DslSpec
   describe "Tapioca::Compilers::Dsl::ActionControllerHelpers" do
     describe "initialize" do
-      after do
-        T.unsafe(self).assert_no_generated_errors
-      end
-
       it "gathers no constants if there are no  classes" do
         assert_empty(gathered_constants)
       end
@@ -74,10 +70,6 @@ class Tapioca::Compilers::Dsl::ActionControllerHelpersSpec < DslSpec
     end
 
     describe "decorate" do
-      after do
-        T.unsafe(self).assert_no_generated_errors
-      end
-
       it "generates empty helper module when there are no helper methods specified" do
         add_ruby_file("controller.rb", <<~RUBY)
           class UserController < ActionController::Base

--- a/spec/tapioca/compilers/dsl/action_mailer_spec.rb
+++ b/spec/tapioca/compilers/dsl/action_mailer_spec.rb
@@ -6,10 +6,6 @@ require "spec_helper"
 class Tapioca::Compilers::Dsl::ActionMailerSpec < DslSpec
   describe "Tapioca::Compilers::Dsl::ActionMailer" do
     describe "initialize" do
-      after do
-        T.unsafe(self).assert_no_generated_errors
-      end
-
       it "gathers no constants if there are no ActionMailer subclasses" do
         assert_empty(gathered_constants)
       end
@@ -53,10 +49,6 @@ class Tapioca::Compilers::Dsl::ActionMailerSpec < DslSpec
     end
 
     describe "decorate" do
-      after do
-        T.unsafe(self).assert_no_generated_errors
-      end
-
       it "generates empty RBI file if there are no methods" do
         add_ruby_file("mailer.rb", <<~RUBY)
           class NotifierMailer < ActionMailer::Base

--- a/spec/tapioca/compilers/dsl/active_job_spec.rb
+++ b/spec/tapioca/compilers/dsl/active_job_spec.rb
@@ -6,10 +6,6 @@ require "spec_helper"
 class Tapioca::Compilers::Dsl::ActiveJobSpec < DslSpec
   describe "Tapioca::Compilers::Dsl::ActiveJob" do
     describe "initialize" do
-      after do
-        T.unsafe(self).assert_no_generated_errors
-      end
-
       it "gathers no constants if there are no ActiveJob subclasses" do
         assert_empty(gathered_constants)
       end
@@ -40,10 +36,6 @@ class Tapioca::Compilers::Dsl::ActiveJobSpec < DslSpec
     end
 
     describe "decorate" do
-      after do
-        T.unsafe(self).assert_no_generated_errors
-      end
-
       it "generates an empty RBI file if there is no perform method" do
         add_ruby_file("job.rb", <<~RUBY)
           class NotifyJob < ActiveJob::Base

--- a/spec/tapioca/compilers/dsl/active_model_attributes_spec.rb
+++ b/spec/tapioca/compilers/dsl/active_model_attributes_spec.rb
@@ -6,10 +6,6 @@ require "spec_helper"
 class Tapioca::Compilers::Dsl::ActiveModelAttributesSpec < DslSpec
   describe "Tapioca::Compilers::Dsl::ActiveModelAttributes" do
     describe "initialize" do
-      after do
-        T.unsafe(self).assert_no_generated_errors
-      end
-
       it "gathers no constants if there are no classes using ActiveModel::Attributes" do
         assert_empty(gathered_constants)
       end
@@ -39,10 +35,6 @@ class Tapioca::Compilers::Dsl::ActiveModelAttributesSpec < DslSpec
     end
 
     describe "decorate" do
-      after do
-        T.unsafe(self).assert_no_generated_errors
-      end
-
       it "generates empty RBI file if there are no attributes in the class" do
         add_ruby_file("shop.rb", <<~RUBY)
           class Shop

--- a/spec/tapioca/compilers/dsl/active_record_associations_spec.rb
+++ b/spec/tapioca/compilers/dsl/active_record_associations_spec.rb
@@ -6,10 +6,6 @@ require "spec_helper"
 class Tapioca::Compilers::Dsl::ActiveRecordAssociationsSpec < DslSpec
   describe "Tapioca::Compilers::Dsl::ActiveRecordAssociationsSpec" do
     describe "initialize" do
-      after do
-        T.unsafe(self).assert_no_generated_errors
-      end
-
       it "gathers no constants if there are no ActiveRecord subclasses" do
         assert_empty(gathered_constants)
       end
@@ -60,10 +56,6 @@ class Tapioca::Compilers::Dsl::ActiveRecordAssociationsSpec < DslSpec
         end
 
         describe "without errors" do
-          after do
-            T.unsafe(self).assert_no_generated_errors
-          end
-
           it "generates empty RBI file if there are no associations" do
             add_ruby_file("post.rb", <<~RUBY)
               class Post < ActiveRecord::Base
@@ -622,6 +614,10 @@ class Tapioca::Compilers::Dsl::ActiveRecordAssociationsSpec < DslSpec
         end
 
         describe "with errors" do
+          before do
+            expect_dsl_compiler_errors!
+          end
+
           it "generates RBI file for broken associations" do
             add_ruby_file("schema.rb", <<~RUBY)
               ActiveRecord::Migration.suppress_messages do
@@ -748,10 +744,6 @@ class Tapioca::Compilers::Dsl::ActiveRecordAssociationsSpec < DslSpec
 
       describe "without relations enabled" do
         describe "without errors" do
-          after do
-            T.unsafe(self).assert_no_generated_errors
-          end
-
           it "generates empty RBI file if there are no associations" do
             add_ruby_file("post.rb", <<~RUBY)
               class Post < ActiveRecord::Base
@@ -1310,6 +1302,10 @@ class Tapioca::Compilers::Dsl::ActiveRecordAssociationsSpec < DslSpec
         end
 
         describe "with errors" do
+          before do
+            expect_dsl_compiler_errors!
+          end
+
           it "generates RBI file for broken associations" do
             add_ruby_file("schema.rb", <<~RUBY)
               ActiveRecord::Migration.suppress_messages do
@@ -1458,10 +1454,6 @@ class Tapioca::Compilers::Dsl::ActiveRecordAssociationsSpec < DslSpec
           end
           Rails.application.initialize!
         RUBY
-      end
-
-      after do
-        T.unsafe(self).assert_no_generated_errors
       end
 
       it "generates RBI file for has_one_attached ActiveStorage association" do

--- a/spec/tapioca/compilers/dsl/active_record_associations_spec.rb
+++ b/spec/tapioca/compilers/dsl/active_record_associations_spec.rb
@@ -54,10 +54,9 @@ class Tapioca::Compilers::Dsl::ActiveRecordAssociationsSpec < DslSpec
       end
 
       describe "with relations enabled" do
-        subject do
-          T.bind(self, DslSpec)
+        before do
           require "tapioca/compilers/dsl/active_record_relations"
-          generator_for_names(target_class_name, "Tapioca::Compilers::Dsl::ActiveRecordRelations")
+          activate_other_dsl_compilers(Tapioca::Compilers::Dsl::ActiveRecordRelations)
         end
 
         describe "without errors" do
@@ -1437,13 +1436,10 @@ class Tapioca::Compilers::Dsl::ActiveRecordAssociationsSpec < DslSpec
     end
 
     describe "decorate_active_storage" do
-      subject do
-        T.bind(self, DslSpec)
-        require "tapioca/compilers/dsl/active_record_relations"
-        generator_for_names(target_class_name, "Tapioca::Compilers::Dsl::ActiveRecordRelations")
-      end
-
       before do
+        require "tapioca/compilers/dsl/active_record_relations"
+        activate_other_dsl_compilers(Tapioca::Compilers::Dsl::ActiveRecordRelations)
+
         add_ruby_file("application.rb", <<~RUBY)
           ENV["DATABASE_URL"] = "sqlite3::memory:"
 

--- a/spec/tapioca/compilers/dsl/active_record_columns_spec.rb
+++ b/spec/tapioca/compilers/dsl/active_record_columns_spec.rb
@@ -6,10 +6,6 @@ require "spec_helper"
 class Tapioca::Compilers::Dsl::ActiveRecordColumnsSpec < DslSpec
   describe "Tapioca::Compilers::Dsl::ActiveRecordColumns" do
     describe "initialize" do
-      after do
-        T.unsafe(self).assert_no_generated_errors
-      end
-
       it "gathers no constants if there are no ActiveRecord subclasses" do
         assert_empty(gathered_constants)
       end
@@ -51,10 +47,6 @@ class Tapioca::Compilers::Dsl::ActiveRecordColumnsSpec < DslSpec
       end
 
       describe "by default" do
-        after do
-          T.unsafe(self).assert_no_generated_errors
-        end
-
         it "generates default columns with strong types" do
           add_ruby_file("schema.rb", <<~RUBY)
             ActiveRecord::Migration.suppress_messages do
@@ -825,10 +817,6 @@ class Tapioca::Compilers::Dsl::ActiveRecordColumnsSpec < DslSpec
       end
 
       describe "when StrongTypeGeneration is defined" do
-        after do
-          T.unsafe(self).assert_no_generated_errors
-        end
-
         before do
           add_ruby_file("strong_type_generation.rb", <<~RUBY)
             module StrongTypeGeneration

--- a/spec/tapioca/compilers/dsl/active_record_enum_spec.rb
+++ b/spec/tapioca/compilers/dsl/active_record_enum_spec.rb
@@ -6,10 +6,6 @@ require "spec_helper"
 class Tapioca::Compilers::Dsl::ActiveRecordEnumSpec < DslSpec
   describe "Tapioca::Compilers::Dsl::ActiveRecordEnum" do
     describe "initialize" do
-      after do
-        T.unsafe(self).assert_no_generated_errors
-      end
-
       it "gathers no constants if there are no ActiveRecord classes" do
         assert_empty(gathered_constants)
       end
@@ -32,10 +28,6 @@ class Tapioca::Compilers::Dsl::ActiveRecordEnumSpec < DslSpec
     end
 
     describe "decorate" do
-      after do
-        T.unsafe(self).assert_no_generated_errors
-      end
-
       it "generates RBI file for classes with an enum attribute" do
         add_ruby_file("conversation.rb", <<~RUBY)
           class Conversation < ActiveRecord::Base

--- a/spec/tapioca/compilers/dsl/active_record_fixtures_spec.rb
+++ b/spec/tapioca/compilers/dsl/active_record_fixtures_spec.rb
@@ -6,10 +6,6 @@ require "spec_helper"
 class Tapioca::Compilers::Dsl::ActiveRecordFixturesSpec < DslSpec
   describe "Tapioca::Compilers::Dsl::ActiveRecordFixtures" do
     describe "initialize" do
-      after do
-        T.unsafe(self).assert_no_generated_errors
-      end
-
       it "gathers only the ActiveSupport::TestCase base class" do
         add_ruby_file("post_test.rb", <<~RUBY)
           class PostTest < ActiveSupport::TestCase
@@ -29,10 +25,6 @@ class Tapioca::Compilers::Dsl::ActiveRecordFixturesSpec < DslSpec
         require "rails"
 
         define_fake_rails_app
-      end
-
-      after do
-        T.unsafe(self).assert_no_generated_errors
       end
 
       it "does nothing if there are no fixtures" do

--- a/spec/tapioca/compilers/dsl/active_record_scope_spec.rb
+++ b/spec/tapioca/compilers/dsl/active_record_scope_spec.rb
@@ -37,10 +37,9 @@ class Tapioca::Compilers::Dsl::ActiveRecordScopeSpec < DslSpec
       end
 
       describe "with relations enabled" do
-        subject do
-          T.bind(self, DslSpec)
+        before do
           require "tapioca/compilers/dsl/active_record_relations"
-          generator_for_names(target_class_name, "Tapioca::Compilers::Dsl::ActiveRecordRelations")
+          activate_other_dsl_compilers(Tapioca::Compilers::Dsl::ActiveRecordRelations)
         end
 
         it "generates an empty RBI file for ActiveRecord classes with no scope field" do
@@ -344,17 +343,14 @@ class Tapioca::Compilers::Dsl::ActiveRecordScopeSpec < DslSpec
     end
 
     describe "decorate_active_storage" do
-      subject do
-        T.bind(self, DslSpec)
-        require "tapioca/compilers/dsl/active_record_relations"
-        generator_for_names(target_class_name, "Tapioca::Compilers::Dsl::ActiveRecordRelations")
-      end
-
       after do
-        T.unsafe(self).assert_no_generated_errors
+        assert_no_generated_errors
       end
 
       before do
+        require "tapioca/compilers/dsl/active_record_relations"
+        activate_other_dsl_compilers(Tapioca::Compilers::Dsl::ActiveRecordRelations)
+
         require "active_record"
         require "active_storage/attached"
         require "active_storage/reflection"

--- a/spec/tapioca/compilers/dsl/active_record_scope_spec.rb
+++ b/spec/tapioca/compilers/dsl/active_record_scope_spec.rb
@@ -6,10 +6,6 @@ require "spec_helper"
 class Tapioca::Compilers::Dsl::ActiveRecordScopeSpec < DslSpec
   describe "Tapioca::Compilers::Dsl::ActiveRecordScope" do
     describe "initialize" do
-      after do
-        T.unsafe(self).assert_no_generated_errors
-      end
-
       it "gathers no constants if there are no ActiveRecord classes" do
         assert_empty(gathered_constants)
       end
@@ -32,10 +28,6 @@ class Tapioca::Compilers::Dsl::ActiveRecordScopeSpec < DslSpec
     end
 
     describe "decorate" do
-      after do
-        T.unsafe(self).assert_no_generated_errors
-      end
-
       describe "with relations enabled" do
         before do
           require "tapioca/compilers/dsl/active_record_relations"
@@ -343,10 +335,6 @@ class Tapioca::Compilers::Dsl::ActiveRecordScopeSpec < DslSpec
     end
 
     describe "decorate_active_storage" do
-      after do
-        assert_no_generated_errors
-      end
-
       before do
         require "tapioca/compilers/dsl/active_record_relations"
         activate_other_dsl_compilers(Tapioca::Compilers::Dsl::ActiveRecordRelations)

--- a/spec/tapioca/compilers/dsl/active_record_typed_store_spec.rb
+++ b/spec/tapioca/compilers/dsl/active_record_typed_store_spec.rb
@@ -5,10 +5,9 @@ require "spec_helper"
 
 class Tapioca::Compilers::Dsl::ActiveRecordTypedStoreSpec < DslSpec
   describe "Tapioca::Compilers::Dsl::ActiveRecordTypedStore" do
-    before do
-      add_ruby_file("require.rb", <<~RUBY)
-        require "active_record"
-      RUBY
+    sig { void }
+    def before_setup
+      require "active_record"
     end
 
     describe "initialize" do

--- a/spec/tapioca/compilers/dsl/active_record_typed_store_spec.rb
+++ b/spec/tapioca/compilers/dsl/active_record_typed_store_spec.rb
@@ -11,10 +11,6 @@ class Tapioca::Compilers::Dsl::ActiveRecordTypedStoreSpec < DslSpec
     end
 
     describe "initialize" do
-      after do
-        T.unsafe(self).assert_no_generated_errors
-      end
-
       it "gathers no constants if there are no ActiveRecordTypedStore classes" do
         assert_empty(gathered_constants)
       end
@@ -42,10 +38,6 @@ class Tapioca::Compilers::Dsl::ActiveRecordTypedStoreSpec < DslSpec
     end
 
     describe "decorate" do
-      after do
-        T.unsafe(self).assert_no_generated_errors
-      end
-
       it "generates no definitions if there are no accessors to define" do
         add_ruby_file("post.rb", <<~RUBY)
           class Post < ActiveRecord::Base

--- a/spec/tapioca/compilers/dsl/active_resource_spec.rb
+++ b/spec/tapioca/compilers/dsl/active_resource_spec.rb
@@ -6,10 +6,6 @@ require "spec_helper"
 class Tapioca::Compilers::Dsl::ActiveResourceSpec < DslSpec
   describe "Tapioca::Compilers::Dsl::ActiveResource" do
     describe "initialize" do
-      after do
-        T.unsafe(self).assert_no_generated_errors
-      end
-
       it "gathers no constants if there are no ActiveResource classes" do
         assert_empty(gathered_constants)
       end
@@ -31,10 +27,6 @@ class Tapioca::Compilers::Dsl::ActiveResourceSpec < DslSpec
     end
 
     describe "decorate" do
-      after do
-        T.unsafe(self).assert_no_generated_errors
-      end
-
       it "generates RBI file for ActiveResource classes with an integer schema field" do
         add_ruby_file("post.rb", <<~RUBY)
           class Post < ActiveResource::Base

--- a/spec/tapioca/compilers/dsl/active_storage_spec.rb
+++ b/spec/tapioca/compilers/dsl/active_storage_spec.rb
@@ -17,10 +17,6 @@ class Tapioca::Compilers::Dsl::ActiveStorageSpec < DslSpec
     end
 
     describe "initialize" do
-      after do
-        T.unsafe(self).assert_no_generated_errors
-      end
-
       it "gathers no constants if there are no ActiveRecord classes" do
         assert_empty(gathered_constants)
       end
@@ -43,10 +39,6 @@ class Tapioca::Compilers::Dsl::ActiveStorageSpec < DslSpec
     end
 
     describe "decorate" do
-      after do
-        T.unsafe(self).assert_no_generated_errors
-      end
-
       it "generates an empty RBI file for ActiveRecord classes with no attachment" do
         add_ruby_file("post.rb", <<~RUBY)
           class Post < ActiveRecord::Base

--- a/spec/tapioca/compilers/dsl/active_support_concern_spec.rb
+++ b/spec/tapioca/compilers/dsl/active_support_concern_spec.rb
@@ -6,10 +6,6 @@ require "spec_helper"
 class Tapioca::Compilers::Dsl::ActiveSupportConcernSpec < DslSpec
   describe "Tapioca::Compilers::Dsl::ActiveSupportConcern" do
     describe "gather_constants" do
-      after do
-        T.unsafe(self).assert_no_generated_errors
-      end
-
       it "does not gather anonymous constants" do
         add_ruby_file("test_case.rb", <<~RUBY)
           module TestCase
@@ -148,10 +144,6 @@ class Tapioca::Compilers::Dsl::ActiveSupportConcernSpec < DslSpec
     end
 
     describe "decorate" do
-      after do
-        T.unsafe(self).assert_no_generated_errors
-      end
-
       it "does not generate RBI when constant does not define a ClassMethods module" do
         add_ruby_file("test_case.rb", <<~RUBY)
           module Foo

--- a/spec/tapioca/compilers/dsl/active_support_current_attributes_spec.rb
+++ b/spec/tapioca/compilers/dsl/active_support_current_attributes_spec.rb
@@ -6,10 +6,6 @@ require "spec_helper"
 class Tapioca::Compilers::Dsl::ActiveSupportCurrentAttributesSpec < DslSpec
   describe "Tapioca::Compilers::Dsl::ActiveSupportCurrentAttributes" do
     describe "initialize" do
-      after do
-        T.unsafe(self).assert_no_generated_errors
-      end
-
       it "gathers no constants if there are no ActiveSupport::CurrentAttributes subclasses" do
         assert_empty(gathered_constants)
       end
@@ -28,10 +24,6 @@ class Tapioca::Compilers::Dsl::ActiveSupportCurrentAttributesSpec < DslSpec
     end
 
     describe "decorate" do
-      after do
-        T.unsafe(self).assert_no_generated_errors
-      end
-
       it "generates empty RBI file if there are no current attributes" do
         add_ruby_file("current.rb", <<~RUBY)
           class Current < ActiveSupport::CurrentAttributes

--- a/spec/tapioca/compilers/dsl/config_spec.rb
+++ b/spec/tapioca/compilers/dsl/config_spec.rb
@@ -11,10 +11,6 @@ class Tapioca::Compilers::Dsl::ConfigSpec < DslSpec
     end
 
     describe "gather_constants" do
-      after do
-        T.unsafe(self).assert_no_generated_errors
-      end
-
       it "gathers `Settings` if there are no special config constant set" do
         ::Config.load_and_set_settings("")
 
@@ -30,10 +26,6 @@ class Tapioca::Compilers::Dsl::ConfigSpec < DslSpec
     end
 
     describe "decorate" do
-      after do
-        T.unsafe(self).assert_no_generated_errors
-      end
-
       it "generates a module definition for a simple config" do
         add_content_file("settings.yml", <<~YAML)
           github_key: 12345

--- a/spec/tapioca/compilers/dsl/config_spec.rb
+++ b/spec/tapioca/compilers/dsl/config_spec.rb
@@ -1,11 +1,12 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 require "spec_helper"
 
 class Tapioca::Compilers::Dsl::ConfigSpec < DslSpec
   describe "Tapioca::Compilers::Dsl::Config" do
-    before do
+    sig { void }
+    def before_setup
       Object.send(:remove_const, :Rails)
     end
 

--- a/spec/tapioca/compilers/dsl/frozen_record_spec.rb
+++ b/spec/tapioca/compilers/dsl/frozen_record_spec.rb
@@ -5,7 +5,8 @@ require "spec_helper"
 
 class Tapioca::Compilers::Dsl::FrozenRecordSpec < DslSpec
   describe "Tapioca::Compilers::Dsl::FrozenRecord" do
-    before do
+    sig { void }
+    def before_setup
       require "rails/railtie"
       require "tapioca/compilers/dsl/extensions/frozen_record"
     end

--- a/spec/tapioca/compilers/dsl/frozen_record_spec.rb
+++ b/spec/tapioca/compilers/dsl/frozen_record_spec.rb
@@ -12,10 +12,6 @@ class Tapioca::Compilers::Dsl::FrozenRecordSpec < DslSpec
     end
 
     describe "initialize" do
-      after do
-        T.unsafe(self).assert_no_generated_errors
-      end
-
       it "gathers no constants if there are no FrozenRecord classes" do
         assert_empty(gathered_constants)
       end
@@ -34,10 +30,6 @@ class Tapioca::Compilers::Dsl::FrozenRecordSpec < DslSpec
     end
 
     describe "decorate" do
-      after do
-        T.unsafe(self).assert_no_generated_errors
-      end
-
       it "generates empty RBI file if there are no frozen records" do
         add_ruby_file("student.rb", <<~RUBY)
           class Student < FrozenRecord::Base

--- a/spec/tapioca/compilers/dsl/identity_cache_spec.rb
+++ b/spec/tapioca/compilers/dsl/identity_cache_spec.rb
@@ -5,7 +5,8 @@ require "spec_helper"
 
 class Tapioca::Compilers::Dsl::IdentityCacheSpec < DslSpec
   describe "Tapioca::Compilers::Dsl::IdentityCache" do
-    before do
+    sig { void }
+    def before_setup
       require "rails/railtie"
     end
 

--- a/spec/tapioca/compilers/dsl/identity_cache_spec.rb
+++ b/spec/tapioca/compilers/dsl/identity_cache_spec.rb
@@ -11,10 +11,6 @@ class Tapioca::Compilers::Dsl::IdentityCacheSpec < DslSpec
     end
 
     describe "initialize" do
-      after do
-        T.unsafe(self).assert_no_generated_errors
-      end
-
       it "gathers no constants if there are no IdentityCache classes" do
         assert_empty(gathered_constants)
       end
@@ -50,10 +46,6 @@ class Tapioca::Compilers::Dsl::IdentityCacheSpec < DslSpec
     end
 
     describe "decorate" do
-      after do
-        T.unsafe(self).assert_no_generated_errors
-      end
-
       before do
         require "active_record"
 

--- a/spec/tapioca/compilers/dsl/mixed_in_class_attributes_spec.rb
+++ b/spec/tapioca/compilers/dsl/mixed_in_class_attributes_spec.rb
@@ -11,10 +11,6 @@ class Tapioca::Compilers::Dsl::MixedInClassAttributesSpec < DslSpec
     end
 
     describe "gather_constants" do
-      after do
-        T.unsafe(self).assert_no_generated_errors
-      end
-
       it "gathers modules that respond to class_attribute" do
         add_ruby_file("file.rb", <<~RUBY)
           module ManualIncluded
@@ -47,10 +43,6 @@ class Tapioca::Compilers::Dsl::MixedInClassAttributesSpec < DslSpec
     end
 
     describe "decorate" do
-      after do
-        T.unsafe(self).assert_no_generated_errors
-      end
-
       it "does nothing if the module doesn't use class_attribute" do
         add_ruby_file("empty.rb", <<~RUBY)
           module Empty

--- a/spec/tapioca/compilers/dsl/protobuf_spec.rb
+++ b/spec/tapioca/compilers/dsl/protobuf_spec.rb
@@ -6,10 +6,6 @@ require "spec_helper"
 class Tapioca::Compilers::Dsl::ProtobufSpec < DslSpec
   describe "Tapioca::Compilers::Dsl::Protobuf" do
     describe "gather_constants" do
-      after do
-        T.unsafe(self).assert_no_generated_errors
-      end
-
       it "gathers no constants if there are no Google::Protobuf classes" do
         add_ruby_file("content.rb", <<~RUBY)
           Google::Protobuf::DescriptorPool.generated_pool.build do
@@ -40,10 +36,6 @@ class Tapioca::Compilers::Dsl::ProtobufSpec < DslSpec
     end
 
     describe "decorate" do
-      after do
-        T.unsafe(self).assert_no_generated_errors
-      end
-
       it "generates methods in RBI files for classes with Protobuf with integer field type" do
         add_ruby_file("protobuf.rb", <<~RUBY)
           Google::Protobuf::DescriptorPool.generated_pool.build do

--- a/spec/tapioca/compilers/dsl/rails_generators_spec.rb
+++ b/spec/tapioca/compilers/dsl/rails_generators_spec.rb
@@ -6,10 +6,6 @@ require "spec_helper"
 class Tapioca::Compilers::Dsl::RailsGeneratorsSpec < DslSpec
   describe "Tapioca::Compilers::Dsl::RailsGenerators" do
     describe "initialize" do
-      after do
-        T.unsafe(self).assert_no_generated_errors
-      end
-
       it "gathers no constants if there are no Rails generator classes" do
         assert_empty(gathered_constants)
       end
@@ -55,10 +51,6 @@ class Tapioca::Compilers::Dsl::RailsGeneratorsSpec < DslSpec
     end
 
     describe "decorate" do
-      after do
-        T.unsafe(self).assert_no_generated_errors
-      end
-
       it "generates empty RBI file if there are no extra arguments or options" do
         add_ruby_file("contents.rb", <<~RUBY)
           class EmptyGenerator < ::Rails::Generators::Base

--- a/spec/tapioca/compilers/dsl/sidekiq_worker_spec.rb
+++ b/spec/tapioca/compilers/dsl/sidekiq_worker_spec.rb
@@ -6,10 +6,6 @@ require "spec_helper"
 class Tapioca::Compilers::Dsl::SidekiqWorkerSpec < DslSpec
   describe "Tapioca::Compilers::Dsl::SidekiqWorker" do
     describe "initialize" do
-      after do
-        T.unsafe(self).assert_no_generated_errors
-      end
-
       it "gathers no constants if there are no classes with Sidekiq::Worker as ancestor" do
         assert_empty(gathered_constants)
       end
@@ -32,10 +28,6 @@ class Tapioca::Compilers::Dsl::SidekiqWorkerSpec < DslSpec
     end
 
     describe "decorate" do
-      after do
-        T.unsafe(self).assert_no_generated_errors
-      end
-
       it "generates empty RBI file if there is no perform method" do
         add_ruby_file("mailer.rb", <<~RUBY)
           class NotifierWorker

--- a/spec/tapioca/compilers/dsl/smart_properties_spec.rb
+++ b/spec/tapioca/compilers/dsl/smart_properties_spec.rb
@@ -6,10 +6,6 @@ require "spec_helper"
 class Tapioca::Compilers::Dsl::SmartPropertiesSpec < DslSpec
   describe "Tapioca::Compilers::Dsl::SmartProperties" do
     describe "initialize" do
-      after do
-        T.unsafe(self).assert_no_generated_errors
-      end
-
       it "gathers no constants if there are no SmartProperty classes" do
         assert_empty(gathered_constants)
       end
@@ -54,10 +50,6 @@ class Tapioca::Compilers::Dsl::SmartPropertiesSpec < DslSpec
     end
 
     describe "decorate" do
-      after do
-        T.unsafe(self).assert_no_generated_errors
-      end
-
       it "generates empty RBI file if there are no smart properties" do
         add_ruby_file("post.rb", <<~RUBY)
           class Post

--- a/spec/tapioca/compilers/dsl/state_machines_spec.rb
+++ b/spec/tapioca/compilers/dsl/state_machines_spec.rb
@@ -6,10 +6,6 @@ require "spec_helper"
 class Tapioca::Compilers::Dsl::StateMachinesSpec < DslSpec
   describe "Tapioca::Compilers::Dsl::StateMachine" do
     describe "initialize" do
-      after do
-        T.unsafe(self).assert_no_generated_errors
-      end
-
       it "gathers no constants if there are no StateMachines classes" do
         assert_empty(gathered_constants)
       end
@@ -33,10 +29,6 @@ class Tapioca::Compilers::Dsl::StateMachinesSpec < DslSpec
     end
 
     describe "decorate" do
-      after do
-        T.unsafe(self).assert_no_generated_errors
-      end
-
       it " generates an RBI that includes state accessor methods" do
         add_ruby_file("vehicle.rb", <<~RUBY)
           class Vehicle

--- a/spec/tapioca/compilers/dsl/url_helpers_spec.rb
+++ b/spec/tapioca/compilers/dsl/url_helpers_spec.rb
@@ -6,10 +6,6 @@ require "spec_helper"
 class Tapioca::Compilers::Dsl::UrlHelpersSpec < DslSpec
   describe "Tapioca::Compilers::Dsl::UrlHelper" do
     describe "initialize" do
-      after do
-        T.unsafe(self).assert_no_generated_errors
-      end
-
       it "does not gather constants when url_helpers is not included" do
         add_ruby_file("content.rb", <<~RUBY)
           class Application < Rails::Application
@@ -171,10 +167,6 @@ class Tapioca::Compilers::Dsl::UrlHelpersSpec < DslSpec
     end
 
     describe "decorate" do
-      after do
-        T.unsafe(self).assert_no_generated_errors
-      end
-
       it "generates RBI when there are no helper methods" do
         add_ruby_file("routes.rb", <<~RUBY)
           class Application < Rails::Application


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
We currently have too much magic inside the `DslSpec` test superclass which makes it hard for other projects to write tests for their own DSL compilers, and it also makes it hard to understand what is going on inside that superclass as well.

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
Extract logic to a reusable module that should work independently of the testing framework used. This module provides helper methods to setup DSL compiler under test and possibly collaborating DSL compilers that should also be activated. Moreover it provides convenience methods like `rbi_for` and `gathered_constants` that tests can use for assertions.

While I was refactoring tests, I also took the opportunity to make sure our "no errors raised" assertions didn't end up being intrusive across the whole test suite.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->
No new tests.
