### PR TITLE
Test Tapioca own gem RBIs on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,4 +31,4 @@ jobs:
       - name: Run tests
         run: bin/test
       - name: Verify gem RBIs are up-to-date
-        run: bundle exec exe/tapioca gem --verify
+        run: bin/check-rbis

--- a/bin/check-rbis
+++ b/bin/check-rbis
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+bundle exec tapioca gems --all -o tmp/generated-rbis
+
+if [ $? -ne 0 ]; then
+  rm -rf tmp/generated-rbis
+  echo -e "\nError: Tapioca failed generating it's own RBIs" >&2
+  exit 1
+fi
+
+diff "sorbet/rbi/gems" "tmp/generated-rbis"
+
+if [ $? -ne 0 ]; then
+  rm -rf tmp/generated-rbis
+  echo -e "\nError: Tapioca RBIs are out-of-date" >&2
+  exit 1
+fi
+
+rm -rf tmp/generated-rbis


### PR DESCRIPTION
### Motivation

Allow us to catch more errors when pushing new changes.

This test is currently broken until we 1) fix Tapioca load order and 2) regenerate the RBIs.
