### PR TITLE
Add descriptive message for unexpected DSL exceptions

### DIFF
--- a/lib/tapioca/dsl/pipeline.rb
+++ b/lib/tapioca/dsl/pipeline.rb
@@ -152,6 +152,9 @@ module Tapioca
 
           compiler = compiler_class.new(self, file.root, constant)
           compiler.decorate
+        rescue
+          $stderr.puts("Error: `#{compiler_class.name}` failed to generate RBI for `#{constant}`")
+          raise # This is an unexpected error, so re-raise it
         end
 
         return if file.root.empty?


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
Currently, when a DSL compiler raises an error while running a `decorate` operation, it is not very obvious which compiler failed and during the processing of which constant. The failing DSL compiler is kind of obvious if one looks at the backtrace, but the constant that it is failing on is very hard to understand if one is not running DSL generation in verbose mode.

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
This PR handles unexpected exceptions, shows a friendly error message for them and re-raises the exception to keep the current behaviour.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->
Added a test with a failing DSL compiler.
