### PR TITLE
More effectively determine method ownership for RBI generation

### DIFF
--- a/spec/tapioca/gem/pipeline_spec.rb
+++ b/spec/tapioca/gem/pipeline_spec.rb
@@ -1210,6 +1210,64 @@ class Tapioca::Gem::PipelineSpec < Minitest::HooksSpec
       assert_equal(output, compile)
     end
 
+    it "compiles method that is also prepended" do
+      add_ruby_file("foo.rb", <<~RUBY)
+        module Foo
+          def bar
+            super
+          end
+        end
+
+        class Baz
+          prepend Foo
+
+          def bar; end
+        end
+      RUBY
+
+      output = template(<<~RBI)
+        class Baz
+          include ::Foo
+
+          def bar; end
+        end
+
+        module Foo
+          def bar; end
+        end
+      RBI
+
+      assert_equal(output, compile)
+    end
+
+    it "compiles a method that is prepended without calling super" do
+      add_ruby_file("foo.rb", <<~RUBY)
+        module Foo
+          def bar; end
+        end
+
+        class Baz
+          prepend Foo
+
+          def bar; end
+        end
+      RUBY
+
+      output = template(<<~RBI)
+        class Baz
+          include ::Foo
+
+          def bar; end
+        end
+
+        module Foo
+          def bar; end
+        end
+      RBI
+
+      assert_equal(output, compile)
+    end
+
     it "ignores methods on other objects" do
       add_ruby_file("bar.rb", <<~RUBY)
         class Bar


### PR DESCRIPTION
### Motivation
This issue was discovered by @paracycle while investigating #890, but it is technically unrelated to mixin generation.

While generating RBIs for a method, tapioca implements a check to determine which constant "owns" or defines that method. We only want to generate RBIs for a method on the module or class that defines it, not any that just happen to inherit it.

Historically, we have been checking the `method.owner` and verifying that it matches the class/module for which we are generating RBIs. However, this check misses one particular case: when a method is also defined on a prepended module, it will always appear as if it belongs to the prepended module, even when it is also defined on the class that prepends the module.

This means that tapioca will not generate RBI for that method on the class that defines it.

### Implementation
This code was originally written by @paracycle on commit 80faabc8ace1af686589278c80ff24a5069e7748. I've just cleaned it up and moved it to the correct spot.

Instead of just checking the method owner, this implementation walks up the ancestor chain via the `super_method` method, checking if any of the super methods are owned by the constant. If that is the case, that means the constant also defines the method, and we should generate RBIs for this method on the constant.

### Tests
I have added a test which fails without the changes but passes with the changes included.

### Tophatting
I tested this change by generating gem and dsl RBIs on Shopify core using this branch of tapioca and verifying that the change did not introduce any new typing issues.