### PR TITLE
Add enum column support to `ActiveRecordColumns`

### DIFF
--- a/lib/tapioca/dsl/helpers/active_record_column_type_helper.rb
+++ b/lib/tapioca/dsl/helpers/active_record_column_type_helper.rb
@@ -45,7 +45,13 @@ module Tapioca
             end
 
           column = @constant.columns_hash[column_name]
-          setter_type = getter_type
+          setter_type =
+            case column_type
+            when ActiveRecord::Enum::EnumType
+              enum_setter_type(column_type)
+            else
+              getter_type
+            end
 
           if column&.null
             return [as_nilable_type(getter_type), as_nilable_type(setter_type)]
@@ -109,6 +115,16 @@ module Tapioca
           _, first_argument_type = signature.arg_types.first
 
           first_argument_type.to_s
+        end
+
+        sig { params(column_type: ActiveRecord::Enum::EnumType).returns(String) }
+        def enum_setter_type(column_type)
+          case column_type.subtype
+          when ActiveRecord::Type::Integer
+            "T.any(::String, ::Symbol, ::Integer)"
+          else
+            "T.any(::String, ::Symbol)"
+          end
         end
       end
     end

--- a/spec/tapioca/dsl/compilers/active_record_columns_spec.rb
+++ b/spec/tapioca/dsl/compilers/active_record_columns_spec.rb
@@ -225,8 +225,9 @@ module Tapioca
                         t.datetime :datetime_column
                         t.decimal :money_column
                         t.text :serialized_column
-                        # Ideally this would test t.enum but that is not supported by sqlite
-                        t.string :enum_column
+                        # Ideally this would also test t.enum but that is not supported by sqlite
+                        t.integer :integer_enum_column
+                        t.string :string_enum_column
                       end
                     end
                   end
@@ -239,7 +240,8 @@ module Tapioca
                   class Post < ActiveRecord::Base
                     money_column(:money_column, currency: "USD")
                     serialize :serialized_column, JSON
-                    enum :enum_column, [ :active, :archived ]
+                    enum :integer_enum_column, [ :active, :archived ]
+                    enum :string_enum_column, { high: 'high', low: 'low' }
                   end
                 RUBY
 
@@ -300,8 +302,26 @@ module Tapioca
                 assert_includes(output, expected)
 
                 expected = indented(<<~RBI, 4)
-                  sig { params(value: T.nilable(::String)).returns(T.nilable(::String)) }
-                  def enum_column=(value); end
+                  sig { returns(T.nilable(::String)) }
+                  def integer_enum_column; end
+                RBI
+                assert_includes(output, expected)
+
+                expected = indented(<<~RBI, 4)
+                  sig { params(value: T.nilable(T.any(::String, ::Symbol, ::Integer))).returns(T.nilable(T.any(::String, ::Symbol, ::Integer))) }
+                  def integer_enum_column=(value); end
+                RBI
+                assert_includes(output, expected)
+
+                expected = indented(<<~RBI, 4)
+                  sig { returns(T.nilable(::String)) }
+                  def string_enum_column; end
+                RBI
+                assert_includes(output, expected)
+
+                expected = indented(<<~RBI, 4)
+                  sig { params(value: T.nilable(T.any(::String, ::Symbol))).returns(T.nilable(T.any(::String, ::Symbol))) }
+                  def string_enum_column=(value); end
                 RBI
                 assert_includes(output, expected)
               end


### PR DESCRIPTION
### Motivation
Handle enum columns so they do not fall back to untyped. Primarily I want this so that the type includes `T.nilable` when appropriate which does not happen when it is untyped.

### Implementation
I added support for `ActiveRecord::Enum::EnumType` in `ActiveRecordColumnTypeHelper`. The setter method's type supports all coercible types. This requires inspecting the underlying column type to differentiate between numeric and non-numeric backing columns.

### Tests
Added coverage in existing test for generating proper types for every ActiveRecord column type.