### PR TITLE
Better name validation for methods and parameters

### DIFF
--- a/lib/tapioca/dsl/compiler.rb
+++ b/lib/tapioca/dsl/compiler.rb
@@ -168,11 +168,6 @@ module Tapioca
           "T.nilable(#{type})"
         end
       end
-
-      sig { params(name: String).returns(T::Boolean) }
-      def valid_parameter_name?(name)
-        name.match?(/^[[[:alnum:]]_]+$/)
-      end
     end
   end
 end

--- a/lib/tapioca/gem/listeners/methods.rb
+++ b/lib/tapioca/gem/listeners/methods.rb
@@ -180,11 +180,6 @@ module Tapioca
             .include?(method_name.gsub(/=$/, "").to_sym)
         end
 
-        sig { params(name: String).returns(T::Boolean) }
-        def valid_parameter_name?(name)
-          name.match?(/^[[[:alnum:]]_]+$/)
-        end
-
         sig { params(constant: Module).returns(T.nilable(UnboundMethod)) }
         def initialize_method_for(constant)
           constant.instance_method(:initialize)

--- a/lib/tapioca/gem/listeners/methods.rb
+++ b/lib/tapioca/gem/listeners/methods.rb
@@ -7,12 +7,8 @@ module Tapioca
       class Methods < Base
         extend T::Sig
 
+        include RBIHelper
         include Runtime::Reflection
-
-        SPECIAL_METHOD_NAMES = T.let([
-          "!", "~", "+@", "**", "-@", "*", "/", "%", "+", "-", "<<", ">>", "&", "|", "^",
-          "<", "<=", "=>", ">", ">=", "==", "===", "!=", "=~", "!~", "<=>", "[]", "[]=", "`",
-        ], T::Array[String])
 
         private
 
@@ -182,13 +178,6 @@ module Tapioca
             .props
             .keys
             .include?(method_name.gsub(/=$/, "").to_sym)
-        end
-
-        sig { params(name: String).returns(T::Boolean) }
-        def valid_method_name?(name)
-          return true if SPECIAL_METHOD_NAMES.include?(name)
-
-          !!name.match(/^[[:word:]]+[?!=]?$/)
         end
 
         sig { params(name: String).returns(T::Boolean) }

--- a/lib/tapioca/helpers/rbi_helper.rb
+++ b/lib/tapioca/helpers/rbi_helper.rb
@@ -6,6 +6,7 @@ module Tapioca
     extend T::Sig
     include SorbetHelper
     extend SorbetHelper
+    extend self
 
     sig { params(name: String, type: String).returns(RBI::TypedParam) }
     def create_param(name, type:)
@@ -88,6 +89,11 @@ module Tapioca
       serialized << "(#{parameters.join(", ")})" unless parameters.empty?
       serialized << " { { #{block.join(", ")} } }" unless block.empty?
       serialized
+    end
+
+    sig { params(name: String).returns(T::Boolean) }
+    def valid_method_name?(name)
+      !name.to_sym.inspect.start_with?(':"', ":@", ":$")
     end
   end
 end

--- a/lib/tapioca/helpers/rbi_helper.rb
+++ b/lib/tapioca/helpers/rbi_helper.rb
@@ -95,5 +95,10 @@ module Tapioca
     def valid_method_name?(name)
       !name.to_sym.inspect.start_with?(':"', ":@", ":$")
     end
+
+    sig { params(name: String).returns(T::Boolean) }
+    def valid_parameter_name?(name)
+      /^([[:lower:]]|_|[^[[:ascii:]]])([[:alnum:]]|_|[^[[:ascii:]]])*$/.match?(name)
+    end
   end
 end

--- a/lib/tapioca/rbi_ext/model.rb
+++ b/lib/tapioca/rbi_ext/model.rb
@@ -86,7 +86,7 @@ module RBI
       ).void
     end
     def create_method(name, parameters: [], return_type: "T.untyped", class_method: false, visibility: RBI::Public.new)
-      return unless valid_method_name?(name)
+      return unless Tapioca::RBIHelper.valid_method_name?(name)
 
       sig = RBI::Sig.new(return_type: return_type)
       method = RBI::Method.new(name, sigs: [sig], is_singleton: class_method, visibility: visibility)
