### PR TITLE
Load nothing from Tapioca by default

### DIFF
--- a/lib/tapioca.rb
+++ b/lib/tapioca.rb
@@ -43,8 +43,4 @@ module Tapioca
   }.freeze, T::Hash[String, String])
 end
 
-require "tapioca/runtime/reflection"
-require "tapioca/runtime/trackers"
-require "tapioca/dsl/compiler"
-require "tapioca/runtime/dynamic_mixin_compiler"
 require "tapioca/version"

--- a/lib/tapioca/internal.rb
+++ b/lib/tapioca/internal.rb
@@ -2,6 +2,9 @@
 # frozen_string_literal: true
 
 require "tapioca"
+require "tapioca/runtime/reflection"
+require "tapioca/runtime/trackers"
+require "tapioca/runtime/dynamic_mixin_compiler"
 require "tapioca/runtime/loader"
 require "tapioca/sorbet_ext/generic_name_patch"
 require "tapioca/sorbet_ext/fixed_hash_patch"
@@ -20,5 +23,6 @@ require "tapioca/static/symbol_loader"
 require "tapioca/gem/events"
 require "tapioca/gem/listeners"
 require "tapioca/gem/pipeline"
-require "tapioca/static/requires_compiler"
+require "tapioca/dsl/compiler"
 require "tapioca/dsl/pipeline"
+require "tapioca/static/requires_compiler"


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
The split between top level `tapioca.rb` requires and `tapioca/internal.rb` requires was creating an ordering problem. Also, the default require of Tapioca might be pulling into the requiring much more than we intended, and since we do messy things with Sorbet runtime, that could end up being distruptive.

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
It is best to not load anything from the default require (we basically define the top-level `Tapioca` namespace and some constants under it, only) and to load everything for the CLI using `tapioca/internal.rb`. This allows us to order the requires so that all the trackers and other runtime patches get loaded before things that depend on them.

**NOTE:** This implies that people who write their own DSL compilers will have to explicitly do a `require "tapioca/dsl/compiler"`.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->
No new tests.
