### PR TITLE
Implement Rubocop DSL RBI compiler

### DIFF
--- a/lib/tapioca/dsl/compilers/rubocop.rb
+++ b/lib/tapioca/dsl/compilers/rubocop.rb
@@ -1,0 +1,72 @@
+# typed: strict
+# frozen_string_literal: true
+
+begin
+  require "rubocop"
+rescue LoadError
+  return
+end
+
+module Tapioca
+  module Dsl
+    module Compilers
+      # TODO: documentation
+      # TODO: Should we call this Rubocop or RuboCop?
+      class Rubocop < Compiler
+        GEM_LOAD_PATH_PREFIX_PATTERN = /\A#{Regexp.union(
+          ::Gem.loaded_specs.each_value.flat_map(&:load_paths),
+        )}/
+
+        # TODO: Should this define a CONSTANT_TYPE?
+
+        def self.gather_constants
+          descendants_of(::RuboCop::Cop::Base).reject do |constant|
+            constant_name = name_of(constant)
+            next true if constant_name.nil?
+
+            # All cops (built-in, extensions, custom) are supposed to be of the
+            # form ::Rubocop::Cop::<department>::<name>, so we can't just look at
+            # the name prefix. Best we can do is look at if the constant
+            # definition path is in a gem or not.
+
+            path = const_source_location(constant_name)&.first
+            next true if path.nil?
+
+            GEM_LOAD_PATH_PREFIX_PATTERN.match?(path)
+          end
+        end
+
+        def decorate
+          return unless used_macros?
+
+          root.create_path(constant) do |cop_klass|
+            node_matchers.each do |name|
+              create_method_from_def(cop_klass, constant.instance_method(name))
+            end
+
+            node_searches.each do |name|
+              create_method_from_def(cop_klass, constant.instance_method(name))
+            end
+          end
+        end
+
+        private
+
+        def used_macros?
+          return true unless node_matchers.empty?
+          return true unless node_searches.empty?
+
+          false
+        end
+
+        def node_matchers
+          constant.__tapioca_node_matchers
+        end
+
+        def node_searches
+          constant.__tapioca_node_searches
+        end
+      end
+    end
+  end
+end

--- a/lib/tapioca/dsl/extensions/rubocop.rb
+++ b/lib/tapioca/dsl/extensions/rubocop.rb
@@ -1,0 +1,44 @@
+# typed: strict
+# frozen_string_literal: true
+
+begin
+  require "rubocop"
+rescue LoadError
+  return
+end
+
+module Tapioca
+  module Dsl
+    module Compilers
+      module Extensions
+        module Rubocop
+          def def_node_matcher(name, *, **defaults)
+            __tapioca_node_matchers << name
+            __tapioca_node_matchers << :"without_defaults_#{name}" unless defaults.empty?
+
+            super
+          end
+
+          def def_node_search(name, *, **defaults)
+            __tapioca_node_searches << name
+            __tapioca_node_searches << :"without_defaults_#{name}" unless defaults.empty?
+
+            super
+          end
+
+          def __tapioca_node_matchers
+            @__tapioca_node_matchers = T.let(@__tapioca_node_matchers, T.nilable(T::Array[Symbol]))
+            @__tapioca_node_matchers ||= []
+          end
+
+          def __tapioca_node_searches
+            @__tapioca_node_searches = T.let(@__tapioca_node_searches, T.nilable(T::Array[Symbol]))
+            @__tapioca_node_searches ||= []
+          end
+
+          ::RuboCop::Cop::Base.singleton_class.prepend(self)
+        end
+      end
+    end
+  end
+end

