### PR TITLE
Add CODEOWNERS to repo

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Request a review from @Shopify/sorbet when a new PR is created
+* @Shopify/sorbet


### PR DESCRIPTION
### Motivation

I find myself requesting the same group over and over again. As code maintainers it seems that `@Sorbet` should be required for review on every pull-request. 

By adding this file we automate the process.

### Implementation

https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners

