### PR TITLE
Automerge patch and minor dependency version bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,10 @@ updates:
   - package-ecosystem: "bundler"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: weekly
+      day: friday
+      time: "10:00"
+      timezone: America/New_York
     reviewers:
       - "Shopify/sorbet"
     labels:
@@ -12,7 +15,10 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: weekly
+      day: friday
+      time: "10:00"
+      timezone: America/New_York
     reviewers:
       - "Shopify/sorbet"
     labels:

--- a/.github/workflows/automate_dependabot.yml
+++ b/.github/workflows/automate_dependabot.yml
@@ -1,0 +1,65 @@
+name: Dependabot auto-merge
+on: pull_request_target
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  dependabot:
+    runs-on: self-hosted
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v1.1.1
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Enable auto-merge for Dependabot PRs
+        if: ${{ steps.metadata.outputs.update-type != 'version-update:semver-major' }}
+        uses: actions/github-script@v5
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          script: |
+            const getPullRequestIdQuery = `query GetPullRequestId($owner: String!, $repo: String!, $pullRequestNumber: Int!) {
+              repository(owner: $owner, name: $repo) {
+                pullRequest(number: $pullRequestNumber) {
+                  id
+                }
+              }
+            }`
+            const repoInfo = {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pullRequestNumber: context.issue.number,
+            }
+            const response = await github.graphql(getPullRequestIdQuery, repoInfo)
+
+            await github.rest.pulls.createReview({
+              pull_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              event: 'APPROVE',
+            })
+
+            const enableAutoMergeQuery = `mutation ($pullRequestId: ID!, $mergeMethod: PullRequestMergeMethod!) {
+              enablePullRequestAutoMerge(input: {
+                pullRequestId: $pullRequestId,
+                mergeMethod: $mergeMethod
+              }) {
+                pullRequest {
+                  autoMergeRequest {
+                    enabledAt
+                    enabledBy {
+                      login
+                    }
+                  }
+                }
+              }
+            }`
+            const data = {
+              pullRequestId: response.repository.pullRequest.id,
+              mergeMethod: 'MERGE',
+            }
+
+            await github.graphql(enableAutoMergeQuery, data)


### PR DESCRIPTION
### Motivation

Dependency maintenance takes a lot of time. Merging minor and patch version changes is quite safe, especially given that they are not released right away.

### Implementation

Leaning on the automerge feature and branch protection, we can let Github actions take care of it. This will mark dependabot pull requests as automergable if all the CI checks pass.

I scheduled them for daytime ET since a lot of us are around then in case anything is weird.

This will still require human intervention if tests fail, if there are merge conflicts, or if there are major version changes.
In a lot of cases, merge conflicts can be resolved with `@dependabot rebase` or `@dependabot recreate`.