### PR TITLE
Enable documentation generation by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ Options:
                                                               # Default: {"activesupport"=>"false"}
           [--verify], [--no-verify]                           # Verify RBIs are up-to-date
           [--doc], [--no-doc]                                 # Include YARD documentation from sources when generating RBIs. Warning: this might be slow
+                                                              # Default: true
           [--exported-gem-rbis], [--no-exported-gem-rbis]     # Include RBIs found in the `rbi/` directory of the gem
                                                               # Default: true
   -w, [--workers=N]                                           # EXPERIMENTAL: Number of parallel workers to use when generating RBIs
@@ -247,7 +248,7 @@ gem:
   typed_overrides:
     activesupport: 'false'
   verify: false
-  doc: false
+  doc: true
   exported_gem_rbis: true
   workers: 1
   auto_strictness: true

--- a/lib/tapioca/cli.rb
+++ b/lib/tapioca/cli.rb
@@ -172,7 +172,7 @@ module Tapioca
     option :doc,
       type: :boolean,
       desc: "Include YARD documentation from sources when generating RBIs. Warning: this might be slow",
-      default: false
+      default: true
     option :exported_gem_rbis,
       type: :boolean,
       desc: "Include RBIs found in the `rbi/` directory of the gem",

--- a/sorbet/tapioca/config.yml
+++ b/sorbet/tapioca/config.yml
@@ -1,7 +1,6 @@
 ---
 gem:
   exclude: []
-  doc: true
   typed_overrides:
     "net-protocol": "false"
     "net-smtp": "false"


### PR DESCRIPTION
### Motivation

* This feature makes the whole VS Code experience so much better
* It's been battle tested for quite a long now and works well
* It's slow only for a very limited number of gems, let's have people disable it if needed instead

### Implementation

`!false`

### Tests

See automated tests.

