### PR TITLE
Skip debug and fakefs gems

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ Once the file is generated, you should review it, remove all unnecessary require
 
 #### Excluding a gem from RBI generation
 
-It may be useful to exclude some gems from the generation process. For example for gems that are in Bundle's debug group or gems of which the contents are dependent on the architecture they are loaded on. A typical example is `fakefs`, which, if loaded into memory, changes `File` operations to be no-ops and breaks Tapioca RBI file generation altogether.
+It may be useful to exclude some gems from the generation process. For example for gems that are in Bundle's debug group or gems of which the contents are dependent on the architecture they are loaded on. 
 
 To do so you can pass the list of gems you want to exclude in the command line with the `--exclude` option:
 
@@ -239,6 +239,11 @@ gem:
     - gemA
     - gemB
 ```
+
+There are a few development/test environment gems that can cause RBI generation issues, so Tapioca skips them by default:
+
+- `debug`
+- `fakefs`
 
 #### Changing the strictness level of the RBI for a gem
 

--- a/lib/tapioca/gemfile.rb
+++ b/lib/tapioca/gemfile.rb
@@ -139,8 +139,13 @@ module Tapioca
     class GemSpec
       extend(T::Sig)
 
-      IGNORED_GEMS = T.let(["sorbet", "sorbet-static", "sorbet-runtime", "sorbet-static-and-runtime"].freeze,
-        T::Array[String])
+      IGNORED_GEMS = T.let(
+        [
+          "sorbet", "sorbet-static", "sorbet-runtime", "sorbet-static-and-runtime",
+          "debug", "fakefs",
+        ].freeze,
+        T::Array[String]
+      )
 
       sig { returns(String) }
       attr_reader :full_gem_path, :version


### PR DESCRIPTION
### Motivation

These 2 gems are dev/test only gems and have been proven to be
disrupting to RBI generation. So instead of telling every users to skip
them manually, Tapioca should just skip them by default.

### Implementation

Just add them to the `IGNORED_GEMS` constant.

### Tests

I'm not sure if we want to add tests for this the ignored gems list? 

Closes #946

