### PR TITLE
Fix method name validation edge-case

### DIFF
--- a/lib/tapioca/helpers/rbi_helper.rb
+++ b/lib/tapioca/helpers/rbi_helper.rb
@@ -93,7 +93,10 @@ module Tapioca
 
     sig { params(name: String).returns(T::Boolean) }
     def valid_method_name?(name)
-      !name.to_sym.inspect.start_with?(':"', ":@", ":$")
+      name == "==" || !(
+        name.to_sym.inspect.start_with?(':"', ":@", ":$") ||
+        name.delete_suffix("=").to_sym.inspect.start_with?(':"', ":@", ":$")
+      )
     end
 
     sig { params(name: String).returns(T::Boolean) }

--- a/spec/tapioca/helpers/rbi_helper_spec.rb
+++ b/spec/tapioca/helpers/rbi_helper_spec.rb
@@ -13,19 +13,19 @@ class Tapioca::RBIHelperSpec < Minitest::Spec
         "!", "~", "+@", "**", "-@", "*", "/", "%", "+", "-", "<<", ">>", "&", "|", "^",
         "<", "<=", ">", ">=", "==", "===", "!=", "=~", "!~", "<=>", "[]", "[]=", "`",
       ].each do |name|
-        assert(valid_method_name?(name))
+        assert(valid_method_name?(name), "Expected `#{name}` to be a valid method name")
       end
     end
 
     it "rejects invalid method names" do
-      ["", "42", "42foo", "!foo", "-@foo", "foo-", "foo-bar", "foo.bar", "=>"].each do |name|
-        refute(valid_method_name?(name))
+      ["", "42", "42foo", "42foo=", "!foo", "-@foo", "foo-", "foo-bar", "foo.bar", "=>"].each do |name|
+        refute(valid_method_name?(name), "Expected `#{name}` to be an invalid method name")
       end
     end
 
     it "accepts valid parameter names" do
       ["f", "foo", "_foo", "foo_", "fOO", "f00", "éxéctôr", "❨╯°□°❩╯︵┻━┻"].each do |name|
-        assert(valid_parameter_name?(name))
+        assert(valid_parameter_name?(name), "Expected `#{name}` to be a valid parameter name")
       end
     end
 


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
Fixes #1042 

It turns out that `:4_to_5=` is not a valid symbol but `"4_to_5=".to_sym` does not quote it and represents it as `:4_to_5=` instead of `:"4_to_5"`, which throws off our whole method name validation logic.

The behaviour of Ruby was correct on this symbol until `ruby-2.2.0-preview2`, after which it was broken:
```shell
$ docker run --rm -e "ALL_RUBY_SINCE=ruby-2.0" rubylang/all-ruby ./all-ruby -e "puts '4_to_5='.to_sym.inspect"
ruby-2.0.0-p0       :"4_to_5="
...
ruby-2.2.0-preview1 :"4_to_5="
ruby-2.2.0-preview2 :4_to_5=
...
ruby-3.2.0-preview1 :4_to_5=
```
I think it is related to this change: https://github.com/ruby/ruby/commit/986a893d7a420b8472c06b2e36b71b8bf00e9e21

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
The fix is to check validity of the name after stripping trailing `=` as well. That leaves `==` as an edge-case, that we handle separately.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->
Improved existing tests and added explicit AR column tests for invalid method named column names
