### PR TITLE
Parallelize RBI parsing to speed up the `check-shims` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -742,6 +742,8 @@ Options:
                                                    # Default: sorbet/rbi/todo.rbi
       [--payload], [--no-payload]                  # Check shims against Sorbet's payload
                                                    # Default: true
+  -w, [--workers=N]                                # EXPERIMENTAL: Number of parallel workers
+                                                   # Default: 1
   -c, [--config=<config file path>]                # Path to the Tapioca configuration file
                                                    # Default: sorbet/tapioca/config.yml
   -V, [--verbose], [--no-verbose]                  # Verbose output for debugging purposes
@@ -818,6 +820,7 @@ check_shims:
   annotations_rbi_dir: sorbet/rbi/annotations
   todo_rbi_file: sorbet/rbi/todo.rbi
   payload: true
+  workers: 1
 annotations:
   sources:
   - https://raw.githubusercontent.com/Shopify/rbi-central/main

--- a/lib/tapioca/cli.rb
+++ b/lib/tapioca/cli.rb
@@ -275,6 +275,7 @@ module Tapioca
     option :annotations_rbi_dir, type: :string, desc: "Path to annotations RBIs", default: DEFAULT_ANNOTATIONS_DIR
     option :todo_rbi_file, type: :string, desc: "Path to the generated todo RBI file", default: DEFAULT_TODO_FILE
     option :payload, type: :boolean, desc: "Check shims against Sorbet's payload", default: true
+    option :workers, aliases: ["-w"], type: :numeric, desc: "EXPERIMENTAL: Number of parallel workers", default: 1
     def check_shims
       command = Commands::CheckShims.new(
         gem_rbi_dir: options[:gem_rbi_dir],
@@ -282,7 +283,8 @@ module Tapioca
         shim_rbi_dir: options[:shim_rbi_dir],
         annotations_rbi_dir: options[:annotations_rbi_dir],
         todo_rbi_file: options[:todo_rbi_file],
-        payload: options[:payload]
+        payload: options[:payload],
+        number_of_workers: options[:workers]
       )
       command.execute
     end

--- a/lib/tapioca/commands/check_shims.rb
+++ b/lib/tapioca/commands/check_shims.rb
@@ -15,10 +15,19 @@ module Tapioca
           annotations_rbi_dir: String,
           shim_rbi_dir: String,
           todo_rbi_file: String,
-          payload: T::Boolean
+          payload: T::Boolean,
+          number_of_workers: T.nilable(Integer)
         ).void
       end
-      def initialize(gem_rbi_dir:, dsl_rbi_dir:, annotations_rbi_dir:, shim_rbi_dir:, todo_rbi_file:, payload:)
+      def initialize(
+        gem_rbi_dir:,
+        dsl_rbi_dir:,
+        annotations_rbi_dir:,
+        shim_rbi_dir:,
+        todo_rbi_file:,
+        payload:,
+        number_of_workers:
+      )
         super()
         @gem_rbi_dir = gem_rbi_dir
         @dsl_rbi_dir = dsl_rbi_dir
@@ -26,6 +35,7 @@ module Tapioca
         @shim_rbi_dir = shim_rbi_dir
         @todo_rbi_file = todo_rbi_file
         @payload = payload
+        @number_of_workers = number_of_workers
       end
 
       sig { override.void }
@@ -51,7 +61,7 @@ module Tapioca
                 exit(1)
               end
 
-              index_rbis(index, "payload", payload_path)
+              index_rbis(index, "payload", payload_path, number_of_workers: @number_of_workers)
             end
           else
             say_error("The version of Sorbet used in your Gemfile.lock does not support `--print=payload-sources`")
@@ -62,10 +72,10 @@ module Tapioca
         end
 
         index_rbi(index, "todo", @todo_rbi_file)
