### PR TITLE
Use `--config` and `--postrequire` when calling the `init` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ Usage:
   tapioca init
 
 Options:
+      [--postrequire=POSTREQUIRE]    
+                                     # Default: sorbet/tapioca/require.rb
   -c, [--config=<config file path>]  # Path to the Tapioca configuration file
                                      # Default: sorbet/tapioca/config.yml
   -V, [--verbose], [--no-verbose]    # Verbose output for debugging purposes

--- a/README.md
+++ b/README.md
@@ -594,9 +594,9 @@ Please remove the duplicated definitions from the sorbet/rbi/shims directory.
 
 This command can be used on CI to make sure the RBI shims are always up-to-date and non-redundant with generated files.
 
-<!-- START_HELP_COMMAND_CHECK-SHIMS -->
+<!-- START_HELP_COMMAND_CHECK_SHIMS -->
 ```shell
-$ bin/tapioca help check-shims
+$ tapioca help check_shims
 
 Usage:
   tapioca check-shims
@@ -608,13 +608,15 @@ Options:
                                      # Default: sorbet/rbi/dsl
       [--shim-rbi-dir=SHIM_RBI_DIR]  # Path to shim RBIs
                                      # Default: sorbet/rbi/shims
+      [--payload], [--no-payload]    # Check shims against Sorbet's payload
+                                     # Default: true
   -c, [--config=<config file path>]  # Path to the Tapioca configuration file
                                      # Default: sorbet/tapioca/config.yml
   -V, [--verbose], [--no-verbose]    # Verbose output for debugging purposes
 
 check duplicated definitions in shim RBIs
 ```
-<!-- END_HELP_COMMAND_CHECK-SHIMS -->
+<!-- END_HELP_COMMAND_CHECK_SHIMS -->
 
 ### Configuration
 

--- a/lib/tapioca/cli.rb
+++ b/lib/tapioca/cli.rb
@@ -26,7 +26,7 @@ module Tapioca
     def init
       command = Commands::Init.new(
         sorbet_config: SORBET_CONFIG_FILE,
-        tapioca_config: TAPIOCA_CONFIG_FILE,
+        tapioca_config: options[:config],
         default_postrequire: DEFAULT_POSTREQUIRE_FILE
       )
       command.execute

--- a/lib/tapioca/cli.rb
+++ b/lib/tapioca/cli.rb
@@ -23,11 +23,12 @@ module Tapioca
       default: false
 
     desc "init", "initializes folder structure"
+    option :postrequire, type: :string, default: DEFAULT_POSTREQUIRE_FILE
     def init
       command = Commands::Init.new(
         sorbet_config: SORBET_CONFIG_FILE,
         tapioca_config: options[:config],
-        default_postrequire: DEFAULT_POSTREQUIRE_FILE
+        default_postrequire: options[:postrequire]
       )
       command.execute
     end

--- a/spec/tapioca/cli/config_spec.rb
+++ b/spec/tapioca/cli/config_spec.rb
@@ -148,6 +148,26 @@ module Tapioca
         assert_empty_stdout(result)
         refute_success_status(result)
       end
+
+      it "loads the configuration file from a custom location" do
+        @project.write("tapioca_custom_config.yml", <<~YAML)
+          foo: true
+        YAML
+
+        result = @project.tapioca("gem --config tapioca_custom_config.yml")
+
+        assert_equal(<<~ERR, result.err)
+
+          Configuration file tapioca_custom_config.yml has the following errors:
+
+          - unknown key foo
+        ERR
+
+        assert_empty_stdout(result)
+        refute_success_status(result)
+
+        @project.remove("tapioca_custom_config.yml")
+      end
     end
   end
 end

--- a/spec/tapioca/cli/init_spec.rb
+++ b/spec/tapioca/cli/init_spec.rb
@@ -76,6 +76,14 @@ module Tapioca
         assert_empty_stderr(result)
         assert_success_status(result)
       end
+
+      it "creates the Tapioca post-require file in a custom location" do
+        result = @project.tapioca("init --postrequire sorbet/tapioca/custom_require.rb")
+        assert_includes(result.out, "create  sorbet/tapioca/custom_require.rb")
+        assert_project_file_exist("sorbet/tapioca/custom_require.rb")
+        assert_empty_stderr(result)
+        assert_success_status(result)
+      end
     end
   end
 end

--- a/spec/tapioca/cli/init_spec.rb
+++ b/spec/tapioca/cli/init_spec.rb
@@ -68,6 +68,14 @@ module Tapioca
         assert_empty_stderr(result)
         assert_success_status(result)
       end
+
+      it "creates the Tapioca config file in a custom location" do
+        result = @project.tapioca("init --config sorbet/tapioca/custom_config.yml")
+        assert_includes(result.out, "create  sorbet/tapioca/custom_config.yml")
+        assert_project_file_exist("sorbet/tapioca/custom_config.yml")
+        assert_empty_stderr(result)
+        assert_success_status(result)
+      end
     end
   end
 end


### PR DESCRIPTION
### Motivation

I noticed that we were defining the option `--config` at the top level and loaded the configuration from the path provided by this option yet, we always created the config at a fixed location when calling `tapioca init`.

Same for the `require.rb` file. It was loaded from the path provided through the `--postrequire` option yet the file was always created at a fixed path when calling `tapioca init`.

### Tests

See automated tests.
