### PR TITLE
Fix type variable patch to respect references to late defined types

### DIFF
--- a/spec/tapioca/gem/pipeline_spec.rb
+++ b/spec/tapioca/gem/pipeline_spec.rb
@@ -2663,6 +2663,16 @@ class Tapioca::Gem::PipelineSpec < Minitest::HooksSpec
 
             NullGenericType = SimpleGenericType[Integer].new(0)
           end
+
+          module ForwardDeclaration
+            extend T::Sig
+            extend T::Generic
+
+            Elem = type_member { { fixed: LateDeclaredModule }}
+
+            module LateDeclaredModule
+            end
+          end
         end
       RUBY
 
@@ -2770,6 +2780,14 @@ class Tapioca::Gem::PipelineSpec < Minitest::HooksSpec
             I = type_member(:in) { { fixed: Integer, lower: Complex, upper: Numeric } }
           end
         end
+
+        module Generics::ForwardDeclaration
+          extend T::Generic
+
+          Elem = type_member { { fixed: Generics::ForwardDeclaration::LateDeclaredModule } }
+        end
+
+        module Generics::ForwardDeclaration::LateDeclaredModule; end
 
         class Generics::SimpleGenericType
           extend T::Generic


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->

Now that Sorbet syntax for declaring type variables is via a block, code authors can very well refer from that block to types that have not been defined yet. Since the values of `fixed`, `lower` and `upper` are late evaluated, this should work normally.

However, our current attempt to retrofit the new type variable syntax was trying to early evaluate the block that was passed so that we could unify on the old syntax. However, that early evaluation breaks for the case outlined above.

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
We should instead convert the bounds passed to type variables into the block format, if a block is not passed, and always work with blocks until the point where we need to serialize the type variable. We should be pretty guaranteed that the types referred to from the block will be defined by the time we get to serialize the type variable. In any case, that is as late we can evaluate the bounds anyway.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->
Added a test that breaks without this change and is fixed by it.
