### PR TITLE
Use `T.untyped` safe nilability

### DIFF
--- a/lib/tapioca/dsl/compilers/protobuf.rb
+++ b/lib/tapioca/dsl/compilers/protobuf.rb
@@ -146,6 +146,11 @@ module Tapioca
           end
         end
 
+        sig { params(descriptor: Google::Protobuf::FieldDescriptor).returns(T::Boolean) }
+        def nilable_descriptor?(descriptor)
+          descriptor.label == :optional && descriptor.type == :message
+        end
+
         sig { params(descriptor: Google::Protobuf::FieldDescriptor).returns(Field) }
         def field_of(descriptor)
           if descriptor.label == :repeated
@@ -184,11 +189,8 @@ module Tapioca
               )
             end
           else
-            type = if descriptor.label == :optional && descriptor.type == :message
-              "T.nilable(#{type_of(descriptor)})"
-            else
-              type_of(descriptor)
-            end
+            type = type_of(descriptor)
+            type = as_nilable_type(type) if nilable_descriptor?(descriptor)
 
             Field.new(
               name: descriptor.name,


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
We should not blindly use `"T.nilable(#{type})"` interpolation to generate nilable types since `T.nilable(T.untyped)` is illegal now. We should instead use the `as_nilable_type` helper to generate nilable types.

Also simplifying the logic to check for a nilable type here as well.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->
Existing tests are unchanged
