### PR TITLE
Bump version on main to latest

### DIFF
--- a/lib/tapioca/version.rb
+++ b/lib/tapioca/version.rb
@@ -2,5 +2,5 @@
 # frozen_string_literal: true
 
 module Tapioca
-  VERSION = "0.7.0"
+  VERSION = "0.7.2"
 end


### PR DESCRIPTION
### Motivation

Want to try out "main" but shopify-types already specifies later version.