### PR TITLE
Validate config values for arrays and hashes

### DIFF
--- a/lib/tapioca/helpers/config_helper.rb
+++ b/lib/tapioca/helpers/config_helper.rb
@@ -126,6 +126,18 @@ module Tapioca
         error_msg = "invalid value for option `#{config_option_key}` for key `#{config_key}` - expected " \
           "`#{command_option.type.capitalize}` but found #{config_option_value_type.capitalize}"
         next build_error(error_msg) unless config_option_value_type == command_option.type
+
+        case config_option_value_type
+        when :array
+          error_msg = "invalid value for option `#{config_option_key}` for key `#{config_key}` - expected " \
+            "`Array[String]` but found `#{config_option_value}`"
+          next build_error(error_msg) unless config_option_value.all? { |v| v.is_a?(String) }
+        when :hash
+          error_msg = "invalid value for option `#{config_option_key}` for key `#{config_key}` - expected " \
+            "`Hash[String, String]` but found `#{config_option_value}`"
+          all_strings = (config_option_value.keys + config_option_value.values).all? { |v| v.is_a?(String) }
+          next build_error(error_msg) unless all_strings
+        end
       end.compact
     end
 

--- a/spec/tapioca/cli/config_spec.rb
+++ b/spec/tapioca/cli/config_spec.rb
@@ -93,6 +93,33 @@ module Tapioca
         refute_success_status(result)
       end
 
+      it "validates invalid configuration option values inside arrays and hashes" do
+        @project.write("sorbet/tapioca/config.yml", <<~YAML)
+          dsl:
+            only: [1, false]
+            exclude: [1, false]
+          gem:
+            exclude: [1, false]
+            typed_overrides:
+              msgpack: false
+        YAML
+
+        result = @project.tapioca("gem")
+
+        assert_equal(<<~ERR, result.err)
+
+          Configuration file sorbet/tapioca/config.yml has the following errors:
+
+          - invalid value for option only for key dsl - expected Array[String] but found [1, false]
+          - invalid value for option exclude for key dsl - expected Array[String] but found [1, false]
+          - invalid value for option exclude for key gem - expected Array[String] but found [1, false]
+          - invalid value for option typed_overrides for key gem - expected Hash[String, String] but found {\"msgpack\"=>false}
+        ERR
+
+        assert_empty_stdout(result)
+        refute_success_status(result)
+      end
+
       it "validates unknown configuration keys, options, and invalid values" do
         @project.write("sorbet/tapioca/config.yml", <<~YAML)
           gem:


### PR DESCRIPTION
### Motivation

Since we write Tapioca config as a YAML file, it's easy to make type errors that will result in unexpected behaviors.

For example, even if this config file looks ok, the `msgpack` gem will _not_ be turned `typed: false`:

```yaml
gem:
  typed_overrides:
    msgpack: false
```

Because we expect the values inside the `typed_overrides` hash to be strings rather than booleans.

This actually happened today to one of our users: https://github.com/Shopify/tapioca/issues/895#issuecomment-1097257106. Having an error message earlier would have saved both of us some time and confusion.

### Implementation

The solution choose here seems a bit hack-ish but we can't rely on Thor expected types for the content of `:array` and `:hash` options:

Once we validated all others criteria for options keys and values we add an additional check for arrays and hashes to make sure the values (and keys in the case of a hash) are all of the type `String`.

Even if rather limited, this works in practice because the only arrays and hashes we take in the config always expect string (iirc?). 

I guess we can revisit this later if we add different options but I'm open to better suggestions.

### Tests

See automated tests.

