### PR TITLE
Many protubuf dsl fixes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 PATH
   remote: .
   specs:
-    tapioca (0.8.10.pre)
+    tapioca (0.8.13.pre)
       bundler (>= 1.17.3)
       parallel (>= 1.21.0)
       pry (>= 0.12.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 PATH
   remote: .
   specs:
-    tapioca (0.8.15.pre)
+    tapioca (0.8.16.pre)
       bundler (>= 1.17.3)
       parallel (>= 1.21.0)
       pry (>= 0.12.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 PATH
   remote: .
   specs:
-    tapioca (0.8.0.pre)
+    tapioca (0.8.1.pre)
       bundler (>= 1.17.3)
       parallel (>= 1.21.0)
       pry (>= 0.12.2)
@@ -273,21 +273,21 @@ GEM
       rack (~> 2.0)
       redis (>= 4.2.0)
     smart_properties (1.17.0)
-    sorbet (0.5.9988)
-      sorbet-static (= 0.5.9988)
-    sorbet-runtime (0.5.9988)
-    sorbet-static (0.5.9988-universal-darwin-14)
-    sorbet-static (0.5.9988-universal-darwin-15)
-    sorbet-static (0.5.9988-universal-darwin-16)
-    sorbet-static (0.5.9988-universal-darwin-17)
-    sorbet-static (0.5.9988-universal-darwin-18)
-    sorbet-static (0.5.9988-universal-darwin-19)
-    sorbet-static (0.5.9988-universal-darwin-20)
-    sorbet-static (0.5.9988-universal-darwin-21)
-    sorbet-static (0.5.9988-x86_64-linux)
-    sorbet-static-and-runtime (0.5.9988)
-      sorbet (= 0.5.9988)
-      sorbet-runtime (= 0.5.9988)
+    sorbet (0.5.10028)
+      sorbet-static (= 0.5.10028)
+    sorbet-runtime (0.5.10028)
+    sorbet-static (0.5.10028-universal-darwin-14)
+    sorbet-static (0.5.10028-universal-darwin-15)
+    sorbet-static (0.5.10028-universal-darwin-16)
+    sorbet-static (0.5.10028-universal-darwin-17)
+    sorbet-static (0.5.10028-universal-darwin-18)
+    sorbet-static (0.5.10028-universal-darwin-19)
+    sorbet-static (0.5.10028-universal-darwin-20)
+    sorbet-static (0.5.10028-universal-darwin-21)
+    sorbet-static (0.5.10028-x86_64-linux)
+    sorbet-static-and-runtime (0.5.10028)
+      sorbet (= 0.5.10028)
+      sorbet-runtime (= 0.5.10028)
     spoom (1.1.11)
       sorbet (>= 0.5.9204)
       sorbet-runtime (>= 0.5.9204)
@@ -304,7 +304,7 @@ GEM
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.1.0)
-    unparser (0.6.4)
+    unparser (0.6.5)
       diff-lcs (~> 1.3)
       parser (>= 3.1.0)
     webrick (1.7.0)
@@ -356,4 +356,4 @@ DEPENDENCIES
   xpath
 
 BUNDLED WITH
-   2.3.3
+   2.3.4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 PATH
   remote: .
   specs:
-    tapioca (0.8.14.pre)
+    tapioca (0.8.15.pre)
       bundler (>= 1.17.3)
       parallel (>= 1.21.0)
       pry (>= 0.12.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 PATH
   remote: .
   specs:
-    tapioca (0.8.13.pre)
+    tapioca (0.8.14.pre)
       bundler (>= 1.17.3)
       parallel (>= 1.21.0)
       pry (>= 0.12.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 PATH
   remote: .
   specs:
-    tapioca (0.8.1.pre)
+    tapioca (0.8.10.pre)
       bundler (>= 1.17.3)
       parallel (>= 1.21.0)
       pry (>= 0.12.2)

--- a/lib/tapioca/dsl/compilers/protobuf.rb
+++ b/lib/tapioca/dsl/compilers/protobuf.rb
@@ -63,11 +63,10 @@ module Tapioca
       class Protobuf < Compiler
         class Field < T::Struct
           prop :name, String
-          prop :type, String  # Used for accessor param & return sig
           prop :init_type, String  # Type for `initialize` kw arg sig
           prop :init_default, String  # Default value for `initialize`
-          prop :return_type, String  # Return type when reading the field, may differ from init_type
-          prop :assignable_type, String  # Type for arg to foo=, may differ
+          prop :return_type, String  # Return type from field may differ from init_type
+          prop :assignable_type, String  # Assignable type for field may differ from init_type
         end
 
         extend T::Sig
@@ -187,14 +186,12 @@ module Tapioca
 
               Field.new(
                 name: descriptor.name,
-                type: type,
                 init_type: "T.any(#{type}, T::Hash[#{key_type}, #{value_type}])",
                 init_default: "Google::Protobuf::Map.new(#{default_args.join(", ")})",
-                return_type: "T.any(#{type}, T::Hash[#{key_type}, #{value_type}])", # XXX nilable??
-                assignable_type: "T.any(#{type}, T::Hash[#{key_type}, #{value_type}])", # XXX nilable??
+                return_type: type,
+                assignable_type: type,
               )
             else
-              require 'pry'; binding.pry
               elem_type = type_of(descriptor)
               type = "Google::Protobuf::RepeatedField[#{elem_type}]"
 
@@ -203,7 +200,6 @@ module Tapioca
 
               Field.new(
                 name: descriptor.name,
-                type: type,
                 init_type: "T.any(#{type}, T::Array[#{elem_type}])",
                 init_default: "Google::Protobuf::RepeatedField.new(#{default_args.join(", ")})",
                 return_type: type,
@@ -217,7 +213,6 @@ module Tapioca
 
             Field.new(
               name: descriptor.name,
-              type: type,
               init_type: type,
               init_default: "nil",
               return_type: return_type,

--- a/lib/tapioca/dsl/compilers/protobuf.rb
+++ b/lib/tapioca/dsl/compilers/protobuf.rb
@@ -204,7 +204,9 @@ module Tapioca
         def create_descriptor_method(klass, desc)
           field = field_of(desc)
 
-          require 'pry'; binding.pry
+          if field.default.include("Protobuf")
+            require 'pry'; binding.pry
+          end
           # `field.default` is a string
           # If nilable, it's "nil"
           # eg

--- a/lib/tapioca/dsl/compilers/protobuf.rb
+++ b/lib/tapioca/dsl/compilers/protobuf.rb
@@ -204,6 +204,7 @@ module Tapioca
         def create_descriptor_method(klass, desc)
           field = field_of(desc)
 
+          require 'pry'; binding.pry
           klass.create_method(
             field.name,
             return_type: "T.nilable(#{field.type})"

--- a/lib/tapioca/dsl/compilers/protobuf.rb
+++ b/lib/tapioca/dsl/compilers/protobuf.rb
@@ -248,6 +248,18 @@ module Tapioca
             return_type: field.return_type,
           )
 
+          unless desc.label == :repeated
+            klass.create_method(
+              "has_#{field.name}?",
+              return_type: "T::Boolean",
+            )
+          end
+
+          klass.create_method(
+            "clear_#{field.name}",
+            return_type: "void",
+          )
+
           field
         end
 

--- a/lib/tapioca/dsl/compilers/protobuf.rb
+++ b/lib/tapioca/dsl/compilers/protobuf.rb
@@ -194,6 +194,7 @@ module Tapioca
                 assignable_type: "T.any(#{type}, T::Hash[#{key_type}, #{value_type}])", # XXX nilable??
               )
             else
+              require 'pry'; binding.pry
               elem_type = type_of(descriptor)
               type = "Google::Protobuf::RepeatedField[#{elem_type}]"
 

--- a/lib/tapioca/dsl/compilers/protobuf.rb
+++ b/lib/tapioca/dsl/compilers/protobuf.rb
@@ -237,26 +237,6 @@ module Tapioca
         end
         def create_descriptor_method(klass, desc)
           field = field_of(desc)
-
-          # `field.init_default` is a string
-          # If nilable, it's "nil"
-          # eg
-          # [5] pry(#<Tapioca::Dsl::Compilers::Protobuf>)> field.type
-          # => "Google::Protobuf::RepeatedField[Google::Api::HttpRule]"
-          # [6] pry(#<Tapioca::Dsl::Compilers::Protobuf>)> field.init_default
-          # => "Google::Protobuf::RepeatedField.new(:message, Google::Api::HttpRule)"
-          # [7] pry(#<Tapioca::Dsl::Compilers::Protobuf>)> field.name
-          # => "rules"
-          # [10] pry(#<Tapioca::Dsl::Compilers::Protobuf>)> klass.name
-          # => "Google::Api::Http"
-          #
-          # Hmm this seems wrong for a string field though
-          # [1] pry(#<Tapioca::Dsl::Compilers::Protobuf>)> field.type
-          #=> "String"
-          #[2] pry(#<Tapioca::Dsl::Compilers::Protobuf>)> field.init_default
-          #=> "nil"
-          #[3] pry(#<Tapioca::Dsl::Compilers::Protobuf>)> field.init_type
-          #=> "String"
           klass.create_method(
             field.name,
             return_type: field.return_type,

--- a/lib/tapioca/dsl/compilers/protobuf.rb
+++ b/lib/tapioca/dsl/compilers/protobuf.rb
@@ -204,7 +204,7 @@ module Tapioca
         def create_descriptor_method(klass, desc)
           field = field_of(desc)
 
-          if field.default.include("Protobuf")
+          if field.default.include?("Protobuf")
             require 'pry'; binding.pry
           end
           # `field.default` is a string

--- a/lib/tapioca/dsl/compilers/protobuf.rb
+++ b/lib/tapioca/dsl/compilers/protobuf.rb
@@ -151,9 +151,10 @@ module Tapioca
         def return_type_of(descriptor)
           type = type_of(descriptor)
           case descriptor.type
-          when :enum
-            require 'pry'; binding.pry
-            "T.any(Symbol, Integer)"
+          # when :enum
+          # NOT SURE ABOUT THIS
+          #   require 'pry'; binding.pry
+          #   "T.any(Symbol, Integer)"
           when :message
             # XXX what about repeats & maps?
             "T.nilable(#{type})"
@@ -204,8 +205,8 @@ module Tapioca
                 type: type,
                 init_type: "T.any(#{type}, T::Array[#{elem_type}])",
                 init_default: "Google::Protobuf::RepeatedField.new(#{default_args.join(", ")})",
-                return_type: "T.any(#{type}, T::Array[#{elem_type}])", # XXX nilable?
-                assignable_type: "T.any(#{type}, T::Array[#{elem_type}])", # XXX nilable?
+                return_type: type,
+                assignable_type: type,
               )
             end
           else

--- a/lib/tapioca/dsl/compilers/protobuf.rb
+++ b/lib/tapioca/dsl/compilers/protobuf.rb
@@ -174,6 +174,11 @@ module Tapioca
           case descriptor.type
           when :message
             "T.nilable(#{type})"
+          when :enum
+            # Per the docs: "When reading the value back, it will be a symbol if
+            # the enum value is known, or a number if it is unknown."
+            # https://developers.google.com/protocol-buffers/docs/reference/ruby-generated#enum
+            "T.any(Integer, Symbol)"
           else
             type
           end

--- a/lib/tapioca/dsl/compilers/protobuf.rb
+++ b/lib/tapioca/dsl/compilers/protobuf.rb
@@ -186,11 +186,12 @@ module Tapioca
           else
             type = type_of(descriptor)
 
+            require 'pry'; binding.pry
             Field.new(
               name: descriptor.name,
               type: type,
               init_type: type,
-              default: "nil"
+              default: descriptor.default.class
             )
           end
         end
@@ -202,11 +203,9 @@ module Tapioca
           ).returns(Field)
         end
         def create_descriptor_method(klass, desc)
+          require 'pry'; binding.pry
           field = field_of(desc)
 
-          if field.default.include?("Protobuf")
-            require 'pry'; binding.pry
-          end
           # `field.default` is a string
           # If nilable, it's "nil"
           # eg

--- a/lib/tapioca/dsl/compilers/protobuf.rb
+++ b/lib/tapioca/dsl/compilers/protobuf.rb
@@ -150,8 +150,11 @@ module Tapioca
 
         def return_type_of(descriptor)
           type = type_of(descriptor)
-          if descriptor.type == :message
-            # XXX what about enum?
+          case descriptor.type
+          when :enum
+            require 'pry'; binding.pry
+            "T.any(Symbol, Integer)"
+          when :message
             # XXX what about repeats & maps?
             "T.nilable(#{type})"
           else
@@ -160,7 +163,7 @@ module Tapioca
         end
 
         def assignable_type_of(descriptor)
-          # XXX same logic always?
+          # TODO Is this always true?
           return_type_of(descriptor)
         end
 

--- a/lib/tapioca/dsl/compilers/protobuf.rb
+++ b/lib/tapioca/dsl/compilers/protobuf.rb
@@ -253,13 +253,6 @@ module Tapioca
             return_type: field.return_type,
           )
 
-          unless desc.label == :repeated
-            klass.create_method(
-              "has_#{field.name}?",
-              return_type: "T::Boolean",
-            )
-          end
-
           klass.create_method(
             "clear_#{field.name}",
             return_type: "void",

--- a/lib/tapioca/dsl/compilers/protobuf.rb
+++ b/lib/tapioca/dsl/compilers/protobuf.rb
@@ -205,6 +205,25 @@ module Tapioca
           field = field_of(desc)
 
           require 'pry'; binding.pry
+          # `field.default` is a string
+          # If nilable, it's "nil"
+          # eg
+          # [5] pry(#<Tapioca::Dsl::Compilers::Protobuf>)> field.type
+          # => "Google::Protobuf::RepeatedField[Google::Api::HttpRule]"
+          # [6] pry(#<Tapioca::Dsl::Compilers::Protobuf>)> field.default
+          # => "Google::Protobuf::RepeatedField.new(:message, Google::Api::HttpRule)"
+          # [7] pry(#<Tapioca::Dsl::Compilers::Protobuf>)> field.name
+          # => "rules"
+          # [10] pry(#<Tapioca::Dsl::Compilers::Protobuf>)> klass.name
+          # => "Google::Api::Http"
+          #
+          # Hmm this seems wrong for a string field though
+          # [1] pry(#<Tapioca::Dsl::Compilers::Protobuf>)> field.type
+          #=> "String"
+          #[2] pry(#<Tapioca::Dsl::Compilers::Protobuf>)> field.default
+          #=> "nil"
+          #[3] pry(#<Tapioca::Dsl::Compilers::Protobuf>)> field.init_type
+          #=> "String"          
           klass.create_method(
             field.name,
             return_type: "T.nilable(#{field.type})"

--- a/lib/tapioca/version.rb
+++ b/lib/tapioca/version.rb
@@ -2,5 +2,5 @@
 # frozen_string_literal: true
 
 module Tapioca
-  VERSION = "0.8.2.pre"
+  VERSION = "0.8.4.pre"
 end

--- a/lib/tapioca/version.rb
+++ b/lib/tapioca/version.rb
@@ -2,5 +2,5 @@
 # frozen_string_literal: true
 
 module Tapioca
-  VERSION = "0.8.16.pre"
+  VERSION = "0.8.17.pre"
 end

--- a/lib/tapioca/version.rb
+++ b/lib/tapioca/version.rb
@@ -2,5 +2,5 @@
 # frozen_string_literal: true
 
 module Tapioca
-  VERSION = "0.8.11.pre"
+  VERSION = "0.8.12.pre"
 end

--- a/lib/tapioca/version.rb
+++ b/lib/tapioca/version.rb
@@ -2,5 +2,5 @@
 # frozen_string_literal: true
 
 module Tapioca
-  VERSION = "0.8.12.pre"
+  VERSION = "0.8.13.pre"
 end

--- a/lib/tapioca/version.rb
+++ b/lib/tapioca/version.rb
@@ -2,5 +2,5 @@
 # frozen_string_literal: true
 
 module Tapioca
-  VERSION = "0.8.5.pre"
+  VERSION = "0.8.7.pre"
 end

--- a/lib/tapioca/version.rb
+++ b/lib/tapioca/version.rb
@@ -2,5 +2,5 @@
 # frozen_string_literal: true
 
 module Tapioca
-  VERSION = "0.8.15.pre"
+  VERSION = "0.8.16.pre"
 end

--- a/lib/tapioca/version.rb
+++ b/lib/tapioca/version.rb
@@ -2,5 +2,5 @@
 # frozen_string_literal: true
 
 module Tapioca
-  VERSION = "0.8.10.pre"
+  VERSION = "0.8.11.pre"
 end

--- a/lib/tapioca/version.rb
+++ b/lib/tapioca/version.rb
@@ -2,5 +2,5 @@
 # frozen_string_literal: true
 
 module Tapioca
-  VERSION = "0.8.1.pre"
+  VERSION = "0.8.2.pre"
 end

--- a/lib/tapioca/version.rb
+++ b/lib/tapioca/version.rb
@@ -2,5 +2,5 @@
 # frozen_string_literal: true
 
 module Tapioca
-  VERSION = "0.8.13.pre"
+  VERSION = "0.8.14.pre"
 end

--- a/lib/tapioca/version.rb
+++ b/lib/tapioca/version.rb
@@ -2,5 +2,5 @@
 # frozen_string_literal: true
 
 module Tapioca
-  VERSION = "0.8.7.pre"
+  VERSION = "0.8.9.pre"
 end

--- a/lib/tapioca/version.rb
+++ b/lib/tapioca/version.rb
@@ -2,5 +2,5 @@
 # frozen_string_literal: true
 
 module Tapioca
-  VERSION = "0.8.9.pre"
+  VERSION = "0.8.10.pre"
 end

--- a/lib/tapioca/version.rb
+++ b/lib/tapioca/version.rb
@@ -2,5 +2,5 @@
 # frozen_string_literal: true
 
 module Tapioca
-  VERSION = "0.8.4.pre"
+  VERSION = "0.8.5.pre"
 end

--- a/lib/tapioca/version.rb
+++ b/lib/tapioca/version.rb
@@ -2,5 +2,5 @@
 # frozen_string_literal: true
 
 module Tapioca
-  VERSION = "0.8.0.pre"
+  VERSION = "0.8.1.pre"
 end

--- a/lib/tapioca/version.rb
+++ b/lib/tapioca/version.rb
@@ -2,5 +2,5 @@
 # frozen_string_literal: true
 
 module Tapioca
-  VERSION = "0.8.14.pre"
+  VERSION = "0.8.15.pre"
 end

--- a/spec/tapioca/dsl/compilers/protobuf_spec.rb
+++ b/spec/tapioca/dsl/compilers/protobuf_spec.rb
@@ -60,11 +60,23 @@ module Tapioca
                   sig { params(customer_id: T.nilable(Integer), shop_id: T.nilable(Integer)).void }
                   def initialize(customer_id: nil, shop_id: nil); end
 
+                  sig { void }
+                  def clear_customer_id; end
+
+                  sig { void }
+                  def clear_shop_id; end
+
                   sig { returns(Integer) }
                   def customer_id; end
 
                   sig { params(value: Integer).returns(Integer) }
                   def customer_id=(value); end
+
+                  sig { returns(T::Boolean) }
+                  def has_customer_id?; end
+
+                  sig { returns(T::Boolean) }
+                  def has_shop_id?; end
 
                   sig { returns(Integer) }
                   def shop_id; end
@@ -97,11 +109,17 @@ module Tapioca
                   sig { params(events: T.nilable(String)).void }
                   def initialize(events: nil); end
 
+                  sig { void }
+                  def clear_events; end
+
                   sig { returns(String) }
                   def events; end
 
                   sig { params(value: String).returns(String) }
                   def events=(value); end
+
+                  sig { returns(T::Boolean) }
+                  def has_events?; end
                 end
               RBI
 
@@ -136,6 +154,12 @@ module Tapioca
 
                   sig { params(value: T.nilable(Google::Protobuf::UInt64Value)).returns(T.nilable(Google::Protobuf::UInt64Value)) }
                   def cart_item_index=(value); end
+
+                  sig { void }
+                  def clear_cart_item_index; end
+
+                  sig { returns(T::Boolean) }
+                  def has_cart_item_index?; end
                 end
               RBI
 
@@ -170,6 +194,12 @@ module Tapioca
                 class Cart
                   sig { params(value_type: T.nilable(Cart::VALUE_TYPE)).void }
                   def initialize(value_type: nil); end
+
+                  sig { void }
+                  def clear_value_type; end
+
+                  sig { returns(T::Boolean) }
+                  def has_value_type?; end
 
                   sig { returns(Cart::VALUE_TYPE) }
                   def value_type; end
@@ -211,6 +241,12 @@ module Tapioca
                   sig { params(value_type: T.nilable(Cart::MYVALUETYPE)).void }
                   def initialize(value_type: nil); end
 
+                  sig { void }
+                  def clear_value_type; end
+
+                  sig { returns(T::Boolean) }
+                  def has_value_type?; end
+
                   sig { returns(Cart::MYVALUETYPE) }
                   def value_type; end
 
@@ -244,6 +280,12 @@ module Tapioca
                 class Cart
                   sig { params(customer_ids: T.nilable(T.any(Google::Protobuf::RepeatedField[Integer], T::Array[Integer])), indices: T.nilable(T.any(Google::Protobuf::RepeatedField[Google::Protobuf::UInt64Value], T::Array[Google::Protobuf::UInt64Value]))).void }
                   def initialize(customer_ids: Google::Protobuf::RepeatedField.new(:int32), indices: Google::Protobuf::RepeatedField.new(:message, Google::Protobuf::UInt64Value)); end
+
+                  sig { void }
+                  def clear_customer_ids; end
+
+                  sig { void }
+                  def clear_indices; end
 
                   sig { returns(Google::Protobuf::RepeatedField[Integer]) }
                   def customer_ids; end
@@ -284,6 +326,12 @@ module Tapioca
                 class Cart
                   sig { params(customers: T.nilable(T.any(Google::Protobuf::Map[String, Integer], T::Hash[String, Integer])), stores: T.nilable(T.any(Google::Protobuf::Map[String, Google::Protobuf::UInt64Value], T::Hash[String, Google::Protobuf::UInt64Value]))).void }
                   def initialize(customers: Google::Protobuf::Map.new(:string, :int32), stores: Google::Protobuf::Map.new(:string, :message, Google::Protobuf::UInt64Value)); end
+
+                  sig { void }
+                  def clear_customers; end
+
+                  sig { void }
+                  def clear_stores; end
 
                   sig { returns(Google::Protobuf::Map[String, Integer]) }
                   def customers; end
@@ -406,6 +454,18 @@ module Tapioca
 
                   sig { params(value: String).returns(String) }
                   def ShopName=(value); end
+
+                  sig { void }
+                  def clear_ShopID; end
+
+                  sig { void }
+                  def clear_ShopName; end
+
+                  sig { returns(T::Boolean) }
+                  def has_ShopID?; end
+
+                  sig { returns(T::Boolean) }
+                  def has_ShopName?; end
                 end
               RBI
 

--- a/spec/tapioca/dsl/compilers/protobuf_spec.rb
+++ b/spec/tapioca/dsl/compilers/protobuf_spec.rb
@@ -72,12 +72,6 @@ module Tapioca
                   sig { params(value: Integer).returns(Integer) }
                   def customer_id=(value); end
 
-                  sig { returns(T::Boolean) }
-                  def has_customer_id?; end
-
-                  sig { returns(T::Boolean) }
-                  def has_shop_id?; end
-
                   sig { returns(Integer) }
                   def shop_id; end
 
@@ -117,9 +111,6 @@ module Tapioca
 
                   sig { params(value: String).returns(String) }
                   def events=(value); end
-
-                  sig { returns(T::Boolean) }
-                  def has_events?; end
                 end
               RBI
 
@@ -157,9 +148,6 @@ module Tapioca
 
                   sig { void }
                   def clear_cart_item_index; end
-
-                  sig { returns(T::Boolean) }
-                  def has_cart_item_index?; end
                 end
               RBI
 
@@ -197,9 +185,6 @@ module Tapioca
 
                   sig { void }
                   def clear_value_type; end
-
-                  sig { returns(T::Boolean) }
-                  def has_value_type?; end
 
                   sig { returns(T.any(Integer, Symbol)) }
                   def value_type; end
@@ -243,9 +228,6 @@ module Tapioca
 
                   sig { void }
                   def clear_value_type; end
-
-                  sig { returns(T::Boolean) }
-                  def has_value_type?; end
 
                   sig { returns(T.any(Integer, Symbol)) }
                   def value_type; end
@@ -460,12 +442,6 @@ module Tapioca
 
                   sig { void }
                   def clear_ShopName; end
-
-                  sig { returns(T::Boolean) }
-                  def has_ShopID?; end
-
-                  sig { returns(T::Boolean) }
-                  def has_ShopName?; end
                 end
               RBI
 

--- a/spec/tapioca/dsl/compilers/protobuf_spec.rb
+++ b/spec/tapioca/dsl/compilers/protobuf_spec.rb
@@ -45,7 +45,7 @@ module Tapioca
                   add_file("cart.proto", :syntax => :proto3) do
                     add_message "MyCart" do
                       optional :shop_id, :int32, 1
-                      optional :customer_id, :int32, 2
+                      optional :customer_id, :int64, 2
                     end
                   end
                 end
@@ -60,16 +60,16 @@ module Tapioca
                   sig { params(customer_id: T.nilable(Integer), shop_id: T.nilable(Integer)).void }
                   def initialize(customer_id: nil, shop_id: nil); end
 
-                  sig { returns(T.nilable(Integer)) }
+                  sig { returns(Integer) }
                   def customer_id; end
 
-                  sig { params(value: T.nilable(Integer)).returns(T.nilable(Integer)) }
+                  sig { params(value: Integer).returns(Integer) }
                   def customer_id=(value); end
 
-                  sig { returns(T.nilable(Integer)) }
+                  sig { returns(Integer) }
                   def shop_id; end
 
-                  sig { params(value: T.nilable(Integer)).returns(T.nilable(Integer)) }
+                  sig { params(value: Integer).returns(Integer) }
                   def shop_id=(value); end
                 end
               RBI
@@ -97,10 +97,10 @@ module Tapioca
                   sig { params(events: T.nilable(String)).void }
                   def initialize(events: nil); end
 
-                  sig { returns(T.nilable(String)) }
+                  sig { returns(String) }
                   def events; end
 
-                  sig { params(value: T.nilable(String)).returns(T.nilable(String)) }
+                  sig { params(value: String).returns(String) }
                   def events=(value); end
                 end
               RBI
@@ -171,10 +171,10 @@ module Tapioca
                   sig { params(value_type: T.nilable(Cart::VALUE_TYPE)).void }
                   def initialize(value_type: nil); end
 
-                  sig { returns(T.nilable(Cart::VALUE_TYPE)) }
+                  sig { returns(Cart::VALUE_TYPE) }
                   def value_type; end
 
-                  sig { params(value: T.nilable(Cart::VALUE_TYPE)).returns(T.nilable(Cart::VALUE_TYPE)) }
+                  sig { params(value: Cart::VALUE_TYPE).returns(Cart::VALUE_TYPE) }
                   def value_type=(value); end
                 end
               RBI
@@ -211,10 +211,10 @@ module Tapioca
                   sig { params(value_type: T.nilable(Cart::MYVALUETYPE)).void }
                   def initialize(value_type: nil); end
 
-                  sig { returns(T.nilable(Cart::MYVALUETYPE)) }
+                  sig { returns(Cart::MYVALUETYPE) }
                   def value_type; end
 
-                  sig { params(value: T.nilable(Cart::MYVALUETYPE)).returns(T.nilable(Cart::MYVALUETYPE)) }
+                  sig { params(value: Cart::MYVALUETYPE).returns(Cart::MYVALUETYPE) }
                   def value_type=(value); end
                 end
               RBI
@@ -245,16 +245,16 @@ module Tapioca
                   sig { params(customer_ids: T.nilable(T.any(Google::Protobuf::RepeatedField[Integer], T::Array[Integer])), indices: T.nilable(T.any(Google::Protobuf::RepeatedField[Google::Protobuf::UInt64Value], T::Array[Google::Protobuf::UInt64Value]))).void }
                   def initialize(customer_ids: Google::Protobuf::RepeatedField.new(:int32), indices: Google::Protobuf::RepeatedField.new(:message, Google::Protobuf::UInt64Value)); end
 
-                  sig { returns(T.nilable(Google::Protobuf::RepeatedField[Integer])) }
+                  sig { returns(Google::Protobuf::RepeatedField[Integer]) }
                   def customer_ids; end
 
-                  sig { params(value: T.nilable(Google::Protobuf::RepeatedField[Integer])).returns(T.nilable(Google::Protobuf::RepeatedField[Integer])) }
+                  sig { params(value: Google::Protobuf::RepeatedField[Integer]).returns(Google::Protobuf::RepeatedField[Integer]) }
                   def customer_ids=(value); end
 
-                  sig { returns(T.nilable(Google::Protobuf::RepeatedField[Google::Protobuf::UInt64Value])) }
+                  sig { returns(Google::Protobuf::RepeatedField[Google::Protobuf::UInt64Value]) }
                   def indices; end
 
-                  sig { params(value: T.nilable(Google::Protobuf::RepeatedField[Google::Protobuf::UInt64Value])).returns(T.nilable(Google::Protobuf::RepeatedField[Google::Protobuf::UInt64Value])) }
+                  sig { params(value: Google::Protobuf::RepeatedField[Google::Protobuf::UInt64Value]).returns(Google::Protobuf::RepeatedField[Google::Protobuf::UInt64Value]) }
                   def indices=(value); end
                 end
               RBI
@@ -285,16 +285,16 @@ module Tapioca
                   sig { params(customers: T.nilable(T.any(Google::Protobuf::Map[String, Integer], T::Hash[String, Integer])), stores: T.nilable(T.any(Google::Protobuf::Map[String, Google::Protobuf::UInt64Value], T::Hash[String, Google::Protobuf::UInt64Value]))).void }
                   def initialize(customers: Google::Protobuf::Map.new(:string, :int32), stores: Google::Protobuf::Map.new(:string, :message, Google::Protobuf::UInt64Value)); end
 
-                  sig { returns(T.nilable(Google::Protobuf::Map[String, Integer])) }
+                  sig { returns(Google::Protobuf::Map[String, Integer]) }
                   def customers; end
 
-                  sig { params(value: T.nilable(Google::Protobuf::Map[String, Integer])).returns(T.nilable(Google::Protobuf::Map[String, Integer])) }
+                  sig { params(value: Google::Protobuf::Map[String, Integer]).returns(Google::Protobuf::Map[String, Integer]) }
                   def customers=(value); end
 
-                  sig { returns(T.nilable(Google::Protobuf::Map[String, Google::Protobuf::UInt64Value])) }
+                  sig { returns(Google::Protobuf::Map[String, Google::Protobuf::UInt64Value]) }
                   def stores; end
 
-                  sig { params(value: T.nilable(Google::Protobuf::Map[String, Google::Protobuf::UInt64Value])).returns(T.nilable(Google::Protobuf::Map[String, Google::Protobuf::UInt64Value])) }
+                  sig { params(value: Google::Protobuf::Map[String, Google::Protobuf::UInt64Value]).returns(Google::Protobuf::Map[String, Google::Protobuf::UInt64Value]) }
                   def stores=(value); end
                 end
               RBI
@@ -329,47 +329,47 @@ module Tapioca
               rbi_output = rbi_for(:Cart)
 
               assert_includes(rbi_output, indented(<<~RBI, 2))
-                sig { params(value: T.nilable(T::Boolean)).returns(T.nilable(T::Boolean)) }
+                sig { params(value: T::Boolean).returns(T::Boolean) }
                 def bool_value=(value); end
               RBI
 
               assert_includes(rbi_output, indented(<<~RBI, 2))
-                sig { params(value: T.nilable(String)).returns(T.nilable(String)) }
+                sig { params(value: String).returns(String) }
                 def byte_value=(value); end
               RBI
 
               assert_includes(rbi_output, indented(<<~RBI, 2))
-                sig { params(value: T.nilable(Integer)).returns(T.nilable(Integer)) }
+                sig { params(value: Integer).returns(Integer) }
                 def customer_id=(value); end
               RBI
 
               assert_includes(rbi_output, indented(<<~RBI, 2))
-                sig { params(value: T.nilable(Integer)).returns(T.nilable(Integer)) }
+                sig { params(value: Integer).returns(Integer) }
                 def id=(value); end
               RBI
 
               assert_includes(rbi_output, indented(<<~RBI, 2))
-                sig { params(value: T.nilable(Integer)).returns(T.nilable(Integer)) }
+                sig { params(value: Integer).returns(Integer) }
                 def item_id=(value); end
               RBI
 
               assert_includes(rbi_output, indented(<<~RBI, 2))
-                sig { params(value: T.nilable(Float)).returns(T.nilable(Float)) }
+                sig { params(value: Float).returns(Float) }
                 def money_value=(value); end
               RBI
 
               assert_includes(rbi_output, indented(<<~RBI, 2))
-                sig { params(value: T.nilable(Float)).returns(T.nilable(Float)) }
+                sig { params(value: Float).returns(Float) }
                 def number_value=(value); end
               RBI
 
               assert_includes(rbi_output, indented(<<~RBI, 2))
-                sig { params(value: T.nilable(Integer)).returns(T.nilable(Integer)) }
+                sig { params(value: Integer).returns(Integer) }
                 def shop_id=(value); end
               RBI
 
               assert_includes(rbi_output, indented(<<~RBI, 2))
-                sig { params(value: T.nilable(String)).returns(T.nilable(String)) }
+                sig { params(value: String).returns(String) }
                 def string_value=(value); end
               RBI
             end
@@ -395,16 +395,16 @@ module Tapioca
                   sig { params(fields: T.untyped).void }
                   def initialize(**fields); end
 
-                  sig { returns(T.nilable(Integer)) }
+                  sig { returns(Integer) }
                   def ShopID; end
 
-                  sig { params(value: T.nilable(Integer)).returns(T.nilable(Integer)) }
+                  sig { params(value: Integer).returns(Integer) }
                   def ShopID=(value); end
 
-                  sig { returns(T.nilable(String)) }
+                  sig { returns(String) }
                   def ShopName; end
 
-                  sig { params(value: T.nilable(String)).returns(T.nilable(String)) }
+                  sig { params(value: String).returns(String) }
                   def ShopName=(value); end
                 end
               RBI

--- a/spec/tapioca/dsl/compilers/protobuf_spec.rb
+++ b/spec/tapioca/dsl/compilers/protobuf_spec.rb
@@ -201,10 +201,10 @@ module Tapioca
                   sig { returns(T::Boolean) }
                   def has_value_type?; end
 
-                  sig { returns(Cart::VALUE_TYPE) }
+                  sig { returns(T.any(Integer, Symbol)) }
                   def value_type; end
 
-                  sig { params(value: Cart::VALUE_TYPE).returns(Cart::VALUE_TYPE) }
+                  sig { params(value: Cart::VALUE_TYPE).returns(T.any(Integer, Symbol)) }
                   def value_type=(value); end
                 end
               RBI
@@ -247,10 +247,10 @@ module Tapioca
                   sig { returns(T::Boolean) }
                   def has_value_type?; end
 
-                  sig { returns(Cart::MYVALUETYPE) }
+                  sig { returns(T.any(Integer, Symbol)) }
                   def value_type; end
 
-                  sig { params(value: Cart::MYVALUETYPE).returns(Cart::MYVALUETYPE) }
+                  sig { params(value: Cart::MYVALUETYPE).returns(T.any(Integer, Symbol)) }
                   def value_type=(value); end
                 end
               RBI


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->

**I will probably abandon this and pull bits of it into smaller PRs after #966 merges**

Generated RBIs differ in many ways from the ruby protobuf documentation and the code actually generated by `protoc`.
Attempting to fix as many of them as possible.



**Ignore spurious gemfile & version bumps** - will revert those

**Rebase badly needed**

- [x] All parameters to `#initialize` should actually be nilable
- [x] [Per docs](https://developers.google.com/protocol-buffers/docs/reference/ruby-generated#embedded_message): Readers for fields of `:message` type can return `nil`. Setters for fields of `:message` type can accept `nil`. Primitive field types (`string` et al) can't be assigned nor return `nil`.  (But see the previous point - you can still pass nil to `#initialize`)
- [x] There's a generated [`clear_foo` method for all fields](https://developers.google.com/protocol-buffers/docs/reference/ruby-generated#checking-presence), was missing.
- [x] `:enum` fields can accept or return Integer or Symbol [per the docs](https://developers.google.com/protocol-buffers/docs/reference/ruby-generated#enum).
- [x] TODO: there's a missing type declaration for Enum values.  I've seen these shimmed like `FOO = type_alias(T.untyped)` but maybe should be `FOO = type_alias(T.any(Integer, Symbol))` ?
- [ ] TODO: The docs say there should be a [`has_foo?` generated method for all non-repeated fields](https://developers.google.com/protocol-buffers/docs/reference/ruby-generated#fields), but it doesn't seem to actually exist 🤔  ... maybe a more recent version of `protoc` than I have?
- [x] TODO: [per the docs there are module methods on Enums:](https://developers.google.com/protocol-buffers/docs/reference/ruby-generated#enum) `#lookup`, `#resolve`, `#descriptor` and we are missing declarations for those


### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->

Building on top of Ray's `make_protobuf_signature_nilable` [PR](https://github.com/Shopify/tapioca/pull/931)

The code with my changes is getting a bit hard to follow and could use some OO refactoring.
In particular, the handling of repeated and map fields is not consistent with the others.
In current state, i mainly wanted to see if I could get something working and confirm the RBI output.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->

Yes, following the existing approach.  However, we are lacking tests that the generated sigs actually work as intended
