### PR TITLE
Track proc bindings of existing signatures

### DIFF
--- a/lib/tapioca/internal.rb
+++ b/lib/tapioca/internal.rb
@@ -34,6 +34,7 @@ require "tapioca/helpers/rbi_helper"
 require "tapioca/sorbet_ext/fixed_hash_patch"
 require "tapioca/sorbet_ext/name_patch"
 require "tapioca/sorbet_ext/generic_name_patch"
+require "tapioca/sorbet_ext/proc_bind_patch"
 require "tapioca/runtime/generic_type_registry"
 
 require "tapioca/helpers/cli_helper"

--- a/lib/tapioca/sorbet_ext/proc_bind_patch.rb
+++ b/lib/tapioca/sorbet_ext/proc_bind_patch.rb
@@ -4,7 +4,7 @@
 module T
   module Types
     module ProcBindPatch
-      def initialize(arg_types, returns, bind)
+      def initialize(arg_types, returns, bind = T::Private::Methods::ARG_NOT_PROVIDED)
         super(arg_types, returns)
 
         unless bind == T::Private::Methods::ARG_NOT_PROVIDED
@@ -13,14 +13,9 @@ module T
       end
 
       def name
-        args = []
-        @arg_types.each do |k, v|
-          args << "#{k}: #{v.name}"
-        end
-
-        base_name = +"T.proc"
-        base_name << ".bind(#{@bind})" if @bind
-        "#{base_name}.params(#{args.join(", ")}).returns(#{@returns})"
+        name = super
+        name = name.sub("T.proc", "T.proc.bind(#{@bind})") unless @bind.nil?
+        name
       end
     end
 
@@ -33,8 +28,7 @@ module T
     module Methods
       module ProcBindPatch
         def finalize_proc(decl)
-          decl.finalized = true
-          decl.params = {} if decl.params == ARG_NOT_PROVIDED
+          super
 
           T.unsafe(T::Types::Proc).new(decl.params, decl.returns, decl.bind)
         end

--- a/lib/tapioca/sorbet_ext/proc_bind_patch.rb
+++ b/lib/tapioca/sorbet_ext/proc_bind_patch.rb
@@ -1,0 +1,46 @@
+# typed: true
+# frozen_string_literal: true
+
+module T
+  module Types
+    module ProcBindPatch
+      def initialize(arg_types, returns, bind)
+        super(arg_types, returns)
+
+        unless bind == T::Private::Methods::ARG_NOT_PROVIDED
+          @bind = T.let(T::Utils.coerce(bind), T::Types::Base)
+        end
+      end
+
+      def name
+        args = []
+        @arg_types.each do |k, v|
+          args << "#{k}: #{v.name}"
+        end
+
+        base_name = +"T.proc"
+        base_name << ".bind(#{@bind})" if @bind
+        "#{base_name}.params(#{args.join(", ")}).returns(#{@returns})"
+      end
+    end
+
+    Proc.prepend(ProcBindPatch)
+  end
+end
+
+module T
+  module Private
+    module Methods
+      module ProcBindPatch
+        def finalize_proc(decl)
+          decl.finalized = true
+          decl.params = {} if decl.params == ARG_NOT_PROVIDED
+
+          T.unsafe(T::Types::Proc).new(decl.params, decl.returns, decl.bind)
+        end
+      end
+
+      singleton_class.prepend(ProcBindPatch)
+    end
+  end
+end

--- a/sorbet/rbi/shims/sorbet.rbi
+++ b/sorbet/rbi/shims/sorbet.rbi
@@ -15,6 +15,45 @@ module T::Private
   end
 
   class Types::NotTyped < T::Types::Base; end
+
+  module Methods
+    ARG_NOT_PROVIDED = T.let(T.unsafe(nil), Object)
+
+    class Declaration
+      def on_failure; end
+      def on_failure=(on_failure); end
+
+      def override_allow_incompatible; end
+      def override_allow_incompatible=(override_allow_incompatible); end
+
+      def type_parameters; end
+      def type_parameters=(type_parameters); end
+
+      def raw; end
+      def raw=(raw); end
+
+      def mod; end
+      def mod=(mod); end
+
+      def params; end
+      def params=(params); end
+
+      def returns; end
+      def returns=(returns); end
+
+      def bind; end
+      def bind=(bind); end
+
+      def mode; end
+      def mode=(mode); end
+
+      def checked; end
+      def checked=(checked); end
+
+      def finalized; end
+      def finalized=(finalized); end
+    end
+  end
 end
 
 class T::Enum

--- a/spec/tapioca/gem/pipeline_spec.rb
+++ b/spec/tapioca/gem/pipeline_spec.rb
@@ -3868,6 +3868,26 @@ class Tapioca::Gem::PipelineSpec < Minitest::HooksSpec
       assert_equal(output, compile)
     end
 
+    it "compiles proc bindings" do
+      add_ruby_file("foo.rb", <<~RUBY)
+        class Foo
+          extend T::Sig
+
+          sig { params(block: T.proc.bind(String).void).void }
+          def bar(&block); end
+        end
+      RUBY
+
+      output = template(<<~RBI)
+        class Foo
+          sig { params(block: T.proc.bind(::String).void).void }
+          def bar(&block); end
+        end
+      RBI
+
+      assert_equal(output, compile)
+    end
+
     it "compile RBIs with location from gem source" do
       add_ruby_file("bar.rb", <<~RB)
         module Bar

--- a/spec/tapioca/gem/pipeline_spec.rb
+++ b/spec/tapioca/gem/pipeline_spec.rb
@@ -3875,6 +3875,9 @@ class Tapioca::Gem::PipelineSpec < Minitest::HooksSpec
 
           sig { params(block: T.proc.bind(String).void).void }
           def bar(&block); end
+
+          sig { params(block: T.proc.params(arg0: Integer).bind(String).void).void }
+          def baz(&block); end
         end
       RUBY
 
@@ -3882,6 +3885,9 @@ class Tapioca::Gem::PipelineSpec < Minitest::HooksSpec
         class Foo
           sig { params(block: T.proc.bind(::String).void).void }
           def bar(&block); end
+
+          sig { params(block: T.proc.bind(::String).params(arg0: ::Integer).void).void }
+          def baz(&block); end
         end
       RBI
 


### PR DESCRIPTION
### Motivation

When we generate gem RBIs, we're not carrying over proc bindings from existing signatures. The reason is because `sorbet-runtime` doesn't actually keep track of the bind and just discards it.

This ends up creating some frustration when generating gem RBIs as proc bindings are ignored.

### Implementation

Add a new Sorbet patch to keep track of the bind and print the `T::Types::Proc` name including it.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->

Added an example in the pipeline spec.