### PR TITLE
Fix CI

### DIFF
--- a/tasks/generator_documentation.rake
+++ b/tasks/generator_documentation.rake
@@ -1,6 +1,12 @@
 # typed: true
 # frozen_string_literal: true
 
+# Temporary fix for CI
+# A patch as been upstreamed, we're waiting for it to be merged.
+# See https://github.com/rubyconfig/config/pull/319
+# TODO: remove this one the patch is released.
+require "rails"
+
 require "yard"
 require "tapioca"
 require "tapioca/runtime/reflection"


### PR DESCRIPTION
### Motivation

Temporary fix until https://github.com/rubyconfig/config/pull/319 is merged and released.

Fixes intermittent CI failures such as https://github.com/Shopify/tapioca/runs/6730332048?check_suite_focus=true#step:6:35.

### Implementation

Making sure `rails` is required before requiring `config`.

Depending on the order files are loaded we'll require a sub-part of Rails which will define the constant `Rails` and make loading `config` crash.

### Tests

Green CI.