### PR TITLE
Add an easy way to print `ExecResult` in tests

### DIFF
--- a/spec/helpers/mock_project.rb
+++ b/spec/helpers/mock_project.rb
@@ -66,9 +66,22 @@ module Tapioca
     end
 
     class ExecResult < T::Struct
+      extend T::Sig
+
       const :out, String
       const :err, String
       const :status, T::Boolean
+
+      sig { returns(String) }
+      def to_s
+        <<~STR
+          ########## STDOUT ##########
+          #{out.empty? ? "<empty>" : out}
+          ########## STDERR ##########
+          #{err.empty? ? "<empty>" : err}
+          ########## STATUS: #{status} ##########
+        STR
+      end
     end
 
     # Run `bundle install` in this project context (unbundled env)


### PR DESCRIPTION
### Motivation

Just a shortcut so we can do:

```rb
puts result
```

Instead of

```rb
puts result.out
puts result.err
puts result.status
```

When debugging tests.