--- a/spec/tapioca/dsl/compilers/rubocop_spec.rb
+++ b/spec/tapioca/dsl/compilers/rubocop_spec.rb
@@ -1,0 +1,110 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "spec_helper"
+require "rubocop"
+require "rubocop-sorbet"
+
+module Tapioca
+  module Dsl
+    module Compilers
+      class RubocopSpec < ::DslSpec
+        describe "Tapioca::Dsl::Compilers::Rubocop" do
+          def before_setup
+            require "tapioca/dsl/extensions/rubocop"
+            super
+          end
+
+          describe "initialize" do
+            it "gathers no constants if there are no classes that inherit from Rubocop::Cop::Base" do
+              assert_empty(gathered_constants)
+            end
+
+            it "gathers only cops defined in the app" do
+              add_ruby_file("content.rb", <<~RUBY)
+                class MyCop < ::RuboCop::Cop::Base
+                end
+
+                class MyLegacyCop < ::RuboCop::Cop::Cop
+                end
+
+                module ::RuboCop
+                  module Cop
+                    module MyApp
+                      class MyNamespacedCop < Base
+                      end
+                    end
+                  end
+                end
+              RUBY
+
+              assert_equal(["MyCop", "MyLegacyCop", "RuboCop::Cop::MyApp::MyNamespacedCop"], gathered_constants)
+            end
+          end
+
+          describe "decorate" do
+            it "generates empty RBI when no DSL used" do
+              add_ruby_file("content.rb", <<~RUBY)
+                class MyCop < ::RuboCop::Cop::Base
+                end
+              RUBY
+
+              expected = <<~RBI
+                # typed: strong
+              RBI
+
+              assert_equal(expected, rbi_for(:MyCop))
+            end
+
+            it "generates correct RBI file" do
+              add_ruby_file("content.rb", <<~RUBY)
+                class MyCop < ::RuboCop::Cop::Base
+                  def_node_matcher :some_matcher, "(...)"
+                  def_node_matcher :some_matcher_with_params, "(%1 %two ...)"
+                  def_node_matcher :some_matcher_with_params_and_defaults, "(%1 %two ...)", two: :default
+                  def_node_search :some_search, "(...)"
+                  def_node_search :some_search_with_params, "(%1 %two ...)"
+                  def_node_search :some_search_with_params_and_defaults, "(%1 %two ...)", two: :default
+
+                  def on_send(node);end
+                end
+              RUBY
+
+              expected = <<~RBI
+                # typed: strong
+
+                class MyCop
+                  sig { params(param0: T.untyped).returns(T.untyped) }
+                  def some_matcher(param0 = T.unsafe(nil)); end
+               
+                  sig { params(param0: T.untyped, param1: T.untyped, two: T.untyped).returns(T.untyped) }
+                  def some_matcher_with_params(param0 = T.unsafe(nil), param1, two:); end
+                
+                  sig { params(args: T.untyped, values: T.untyped).returns(T.untyped) }
+                  def some_matcher_with_params_and_defaults(*args, **values); end
+               
+                  sig { params(param0: T.untyped).returns(T.untyped) }
+                  def some_search(param0); end
+               
+                  sig { params(param0: T.untyped, param1: T.untyped, two: T.untyped).returns(T.untyped) }
+                  def some_search_with_params(param0, param1, two:); end
+                
+                  sig { params(args: T.untyped, values: T.untyped).returns(T.untyped) }
+                  def some_search_with_params_and_defaults(*args, **values); end
+               
+                  sig { params(param0: T.untyped, param1: T.untyped, two: T.untyped).returns(T.untyped) }
+                  def without_defaults_some_matcher_with_params_and_defaults(param0 = T.unsafe(nil), param1, two:); end
+               
+                  sig { params(param0: T.untyped, param1: T.untyped, two: T.untyped).returns(T.untyped) }
+                  def without_defaults_some_search_with_params_and_defaults(param0, param1, two:); end
+                end
+              RBI
+
+              assert_equal(expected, rbi_for(:MyCop))
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->

When authoring a custom cop, one is likely to use the `def_node_matcher` or `def_node_search` macros, which generate methods. Sorbet will complain if the generated methods are used, as it does not know they exist, requiring the developer to write a shim.

Let's automate that.

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->

I looked at a couple other DSL compilers and based my work off of them.

One tricky thing is that Rubocop expects custom cops to be defined in its namespace (i.e. `RuboCop::Cop::<department name>::<cop name>`). Therefore, we need a way to figure out which constants to generate DSLs for, and which to skip. The approach I came up with was to check if the `const_source_location` is in a gem, or within the host app. Although there may be a better way to do this.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->

I've added simple tests that check a couple uses of the macros, which result in slightly different method signatures.