### PR TITLE
Add `tapioca/dsl` entrypoint for custom DSL compilers

### DIFF
--- a/lib/tapioca/dsl.rb
+++ b/lib/tapioca/dsl.rb
@@ -1,0 +1,6 @@
+# typed: true
+# frozen_string_literal: true
+
+require "tapioca"
+require "tapioca/runtime/reflection"
+require "tapioca/dsl/compiler"


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
When writing a custom DSL compiler, the client code needs to require a minimal set of files from Tapioca, so that the DSL compiler can be loaded in isolation and tested inside the project. However, we don't have an entrypoint for that minimal require set and clients end up having to do `require "tapioca/internal"` to achieve this, which is not great.

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
This PR adds a `tapioca/dsl` entrypoint, which DSL compiler classes can add as a require.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->
The test is super custom, since I wanted to test the experience of a client app declaring and loading a custom DSL compiler in isolation from the Tapioca CLI runner. When we load the Tapioca CLI `dsl` command and, that, in turn, loads custom compilers, everything works regardless of any Tapioca requires, since the CLI already bring everything with it.

The custom test defines a small executable inside the mock project that loads the custom compiler and tries to generate an RBI using it, just as how tests would do it. That allows us to test the loading and operation of a custom DSL compiler in isolation using only the minimal `tapioca/dsl` require.
