### PR TITLE
Rename parameter `doc` into `include_doc`

### DIFF
--- a/lib/tapioca/cli.rb
+++ b/lib/tapioca/cli.rb
@@ -209,7 +209,7 @@ module Tapioca
           typed_overrides: options[:typed_overrides],
           outpath: Pathname.new(options[:outdir]),
           file_header: options[:file_header],
-          doc: options[:doc],
+          include_doc: options[:doc],
           include_exported_rbis: options[:exported_gem_rbis],
           number_of_workers: options[:workers],
           auto_strictness: options[:auto_strictness],

--- a/lib/tapioca/commands/gem.rb
+++ b/lib/tapioca/commands/gem.rb
@@ -16,7 +16,7 @@ module Tapioca
           typed_overrides: T::Hash[String, String],
           outpath: Pathname,
           file_header: T::Boolean,
-          doc: T::Boolean,
+          include_doc: T::Boolean,
           include_exported_rbis: T::Boolean,
           number_of_workers: T.nilable(Integer),
           auto_strictness: T::Boolean,
@@ -32,7 +32,7 @@ module Tapioca
         typed_overrides:,
         outpath:,
         file_header:,
-        doc:,
+        include_doc:,
         include_exported_rbis:,
         number_of_workers: nil,
         auto_strictness: true,
@@ -57,7 +57,7 @@ module Tapioca
         @bundle = T.let(nil, T.nilable(Gemfile))
         @existing_rbis = T.let(nil, T.nilable(T::Hash[String, String]))
         @expected_rbis = T.let(nil, T.nilable(T::Hash[String, String]))
-        @doc = T.let(doc, T::Boolean)
+        @include_doc = T.let(include_doc, T::Boolean)
         @include_exported_rbis = include_exported_rbis
       end
 
@@ -182,7 +182,7 @@ module Tapioca
           default_command(:gem, gem.name),
           reason: "types exported from the `#{gem.name}` gem",) if @file_header
 
-        rbi.root = Tapioca::Gem::Pipeline.new(gem, include_doc: @doc).compile
+        rbi.root = Tapioca::Gem::Pipeline.new(gem, include_doc: @include_doc).compile
 
         merge_with_exported_rbi(gem, rbi) if @include_exported_rbis
 


### PR DESCRIPTION
### Motivation

Some renaming to make things more explicit.

### Tests

No behavior change.

