### PR TITLE
Add help command input in README snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ This will create the `sorbet/config` and `sorbet/tapioca/require.rb` files for y
 
 <!-- START_HELP_COMMAND_INIT -->
 ```shell
+$ tapioca help init
+
 Usage:
   tapioca init
 
@@ -102,6 +104,8 @@ This will generate RBIs for the specified gems and place them in the RBI directo
 
 <!-- START_HELP_COMMAND_GEM -->
 ```shell
+$ tapioca help gem
+
 Usage:
   tapioca gem [gem...]
 
@@ -145,6 +149,8 @@ This will generate the file `sorbet/rbi/todo.rbi` defining all unresolved consta
 
 <!-- START_HELP_COMMAND_TODO -->
 ```shell
+$ tapioca help todo
+
 Usage:
   tapioca todo
 
@@ -169,6 +175,8 @@ This will generate DSL RBIs for specified constants (or for all handled constant
 
 <!-- START_HELP_COMMAND_DSL -->
 ```shell
+$ tapioca help dsl
+
 Usage:
   tapioca dsl [constant...]
 

--- a/tasks/readme.rake
+++ b/tasks/readme.rake
@@ -106,6 +106,8 @@ task :readme do
 
       contents = replace_section(contents, section, <<~MARKDOWN)
         ```shell
+        $ #{$PROGRAM_NAME} help #{command_name}
+
         #{shell.contents.chomp}
         ```
       MARKDOWN


### PR DESCRIPTION
### Motivation

Make it obvious where this content is coming from so users can run the commands themselves.

I, for one, am always fighting with Thor:

* `tapioca gem --help`, urgh wrong...
* `tapioca gem help`, damn it!
* `tapioca help gem` ah.

