### PR TITLE
Fix generic type variable argument serialization

### DIFF
--- a/lib/tapioca/runtime/generic_type_registry.rb
+++ b/lib/tapioca/runtime/generic_type_registry.rb
@@ -111,8 +111,10 @@ module Tapioca
             constant.clone
           end
 
-          # Let's set the `name` method to return the proper generic name
-          generic_type.define_singleton_method(:name) { name }
+          # Let's set the `name` and `to_s` methods to return the proper generic name
+          name_proc = -> { name }
+          generic_type.define_singleton_method(:name, name_proc)
+          generic_type.define_singleton_method(:to_s, name_proc)
 
           # We need to define a `<=` method on the cloned constant, so that Sorbet
           # can do covariance/contravariance checks on the type variables.

--- a/spec/tapioca/gem/pipeline_spec.rb
+++ b/spec/tapioca/gem/pipeline_spec.rb
@@ -2819,6 +2819,44 @@ class Tapioca::Gem::PipelineSpec < Minitest::HooksSpec
       assert_equal(output, compile)
     end
 
+    it "can compile generics in type variable arguments" do
+      add_ruby_file("service.rb", <<~RUBY)
+        class Result
+          extend T::Generic
+
+          OkType = type_member
+          ErrType = type_member
+        end
+
+        class Service
+          extend T::Generic
+
+          InputType = type_member(upper: Result[Integer, String])
+          ReturnType = type_member(fixed: Result[Integer, String])
+          TempType = type_member(lower: Result[Integer, String])
+        end
+      RUBY
+
+      output = template(<<~RBI)
+        class Result
+          extend T::Generic
+
+          OkType = type_member
+          ErrType = type_member
+        end
+
+        class Service
+          extend T::Generic
+
+          InputType = type_member(upper: Result[::Integer, ::String])
+          ReturnType = type_member(fixed: Result[::Integer, ::String])
+          TempType = type_member(lower: Result[::Integer, ::String])
+        end
+      RBI
+
+      assert_equal(output, compile)
+    end
+
     it "can compile typed struct generics" do
       add_ruby_file("tstruct_generic.rb", <<~RUBY)
         class Foo < T::Struct


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
Fixes #838 

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
The `GenericNamePatch` is [using string interpolation to serialize the names of `fixed`, `lower` and `upper` arguments](https://github.com/Shopify/tapioca/blob/9297b51bcf560c1416f27c0523a6cd15822cc59d/lib/tapioca/sorbet_ext/generic_name_patch.rb#L158-L160) but we have been only overriding the `name` method on generic types. Since generic types that we create are actually anonymous, calling `to_s` on them returns something like `#<Class:0x00007fb9d58fdce8>` which is both unexpected and wrong.

The implementation makes sure that whoever calls `to_s` on a generic type also gets the expected generic type name.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->
Add a failing test based on the report in #838.
