### PR TITLE
Make `--workers` option not experimental

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,8 +156,7 @@ Options:
                                                               # Default: true
           [--exported-gem-rbis], [--no-exported-gem-rbis]     # Include RBIs found in the `rbi/` directory of the gem
                                                               # Default: true
-  -w, [--workers=N]                                           # EXPERIMENTAL: Number of parallel workers to use when generating RBIs
-                                                              # Default: 1
+  -w, [--workers=N]                                           # Number of parallel workers to use when generating RBIs (default: auto)
           [--auto-strictness], [--no-auto-strictness]         # Autocorrect strictness in gem RBIs in case of conflict with the DSL RBIs
                                                               # Default: true
   --dsl-dir, [--dsl-dir=directory]                            # The DSL directory used to correct gems strictnesses
@@ -442,8 +441,7 @@ Options:
           [--exclude=compiler [compiler ...]]  # Exclude supplied DSL compiler(s)
           [--verify], [--no-verify]            # Verifies RBIs are up-to-date
   -q, [--quiet], [--no-quiet]                  # Suppresses file creation output
-  -w, [--workers=N]                            # EXPERIMENTAL: Number of parallel workers to use when generating RBIs
-                                               # Default: 1
+  -w, [--workers=N]                            # Number of parallel workers to use when generating RBIs (default: auto)
           [--rbi-max-line-length=N]            # Set the max line length of generated RBIs. Signatures longer than the max line length will be wrapped
                                                # Default: 120
   -e, [--environment=ENVIRONMENT]              # The Rack/Rails environment to use when generating RBIs
@@ -742,8 +740,7 @@ Options:
                                                    # Default: sorbet/rbi/todo.rbi
       [--payload], [--no-payload]                  # Check shims against Sorbet's payload
                                                    # Default: true
-  -w, [--workers=N]                                # EXPERIMENTAL: Number of parallel workers
-                                                   # Default: 1
+  -w, [--workers=N]                                # Number of parallel workers (default: auto)
   -c, [--config=<config file path>]                # Path to the Tapioca configuration file
                                                    # Default: sorbet/tapioca/config.yml
   -V, [--verbose], [--no-verbose]                  # Verbose output for debugging purposes

--- a/lib/tapioca/cli.rb
+++ b/lib/tapioca/cli.rb
@@ -105,8 +105,7 @@ module Tapioca
     option :workers,
       aliases: ["-w"],
       type: :numeric,
-      desc: "EXPERIMENTAL: Number of parallel workers to use when generating RBIs",
-      default: 1
+      desc: "Number of parallel workers to use when generating RBIs (default: auto)"
     option :rbi_max_line_length,
       type: :numeric,
       desc: "Set the max line length of generated RBIs. Signatures longer than the max line length will be wrapped",
@@ -133,13 +132,6 @@ module Tapioca
         number_of_workers: options[:workers],
         rbi_formatter: rbi_formatter(options)
       )
-
-      if options[:workers] != 1
-        say(
-          "Using more than one worker is experimental and might produce results that are not deterministic",
-          :red
-        )
-      end
 
       Tapioca.silence_warnings do
         command.execute
@@ -201,8 +193,7 @@ module Tapioca
     option :workers,
       aliases: ["-w"],
       type: :numeric,
-      desc: "EXPERIMENTAL: Number of parallel workers to use when generating RBIs",
-      default: 1
+      desc: "Number of parallel workers to use when generating RBIs (default: auto)"
     option :auto_strictness,
       type: :boolean,
       desc: "Autocorrect strictness in gem RBIs in case of conflict with the DSL RBIs",
@@ -252,13 +243,6 @@ module Tapioca
           raise MalformattedArgumentError, "Option '--verify' must be provided without any other arguments" if verify
         end
 
-        if options[:workers] != 1
-          say(
-            "Using more than one worker is experimental and might produce results that are not deterministic",
-            :red
-          )
-        end
-
         if gems.empty? && !all
           command.sync(should_verify: verify, exclude: options[:exclude])
         else
@@ -275,7 +259,7 @@ module Tapioca
     option :annotations_rbi_dir, type: :string, desc: "Path to annotations RBIs", default: DEFAULT_ANNOTATIONS_DIR
     option :todo_rbi_file, type: :string, desc: "Path to the generated todo RBI file", default: DEFAULT_TODO_FILE
     option :payload, type: :boolean, desc: "Check shims against Sorbet's payload", default: true
-    option :workers, aliases: ["-w"], type: :numeric, desc: "EXPERIMENTAL: Number of parallel workers", default: 1
+    option :workers, aliases: ["-w"], type: :numeric, desc: "Number of parallel workers (default: auto)"
     def check_shims
       command = Commands::CheckShims.new(
         gem_rbi_dir: options[:gem_rbi_dir],

--- a/spec/helpers/mock_project.rb
+++ b/spec/helpers/mock_project.rb
@@ -117,6 +117,8 @@ module Tapioca
         exec_command << "--workers=1" unless command.match?("--workers")
         exec_command << "--no-doc" unless command.match?("--doc")
         exec_command << "--no-loc" unless command.match?("--loc")
+      elsif command.start_with?(/dsl/)
+        exec_command << "--workers=1" unless command.match?("--workers")
       end
       bundle_exec(exec_command.join(" "))
     end


### PR DESCRIPTION
### Motivation

Currently if no `--workers` option is pass, we'll fallback to `1` by default.

This is a problem as we can't use `parallel` mechanism to [auto-detect how many processors to use](https://github.com/grosser/parallel/blob/master/lib/parallel.rb#L273). By passing `nil` by default Tapioca will use has many processors as available by default.

This means making the parallel execution not experimental anymore (as it becomes the default behavior) but people can still disable it manually by passing `--workers 1`.

