### PR TITLE
ActiveModel DateTime Attribute is a Time, not a DateTime

### DIFF
--- a/lib/tapioca/dsl/compilers/active_model_attributes.rb
+++ b/lib/tapioca/dsl/compilers/active_model_attributes.rb
@@ -103,7 +103,7 @@ module Tapioca
           when ActiveModel::Type::Date
             "::Date"
           when ActiveModel::Type::DateTime, ActiveModel::Type::Time
-            "::DateTime"
+            "::Time"
           when ActiveModel::Type::Decimal
             "::BigDecimal"
           when ActiveModel::Type::Float

--- a/lib/tapioca/dsl/helpers/active_record_column_type_helper.rb
+++ b/lib/tapioca/dsl/helpers/active_record_column_type_helper.rb
@@ -35,7 +35,7 @@ module Tapioca
             when ActiveRecord::Type::Boolean
               "T::Boolean"
             when ActiveRecord::Type::DateTime, ActiveRecord::Type::Time
-              "::DateTime"
+              "::Time"
             when ActiveRecord::AttributeMethods::TimeZoneConversion::TimeZoneConverter
               "::ActiveSupport::TimeWithZone"
             else

--- a/spec/tapioca/dsl/compilers/active_model_attributes_spec.rb
+++ b/spec/tapioca/dsl/compilers/active_model_attributes_spec.rb
@@ -118,10 +118,10 @@ module Tapioca
                 # typed: strong
 
                 class Shop
-                  sig { returns(T.nilable(::DateTime)) }
+                  sig { returns(T.nilable(::Time)) }
                   def created_at; end
 
-                  sig { params(value: T.nilable(::DateTime)).returns(T.nilable(::DateTime)) }
+                  sig { params(value: T.nilable(::Time)).returns(T.nilable(::Time)) }
                   def created_at=(value); end
 
                   sig { returns(T.nilable(::Integer)) }

--- a/spec/tapioca/dsl/compilers/active_record_columns_spec.rb
+++ b/spec/tapioca/dsl/compilers/active_record_columns_spec.rb
@@ -279,7 +279,7 @@ module Tapioca
                 assert_includes(output, expected)
 
                 expected = indented(<<~RBI, 4)
-                  sig { params(value: T.nilable(::DateTime)).returns(T.nilable(::DateTime)) }
+                  sig { params(value: T.nilable(::Time)).returns(T.nilable(::Time)) }
                   def datetime_column=(value); end
                 RBI
                 assert_includes(output, expected)


### PR DESCRIPTION
### Motivation
From what I can tell, both:
 - empirically from a project I'm working on
 - the rails [code](https://github.com/rails/rails/blob/main/activemodel/lib/active_model/type/date_time.rb) and [spec](https://github.com/rails/rails/blob/main/activemodel/test/cases/type/date_time_test.rb) 

ActiveModel attributes that are a `ActiveModel::Type::DateTime` or a `ActiveModel::Type::Time` end up as a ruby `::Time`, not a ruby `::DateTime`. 

### Implementation
Small change to use `::Time` rather than `::DateTime`

### Tests
I updated the existing test for the ActiveModel compiler

