### PR TITLE
Protobuf: Initializer, getter and setter for optional fields with message subtype should be nilable

### DIFF
--- a/lib/tapioca/dsl/compilers/protobuf.rb
+++ b/lib/tapioca/dsl/compilers/protobuf.rb
@@ -184,7 +184,11 @@ module Tapioca
               )
             end
           else
-            type = type_of(descriptor)
+            type = if descriptor.label == :optional && descriptor.type == :message
+              "T.nilable(#{type_of(descriptor)})"
+            else
+              type_of(descriptor)
+            end
 
             Field.new(
               name: descriptor.name,

--- a/spec/tapioca/dsl/compilers/protobuf_spec.rb
+++ b/spec/tapioca/dsl/compilers/protobuf_spec.rb
@@ -128,13 +128,13 @@ module Tapioca
                 # typed: strong
 
                 class Cart
-                  sig { params(cart_item_index: Google::Protobuf::UInt64Value).void }
+                  sig { params(cart_item_index: T.nilable(Google::Protobuf::UInt64Value)).void }
                   def initialize(cart_item_index: nil); end
 
-                  sig { returns(Google::Protobuf::UInt64Value) }
+                  sig { returns(T.nilable(Google::Protobuf::UInt64Value)) }
                   def cart_item_index; end
 
-                  sig { params(value: Google::Protobuf::UInt64Value).returns(Google::Protobuf::UInt64Value) }
+                  sig { params(value: T.nilable(Google::Protobuf::UInt64Value)).returns(T.nilable(Google::Protobuf::UInt64Value)) }
                   def cart_item_index=(value); end
                 end
               RBI


### PR DESCRIPTION
### Motivation
In protobuf, when an optional field has a message subtype it is nilable. Suppose I have some protobuf like:

```
Google::Protobuf::DescriptorPool.generated_pool.build do
  add_file("cart.proto", :syntax => :proto3) do
    add_message "Cart" do
      optional :customer_name, :string
      optional :notes,  :message, 2, "google.protobuf.StringValue"
    end
  end
end
```

Primitives like `:string` are not nilable. So the following are invalid:

```
Cart.new(customer_name: nil) # will error
Cart.new.customer_name = nil # will error
Cart.new.customer_name # returns ""
```

However, submessages are nilable:

```
cart = Cart.new(notes: nil)
cart.notes = nil
cart.notes # returns nil
```

### Implementation
When assembling the `Field` struct, I check if the `descriptor` is an `:optional` and it is a `:message`. If it is, I wrap the type in `T.nilable()`.

### Tests
I updated the existing test to reflect this case.
