### PR TITLE
Always run tests with `--no-doc` unless specified otherwise

### DIFF
--- a/spec/helpers/mock_project.rb
+++ b/spec/helpers/mock_project.rb
@@ -113,7 +113,10 @@ module Tapioca
     sig { params(command: String).returns(ExecResult) }
     def tapioca(command)
       exec_command = ["tapioca", command]
-      exec_command << "--workers=1" if command.start_with?(/gem/) && !command.match?("--workers")
+      if command.start_with?(/gem/)
+        exec_command << "--workers=1" unless command.match?("--workers")
+        exec_command << "--no-doc" unless command.match?("--doc")
+      end
       bundle_exec(exec_command.join(" "))
     end
   end


### PR DESCRIPTION
### Motivation

Following https://github.com/Shopify/tapioca/pull/920, running the test suite increased from 10 to 40 minutes because we spend a lot of time parsing and generating the documentation in the gem RBIs.

### Implementation

Always pass `--no-doc` unless `--doc` is passed explicitly.

### Tests

See automated tests.

