### PR TITLE
Run command `check-shims` on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,3 +32,5 @@ jobs:
         run: bin/test
       - name: Verify gem RBIs are up-to-date
         run: bundle exec exe/tapioca gem --verify
+      - name: Verify duplicates in shims
+        run: bundle exec exe/tapioca check-shims

--- a/sorbet/rbi/shims/rdoc.rbi
+++ b/sorbet/rbi/shims/rdoc.rbi
@@ -1,3 +1,0 @@
-# typed: true
-
-class RDoc::Task; end


### PR DESCRIPTION
### Motivation

Let's enable this on CI so we can keep our RBI shims up-to-date (as shown in the second commit of this PR).
