### PR TITLE
Disable mixin tracking when we do includes for probing

### DIFF
--- a/lib/tapioca/runtime/dynamic_mixin_compiler.rb
+++ b/lib/tapioca/runtime/dynamic_mixin_compiler.rb
@@ -35,22 +35,24 @@ module Tapioca
             # before the actual include
             before = singleton_class.ancestors
             # Call the actual `include` method with the supplied module
-            super(mod).tap do
-              # Take a snapshot of the list of singleton class ancestors
-              # after the actual include
-              after = singleton_class.ancestors
-              # The difference is the modules that are added to the list
-              # of ancestors of the singleton class. Those are all the
-              # modules that were `extend`ed due to the `include` call.
-              #
-              # We record those modules on our lookup table keyed by
-              # the included module with the values being all the modules
-              # that that module pulls into the singleton class.
-              #
-              # We need to reverse the order, since the extend order should
-              # be the inverse of the ancestor order. That is, earlier
-              # extended modules would be later in the ancestor chain.
-              mixins_from_modules[mod] = (after - before).reverse!
+            ::Tapioca::Runtime::Trackers::Mixin.with_disabled_registration do
+              super(mod).tap do
+                # Take a snapshot of the list of singleton class ancestors
+                # after the actual include
+                after = singleton_class.ancestors
+                # The difference is the modules that are added to the list
+                # of ancestors of the singleton class. Those are all the
+                # modules that were `extend`ed due to the `include` call.
+                #
+                # We record those modules on our lookup table keyed by
+                # the included module with the values being all the modules
+                # that that module pulls into the singleton class.
+                #
+                # We need to reverse the order, since the extend order should
+                # be the inverse of the ancestor order. That is, earlier
+                # extended modules would be later in the ancestor chain.
+                mixins_from_modules[mod] = (after - before).reverse!
+              end
             end
           rescue Exception # rubocop:disable Lint/RescueException
             # this is a best effort, bail if we can't perform this

--- a/lib/tapioca/runtime/trackers/mixin.rb
+++ b/lib/tapioca/runtime/trackers/mixin.rb
@@ -9,6 +9,7 @@ module Tapioca
 
         @constants_to_mixin_locations = {}.compare_by_identity
         @mixins_to_constants = {}.compare_by_identity
+        @enabled = true
 
         class Type < T::Enum
           enums do
@@ -19,6 +20,19 @@ module Tapioca
         end
 
         sig do
+          type_parameters(:Result)
+            .params(block: T.proc.returns(T.type_parameter(:Result)))
+            .returns(T.type_parameter(:Result))
+        end
+        def self.with_disabled_registration(&block)
+          @enabled = false
+
+          block.call
+        ensure
+          @enabled = true
+        end
+
+        sig do
           params(
             constant: Module,
             mixin: Module,
@@ -26,6 +40,8 @@ module Tapioca
           ).void
         end
         def self.register(constant, mixin, mixin_type)
+          return unless @enabled
+
           location = Reflection.required_from_location
 
           constants = constants_with_mixin(mixin)


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
We do dynamic includes of any module that we encounter into an empty anonymous class, so that we can discover side effects of doing such includes. This is how `DynamicMixinCompiler` works. However, that means that our mixin tracker attributes those includes as mixin locations that it needs to consider, which is wrong.

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
Added a means to disable mixin registration during certain blocks where we know that we should not record mixins, and used that in the main block of `DynamicMixinCompiler`.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->
Added a test that fails if we have not disabled mixin recording during `DynamicMixinCompiler` operation.
