### PR TITLE
Support generating DSL RBI by path

### DIFF
--- a/lib/tapioca/cli.rb
+++ b/lib/tapioca/cli.rb
@@ -130,11 +130,15 @@ module Tapioca
       type: :string,
       desc: "The path to the Rails application",
       default: "."
-    def dsl(*constants)
+    def dsl(*constant_or_paths)
       set_environment(options)
+
+      # Assume anything starting with a capital letter or colon is a class, otherwise a path
+      constants, paths = constant_or_paths.partition { |c| c =~ /\A[A-Z:]/ }
 
       command = Commands::Dsl.new(
         requested_constants: constants,
+        requested_paths: paths.map { |p| Pathname.new(p) },
         outpath: Pathname.new(options[:outdir]),
         only: options[:only],
         exclude: options[:exclude],


### PR DESCRIPTION
### Motivation

We often want to generate RBI for every model, worker, etc inside a namespace. Currently the only way to do that involves crawling ObjectSpace in a console or doing grep/sed magic to get the set of constants. We wanted an easier way to do this.

Another future-facing use-case is being able to run `tapioca dsl --verify some/specific/path`.
- Sidenote: At the moment, `--verify` fails unless it's called with no arguments since it thinks there's stale RBI, but that's something that can be fixed separately.

### Implementation

I thought it would be most ergonomic to be able to pass directory/filenames as args to the `tapioca dsl` but currently it's assumed that any non-flag args passed will be class names. Luckily, ruby class names and file names follow disjoint patterns:
- class names must start with a capital letter or colon
- path names typically (99.9% of path names I've ever seen) start with a lower case letter or slash.

Given that, we use that heuristic to split the passed args into either class names or paths and then treat them appropriately downstream. We then use `Tapioca::Static::SymbolLoader.symbols_from_paths` to get all the class names from the given paths.

Wanted to call out a slight difference in the error handling for paths. `tapioca dsl SomeClass SomeOtherClass` currently fails if none of those classes have processable DSL. This makes sense since you're specifically giving classes for which you want RBI generated. For paths, on the other hand you may not know if there's RBI to generate and I think that OK so we actually exist successfully if you've given paths but there's no constants to process. The one exception is if you've given use no paths that actually exist, in which case we'll exit with an error which should prevent typos like `tapioca dsl app/mode`.

### Tests

See tests
