### PR TITLE
Also check duplicated mixins in shims and TODO files

### DIFF
--- a/lib/tapioca/helpers/rbi_files_helper.rb
+++ b/lib/tapioca/helpers/rbi_files_helper.rb
@@ -178,6 +178,9 @@ module Tapioca
       shims_or_todos_empty_scopes = extract_empty_scopes(shims_or_todos)
       return true unless shims_or_todos_empty_scopes.empty?
 
+      mixins = extract_mixins(shims_or_todos)
+      return true unless mixins.empty?
+
       props = extract_methods_and_attrs(shims_or_todos)
       return false if props.empty?
 
@@ -213,6 +216,13 @@ module Tapioca
       T.cast(nodes.select do |node|
         node.is_a?(RBI::Method) || node.is_a?(RBI::Attr)
       end, T::Array[T.any(RBI::Method, RBI::Attr)])
+    end
+
+    sig { params(nodes: T::Array[RBI::Node]).returns(T::Array[T.any(RBI::Mixin, RBI::RequiresAncestor)]) }
+    def extract_mixins(nodes)
+      T.cast(nodes.select do |node|
+        node.is_a?(RBI::Mixin) || node.is_a?(RBI::RequiresAncestor)
+      end, T::Array[T.all(RBI::Mixin, RBI::RequiresAncestor)])
     end
 
     sig { params(nodes: T::Array[T.any(RBI::Method, RBI::Attr)]).returns(T::Array[T.any(RBI::Method, RBI::Attr)]) }


### PR DESCRIPTION
### Motivation

While we check scopes and methods duplicated between generated RBIs and shims, we do not check anything about mixins.

Consider this:

```rbi
# in generated sorbet/rbi/gems/foo@1.0.0.rbi

module Bar; end

class Foo
  include Bar
end
```

```rbi
# in manually written shim sorbet/rbi/shims/gems/foo.rbi

class Foo
  include Bar
end
```

The shim file is actually useless and could be deleted without impacting type checking since the include is already known.

### Implementation

We can reuse the indexing mechanism already in place for other properties to check for duplicates. We just need to look for `RBI::Mixin` nodes and `RBI::RequiresAncestor` nodes.

One limitation of the static approach is that we do not resolve constants when checking for duplicates so something like this would not be considered a duplicate:

```rbi
module A
  class B
    include C
  end
end

module A
  class B
    include ::C
  end
end
```

Because we can't really ensure that `C` is the same thing as `::C` at this level.


### Tests

See automated tests.

Using this feature I tried this in core and found one file that can be safely removed.