### PR TITLE
Add `--typed-overrides` option to the annotations command

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,15 +321,16 @@ Usage:
   tapioca annotations
 
 Options:
-      [--sources=one two three]      # URIs of the sources to pull gem RBI annotations from
-                                     # Default: ["https://raw.githubusercontent.com/Shopify/rbi-central/main"]
-      [--netrc], [--no-netrc]        # Use .netrc to authenticate to private sources
-                                     # Default: true
-      [--netrc-file=NETRC_FILE]      # Path to .netrc file
-      [--auth=AUTH]                  # HTTP authorization header for private sources
-  -c, [--config=<config file path>]  # Path to the Tapioca configuration file
-                                     # Default: sorbet/tapioca/config.yml
-  -V, [--verbose], [--no-verbose]    # Verbose output for debugging purposes
+          [--sources=one two three]                           # URIs of the sources to pull gem RBI annotations from
+                                                              # Default: ["https://raw.githubusercontent.com/Shopify/rbi-central/main"]
+          [--netrc], [--no-netrc]                             # Use .netrc to authenticate to private sources
+                                                              # Default: true
+          [--netrc-file=NETRC_FILE]                           # Path to .netrc file
+          [--auth=AUTH]                                       # HTTP authorization header for private sources
+  --typed, -t, [--typed-overrides=gem:level [gem:level ...]]  # Override for typed sigils for pulled annotations
+  -c, [--config=<config file path>]                           # Path to the Tapioca configuration file
+                                                              # Default: sorbet/tapioca/config.yml
+  -V, [--verbose], [--no-verbose]                             # Verbose output for debugging purposes
 
 Pull gem RBI annotations from remote sources
 ```
@@ -382,6 +383,24 @@ $ TAPIOCA_NETRC_FILE=/path/to/my/netrc/file bin/tapioca annotations
 ```
 
 Tapioca will first try to find the netrc file as specified by the `--netrc-file` option. If that option is not supplied, it will try the `TAPIOCA_NETRC_FILE` environment variable value. If that value is not supplied either, it will fallback to `~/.netrc`.
+
+#### Changing the typed strictness of annotations files
+
+Sometimes the annotations files pulled by Tapioca will create type errors in your project because of incompatibilities.
+It is possible to ignore such files by switching their strictness level `--typed-overrides` option:
+
+```shell
+$ bin/tapioca annotations --typed-overrides gemA:ignore gemB:false
+```
+
+Or through the configuration file:
+
+```yaml
+annotations:
+  typed_overrides:
+    gemA: "ignore"
+    gemB: "false"
+```
 
 ### Generating RBI files for Rails and other DSLs
 
@@ -798,6 +817,7 @@ annotations:
   - https://raw.githubusercontent.com/Shopify/rbi-central/main
   netrc: true
   netrc_file: ''
+  typed_overrides: {}
 ```
 <!-- END_CONFIG_TEMPLATE -->
 

--- a/lib/tapioca/cli.rb
+++ b/lib/tapioca/cli.rb
@@ -276,6 +276,12 @@ module Tapioca
     option :netrc, type: :boolean, default: true, desc: "Use .netrc to authenticate to private sources"
     option :netrc_file, type: :string, desc: "Path to .netrc file"
     option :auth, type: :string, default: nil, desc: "HTTP authorization header for private sources"
+    option :typed_overrides,
+      aliases: ["--typed", "-t"],
+      type: :hash,
+      banner: "gem:level [gem:level ...]",
+      desc: "Override for typed sigils for pulled annotations",
+      default: {}
     def annotations
       if !options[:netrc] && options[:netrc_file]
         say_error("Options `--no-netrc` and `--netrc-file` can't be used together", :bold, :red)
@@ -285,7 +291,8 @@ module Tapioca
       command = Commands::Annotations.new(
         central_repo_root_uris: options[:sources],
         auth: options[:auth],
-        netrc_file: netrc_file(options)
+        netrc_file: netrc_file(options),
+        typed_overrides: options[:typed_overrides]
       )
       command.execute
     end

--- a/spec/tapioca/cli/annotations_spec.rb
+++ b/spec/tapioca/cli/annotations_spec.rb
@@ -289,6 +289,45 @@ module Tapioca
 
         refute_success_status(result)
       end
+
+      it "overrides strictnesses in annotations files" do
+        repo = create_repo({
+          rbi: <<~RBI,
+            # typed: strict
+
+            class AnnotationForRBI; end
+          RBI
+          spoom: <<~RBI,
+            class AnnotationForSpoom; end
+          RBI
+        })
+
+        result = @project.tapioca("annotations --sources #{repo.path} --typed-overrides rbi:ignore spoom:true")
+
+        assert_project_annotation_equal("sorbet/rbi/annotations/rbi.rbi", <<~RBI)
+          # typed: ignore
+
+          # DO NOT EDIT MANUALLY
+          # This file was pulled from a central RBI files repository.
+          # Please run `bin/tapioca annotations` to update it.
+
+          class AnnotationForRBI; end
+        RBI
+
+        assert_project_annotation_equal("sorbet/rbi/annotations/spoom.rbi", <<~RBI)
+          # typed: true
+
+          # DO NOT EDIT MANUALLY
+          # This file was pulled from a central RBI files repository.
+          # Please run `bin/tapioca annotations` to update it.
+
+          class AnnotationForSpoom; end
+        RBI
+
+        assert_success_status(result)
+
+        repo.destroy
+      end
     end
 
     private


### PR DESCRIPTION
### Motivation

Sometimes the annotations files pulled by Tapioca will create type errors in your project because of incompatibilities.
It is possible to ignore such files by switching their strictness level `--typed-overrides` option:

```shell
$ bin/tapioca annotations --typed-overrides gemA:ignore gemB:false
```

Or through the configuration file:

```yaml
annotations:
  typed_overrides:
    gemA: "ignore"
    gemB: "false"
```

Fixes https://github.com/Shopify/tapioca/issues/961.

### Tests

See automated tests.

