### PR TITLE
Remove `classification` from service.yml

### DIFF
--- a/service.yml
+++ b/service.yml
@@ -1,1 +1,0 @@
-classification: library


### PR DESCRIPTION
### Motivation

Fixes https://github.com/Shopify/services/issues/3252.

### Implementation

Following a discussion with the production-excellence team, the file should be kept empty as it is required by `dev` for
some commands.