### PR TITLE
Generate vendor gem rbis

### DIFF
--- a/lib/tapioca/helpers/gem_helper.rb
+++ b/lib/tapioca/helpers/gem_helper.rb
@@ -8,12 +8,18 @@ module Tapioca
     sig { params(gemfile_dir: String, full_gem_path: String).returns(T::Boolean) }
     def gem_in_app_dir?(gemfile_dir, full_gem_path)
       !gem_in_bundle_path?(to_realpath(full_gem_path)) &&
-        full_gem_path.start_with?(to_realpath(gemfile_dir))
+        full_gem_path.start_with?(to_realpath(gemfile_dir)) &&
+        !gem_in_vendor_path?(to_realpath(full_gem_path))
     end
 
     sig { params(full_gem_path: String).returns(T::Boolean) }
     def gem_in_bundle_path?(full_gem_path)
       full_gem_path.start_with?(Bundler.bundle_path.to_s, Bundler.app_cache.to_s)
+    end
+
+    sig { params(full_gem_path: String).returns(T::Boolean) }
+    def gem_in_vendor_path?(full_gem_path)
+      full_gem_path.start_with?(Pathname.new(Bundler.root).join("vendor/gems").to_s)
     end
 
     sig { params(path: T.any(String, Pathname)).returns(String) }

--- a/spec/tapioca/cli/gem_spec.rb
+++ b/spec/tapioca/cli/gem_spec.rb
@@ -1358,6 +1358,18 @@ module Tapioca
           assert_success_status(res)
         end
 
+        it "must generate a gem RBI for vendor gems" do
+          foo = MockGem.new("#{@project.path}/vendor/gems/foo", "foo", "0.0.1")
+          foo.gemspec(foo.default_gemspec_contents)
+
+          @project.require_mock_gem(foo)
+          @project.bundle_install
+
+          result = @project.tapioca("gem foo")
+
+          assert_includes(result.out, "create  sorbet/rbi/gems/foo@0.0.1.rbi")
+        end
+
         it "must generate top-level and namespaced constants from engines" do
           foo = mock_gem("foo", "0.0.2") do
             write("lib/foo.rb", <<~RB)


### PR DESCRIPTION
### Motivation
Closes #343 
RBI files aren't being created for vendor gems & this PR solves that.

### Implementation
I created a vendor gem using [this](https://fuzzyblog.io/blog/ruby/2014/08/22/how-to-vendor-gem-a-gem.html) blog. After that, I went through RBI gem generation with the debugger and found the spot vendor gems were being lost. Vendor gems are excluded in the `gem_in_app_dir?` function because they aren't in the bundle path and their path starts with the root path. To solve this, I created a function similar to `gem_in_bundle_path?` named `gem_in_vendor_path?` that checks if the gem is in the `vendor/gems` folder and added in that logic to `gem_in_app_dir?`.

### Tests
**Manual Test**
1. Open Tapioca
2. Install a random gem into your Gemfile (e.g., [dog_breeds](https://rubygems.org/gems/dog_breeds))  
3. Run `bundle install`
4. Run `gem unpack dog_breeds`
5. `mv dog_breeds-0.4.0 vendor/gems`
6. Go into the Gemfile and modify `gem("dog_breeds")` to `gem("dog_breeds", "0.4.0", :path => "vendor/gems/dog_breeds-0.4.0"`
7. Run `bundle install`
8. Run `bundle exec tapioca gem dog_breeds` and this should print `created sorbet/rbi/gems/dog_breeds@0.4.0.rbi` :)

**Automatic Test**
Wrote a new test that creates a vendor gem and successfully generates a gem RBI file for it.

