### PR TITLE
Improve workspace settings for VSCode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,8 +4,13 @@
     "rubocop": false
   },
   "ruby.codeCompletion": false,
-  "ruby.intellisense": "rubyLocate",
+  "ruby.intellisense": false,
+  "ruby.format": false,
   "byesig.opacity": 0.4,
   "byesig.fold": false,
   "byesig.showIcon": false,
+  "[ruby]": {
+    "editor.defaultFormatter": "Shopify.rubocop-lsp",
+    "editor.formatOnSave": true
+  }
 }


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->

- Disable the Ruby extension intellisense and formatting (these might end up conflicting with Sorbet and RuboCop LSP)
- Make RuboCop-LSP the default formatter
- Enable format on save for Ruby files