-        index_rbis(index, "shim", @shim_rbi_dir)
-        index_rbis(index, "gem", @gem_rbi_dir)
-        index_rbis(index, "dsl", @dsl_rbi_dir)
-        index_rbis(index, "annotation", @annotations_rbi_dir)
+        index_rbis(index, "shim", @shim_rbi_dir, number_of_workers: @number_of_workers)
+        index_rbis(index, "gem", @gem_rbi_dir, number_of_workers: @number_of_workers)
+        index_rbis(index, "dsl", @dsl_rbi_dir, number_of_workers: @number_of_workers)
+        index_rbis(index, "annotation", @annotations_rbi_dir, number_of_workers: @number_of_workers)
 
         duplicates = duplicated_nodes_from_index(index, shim_rbi_dir: @shim_rbi_dir, todo_rbi_file: @todo_rbi_file)
         unless duplicates.empty?

--- a/lib/tapioca/commands/check_shims.rb
+++ b/lib/tapioca/commands/check_shims.rb
@@ -51,7 +51,7 @@ module Tapioca
                 exit(1)
               end
 
-              index_payload(index, payload_path)
+              index_rbis(index, "payload", payload_path)
             end
           else
             say_error("The version of Sorbet used in your Gemfile.lock does not support `--print=payload-sources`")

--- a/lib/tapioca/helpers/rbi_files_helper.rb
+++ b/lib/tapioca/helpers/rbi_files_helper.rb
@@ -9,16 +9,6 @@ module Tapioca
     requires_ancestor { Thor::Shell }
     requires_ancestor { SorbetHelper }
 
-    sig { params(index: RBI::Index, dir: String).void }
-    def index_payload(index, dir)
-      return unless Dir.exist?(dir)
-
-      say("Loading Sorbet payload... ")
-      files = Dir.glob("#{dir}/**/*.rbi").sort
-      parse_and_index_files(index, files)
-      say(" Done", :green)
-    end
-
     sig { params(index: RBI::Index, kind: String, file: String).void }
     def index_rbi(index, kind, file)
       return unless File.exist?(file)
@@ -32,7 +22,11 @@ module Tapioca
     def index_rbis(index, kind, dir)
       return unless Dir.exist?(dir) && !Dir.empty?(dir)
 
-      say("Loading #{kind} RBIs from #{dir}... ")
+      if kind == "payload"
+        say("Loading Sorbet payload... ")
+      else
+        say("Loading #{kind} RBIs from #{dir}... ")
+      end
       files = Dir.glob("#{dir}/**/*.rbi").sort
       parse_and_index_files(index, files)
       say(" Done", :green)

--- a/lib/tapioca/helpers/rbi_files_helper.rb
+++ b/lib/tapioca/helpers/rbi_files_helper.rb
@@ -14,8 +14,11 @@ module Tapioca
       return unless File.exist?(file)
 
       say("Loading #{kind} RBIs from #{file}... ")
-      parse_and_index_file(index, file)
-      say(" Done", :green)
+      time = Benchmark.realtime do
+        parse_and_index_file(index, file)
+      end
+      say(" Done ", :green)
+      say("(#{time.round(2)}s)")
     end
 
     sig { params(index: RBI::Index, kind: String, dir: String).void }
@@ -27,9 +30,12 @@ module Tapioca
       else
         say("Loading #{kind} RBIs from #{dir}... ")
       end
-      files = Dir.glob("#{dir}/**/*.rbi").sort
-      parse_and_index_files(index, files)
-      say(" Done", :green)
+      time = Benchmark.realtime do
+        files = Dir.glob("#{dir}/**/*.rbi").sort
+        parse_and_index_files(index, files)
+      end
+      say(" Done ", :green)
+      say("(#{time.round(2)}s)")
     end
 
     sig do
@@ -42,13 +48,16 @@ module Tapioca
     def duplicated_nodes_from_index(index, shim_rbi_dir:, todo_rbi_file:)
       duplicates = {}
       say("Looking for duplicates... ")
-      index.keys.each do |key|
-        nodes = index[key]
-        next unless shims_or_todos_have_duplicates?(nodes, shim_rbi_dir: shim_rbi_dir, todo_rbi_file: todo_rbi_file)
+      time = Benchmark.realtime do
+        index.keys.each do |key|
+          nodes = index[key]
+          next unless shims_or_todos_have_duplicates?(nodes, shim_rbi_dir: shim_rbi_dir, todo_rbi_file: todo_rbi_file)
 
