### PR TITLE
Use default gemfile path instead of Rails root when listing engines

### DIFF
--- a/lib/tapioca/runtime/loader.rb
+++ b/lib/tapioca/runtime/loader.rb
@@ -55,11 +55,12 @@ module Tapioca
 
         safe_require("active_support/core_ext/class/subclasses")
 
+        project_path = Bundler.default_gemfile.parent.expand_path
         # We can use `Class#descendants` here, since we know Rails is loaded
         Object.const_get("Rails::Engine")
           .descendants
           .reject(&:abstract_railtie?)
-          .reject { |engine| gem_in_app_dir?(Rails.root.to_path, engine.config.root.to_path) }
+          .reject { |engine| gem_in_app_dir?(project_path, engine.config.root.to_path) }
       end
 
       sig { params(path: String).void }


### PR DESCRIPTION
### Motivation

For projects that aren't Rails, such as Tapioca itself, `Rails.root` is `nil`, which then breaks when trying to invoke `Rails.root.to_path`.

### Implementation

Add a check for verifying that `Rails.root` is set before continuing down to list engines. This enables Tapioca to generate RBIs for itself again.

### Tests

I couldn't figure out a way of forcing `Rails.root` to return `nil`. Let me know if you have ideas.