### PR TITLE
Add support for :oneof fields on protobuf messages

### DIFF
--- a/lib/tapioca/dsl/compilers/protobuf.rb
+++ b/lib/tapioca/dsl/compilers/protobuf.rb
@@ -83,6 +83,7 @@ module Tapioca
               create_type_members(klass, "Key", "Value")
             else
               descriptor = T.let(T.unsafe(constant).descriptor, Google::Protobuf::Descriptor)
+              descriptor.each_oneof { |oneof| create_oneof_method(klass, oneof) }
               fields = descriptor.map { |desc| create_descriptor_method(klass, desc) }
               fields.sort_by!(&:name)
 
@@ -215,6 +216,19 @@ module Tapioca
           )
 
           field
+        end
+
+        sig do
+          params(
+            klass: RBI::Scope,
+            desc: Google::Protobuf::OneofDescriptor
+          ).void
+        end
+        def create_oneof_method(klass, desc)
+          klass.create_method(
+            desc.name,
+            return_type: "T.nilable(Symbol)"
+          )
         end
       end
     end

--- a/spec/tapioca/dsl/compilers/protobuf_spec.rb
+++ b/spec/tapioca/dsl/compilers/protobuf_spec.rb
@@ -411,6 +411,30 @@ module Tapioca
 
               assert_equal(expected, rbi_for(:Cart))
             end
+
+            it "generates methods in RBI files with oneof fields" do
+              add_ruby_file("protobuf.rb", <<~RUBY)
+                Google::Protobuf::DescriptorPool.generated_pool.build do
+                  add_file("cart.proto", :syntax => :proto3) do
+                    add_message "MyCart" do
+                      oneof :contact_info do
+                        optional :phone_number, :int32, 1
+                        optional :email, :string, 2
+                      end
+                    end
+                  end
+                end
+
+                Cart = Google::Protobuf::DescriptorPool.generated_pool.lookup("MyCart").msgclass
+              RUBY
+
+              rbi_output = rbi_for(:Cart)
+
+              assert_includes(rbi_output, indented(<<~RBI, 2))
+                sig { returns(T.nilable(Symbol)) }
+                def contact_info; end
+              RBI
+            end
           end
         end
       end


### PR DESCRIPTION
### Motivation
Google Protobuf messages support `oneof` field types:

```
add_message "MyCart" do
  oneof :contact_info do
    optional :phone_number, :int32, 1
    optional :email, :string, 2
  end
end
```

`MyCart` will have a `#contact_info` method that returns the name of the optional that has been used (or nil).

This PR adds a method definition to RBIs for messages with `oneof` fields.

### Implementation
`Descriptor` provides an `each_oneof` method. I iterate over the `oneof` descriptors and create an RBI method for each.

### Tests
👍 
