### PR TITLE
Allow clients to access the command `err` output.

### DIFF
--- a/lib/tapioca/generators/todo.rb
+++ b/lib/tapioca/generators/todo.rb
@@ -70,7 +70,8 @@ module Tapioca
       sig { returns(T::Array[String]) }
       def unresolved_constants
         # Taken from https://github.com/sorbet/sorbet/blob/master/gems/sorbet/lib/todo-rbi.rb
-        sorbet("--print=missing-constants", "--stdout-hup-hack", "--no-error-count")
+        sorbet("--print=missing-constants", "--quiet", "--stdout-hup-hack", "--no-error-count")
+          .out
           .strip
           .each_line
           .map do |line|

--- a/lib/tapioca/helpers/sorbet_helper.rb
+++ b/lib/tapioca/helpers/sorbet_helper.rb
@@ -25,16 +25,16 @@ module Tapioca
       to_ary_nil_support: Gem::Requirement.new(">= 0.5.9220"),
     }.freeze, T::Hash[Symbol, Gem::Requirement])
 
-    sig { params(args: String).returns(String) }
-    def sorbet(*args)
-      IO.popen(
-        [
-          sorbet_path,
-          "--quiet",
-          *args,
-        ].join(" "),
-        err: "/dev/null"
-      ).read
+    class CmdResult < T::Struct
+      const :out, String
+      const :err, String
+      const :status, T::Boolean
+    end
+
+    sig { params(sorbet_args: String).returns(CmdResult) }
+    def sorbet(*sorbet_args)
+      out, err, status = Open3.capture3([sorbet_path, *sorbet_args].join(" "))
+      CmdResult.new(out: out, err: err, status: status.success? || false)
     end
 
     sig { returns(String) }

--- a/lib/tapioca/symbol_loader.rb
+++ b/lib/tapioca/symbol_loader.rb
@@ -38,7 +38,7 @@ module Tapioca
 
       sig { params(input: String, table_type: String).returns(String) }
       def symbol_table_json_from(input, table_type: "symbol-table-json")
-        sorbet("--no-config", "--print=#{table_type}", input)
+        sorbet("--no-config", "--quiet", "--print=#{table_type}", input).out
       end
 
       sig { returns(T::Set[String]) }


### PR DESCRIPTION
### Motivation

While working on #347 I needed to access the error output of the command I ran and realized that the current implementation was not allowing this. 

### Implementation

Copied from https://github.com/Shopify/tapioca/commit/c8195fe35133384a07faffa184659c8fabbf72f0.

### Tests

Not functional change.

