### PR TITLE
Do not crash when trying to generate DSL RBIs on non-rails apps

### DIFF
--- a/lib/tapioca/dsl/compilers/active_record_fixtures.rb
+++ b/lib/tapioca/dsl/compilers/active_record_fixtures.rb
@@ -60,6 +60,8 @@ module Tapioca
 
         sig { override.returns(T::Enumerable[Module]) }
         def self.gather_constants
+          return [] unless Rails.application
+
           [ActiveSupport::TestCase]
         end
 

--- a/lib/tapioca/dsl/compilers/url_helpers.rb
+++ b/lib/tapioca/dsl/compilers/url_helpers.rb
@@ -109,6 +109,8 @@ module Tapioca
 
         sig { override.returns(T::Enumerable[Module]) }
         def self.gather_constants
+          return [] unless Rails.application
+
           Object.const_set(:GeneratedUrlHelpersModule, Rails.application.routes.named_routes.url_helpers_module)
           Object.const_set(:GeneratedPathHelpersModule, Rails.application.routes.named_routes.path_helpers_module)
 

--- a/spec/tapioca/dsl/compilers/active_record_fixtures_spec.rb
+++ b/spec/tapioca/dsl/compilers/active_record_fixtures_spec.rb
@@ -8,8 +8,34 @@ module Tapioca
     module Compilers
       class ActiveRecordFixturesSpec < ::DslSpec
         describe "Tapioca::Dsl::Compilers::ActiveRecordFixtures" do
-          describe "initialize" do
+          describe "without a Rails app" do
+            it "gathers nothing if not in a Rails application" do
+              add_ruby_file("post_test.rb", <<~RUBY)
+                class PostTest < ActiveSupport::TestCase
+                end
+
+                class User
+                end
+              RUBY
+
+              assert_empty(gathered_constants)
+            end
+          end
+
+          describe "with a Rails app" do
+            before do
+              require "active_record"
+              require "rails"
+
+              define_fake_rails_app
+            end
+
             it "gathers only the ActiveSupport::TestCase base class" do
+              require "active_record"
+              require "rails"
+
+              define_fake_rails_app
+
               add_ruby_file("post_test.rb", <<~RUBY)
                 class PostTest < ActiveSupport::TestCase
                 end
@@ -19,15 +45,6 @@ module Tapioca
               RUBY
 
               assert_equal(["ActiveSupport::TestCase"], gathered_constants)
-            end
-          end
-
-          describe "decorate" do
-            before do
-              require "active_record"
-              require "rails"
-
-              define_fake_rails_app
             end
 
             it "does nothing if there are no fixtures" do


### PR DESCRIPTION
### Motivation

Avoid getting a scary stack trace when running `tapioca dsl` in the wrong kind of app:

```
$ bundle exec tapioca dsl
Loading Rails application... Done
Loading DSL compiler classes... Done
Compiling DSL RBI files...

bundler: failed to load command: tapioca
tapioca/lib/tapioca/dsl/compilers/url_helpers.rb:112:in `gather_constants': undefined method `routes' for nil:NilClass (NoMethodError)
```

### Implementation

Check if we are in a Rails app with `Rails.application`.

