### PR TITLE
Dsl::Compilers::ActiveRecordRelations: fix #find_sole_by, #sole

### DIFF
--- a/lib/tapioca/dsl/compilers/active_record_relations.rb
+++ b/lib/tapioca/dsl/compilers/active_record_relations.rb
@@ -543,6 +543,23 @@ module Tapioca
                 ],
                 return_type: constant_name
               )
+            when :find_sole_by
+              create_common_method(
+                "find_sole_by",
+                common_relation_methods_module,
+                parameters: [
+                  create_param("arg", type: "T.untyped"),
+                  create_rest_param("args", type: "T.untyped"),
+                ],
+                return_type: constant_name
+              )
+            when :sole
+              create_common_method(
+                "sole",
+                common_relation_methods_module,
+                parameters: [],
+                return_type: constant_name
+              )
             when :first, :last, :take
               create_common_method(
                 method_name,

--- a/spec/tapioca/dsl/compilers/active_record_relations_spec.rb
+++ b/spec/tapioca/dsl/compilers/active_record_relations_spec.rb
@@ -111,8 +111,8 @@ module Tapioca
                     sig { params(attributes: T.untyped, block: T.nilable(T.proc.params(object: ::Post).void)).returns(::Post) }
                     def find_or_initialize_by(attributes, &block); end
 
-                    sig { returns(T.nilable(::Post)) }
-                    def find_sole_by; end
+                    sig { params(arg: T.untyped, args: T.untyped).returns(::Post) }
+                    def find_sole_by(arg, *args); end
 
                     sig { params(limit: T.untyped).returns(T.untyped) }
                     def first(limit = nil); end
@@ -183,7 +183,7 @@ module Tapioca
                     sig { returns(::Post) }
                     def second_to_last!; end
 
-                    sig { returns(T.nilable(::Post)) }
+                    sig { returns(::Post) }
                     def sole; end
 
                     sig { params(column_name: T.nilable(T.any(String, Symbol)), block: T.nilable(T.proc.params(record: T.untyped).returns(T.untyped))).returns(T.untyped) }


### PR DESCRIPTION
### Motivation
The specs introduced for `sole` and `find_sole_by` in https://github.com/Shopify/tapioca/commit/5f90df17a9d2b6be03f44ad9cf605743cc17cf5a are not quite right.

See https://github.com/kivikakk/rails/blob/9e1cdf27ebaff31005f3d2bf02d97dfb116a3707/activerecord/lib/active_record/relation/finder_methods.rb#L107-L131.

### Implementation
Added logic for each of these to generated the correct signatures.

### Tests
Tests adjusted.