-        duplicates[key] = nodes
+          duplicates[key] = nodes
+        end
       end
-      say(" Done", :green)
+      say(" Done ", :green)
+      say("(#{time.round(2)}s)")
       duplicates
     end
 

--- a/lib/tapioca/internal.rb
+++ b/lib/tapioca/internal.rb
@@ -7,6 +7,7 @@ require "tapioca"
 require "tapioca/runtime/reflection"
 require "tapioca/runtime/trackers"
 
+require "benchmark"
 require "bundler"
 require "erb"
 require "etc"

--- a/spec/tapioca/cli/check_shims_spec.rb
+++ b/spec/tapioca/cli/check_shims_spec.rb
@@ -58,7 +58,7 @@ module Tapioca
 
           result = @project.tapioca("check-shims --no-payload")
 
-          assert_equal(<<~OUT, result.out)
+          assert_equal(<<~OUT, strip_timer(result.out))
             Loading shim RBIs from sorbet/rbi/shims...  Done
             Loading gem RBIs from sorbet/rbi/gems...  Done
             Looking for duplicates...  Done
@@ -312,7 +312,7 @@ module Tapioca
 
           result = @project.tapioca("check-shims")
 
-          assert_includes(result.out, <<~OUT)
+          assert_includes(strip_timer(result.out), <<~OUT)
             Loading Sorbet payload...  Done
             Loading shim RBIs from sorbet/rbi/shims...  Done
             Looking for duplicates...  Done
@@ -666,6 +666,11 @@ module Tapioca
 
           refute_success_status(result)
         end
+      end
+
+      sig { params(string: String).returns(String) }
+      def strip_timer(string)
+        string.gsub(/ \(\d+\.\d+s\)/, "")
       end
     end
   end


### PR DESCRIPTION
### Motivation

Running `tapioca check-shims` can take up to 7min in Core (~13 when running on CI). The culprit is parsing the RBI files.

This PR proposes to speed up the process by parallelizing RBI parsing.

### Implementation

I reused `Executor` that we already use to parallelize RBI generation.

### Tests

No behavior change.

I tested the speed-up on Tapioca itself:

Before:

```shell
$ time bundle exec tapioca check-shims

Loading Sorbet payload...  Done (5.36s)
Loading shim RBIs from sorbet/rbi/shims...  Done (0.01s)
Loading gem RBIs from sorbet/rbi/gems...  Done (17.93s)
Looking for duplicates...  Done (0.02s)

real	0m24.291s
user	0m23.251s
sys	0m0.564s
```

After:

```shell
$ time bundle exec tapioca check-shims -w 10
Loading Sorbet payload...  Done (1.51s)
Loading shim RBIs from sorbet/rbi/shims...  Done (0.21s)
Loading gem RBIs from sorbet/rbi/gems...  Done (7.16s)
Looking for duplicates...  Done (0.03s)

real	0m9.561s
user	0m31.153s
sys	0m3.086s
```

So a > 50% improvement here.

I also tested on Core:

Before:

```shell
$ time bundle exec tapioca check-shims
Loading Sorbet payload...  Done (10.05s)
Loading shim RBIs from sorbet/rbi/shims...  Done (1.32s)
Loading gem RBIs from sorbet/rbi/gems...  Done (165.56s)
Loading dsl RBIs from sorbet/rbi/dsl...  Done (227.36s)
Loading annotation RBIs from sorbet/rbi/annotations...  Done (0.08s)
Looking for duplicates...  Done (0.5s)

real	6m52.147s
user	6m48.205s
sys	0m3.855s
```

After:

```shell
$ time bundle exec tapioca check-shims -w 10
Loading Sorbet payload...  Done (6.49s)
Loading shim RBIs from sorbet/rbi/shims...  Done (3.36s)
Loading gem RBIs from sorbet/rbi/gems...  Done (105.36s)
Loading dsl RBIs from sorbet/rbi/dsl...  Done (78.48s)
Loading annotation RBIs from sorbet/rbi/annotations...  Done (3.02s)
Looking for duplicates...  Done (0.44s)

real	3m24.315s
user	9m19.503s
sys	1m1.437s
```

So a > 50% improvement here too.