### PR TITLE
Fix no_toc annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,7 @@ Tapioca makes it easy to work with [Sorbet](https://sorbet.org) in your codebase
   * Find useless definitions in shim RBI files from Sorbet's embedded RBI for core and stdlib
   * Synchronization validation for your CI
 
-## Table of Contents
-{:.no_toc}
-<!-- the above is so that this header does not appear in the ToC -->
+## Table of Contents <!-- no_toc -->
 <!-- START_TOC -->
 * [Installation](#installation)
 * [Getting started](#getting-started)


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
The Kramdown block attribute was not working properly on Github and we ended up showing a `{:.no_toc}` on the README page.

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
This PR fixes that by moving that annotation to an HTML comment on the raw text of the header that we match against to filter it out.

I also took the opportunity to encapsulate some of the operations we were performing into a custom converter class that inherits from the built-in `Toc` converter. This makes the code more readable.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->
No added tests.
