### PR TITLE
Check duplicates between shims and Sorbet's RBI payload

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,7 @@ check_shims:
   gem_rbi_dir: sorbet/rbi/gems
   dsl_rbi_dir: sorbet/rbi/dsl
   shim_rbi_dir: sorbet/rbi/shims
+  payload: true
 ```
 <!-- END_CONFIG_TEMPLATE -->
 

--- a/lib/tapioca/helpers/sorbet_helper.rb
+++ b/lib/tapioca/helpers/sorbet_helper.rb
@@ -21,8 +21,8 @@ module Tapioca
     SORBET_EXE_PATH_ENV_VAR = "TAPIOCA_SORBET_EXE"
 
     FEATURE_REQUIREMENTS = T.let({
-      # First tag that includes https://github.com/sorbet/sorbet/pull/4706
-      to_ary_nil_support: ::Gem::Requirement.new(">= 0.5.9220"),
+      to_ary_nil_support: ::Gem::Requirement.new(">= 0.5.9220"),    # https://github.com/sorbet/sorbet/pull/4706
+      print_payload_sources: ::Gem::Requirement.new(">= 0.5.9818"), # https://github.com/sorbet/sorbet/pull/5504
     }.freeze, T::Hash[Symbol, ::Gem::Requirement])
 
     sig { params(sorbet_args: String).returns(Spoom::ExecResult) }

--- a/sorbet/rbi/shims/bundler.rbi
+++ b/sorbet/rbi/shims/bundler.rbi
@@ -1,6 +1,0 @@
-# typed: true
-
-class Bundler::StubSpecification
-  sig { returns(T::Boolean) }
-  def default_gem?; end
-end

--- a/spec/tapioca/cli/check_shims_spec.rb
+++ b/spec/tapioca/cli/check_shims_spec.rb
@@ -6,327 +6,329 @@ require "spec_helper"
 module Tapioca
   class CleanShimsTest < SpecWithProject
     describe "cli::clean-shims" do
-      before(:all) do
-        @project.bundle_install
-      end
-
       after do
         @project.remove("sorbet/rbi")
       end
 
-      it "does nothing when there is no shims to check" do
-        @project.write("sorbet/rbi/gems/foo@1.0.0.rbi", <<~RBI)
-          class Foo
-            attr_reader :foo
-          end
-        RBI
-
-        @project.write("sorbet/rbi/dsl/foo.rbi", <<~RBI)
-          class Foo
-            attr_reader :bar
-          end
-        RBI
-
-        result = @project.tapioca("check-shims")
-
-        assert_equal(<<~OUT, result.out)
-          No shim RBIs to check
-        OUT
-
-        assert_success_status(result)
-      end
-
-      it "does nothing when there is no duplicates" do
-        @project.write("sorbet/rbi/gems/foo@1.0.0.rbi", <<~RBI)
-          class Foo
-            attr_reader :foo
-          end
-        RBI
-
-        @project.write("sorbet/rbi/shims/foo.rbi", <<~RBI)
-          class Foo
-            attr_reader :bar
-          end
-        RBI
-
-        result = @project.tapioca("check-shims")
-
-        assert_equal(<<~OUT, result.out)
-          Loading shim RBIs from sorbet/rbi/shims...  Done
-          Loading gem RBIs from sorbet/rbi/gems...  Done
-          Looking for duplicates...  Done
-
-          No duplicates found in shim RBIs
-        OUT
-
-        assert_success_status(result)
-      end
-
-      it "detects duplicated definitions between shim and generated RBIs" do
-        @project.write("sorbet/rbi/gems/foo@1.0.0.rbi", <<~RBI)
-          class Foo
-            attr_reader :foo
-          end
-        RBI
-
-        @project.write("sorbet/rbi/dsl/bar.rbi", <<~RBI)
-          module Bar
-            def bar; end
-          end
-        RBI
-
-        @project.write("sorbet/rbi/shims/foo.rbi", <<~RBI)
-          class Foo
-            attr_reader :foo
-          end
-        RBI
-
-        @project.write("sorbet/rbi/shims/bar.rbi", <<~RBI)
-          module Bar
-            def bar; end
-          end
-        RBI
-
-        result = @project.tapioca("check-shims")
-
-        assert_includes(result.err, <<~ERR)
-          Duplicated RBI for ::Bar#bar:
-           * sorbet/rbi/shims/bar.rbi:2:2-2:14
-           * sorbet/rbi/dsl/bar.rbi:2:2-2:14
-        ERR
-
-        assert_includes(result.err, <<~ERR)
-          Duplicated RBI for ::Foo#foo:
-           * sorbet/rbi/shims/foo.rbi:2:2-2:18
-           * sorbet/rbi/gems/foo@1.0.0.rbi:2:2-2:18
-        ERR
-
-        assert_includes(result.err, <<~ERR)
-          Please remove the duplicated definitions from the sorbet/rbi/shims directory.
-        ERR
-
-        refute_success_status(result)
-      end
-
-      it "ignores duplicates that have a signature" do
-        @project.write("sorbet/rbi/gems/foo@1.0.0.rbi", <<~RBI)
-          class Foo
-            def foo; end
-          end
-        RBI
-
-        @project.write("sorbet/rbi/shims/foo.rbi", <<~RBI)
-          class Foo
-            sig { void }
-            def foo; end
-          end
-        RBI
-
-        result = @project.tapioca("check-shims")
-        assert_success_status(result)
-      end
-
-      it "ignores duplicates that have a different signature" do
-        @project.write("sorbet/rbi/gems/foo@1.0.0.rbi", <<~RBI)
-          class Foo
-            sig { void }
-            def foo; end
-          end
-        RBI
-
-        @project.write("sorbet/rbi/shims/foo.rbi", <<~RBI)
-          class Foo
-            sig { returns(Integer) }
-            def foo; end
-          end
-        RBI
-
-        result = @project.tapioca("check-shims")
-        assert_success_status(result)
-      end
-
-      it "detects duplicates that have the same signature" do
-        @project.write("sorbet/rbi/gems/foo@1.0.0.rbi", <<~RBI)
-          class Foo
-            sig { params(x: Integer, y: String).returns(String) }
-            def foo(x, y); end
-
-            sig { params(x: Integer, y: Integer).returns(String) }
-            def bar(x, y); end
-
-            sig { params(x: Integer, y: Integer).returns(Integer) }
-            def baz(x, y); end
-          end
-        RBI
-
-        @project.write("sorbet/rbi/shims/foo.rbi", <<~RBI)
-          class Foo
-            sig { params(x: Integer, y: String).returns(String) }
-            def foo(x, y); end
-
-            sig { params(x: String, y: Integer).returns(String) }
-            def bar(x, y); end
-
-            sig { params(x: Integer, y: Integer).returns(String) }
-            def baz(x, y); end
-          end
-        RBI
-
-        result = @project.tapioca("check-shims")
-
-        assert_includes(result.err, <<~ERR)
-          Duplicated RBI for ::Foo#foo:
-           * sorbet/rbi/shims/foo.rbi:3:2-3:20
-           * sorbet/rbi/gems/foo@1.0.0.rbi:3:2-3:20
-        ERR
-
-        assert_includes(result.err, <<~ERR)
-          Please remove the duplicated definitions from the sorbet/rbi/shims directory.
-        ERR
-
-        refute_includes(result.err, "Duplicated RBI for ::Foo#bar")
-        refute_includes(result.err, "Duplicated RBI for ::Foo#baz")
-
-        refute_success_status(result)
-      end
-
-      it "detects duplicates from nodes with multiple definitions" do
-        @project.write("sorbet/rbi/gems/foo@1.0.0.rbi", <<~RBI)
-          class Foo
-            attr_reader :foo
-          end
-        RBI
-
-        @project.write("sorbet/rbi/shims/foo.rbi", <<~RBI)
-          class Foo
-            attr_reader :foo, :bar
-          end
-        RBI
-
-        result = @project.tapioca("check-shims")
-
-        assert_includes(result.err, <<~ERR)
-          Duplicated RBI for ::Foo#foo:
-           * sorbet/rbi/shims/foo.rbi:2:2-2:24
-           * sorbet/rbi/gems/foo@1.0.0.rbi:2:2-2:18
-        ERR
-
-        assert_includes(result.err, <<~ERR)
-          Please remove the duplicated definitions from the sorbet/rbi/shims directory.
-        ERR
-
-        refute_success_status(result)
-      end
-
-      it "detects duplicates from the same shim file" do
-        @project.write("sorbet/rbi/gems/foo@1.0.0.rbi", <<~RBI)
-          class Foo
-            attr_reader :foo
-          end
-        RBI
-
-        @project.write("sorbet/rbi/shims/foo.rbi", <<~RBI)
-          class Foo
-            attr_reader :foo, :bar
-            def foo; end
-          end
-        RBI
-
-        result = @project.tapioca("check-shims")
-
-        assert_includes(result.err, <<~ERR)
-          Duplicated RBI for ::Foo#foo:
-           * sorbet/rbi/shims/foo.rbi:2:2-2:24
-           * sorbet/rbi/shims/foo.rbi:3:2-3:14
-           * sorbet/rbi/gems/foo@1.0.0.rbi:2:2-2:18
-        ERR
-
-        assert_includes(result.err, <<~ERR)
-          Please remove the duplicated definitions from the sorbet/rbi/shims directory.
-        ERR
-
-        refute_success_status(result)
-      end
-
-      it "checks shims with custom rbi dirs" do
-        @project.write("rbi/gem/foo@1.0.0.rbi", <<~RBI)
-          class Foo
-            def foo; end
-          end
-        RBI
-
-        @project.write("rbi/dsl/foo.rbi", <<~RBI)
-          class Foo
-            def bar; end
-          end
-        RBI
-
-        @project.write("rbi/shim/foo.rbi", <<~RBI)
-          class Foo
-            def foo; end
-            def bar; end
-          end
-        RBI
-
-        result = @project.tapioca(
-          "check-shims --gem-rbi-dir=rbi/gem --dsl-rbi-dir=rbi/dsl --shim-rbi-dir=rbi/shim"
-        )
-
-        assert_includes(result.err, <<~ERR)
-          Duplicated RBI for ::Foo#bar:
-           * rbi/shim/foo.rbi:3:2-3:14
-           * rbi/dsl/foo.rbi:2:2-2:14
-        ERR
-
-        assert_includes(result.err, <<~ERR)
-          Duplicated RBI for ::Foo#foo:
-           * rbi/shim/foo.rbi:2:2-2:14
-           * rbi/gem/foo@1.0.0.rbi:2:2-2:14
-        ERR
-
-        assert_includes(result.err, <<~ERR)
-          Please remove the duplicated definitions from the rbi/shim directory.
-        ERR
-
-        refute_success_status(result)
-      end
-
-      it "skips files with parse errors" do
-        @project.write("sorbet/rbi/gems/foo@1.0.0.rbi", <<~RBI)
-          class Foo
-            attr_reader :foo
-          end
-        RBI
-
-        @project.write("sorbet/rbi/shims/foo.rbi", <<~RBI)
-          class Foo
-            foo { bar }
-          end
-        RBI
-
-        @project.write("sorbet/rbi/shims/bar.rbi", <<~RBI)
-          module Foo
-            def foo; end
-          end
-        RBI
-
-        result = @project.tapioca("check-shims")
-
-        assert_includes(result.err, <<~ERR)
-          Warning: Unsupported block node type `foo` (sorbet/rbi/shims/foo.rbi:2:2-2:13)
-        ERR
-
-        assert_includes(result.err, <<~ERR)
-          Duplicated RBI for ::Foo#foo:
-           * sorbet/rbi/shims/bar.rbi:2:2-2:14
-           * sorbet/rbi/gems/foo@1.0.0.rbi:2:2-2:18
-        ERR
-
-        assert_includes(result.err, <<~ERR)
-          Please remove the duplicated definitions from the sorbet/rbi/shims directory.
-        ERR
-
-        refute_success_status(result)
+      describe "when Sorbet version is >= 0.5.9818" do
+        before(:all) do
+          @project.bundle_install
+        end
+
+        it "does nothing when there is no shims to check" do
+          @project.write("sorbet/rbi/gems/foo@1.0.0.rbi", <<~RBI)
+            class Foo
+              attr_reader :foo
+            end
+          RBI
+
+          @project.write("sorbet/rbi/dsl/foo.rbi", <<~RBI)
+            class Foo
+              attr_reader :bar
+            end
+          RBI
+
+          result = @project.tapioca("check-shims")
+
+          assert_equal(<<~OUT, result.out)
+            No shim RBIs to check
+          OUT
+
+          assert_success_status(result)
+        end
+
+        it "does nothing when there is no duplicates" do
+          @project.write("sorbet/rbi/gems/foo@1.0.0.rbi", <<~RBI)
+            class Foo
+              attr_reader :foo
+            end
+          RBI
+
+          @project.write("sorbet/rbi/shims/foo.rbi", <<~RBI)
+            class Foo
+              attr_reader :bar
+            end
+          RBI
+
+          result = @project.tapioca("check-shims")
+
+          assert_equal(<<~OUT, result.out)
+            Loading shim RBIs from sorbet/rbi/shims...  Done
+            Loading gem RBIs from sorbet/rbi/gems...  Done
+            Looking for duplicates...  Done
+
+            No duplicates found in shim RBIs
+          OUT
+
+          assert_success_status(result)
+        end
+
+        it "detects duplicated definitions between shim and generated RBIs" do
+          @project.write("sorbet/rbi/gems/foo@1.0.0.rbi", <<~RBI)
+            class Foo
+              attr_reader :foo
+            end
+          RBI
+
+          @project.write("sorbet/rbi/dsl/bar.rbi", <<~RBI)
+            module Bar
+              def bar; end
+            end
+          RBI
+
+          @project.write("sorbet/rbi/shims/foo.rbi", <<~RBI)
+            class Foo
+              attr_reader :foo
+            end
+          RBI
+
+          @project.write("sorbet/rbi/shims/bar.rbi", <<~RBI)
+            module Bar
+              def bar; end
+            end
+          RBI
+
+          result = @project.tapioca("check-shims")
+
+          assert_includes(result.err, <<~ERR)
+            Duplicated RBI for ::Bar#bar:
+             * sorbet/rbi/shims/bar.rbi:2:2-2:14
+             * sorbet/rbi/dsl/bar.rbi:2:2-2:14
+          ERR
+
+          assert_includes(result.err, <<~ERR)
+            Duplicated RBI for ::Foo#foo:
+             * sorbet/rbi/shims/foo.rbi:2:2-2:18
+             * sorbet/rbi/gems/foo@1.0.0.rbi:2:2-2:18
+          ERR
+
+          assert_includes(result.err, <<~ERR)
+            Please remove the duplicated definitions from the sorbet/rbi/shims directory.
+          ERR
+
+          refute_success_status(result)
+        end
+
+        it "ignores duplicates that have a signature" do
+          @project.write("sorbet/rbi/gems/foo@1.0.0.rbi", <<~RBI)
+            class Foo
+              def foo; end
+            end
+          RBI
+
+          @project.write("sorbet/rbi/shims/foo.rbi", <<~RBI)
+            class Foo
+              sig { void }
+              def foo; end
+            end
+          RBI
+
+          result = @project.tapioca("check-shims")
+          assert_success_status(result)
+        end
+
+        it "ignores duplicates that have a different signature" do
+          @project.write("sorbet/rbi/gems/foo@1.0.0.rbi", <<~RBI)
+            class Foo
+              sig { void }
+              def foo; end
+            end
+          RBI
+
+          @project.write("sorbet/rbi/shims/foo.rbi", <<~RBI)
+            class Foo
+              sig { returns(Integer) }
+              def foo; end
+            end
+          RBI
+
+          result = @project.tapioca("check-shims")
+          assert_success_status(result)
+        end
+
+        it "detects duplicates that have the same signature" do
+          @project.write("sorbet/rbi/gems/foo@1.0.0.rbi", <<~RBI)
+            class Foo
+              sig { params(x: Integer, y: String).returns(String) }
+              def foo(x, y); end
+
+              sig { params(x: Integer, y: Integer).returns(String) }
+              def bar(x, y); end
+
+              sig { params(x: Integer, y: Integer).returns(Integer) }
+              def baz(x, y); end
+            end
+          RBI
+
+          @project.write("sorbet/rbi/shims/foo.rbi", <<~RBI)
+            class Foo
+              sig { params(x: Integer, y: String).returns(String) }
+              def foo(x, y); end
+
+              sig { params(x: String, y: Integer).returns(String) }
+              def bar(x, y); end
+
+              sig { params(x: Integer, y: Integer).returns(String) }
+              def baz(x, y); end
+            end
+          RBI
+
+          result = @project.tapioca("check-shims")
+
+          assert_includes(result.err, <<~ERR)
+            Duplicated RBI for ::Foo#foo:
+             * sorbet/rbi/shims/foo.rbi:3:2-3:20
+             * sorbet/rbi/gems/foo@1.0.0.rbi:3:2-3:20
+          ERR
+
+          assert_includes(result.err, <<~ERR)
+            Please remove the duplicated definitions from the sorbet/rbi/shims directory.
+          ERR
+
+          refute_includes(result.err, "Duplicated RBI for ::Foo#bar")
+          refute_includes(result.err, "Duplicated RBI for ::Foo#baz")
+
+          refute_success_status(result)
+        end
+
+        it "detects duplicates from nodes with multiple definitions" do
+          @project.write("sorbet/rbi/gems/foo@1.0.0.rbi", <<~RBI)
+            class Foo
+              attr_reader :foo
+            end
+          RBI
+
+          @project.write("sorbet/rbi/shims/foo.rbi", <<~RBI)
+            class Foo
+              attr_reader :foo, :bar
+            end
+          RBI
+
+          result = @project.tapioca("check-shims")
+
+          assert_includes(result.err, <<~ERR)
+            Duplicated RBI for ::Foo#foo:
+             * sorbet/rbi/shims/foo.rbi:2:2-2:24
+             * sorbet/rbi/gems/foo@1.0.0.rbi:2:2-2:18
+          ERR
+
+          assert_includes(result.err, <<~ERR)
+            Please remove the duplicated definitions from the sorbet/rbi/shims directory.
+          ERR
+
+          refute_success_status(result)
+        end
+
+        it "detects duplicates from the same shim file" do
+          @project.write("sorbet/rbi/gems/foo@1.0.0.rbi", <<~RBI)
+            class Foo
+              attr_reader :foo
+            end
+          RBI
+
+          @project.write("sorbet/rbi/shims/foo.rbi", <<~RBI)
+            class Foo
+              attr_reader :foo, :bar
+              def foo; end
+            end
+          RBI
+
+          result = @project.tapioca("check-shims")
+
+          assert_includes(result.err, <<~ERR)
+            Duplicated RBI for ::Foo#foo:
+             * sorbet/rbi/shims/foo.rbi:2:2-2:24
+             * sorbet/rbi/shims/foo.rbi:3:2-3:14
+             * sorbet/rbi/gems/foo@1.0.0.rbi:2:2-2:18
+          ERR
+
+          assert_includes(result.err, <<~ERR)
+            Please remove the duplicated definitions from the sorbet/rbi/shims directory.
+          ERR
+
+          refute_success_status(result)
+        end
+
+        it "checks shims with custom rbi dirs" do
+          @project.write("rbi/gem/foo@1.0.0.rbi", <<~RBI)
+            class Foo
+              def foo; end
+            end
+          RBI
+
+          @project.write("rbi/dsl/foo.rbi", <<~RBI)
+            class Foo
+              def bar; end
+            end
+          RBI
+
+          @project.write("rbi/shim/foo.rbi", <<~RBI)
+            class Foo
+              def foo; end
+              def bar; end
+            end
+          RBI
+
+          result = @project.tapioca(
+            "check-shims --gem-rbi-dir=rbi/gem --dsl-rbi-dir=rbi/dsl --shim-rbi-dir=rbi/shim"
+          )
+
+          assert_includes(result.err, <<~ERR)
+            Duplicated RBI for ::Foo#bar:
+             * rbi/shim/foo.rbi:3:2-3:14
+             * rbi/dsl/foo.rbi:2:2-2:14
+          ERR
+
+          assert_includes(result.err, <<~ERR)
+            Duplicated RBI for ::Foo#foo:
+             * rbi/shim/foo.rbi:2:2-2:14
+             * rbi/gem/foo@1.0.0.rbi:2:2-2:14
+          ERR
+
+          assert_includes(result.err, <<~ERR)
+            Please remove the duplicated definitions from the rbi/shim directory.
+          ERR
+
+          refute_success_status(result)
+        end
+
+        it "skips files with parse errors" do
+          @project.write("sorbet/rbi/gems/foo@1.0.0.rbi", <<~RBI)
+            class Foo
+              attr_reader :foo
+            end
+          RBI
+
+          @project.write("sorbet/rbi/shims/foo.rbi", <<~RBI)
+            class Foo
+              foo { bar }
+            end
+          RBI
+
+          @project.write("sorbet/rbi/shims/bar.rbi", <<~RBI)
+            module Foo
+              def foo; end
+            end
+          RBI
+
+          result = @project.tapioca("check-shims")
+
+          assert_includes(result.err, <<~ERR)
+            Warning: Unsupported block node type `foo` (sorbet/rbi/shims/foo.rbi:2:2-2:13)
+          ERR
+
+          assert_includes(result.err, <<~ERR)
+            Duplicated RBI for ::Foo#foo:
+             * sorbet/rbi/shims/bar.rbi:2:2-2:14
+             * sorbet/rbi/gems/foo@1.0.0.rbi:2:2-2:18
+          ERR
+
+          assert_includes(result.err, <<~ERR)
+            Please remove the duplicated definitions from the sorbet/rbi/shims directory.
+          ERR
+
+          refute_success_status(result)
+        end
       end
     end
   end

--- a/spec/tapioca/cli/check_shims_spec.rb
+++ b/spec/tapioca/cli/check_shims_spec.rb
@@ -28,7 +28,7 @@ module Tapioca
             end
           RBI
 
-          result = @project.tapioca("check-shims")
+          result = @project.tapioca("check-shims --no-payload")
 
           assert_equal(<<~OUT, result.out)
             No shim RBIs to check
@@ -50,7 +50,7 @@ module Tapioca
             end
           RBI
 
-          result = @project.tapioca("check-shims")
+          result = @project.tapioca("check-shims --no-payload")
 
           assert_equal(<<~OUT, result.out)
             Loading shim RBIs from sorbet/rbi/shims...  Done
@@ -88,7 +88,7 @@ module Tapioca
             end
           RBI
 
-          result = @project.tapioca("check-shims")
+          result = @project.tapioca("check-shims --no-payload")
 
           assert_includes(result.err, <<~ERR)
             Duplicated RBI for ::Bar#bar:
@@ -123,7 +123,7 @@ module Tapioca
             end
           RBI
 
-          result = @project.tapioca("check-shims")
+          result = @project.tapioca("check-shims --no-payload")
           assert_success_status(result)
         end
 
@@ -142,7 +142,7 @@ module Tapioca
             end
           RBI
 
-          result = @project.tapioca("check-shims")
+          result = @project.tapioca("check-shims --no-payload")
           assert_success_status(result)
         end
 
@@ -173,7 +173,7 @@ module Tapioca
             end
           RBI
 
-          result = @project.tapioca("check-shims")
+          result = @project.tapioca("check-shims --no-payload")
 
           assert_includes(result.err, <<~ERR)
             Duplicated RBI for ::Foo#foo:
@@ -204,7 +204,7 @@ module Tapioca
             end
           RBI
 
-          result = @project.tapioca("check-shims")
+          result = @project.tapioca("check-shims --no-payload")
 
           assert_includes(result.err, <<~ERR)
             Duplicated RBI for ::Foo#foo:
@@ -233,7 +233,7 @@ module Tapioca
             end
           RBI
 
-          result = @project.tapioca("check-shims")
+          result = @project.tapioca("check-shims --no-payload")
 
           assert_includes(result.err, <<~ERR)
             Duplicated RBI for ::Foo#foo:
@@ -314,7 +314,7 @@ module Tapioca
           RBI
 
           result = @project.tapioca(
-            "check-shims --gem-rbi-dir=rbi/gem --dsl-rbi-dir=rbi/dsl --shim-rbi-dir=rbi/shim"
+            "check-shims --gem-rbi-dir=rbi/gem --dsl-rbi-dir=rbi/dsl --shim-rbi-dir=rbi/shim --no-payload"
           )
 
           assert_includes(result.err, <<~ERR)
@@ -355,7 +355,7 @@ module Tapioca
             end
           RBI
 
-          result = @project.tapioca("check-shims")
+          result = @project.tapioca("check-shims --no-payload")
 
           assert_includes(result.err, <<~ERR)
             Warning: Unsupported block node type `foo` (sorbet/rbi/shims/foo.rbi:2:2-2:13)


### PR DESCRIPTION
### Motivation

Check duplicates between shims files and Sorbet's payload.

It's frequent that we locally fix Sorbet's payload in our shims waiting for the same patch to be merged upstream. The problem is that after a while we forget the local fixes and they stay there for ever. This can even become dangerous when the definition in the payload is later updated and we keep the shadowing local definition.

This PR introduces a way to check for duplicates between the local shims and Sorbet's payload.

### Implementation

This feature uses Sorbet's `--print=payload_sources` to dump the RBIs from its payload so we can index them in the same way we do for gems RBIs and DSL RBIs.

I gated the feature behind a specific Sorbet version like we did for `to_ary_nil_support`.

### Tests

See automated tests.