### PR TITLE
Rework method/parameter name validation to use the compiler

### DIFF
--- a/spec/tapioca/helpers/rbi_helper_spec.rb
+++ b/spec/tapioca/helpers/rbi_helper_spec.rb
@@ -35,7 +35,7 @@ class Tapioca::RBIHelperSpec < Minitest::Spec
         "!", "~", "+@", "**", "-@", "*", "/", "%", "+", "-", "<<", ">>", "&", "|", "^",
         "<", "<=", "=>", ">", ">=", "==", "===", "!=", "=~", "!~", "<=>", "[]", "[]=", "`",
       ].each do |name|
-        refute(valid_parameter_name?(name))
+        refute(valid_parameter_name?(name), "Expected `#{name}` to be an invalid parameter name")
       end
     end
   end


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
Our current way of doing method name and parameter name checks are a bit hacky and [that's been showing through](https://github.com/Shopify/tapioca/pull/1045).

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
A better way to do this is to use the compiler to do the name checks, similar to [how Ruby does it in its codebase](https://github.com/ruby/ruby/blob/241dced625f9ba8a4071954579778a0940e75179/ext/rubyvm/lib/forwardable/impl.rb#L3-L9). (Thanks to @tenderlove for showing me this method name validation check)

This method relies on compiling a method definition with the given name and then checking if the compiled code actually defines a method with that name.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->
Only updated the error message from a test to make it explicit which case is failing.
