### PR TITLE
Handle the Ruby root in source locations listener

### DIFF
--- a/lib/tapioca/gem/listeners/source_location.rb
+++ b/lib/tapioca/gem/listeners/source_location.rb
@@ -56,7 +56,7 @@ module Tapioca
           end
 
           # Strip out the RUBY_ROOT prefix, which is different for each user
-          path = path.sub(%r{^.*(?=/lib/ruby/[0-9\.]+)}, "RUBY_ROOT")
+          path = path.sub(RbConfig::CONFIG["rubylibdir"], "RUBY_ROOT")
 
           node.comments << RBI::Comment.new("") if node.comments.any?
           node.comments << RBI::Comment.new("source://#{path}:#{line}")

--- a/lib/tapioca/gem/listeners/source_location.rb
+++ b/lib/tapioca/gem/listeners/source_location.rb
@@ -45,11 +45,18 @@ module Tapioca
           path = Pathname.new(file)
           return unless File.exist?(path)
 
+          # On native extensions, the source location may point to a shared object (.so, .bundle) file, which we cannot
+          # use for jump to definition. Only add source comments on Ruby files
+          return unless path.extname == ".rb"
+
           path = if path.realpath.to_s.start_with?(gem.full_gem_path)
             "#{gem.name}-#{gem.version}/#{path.realpath.relative_path_from(gem.full_gem_path)}"
           else
-            path.sub("#{Bundler.bundle_path}/gems/", "")
+            path.sub("#{Bundler.bundle_path}/gems/", "").to_s
           end
+
+          # Strip out the RUBY_ROOT prefix, which is different for each user
+          path = path.sub(%r{^.*(?=/lib/ruby/[0-9\.]+)}, "RUBY_ROOT")
 
           node.comments << RBI::Comment.new("") if node.comments.any?
           node.comments << RBI::Comment.new("source://#{path}:#{line}")

--- a/spec/tapioca/gem/pipeline_spec.rb
+++ b/spec/tapioca/gem/pipeline_spec.rb
@@ -3929,7 +3929,6 @@ class Tapioca::Gem::PipelineSpec < Minitest::HooksSpec
 
       active_support_version = Gem::Specification.find_by_name("activesupport").version
       sorbet_runtime_version = Gem::Specification.find_by_name("sorbet-runtime").version
-      ruby_version = RUBY_VERSION.sub(/\d$/, "0")
       mutex = Class.new { |k| k.include(::Mutex_m) }
 
       output = template(<<~RBI)
@@ -3994,19 +3993,19 @@ class Tapioca::Gem::PipelineSpec < Minitest::HooksSpec
         class Option
           include ::Mutex_m
 
-          # source://RUBY_ROOT/lib/ruby/#{ruby_version}/mutex_m.rb:#{mutex.instance_method(:lock).source_location&.last}
+          # source://RUBY_ROOT/mutex_m.rb:#{mutex.instance_method(:lock).source_location&.last}
           def lock; end
 
-          # source://RUBY_ROOT/lib/ruby/#{ruby_version}/mutex_m.rb:#{mutex.instance_method(:locked?).source_location&.last}
+          # source://RUBY_ROOT/mutex_m.rb:#{mutex.instance_method(:locked?).source_location&.last}
           def locked?; end
 
-          # source://RUBY_ROOT/lib/ruby/#{ruby_version}/mutex_m.rb:#{mutex.instance_method(:synchronize).source_location&.last}
+          # source://RUBY_ROOT/mutex_m.rb:#{mutex.instance_method(:synchronize).source_location&.last}
           def synchronize(&block); end
 
-          # source://RUBY_ROOT/lib/ruby/#{ruby_version}/mutex_m.rb:#{mutex.instance_method(:try_lock).source_location&.last}
+          # source://RUBY_ROOT/mutex_m.rb:#{mutex.instance_method(:try_lock).source_location&.last}
           def try_lock; end
 
-          # source://RUBY_ROOT/lib/ruby/#{ruby_version}/mutex_m.rb:#{mutex.instance_method(:unlock).source_location&.last}
+          # source://RUBY_ROOT/mutex_m.rb:#{mutex.instance_method(:unlock).source_location&.last}
           def unlock; end
         end
 


### PR DESCRIPTION
### Motivation

When methods for gem RBIs come from Ruby itself, we are currently adding the full location. This is not ideal, since each user could have Ruby installed in a different folder, which may also include platform specific labels.

We have to sanitize the `RUBY_ROOT` from the locations printed in order to properly add it in the Ruby LSP and provide navigation to Ruby's original source.

Additionally, we were also adding source locations for native extension files (like `.so` and `.bundle`). I don't think there's value in adding those, since it is not possible to navigate to them.

### Implementation

To address point 1, I have added a new `sub` that changes the Ruby root for the literal `RUBY_ROOT` string, which we can easily replace in the Ruby LSP for the real `ENV["RUBY_ROOT"]` to point to the right URI.

To address point 2, I added an early return in case the symbol was defined in a file that isn't a Ruby file.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->

Added a test include `Mutex_m` to show the Ruby root behaviour.