### PR TITLE
Use asterisks for Markdown lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,8 +257,8 @@ gem:
 
 There are a few development/test environment gems that can cause RBI generation issues, so Tapioca skips them by default:
 
-- `debug`
-- `fakefs`
+* `debug`
+* `fakefs`
 
 #### Changing the strictness level of the RBI for a gem
 


### PR DESCRIPTION
### Motivation

Let's be consistent in how we use Markdown in the whole Readme.

