### PR TITLE
Add line numbers to the ConstantDefinition tracker

### DIFF
--- a/lib/tapioca/runtime/trackers/constant_definition.rb
+++ b/lib/tapioca/runtime/trackers/constant_definition.rb
@@ -45,8 +45,8 @@ module Tapioca
         # or where metaprogramming was used via +eval+, etc.
         def self.files_for(klass)
           name = String === klass ? klass : name_of(klass)
-          files = @class_files[name]
-          files&.map(&:path)&.to_set || Set.new
+          files = @class_files.fetch(name, [])
+          files.map(&:path).to_set
         end
       end
     end


### PR DESCRIPTION
### Motivation

Based on [this suggestion](https://github.com/Shopify/tapioca/pull/1025#discussion_r911400473).

We need the line numbers where constants were defined in order to add the [original gem source locations](https://github.com/Shopify/tapioca/pull/1025) for jump to definition. This PR saves this information in the `ConstantDefinition` tracker.

### Implementation

Added a `T::Struct` to keep track of path and line number, started populating it in the tracker and used the new method in the only occurrence of `files_for`.

### Tests

I contemplated adding a new test only for this tracker, but noticed that's not a pattern we're using in tests. Should I create a new one for this tracker?