### PR TITLE
Handle gracefully if we get unparsable JSON

### DIFF
--- a/lib/tapioca/static/symbol_table_parser.rb
+++ b/lib/tapioca/static/symbol_table_parser.rb
@@ -16,6 +16,8 @@ module Tapioca
         parser = SymbolTableParser.new
         parser.parse_object(obj)
         parser.symbols
+      rescue JSON::ParserError
+        Set.new
       end
 
       sig { returns(T::Set[String]) }


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
We seem to sometimes not read enough bytes from the Sorbet output, which ends up causing us to get an error from the JSON parser. While we investigate and fix that root cause, we might as well gracefully handle JSON parsing errors.

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
Rescue JSON parsing errors

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->
No tests, since I don't know how to recreate this situation.
