### PR TITLE
Filter engines in application directory so they are not loaded

### DIFF
--- a/lib/tapioca/gemfile.rb
+++ b/lib/tapioca/gemfile.rb
@@ -286,13 +286,6 @@ module Tapioca
         false
       end
 
-      sig { params(path: T.any(String, Pathname)).returns(String) }
-      def to_realpath(path)
-        path_string = path.to_s
-        path_string = File.realpath(path_string) if File.exist?(path_string)
-        path_string
-      end
-
       sig { returns(T::Boolean) }
       def gem_ignored?
         IGNORED_GEMS.include?(name)

--- a/lib/tapioca/gemfile.rb
+++ b/lib/tapioca/gemfile.rb
@@ -134,6 +134,7 @@ module Tapioca
 
     class GemSpec
       extend(T::Sig)
+      include GemHelper
 
       IGNORED_GEMS = T.let(
         [
@@ -161,7 +162,7 @@ module Tapioca
 
       sig { params(gemfile_dir: String).returns(T::Boolean) }
       def ignore?(gemfile_dir)
-        gem_ignored? || gem_in_app_dir?(gemfile_dir)
+        gem_ignored? || gem_in_app_dir?(gemfile_dir, full_gem_path)
       end
 
       sig { returns(String) }
@@ -295,16 +296,6 @@ module Tapioca
       sig { returns(T::Boolean) }
       def gem_ignored?
         IGNORED_GEMS.include?(name)
-      end
-
-      sig { params(gemfile_dir: String).returns(T::Boolean) }
-      def gem_in_app_dir?(gemfile_dir)
-        !gem_in_bundle_path? && full_gem_path.start_with?(gemfile_dir)
-      end
-
-      sig { returns(T::Boolean) }
-      def gem_in_bundle_path?
-        full_gem_path.start_with?(Bundler.bundle_path.to_s, Bundler.app_cache.to_s)
       end
     end
   end

--- a/lib/tapioca/helpers/gem_helper.rb
+++ b/lib/tapioca/helpers/gem_helper.rb
@@ -7,12 +7,20 @@ module Tapioca
 
     sig { params(gemfile_dir: String, full_gem_path: String).returns(T::Boolean) }
     def gem_in_app_dir?(gemfile_dir, full_gem_path)
-      !gem_in_bundle_path?(full_gem_path) && full_gem_path.start_with?(gemfile_dir)
+      !gem_in_bundle_path?(to_realpath(full_gem_path)) &&
+        full_gem_path.start_with?(to_realpath(gemfile_dir))
     end
 
     sig { params(full_gem_path: String).returns(T::Boolean) }
     def gem_in_bundle_path?(full_gem_path)
       full_gem_path.start_with?(Bundler.bundle_path.to_s, Bundler.app_cache.to_s)
+    end
+
+    sig { params(path: T.any(String, Pathname)).returns(String) }
+    def to_realpath(path)
+      path_string = path.to_s
+      path_string = File.realpath(path_string) if File.exist?(path_string)
+      path_string
     end
   end
 end

--- a/lib/tapioca/helpers/gem_helper.rb
+++ b/lib/tapioca/helpers/gem_helper.rb
@@ -1,0 +1,18 @@
+# typed: true
+# frozen_string_literal: true
+
+module Tapioca
+  module GemHelper
+    extend T::Sig
+
+    sig { params(gemfile_dir: String, full_gem_path: String).returns(T::Boolean) }
+    def gem_in_app_dir?(gemfile_dir, full_gem_path)
+      !gem_in_bundle_path?(full_gem_path) && full_gem_path.start_with?(gemfile_dir)
+    end
+
+    sig { params(full_gem_path: String).returns(T::Boolean) }
+    def gem_in_bundle_path?(full_gem_path)
+      full_gem_path.start_with?(Bundler.bundle_path.to_s, Bundler.app_cache.to_s)
+    end
+  end
+end

--- a/lib/tapioca/internal.rb
+++ b/lib/tapioca/internal.rb
@@ -24,6 +24,7 @@ require "tapioca"
 require "tapioca/runtime/reflection"
 require "tapioca/runtime/trackers"
 require "tapioca/runtime/dynamic_mixin_compiler"
+require "tapioca/helpers/gem_helper"
 require "tapioca/runtime/loader"
 
 require "tapioca/helpers/sorbet_helper"

--- a/lib/tapioca/runtime/loader.rb
+++ b/lib/tapioca/runtime/loader.rb
@@ -5,6 +5,7 @@ module Tapioca
   module Runtime
     class Loader
       extend(T::Sig)
+      include Tapioca::GemHelper
 
       sig do
         params(gemfile: Tapioca::Gemfile, initialize_file: T.nilable(String), require_file: T.nilable(String)).void
@@ -123,16 +124,6 @@ module Tapioca
             nil
           end
         end
-      end
-
-      sig { params(gemfile_dir: String, full_gem_path: String).returns(T::Boolean) }
-      def gem_in_app_dir?(gemfile_dir, full_gem_path)
-        !gem_in_bundle_path?(full_gem_path) && full_gem_path.start_with?(gemfile_dir)
-      end
-
-      sig { params(full_gem_path: String).returns(T::Boolean) }
-      def gem_in_bundle_path?(full_gem_path)
-        full_gem_path.start_with?(Bundler.bundle_path.to_s, Bundler.app_cache.to_s)
       end
     end
   end

--- a/lib/tapioca/runtime/loader.rb
+++ b/lib/tapioca/runtime/loader.rb
@@ -53,9 +53,13 @@ module Tapioca
         return [] unless Object.const_defined?("Rails::Engine")
 
         safe_require("active_support/core_ext/class/subclasses")
+        root = File.expand_path(".")
 
         # We can use `Class#descendants` here, since we know Rails is loaded
-        Object.const_get("Rails::Engine").descendants.reject(&:abstract_railtie?)
+        Object.const_get("Rails::Engine")
+          .descendants
+          .reject(&:abstract_railtie?)
+          .reject { |engine| File.fnmatch?("#{root}/**", engine.config.root) }
       end
 
       sig { params(path: String).void }


### PR DESCRIPTION
### Motivation

Solves: https://github.com/Shopify/tapioca/issues/993

Also fixes an internal Shopify/shopify issue 

### Implementation

As Rafael suggested in https://github.com/Shopify/tapioca/issues/993#issuecomment-1156876059, add a filter to reject engines that are part of the application directory 

### Tests

Change is part of the application loading - can this be tested? 
