### PR TITLE
Don't crash on rails < 7

### DIFF
--- a/lib/tapioca/dsl/helpers/active_record_column_type_helper.rb
+++ b/lib/tapioca/dsl/helpers/active_record_column_type_helper.rb
@@ -119,7 +119,8 @@ module Tapioca
 
         sig { params(column_type: ActiveRecord::Enum::EnumType).returns(String) }
         def enum_setter_type(column_type)
-          case column_type.subtype
+          # In Rails < 7 this method is private. When support for that is dropped we can call the method directly
+          case column_type.send(:subtype)
           when ActiveRecord::Type::Integer
             "T.any(::String, ::Symbol, ::Integer)"
           else


### PR DESCRIPTION
The method `subtype` was made public in rails 7, but it did exist previously so we can use it via `send`.

### Motivation

With rails < 7, tapioca dsl crashes with: `lib/tapioca/dsl/helpers/active_record_column_type_helper.rb:122:in 'enum_setter_type': private method 'subtype' called for #<ActiveRecord::Enum::EnumType:0x000055c8a8aefb70> (NoMethodError)`


### Implementation

subtype was not public in rails 6, but it did exist since at least 5.0 https://github.com/rails/rails/blob/v5.0.0/activerecord/lib/active_record/enum.rb#L143

### Tests

No idea how to add a test for this.