@@ -98,19 +98,6 @@ module RBI
     end
 
     private
-
-    SPECIAL_METHOD_NAMES = T.let(
-      ["!", "~", "+@", "**", "-@", "*", "/", "%", "+", "-", "<<", ">>", "&", "|", "^", "<", "<=", "=>", ">", ">=",
-       "==", "===", "!=", "=~", "!~", "<=>", "[]", "[]=", "`",].freeze,
-      T::Array[String]
-    )
-
-    sig { params(name: String).returns(T::Boolean) }
-    def valid_method_name?(name)
-      return true if SPECIAL_METHOD_NAMES.include?(name)
-
-      !!name.match(/^[a-zA-Z_][[:word:]]*[?!=]?$/)
-    end
 
     sig { returns(T::Hash[String, RBI::Node]) }
     def nodes_cache

--- a/sorbet/rbi/gems/rbi@0.0.14.rbi
+++ b/sorbet/rbi/gems/rbi@0.0.14.rbi
@@ -2147,12 +2147,7 @@ class RBI::Tree < ::RBI::NodeWithComments
 
   sig { returns(T::Hash[::String, ::RBI::Node]) }
   def nodes_cache; end
-
-  sig { params(name: ::String).returns(T::Boolean) }
-  def valid_method_name?(name); end
 end
-
-RBI::Tree::SPECIAL_METHOD_NAMES = T.let(T.unsafe(nil), Array)
 
 class RBI::TreeBuilder < ::RBI::ASTVisitor
   sig do

--- a/spec/tapioca/helpers/rbi_helper_spec.rb
+++ b/spec/tapioca/helpers/rbi_helper_spec.rb
@@ -1,0 +1,26 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "spec_helper"
+
+class Tapioca::RBIHelperSpec < Minitest::Spec
+  include Tapioca::RBIHelper
+
+  describe Tapioca::RBIHelper do
+    it "accepts valid method names" do
+      [
+        "f", "foo", "_foo", "foo_", "fOO", "f00", "foo!", "foo=", "foo?", "Foo", "éxéctôr", "❨╯°□°❩╯︵┻━┻",
+        "!", "~", "+@", "**", "-@", "*", "/", "%", "+", "-", "<<", ">>", "&", "|", "^",
+        "<", "<=", ">", ">=", "==", "===", "!=", "=~", "!~", "<=>", "[]", "[]=", "`",
+      ].each do |name|
+        assert(valid_method_name?(name))
+      end
+    end
+
+    it "rejects invalid method names" do
+      ["", "42", "42foo", "!foo", "-@foo", "foo-", "foo-bar", "foo.bar", "=>"].each do |name|
+        refute(valid_method_name?(name))
+      end
+    end
+  end
+end

--- a/spec/tapioca/helpers/rbi_helper_spec.rb
+++ b/spec/tapioca/helpers/rbi_helper_spec.rb
@@ -22,5 +22,21 @@ class Tapioca::RBIHelperSpec < Minitest::Spec
         refute(valid_method_name?(name))
       end
     end
+
+    it "accepts valid parameter names" do
+      ["f", "foo", "_foo", "foo_", "fOO", "f00", "éxéctôr", "❨╯°□°❩╯︵┻━┻"].each do |name|
+        assert(valid_parameter_name?(name))
+      end
+    end
+
+    it "rejects invalid parameter names" do
+      [
+        "", "42", "42foo", "foo!", "foo=", "foo?", "Foo", "!foo", "-@foo", "foo-", "foo-bar", "foo.bar",
+        "!", "~", "+@", "**", "-@", "*", "/", "%", "+", "-", "<<", ">>", "&", "|", "^",
+        "<", "<=", "=>", ">", ">=", "==", "===", "!=", "=~", "!~", "<=>", "[]", "[]=", "`",
+      ].each do |name|
+        refute(valid_parameter_name?(name))
+      end
+    end
   end
 end


### PR DESCRIPTION
### Motivation

Fixes #969.
Closes #973.

### Implementation

Use the fix proposed [here](https://github.com/Shopify/tapioca/pull/973#issuecomment-1153129896) and factorize it under `RBIHelper`.

Also tighten the parameter name validation while at it.

### Tests

See included tests.
