### PR TITLE
Remove duplicate sorbet dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,6 @@ gem("pry-byebug")
 gem("rubocop-shopify", require: false)
 gem("rubocop-sorbet", ">= 0.4.1")
 gem("rubocop-rspec", require: false)
-gem("sorbet")
 gem("ruby-lsp", require: false)
 
 group(:deployment, :development) do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -369,7 +369,6 @@ DEPENDENCIES
   shopify-money
   sidekiq
   smart_properties
-  sorbet
   sprockets
   sqlite3
   state_machines


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
It's already specified in `gemspec` under `sorbet-static-and-runtime` gem.https://github.com/Shopify/tapioca/blob/7f18930a1cc587bdc0a291e0493e580d16199ad2/tapioca.gemspec#L31

A gem being specified as both runtime and development dependency seems unnecessary. I also wanted to see a dependabot PR title for `sorbet-static-and-runtime` instead of `sorbet`: https://github.com/Shopify/tapioca/pull/1005


### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
Removed it from the gemfile.
### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->

Existing tests should be enough.