### PR TITLE
Dependabot Automerge: Take 2

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,10 @@ updates:
   - package-ecosystem: "bundler"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: weekly
+      day: friday
+      time: "10:00"
+      timezone: America/New_York
     reviewers:
       - "Shopify/sorbet"
     labels:
@@ -12,7 +15,10 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: weekly
+      day: friday
+      time: "10:00"
+      timezone: America/New_York
     reviewers:
       - "Shopify/sorbet"
     labels:

--- a/.github/workflows/automate_dependabot.yml
+++ b/.github/workflows/automate_dependabot.yml
@@ -7,7 +7,7 @@ permissions:
 
 jobs:
   dependabot:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     if: ${{ github.actor == 'dependabot[bot]' }}
     steps:
       - name: Dependabot metadata

--- a/.github/workflows/automate_dependabot.yml
+++ b/.github/workflows/automate_dependabot.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Update RBI
         run: |
           bundle exec exe/tapioca gem
-          git add --all
+          git add sorbet/rbi
           git commit -m "Update RBI"
           git push origin ${GITHUB_HEAD_REF#refs/heads/}
       - name: Enable auto-merge for Dependabot PRs

--- a/.github/workflows/automate_dependabot.yml
+++ b/.github/workflows/automate_dependabot.yml
@@ -1,0 +1,65 @@
+name: Dependabot auto-merge
+on: pull_request_target
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  dependabot:
+    runs-on: self-hosted
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v1.1.1
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Enable auto-merge for Dependabot PRs
+        if: ${{ steps.metadata.outputs.update-type != 'version-update:semver-major' }}
+        uses: actions/github-script@v5
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          script: |
+            const getPullRequestIdQuery = `query GetPullRequestId($owner: String!, $repo: String!, $pullRequestNumber: Int!) {
+              repository(owner: $owner, name: $repo) {
+                pullRequest(number: $pullRequestNumber) {
+                  id
+                }
+              }
+            }`
+            const repoInfo = {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pullRequestNumber: context.issue.number,
+            }
+            const response = await github.graphql(getPullRequestIdQuery, repoInfo)
+
+            await github.rest.pulls.createReview({
+              pull_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              event: 'APPROVE',
+            })
+
+            const enableAutoMergeQuery = `mutation ($pullRequestId: ID!, $mergeMethod: PullRequestMergeMethod!) {
+              enablePullRequestAutoMerge(input: {
+                pullRequestId: $pullRequestId,
+                mergeMethod: $mergeMethod
+              }) {
+                pullRequest {
+                  autoMergeRequest {
+                    enabledAt
+                    enabledBy {
+                      login
+                    }
+                  }
+                }
+              }
+            }`
+            const data = {
+              pullRequestId: response.repository.pullRequest.id,
+              mergeMethod: 'MERGE',
+            }
+
+            await github.graphql(enableAutoMergeQuery, data)

--- a/.github/workflows/automate_dependabot.yml
+++ b/.github/workflows/automate_dependabot.yml
@@ -15,6 +15,19 @@ jobs:
         uses: dependabot/fetch-metadata@v1.1.1
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.1"
+          bundler-cache: true
+      - name: checkout
+        uses: actions/checkout@v2
+      - name: Update RBI
+        run: |
+          bundle exec exe/tapioca gem
+          git add --all
+          git commit -m "Update RBI"
+          git push origin ${GITHUB_HEAD_REF#refs/heads/}
       - name: Enable auto-merge for Dependabot PRs
         if: ${{ steps.metadata.outputs.update-type != 'version-update:semver-major' }}
         uses: actions/github-script@v5


### PR DESCRIPTION
### Motivation

Revisiting https://github.com/Shopify/tapioca/pull/851

### Implementation

The RBI validity check blocked merging the first time around, which makes perfect sense.
What I'm attempting with this one is to bump the RBI in the dependabot PR before queueing it for automerge. CI will run on the latest commit to the PR so if it still fails then it means something was likely wrong.

Thoughts? Worth a try I think.
