### PR TITLE
Set type of polymorphic CollectionProxy to T.untyped

### DIFF
--- a/lib/tapioca/dsl/compilers/active_record_associations.rb
+++ b/lib/tapioca/dsl/compilers/active_record_associations.rb
@@ -327,14 +327,10 @@ module Tapioca
           relations_enabled = compiler_enabled?("ActiveRecordRelations")
           polymorphic_association = !constant.table_exists? || polymorphic_association?(reflection)
 
-          if relations_enabled
-            if polymorphic_association
-              "ActiveRecord::Associations::CollectionProxy"
-            else
-              "#{qualified_name_of(reflection.klass)}::#{AssociationsCollectionProxyClassName}"
-            end
-          elsif polymorphic_association
+          if polymorphic_association
             "ActiveRecord::Associations::CollectionProxy[T.untyped]"
+          elsif relations_enabled
+            "#{qualified_name_of(reflection.klass)}::#{AssociationsCollectionProxyClassName}"
           else
             "::ActiveRecord::Associations::CollectionProxy[#{qualified_name_of(reflection.klass)}]"
           end

--- a/spec/tapioca/dsl/compilers/active_record_associations_spec.rb
+++ b/spec/tapioca/dsl/compilers/active_record_associations_spec.rb
@@ -225,7 +225,7 @@ module Tapioca
                         sig { params(ids: T::Array[T.untyped]).returns(T::Array[T.untyped]) }
                         def picture_ids=(ids); end
 
-                        sig { returns(ActiveRecord::Associations::CollectionProxy) }
+                        sig { returns(ActiveRecord::Associations::CollectionProxy[T.untyped]) }
                         def pictures; end
 
                         sig { params(value: T::Enumerable[T.untyped]).void }


### PR DESCRIPTION
### Motivation

CollectionProxy doesn't allow bare uses, which is a problem for gems like ActionText. Using a bare CollectionProxy results in:

> Malformed type declaration. Generic class without type arguments

This means that as soon as you enable ActionText, whether you're using it or not, you're unable to have `srb tc` pass.

<details>
<summary>Example of <code>ActionText::RichText</code> failing</summary>

```
sorbet/rbi/dsl/action_text/rich_text.rbi:245: Malformed type declaration. Generic class without type arguments ActiveRecord::Associations::CollectionProxy https://srb.help/5045
     245 |    sig { returns(ActiveRecord::Associations::CollectionProxy) }                                                                          
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
sorbet/rbi/dsl/action_text/rich_text.rbi:257: Malformed type declaration. Generic class without type arguments ActiveRecord::Associations::CollectionProxy https://srb.help/5045                                                                        
     257 |    sig { returns(ActiveRecord::Associations::CollectionProxy) }
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

</details>

### Implementation

By explicitly stating `T.untyped`, we no longer see this issue. Since a bare collection would implicitly mean `T.untyped`, this seems okay!

### Tests

I changed existing tests to reflect the new behavior.
