### PR TITLE
Remove `T.unsafe` from extension method call

### DIFF
--- a/lib/tapioca/dsl/compilers/frozen_record.rb
+++ b/lib/tapioca/dsl/compilers/frozen_record.rb
@@ -65,7 +65,7 @@ module Tapioca
       class FrozenRecord < Compiler
         extend T::Sig
 
-        ConstantType = type_member { { fixed: T.class_of(::FrozenRecord::Base) } }
+        ConstantType = type_member { { fixed: T.all(T.class_of(::FrozenRecord::Base), Extensions::FrozenRecord) } }
 
         sig { override.void }
         def decorate
@@ -97,7 +97,7 @@ module Tapioca
 
         sig { params(record: RBI::Scope).void }
         def decorate_scopes(record)
-          scopes = T.unsafe(constant).__tapioca_scope_names
+          scopes = constant.__tapioca_scope_names
           return if scopes.nil?
 
           module_name = "GeneratedRelationMethods"


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
Sorbet doesn't know that `::FrozenRecord::Base` will have `::Tapioca::Dsl::Compilers::Extensions::FrozenRecord` prepended to its `singleton_class`. Therefore, it does not allow us to call the method provided by that module.

`T.unsafe` is used to allow the call, which can be improved.

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->

If we tell Sorbet that `ConstantType` will be the union of both types, it allows us to call the method.

I came up with this approach in #1046, which also makes use of an extension. I did not want to use `T.usafe` if possible, so I came up with this approach.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->

`bundle exec srb tc` is the test 😅 