### PR TITLE
Always ignore the `vendor/` directory form the sorbet/config

### DIFF
--- a/lib/tapioca/commands/init.rb
+++ b/lib/tapioca/commands/init.rb
@@ -41,6 +41,7 @@ module Tapioca
         create_file(@sorbet_config, <<~CONTENT, skip: true, force: false)
           --dir
           .
+          --ignore=vendor/
         CONTENT
       end
 

--- a/spec/tapioca/cli/init_spec.rb
+++ b/spec/tapioca/cli/init_spec.rb
@@ -28,6 +28,7 @@ module Tapioca
         assert_equal(<<~CONFIG, @project.read("sorbet/config"))
           --dir
           .
+          --ignore=vendor/
         CONFIG
 
         assert_project_file_equal("sorbet/tapioca/require.rb", <<~RB)


### PR DESCRIPTION
### Motivation

This directory can be safely ignored and this will avoid a lot of Sorbet type errors out of the box after a `tapioca init`.
