### PR TITLE
Fix block with no param generation

### DIFF
--- a/lib/tapioca/dsl/helpers/param_helper.rb
+++ b/lib/tapioca/dsl/helpers/param_helper.rb
@@ -6,6 +6,7 @@ module Tapioca
     module Helpers
       module ParamHelper
         extend T::Sig
+        include SignaturesHelper
 
         sig { params(name: String, type: String).returns(RBI::TypedParam) }
         def create_param(name, type:)
@@ -39,7 +40,7 @@ module Tapioca
 
         sig { params(name: String, type: String).returns(RBI::TypedParam) }
         def create_block_param(name, type:)
-          create_typed_param(RBI::BlockParam.new(name), type)
+          create_typed_param(RBI::BlockParam.new(name), sanitize_signature_types(type))
         end
 
         sig { params(param: RBI::Param, type: String).returns(RBI::TypedParam) }

--- a/lib/tapioca/dsl/helpers/param_helper.rb
+++ b/lib/tapioca/dsl/helpers/param_helper.rb
@@ -40,12 +40,12 @@ module Tapioca
 
         sig { params(name: String, type: String).returns(RBI::TypedParam) }
         def create_block_param(name, type:)
-          create_typed_param(RBI::BlockParam.new(name), sanitize_signature_types(type))
+          create_typed_param(RBI::BlockParam.new(name), type)
         end
 
         sig { params(param: RBI::Param, type: String).returns(RBI::TypedParam) }
         def create_typed_param(param, type)
-          RBI::TypedParam.new(param: param, type: type)
+          RBI::TypedParam.new(param: param, type: sanitize_signature_types(type))
         end
       end
     end

--- a/lib/tapioca/dsl/helpers/param_helper.rb
+++ b/lib/tapioca/dsl/helpers/param_helper.rb
@@ -1,6 +1,8 @@
 # typed: strict
 # frozen_string_literal: true
 
+require "tapioca/helpers/signatures_helper"
+
 module Tapioca
   module Dsl
     module Helpers

--- a/spec/tapioca/dsl/compilers/active_support_current_attributes_spec.rb
+++ b/spec/tapioca/dsl/compilers/active_support_current_attributes_spec.rb
@@ -93,8 +93,8 @@ module Tapioca
                     # ...
                   end
 
-                  sig { params(user_id: Integer).void }
-                  def authenticate(user_id)
+                  sig { params(user_id: Integer, block: T.proc.void).void }
+                  def authenticate(user_id, &block)
                     # ...
                   end
                 end
@@ -117,8 +117,8 @@ module Tapioca
                     sig { params(value: T.untyped).returns(T.untyped) }
                     def account=(value); end
 
-                    sig { params(user_id: ::Integer).void }
-                    def authenticate(user_id); end
+                    sig { params(user_id: ::Integer, block: T.proc.void).void }
+                    def authenticate(user_id, &block); end
 
                     sig { returns(T.untyped) }
                     def helper; end


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->

The issue occured when running the dsl command for an
ActiveSupport::CurrentAttributes class with a method accepting a block
with type: `T.proc.void`, resulting in the invalid `.params()` being
generated.

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->

The fix is a total shot in the dark, and I have no idea if it's a good approach, or if there's a better one

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->

The test change is almost 1:1 the issue I faced in my own code
