### PR TITLE
Explicitly load descendants patch in ActiveSupport

### DIFF
--- a/lib/tapioca/runtime/loader.rb
+++ b/lib/tapioca/runtime/loader.rb
@@ -52,6 +52,8 @@ module Tapioca
       def rails_engines
         return [] unless Object.const_defined?("Rails::Engine")
 
+        safe_require("active_support/core_ext/class/subclasses")
+
         # We can use `Class#descendants` here, since we know Rails is loaded
         Object.const_get("Rails::Engine").descendants.reject(&:abstract_railtie?)
       end


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
Resolves https://github.com/Shopify/tapioca/issues/517

We utilize `Class#descendants` in tapioca. As reported in the above issue in Rails versions prior to `v6.1.0`, upon loading of a `Rails::Engine` the `Class` [redefinition](https://github.com/rails/rails/blob/v6.0.4.8/activesupport/lib/active_support/core_ext/class/subclasses.rb#L21-L28) that defines `descendants` isn't loaded.

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
Explicitly load the file using our internal `safe_require` method.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->
I tested it manually. Automated testing is likely not worth the effort in comparison to the change.
