### PR TITLE
Do not remove final newlines from annotations

### DIFF
--- a/lib/tapioca/commands/annotations.rb
+++ b/lib/tapioca/commands/annotations.rb
@@ -193,7 +193,8 @@ module Tapioca
           # Please run `#{default_command(:annotations)}` to update it.
         COMMENT
 
-        contents = content.split("\n")
+        # Split contents into newlines and ensure trailing empty lines are included
+        contents = content.split("\n", -1)
         if contents[0]&.start_with?("# typed:") && contents[1]&.empty?
           contents.insert(2, header).join("\n")
         else

--- a/spec/tapioca/cli/annotations_spec.rb
+++ b/spec/tapioca/cli/annotations_spec.rb
@@ -356,7 +356,7 @@ module Tapioca
 
     sig { params(path: String, content: String).void }
     def assert_project_annotation_equal(path, content)
-      assert_equal(content.strip, @project.read(path).strip)
+      assert_equal(content, @project.read(path))
     end
   end
 end


### PR DESCRIPTION
### Motivation
`tapioca annotations` currently removes the final newline from every annotation RBI file. This triggers linting errors in projects where linters expect every file to have a final newline.

See https://github.com/Shopify/rbi-central/issues/83

### Implementation
Don't remove final newlines when splitting up the annotation files to add the header.

### Tests
Modified existing tests to pass with this change.
