### PR TITLE
Start using compared by identity Set operations for `UrlHelpers#includes_helper?`

### DIFF
--- a/lib/tapioca/dsl/compiler.rb
+++ b/lib/tapioca/dsl/compiler.rb
@@ -54,7 +54,7 @@ module Tapioca
       sig { returns(T::Set[Module]) }
       def self.processable_constants
         @processable_constants ||= T.let(
-          Set.new(gather_constants).tap(&:compare_by_identity),
+          T::Set[Module].new(gather_constants).compare_by_identity,
           T.nilable(T::Set[Module])
         )
         T.must(@processable_constants)

--- a/lib/tapioca/dsl/compilers/url_helpers.rb
+++ b/lib/tapioca/dsl/compilers/url_helpers.rb
@@ -162,7 +162,8 @@ module Tapioca
             superclass_ancestors = ancestors_of(superclass) if superclass
           end
 
-          (ancestors_of(mod) - superclass_ancestors).any? { |ancestor| helper == ancestor }
+          ancestors = Set.new.compare_by_identity.merge(ancestors_of(mod)).subtract(superclass_ancestors)
+          ancestors.any? { |ancestor| helper == ancestor }
         end
       end
     end

--- a/sorbet/rbi/shims/set.rbi
+++ b/sorbet/rbi/shims/set.rbi
@@ -1,5 +1,6 @@
 # typed: strict
 
 class Set
+  sig { returns(T.self_type) }
   def compare_by_identity; end
 end

--- a/spec/tapioca/dsl/compilers/url_helpers_spec.rb
+++ b/spec/tapioca/dsl/compilers/url_helpers_spec.rb
@@ -167,6 +167,35 @@ module Tapioca
                 "GeneratedUrlHelpersModule",
               ], gathered_constants)
             end
+
+            it "gathers constants even when `hash` is overriden" do
+              add_ruby_file("bad_module.rb", <<~RUBY)
+                class Application < Rails::Application
+                end
+
+                module BadModule
+                  extend self
+
+                  def hash(a, b)
+                  end
+                end
+
+                class Bar
+                  extend BadModule
+                end
+
+                class Foo < Bar
+                  extend BadModule
+                end
+              RUBY
+
+              assert_equal([
+                "ActionDispatch::IntegrationTest",
+                "ActionView::Helpers",
+                "GeneratedPathHelpersModule",
+                "GeneratedUrlHelpersModule",
+              ], gathered_constants)
+            end
           end
 
           describe "decorate" do


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
    
When doing a difference of arrays for finding interesting ancestors, we need to be careful in case a constant has overridden `Object#hash`. Since array subtractions use `Object#hash` to determine equality, this operation will fail.

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
Instead, we need to use a Set with compare-by-identity semantics, so that `Object#hash` is never called.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->

