### PR TITLE
Ensure test project cleanup

### DIFF
--- a/spec/tapioca/cli/gem_spec.rb
+++ b/spec/tapioca/cli/gem_spec.rb
@@ -195,6 +195,7 @@ module Tapioca
           project.gemfile(project.tapioca_gemfile)
           project.remove("sorbet/rbi")
           project.remove("../gems")
+          project.remove("sorbet/tapioca/require.rb")
         end
 
         it "must generate a single gem RBI" do
@@ -505,8 +506,6 @@ module Tapioca
 
           assert_empty_stderr(result)
           assert_success_status(result)
-
-          @project.remove("sorbet/tapioca/require.rb")
         end
 
         it "loads gems that are marked `require: false`" do
@@ -752,8 +751,6 @@ module Tapioca
 
           assert_empty_stderr(result)
           assert_success_status(result)
-
-          @project.remove("sorbet/tapioca/require.rb")
         end
 
         it "generate an empty RBI file" do


### PR DESCRIPTION
### Motivation

When errors occurred, some tests weren't doing the appropriate project cleanup, resulting in hard to read failures.

### Tests

Move cleanup to an `after` block to guarantee that it happens regardless of errors.