### PR TITLE
Fix `ConstantType` definitions for DSL compiler specs

### DIFF
--- a/spec/tapioca/cli/dsl_spec.rb
+++ b/spec/tapioca/cli/dsl_spec.rb
@@ -631,7 +631,7 @@ module Tapioca
             class CompilerThatIncludesBarModuleInPost < Tapioca::Dsl::Compiler
               extend T::Sig
 
-              Elem = type_member(fixed: T.class_of(::Post))
+              ConstantType = type_member(fixed: T.class_of(::Post))
 
               sig { override.void }
               def decorate
@@ -654,7 +654,7 @@ module Tapioca
             class CompilerThatIncludesFooModuleInPost < Tapioca::Dsl::Compiler
               extend T::Sig
 
-              Elem = type_member(fixed: T.class_of(::Post))
+              ConstantType = type_member(fixed: T.class_of(::Post))
 
               sig { override.void }
               def decorate
@@ -742,7 +742,7 @@ module Tapioca
               class Compiler < Tapioca::Dsl::Compiler
                 extend T::Sig
 
-                Elem = type_member(fixed: Job)
+                ConstantType = type_member(fixed: Job)
 
                 sig { override.void }
                 def decorate
@@ -845,7 +845,7 @@ module Tapioca
               class Compiler < Tapioca::Dsl::Compiler
                 extend T::Sig
 
-                Elem = type_member(fixed: Job)
+                ConstantType = type_member(fixed: Job)
 
                 sig { override.void }
                 def decorate


### PR DESCRIPTION
Some more renaming following #819.
