### PR TITLE
allow for user-created dsl extensions

### DIFF
--- a/lib/tapioca/commands/dsl.rb
+++ b/lib/tapioca/commands/dsl.rb
@@ -378,7 +378,12 @@ module Tapioca
 
       sig { void }
       def load_dsl_extensions
-        Dir["#{__dir__}/../dsl/extensions/*.rb"].sort.each { |f| require(f) }
+        Dir.glob([
+          "#{__dir__}/../dsl/extensions/*.rb",
+          "#{@tapioca_path}/dsl_extensions/**/*.rb",
+        ]).each do |extension|
+          require File.expand_path(extension)
+        end
       end
     end
   end


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->

I have a need to patch a class so I can track method calls in some DSL. I posted [a message in slack](https://sorbet-ruby.slack.com/archives/C02VD06EQ3U/p1647317966165499?thread_ts=1647312541.927039&cid=C02VD06EQ3U) about it.

The way I'm doing it currently is to have the patch at the top of my compiler, and then re-load the file the constant was defined in. This can be problematic.

This brings extensions into line with compilers, which have a dedicated location in `@tapioca_path` to be stored and loaded.

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->

Copied the code from the `load_dsl_compilers` method, mostly

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->

No tests because this functionality doesn't seem to be tested already. I can add tests if they're really wanted.

