### PR TITLE
Provide a meaningful help for HTTP errors when fetching annotations

### DIFF
--- a/lib/tapioca/commands/annotations.rb
+++ b/lib/tapioca/commands/annotations.rb
@@ -173,11 +173,11 @@ module Tapioca
         when Net::HTTPSuccess
           response.body
         else
-          say_error("\nCan't fetch file `#{path}` from #{repo_uri} (#{response.class})", :bold, :red)
+          say_http_error(path, repo_uri, message: response.class)
           nil
         end
       rescue SocketError, Errno::ECONNREFUSED => e
-        say_error("\nCan't fetch file `#{path}` from #{repo_uri} (#{e.message})", :bold, :red)
+        say_http_error(path, repo_uri, message: e.message)
         nil
       end
 
@@ -251,6 +251,19 @@ module Tapioca
         return nil unless token
 
         "token #{token}"
+      end
+
+      sig { params(path: String, repo_uri: String, message: String).void }
+      def say_http_error(path, repo_uri, message:)
+        say_error("\nCan't fetch file `#{path}` from #{repo_uri} (#{message})\n\n", :bold, :red)
+        say_error(<<~ERROR)
+          Tapioca can't access the annotations at #{repo_uri}.
+
+          Are you trying to access a private repository?
+          If so, please specify your Github credentials in your ~/.netrc file or by specifying the --auth option.
+
+          See https://github.com/Shopify/tapioca#using-a-netrc-file for more details.
+        ERROR
       end
     end
   end

--- a/spec/tapioca/cli/annotations_spec.rb
+++ b/spec/tapioca/cli/annotations_spec.rb
@@ -112,6 +112,14 @@ module Tapioca
 
         assert_includes(result.out, "Retrieving index from central repository #1... Done")
         assert_includes(result.err, "Can't fetch file `index.json` from https://bad-source")
+        assert_includes(result.err, <<~ERROR)
+          Tapioca can't access the annotations at https://bad-source.
+
+          Are you trying to access a private repository?
+          If so, please specify your Github credentials in your ~/.netrc file or by specifying the --auth option.
+
+          See https://github.com/Shopify/tapioca#using-a-netrc-file for more details.
+        ERROR
         assert_success_status(result)
       end
 


### PR DESCRIPTION
### Motivation

Provide some guidance on how to solve HTTP errors when fetching annotations from a private repository:

```shell
$ bundle exec tapioca annotations --sources https://private-repo
```

Will display this:
<img width="937" alt="image" src="https://user-images.githubusercontent.com/583144/174831112-ddce0ac5-17dd-4e99-88b9-e9abd7702995.png">

### Tests

See automated tests.
