### PR TITLE
Generate enum module definitions

### DIFF
--- a/lib/tapioca/compilers/dsl/protobuf.rb
+++ b/lib/tapioca/compilers/dsl/protobuf.rb
@@ -64,7 +64,6 @@ module Tapioca
         class Field < T::Struct
           prop :name, String
           prop :type, String
-          prop :setter_type, String
           prop :init_type, String
           prop :default, String
         end
@@ -167,7 +166,6 @@ module Tapioca
               Field.new(
                 name: descriptor.name,
                 type: type,
-                setter_type: type,
                 init_type: "T.nilable(T.any(#{type}, T::Hash[#{key_type}, #{value_type}]))",
                 default: "Google::Protobuf::Map.new(#{default_args.join(", ")})"
               )
@@ -181,7 +179,6 @@ module Tapioca
               Field.new(
                 name: descriptor.name,
                 type: type,
-                setter_type: type,
                 init_type: "T.nilable(T.any(#{type}, T::Array[#{elem_type}]))",
                 default: "Google::Protobuf::RepeatedField.new(#{default_args.join(", ")})"
               )
@@ -192,7 +189,6 @@ module Tapioca
             Field.new(
               name: descriptor.name,
               type: type,
-              setter_type: type,
               init_type: "T.nilable(#{type})",
               default: "nil"
             )
@@ -215,7 +211,7 @@ module Tapioca
 
           klass.create_method(
             "#{field.name}=",
-            parameters: [create_param("value", type: field.setter_type)],
+            parameters: [create_param("value", type: field.type)],
             return_type: "void"
           )
 

--- a/lib/tapioca/compilers/dsl/protobuf.rb
+++ b/lib/tapioca/compilers/dsl/protobuf.rb
@@ -167,7 +167,7 @@ module Tapioca
                 name: descriptor.name,
                 type: type,
                 setter_type: type,
-                init_type: "T.any(#{type}, T::Hash[#{key_type}, #{value_type}])",
+                init_type: "T.nilable(T.any(#{type}, T::Hash[#{key_type}, #{value_type}]))",
                 default: "Google::Protobuf::Map.new(#{default_args.join(", ")})"
               )
             else
@@ -181,7 +181,7 @@ module Tapioca
                 name: descriptor.name,
                 type: type,
                 setter_type: type,
-                init_type: "T.any(#{type}, T::Array[#{elem_type}])",
+                init_type: "T.nilable(T.any(#{type}, T::Array[#{elem_type}]))",
                 default: "Google::Protobuf::RepeatedField.new(#{default_args.join(", ")})"
               )
             end
@@ -192,7 +192,7 @@ module Tapioca
               name: descriptor.name,
               type: type,
               setter_type: descriptor.type == :enum ? "T.any(#{type}, Integer)" : type,
-              init_type: descriptor.type == :enum ? "T.nilable(T.any(#{type}, Integer))" : type,
+              init_type: descriptor.type == :enum ? "T.nilable(T.any(#{type}, Integer))" : "T.nilable(#{type})",
               default: "nil"
             )
           end

--- a/lib/tapioca/compilers/dsl/protobuf.rb
+++ b/lib/tapioca/compilers/dsl/protobuf.rb
@@ -64,6 +64,7 @@ module Tapioca
         class Field < T::Struct
           prop :name, String
           prop :type, String
+          prop :setter_type, String
           prop :init_type, String
           prop :default, String
         end
@@ -165,6 +166,7 @@ module Tapioca
               Field.new(
                 name: descriptor.name,
                 type: type,
+                setter_type: type,
                 init_type: "T.any(#{type}, T::Hash[#{key_type}, #{value_type}])",
                 default: "Google::Protobuf::Map.new(#{default_args.join(", ")})"
               )
@@ -178,6 +180,7 @@ module Tapioca
               Field.new(
                 name: descriptor.name,
                 type: type,
+                setter_type: type,
                 init_type: "T.any(#{type}, T::Array[#{elem_type}])",
                 default: "Google::Protobuf::RepeatedField.new(#{default_args.join(", ")})"
               )
@@ -188,7 +191,8 @@ module Tapioca
             Field.new(
               name: descriptor.name,
               type: type,
-              init_type: type,
+              setter_type: descriptor.type == :enum ? "T.any(#{type}, Integer)" : type,
+              init_type: descriptor.type == :enum ? "T.any(#{type}, Integer)" : type,
               default: "nil"
             )
           end
@@ -210,7 +214,7 @@ module Tapioca
 
           klass.create_method(
             "#{field.name}=",
-            parameters: [create_param("value", type: field.type)],
+            parameters: [create_param("value", type: field.setter_type)],
             return_type: field.type
           )
 

--- a/lib/tapioca/compilers/dsl/protobuf.rb
+++ b/lib/tapioca/compilers/dsl/protobuf.rb
@@ -216,7 +216,7 @@ module Tapioca
           klass.create_method(
             "#{field.name}=",
             parameters: [create_param("value", type: field.setter_type)],
-            return_type: field.type
+            return_type: "void"
           )
 
           field

--- a/lib/tapioca/compilers/dsl/protobuf.rb
+++ b/lib/tapioca/compilers/dsl/protobuf.rb
@@ -131,7 +131,7 @@ module Tapioca
         def type_of(descriptor)
           case descriptor.type
           when :enum
-            "Symbol"
+            "T.any(Symbol, Integer)"
           when :message
             descriptor.subtype.msgclass.name
           when :int32, :int64, :uint32, :uint64
@@ -192,8 +192,8 @@ module Tapioca
             Field.new(
               name: descriptor.name,
               type: type,
-              setter_type: descriptor.type == :enum ? "T.any(#{type}, Integer)" : type,
-              init_type: descriptor.type == :enum ? "T.nilable(T.any(#{type}, Integer))" : "T.nilable(#{type})",
+              setter_type: type,
+              init_type: "T.nilable(#{type})",
               default: "nil"
             )
           end

--- a/lib/tapioca/compilers/dsl/protobuf.rb
+++ b/lib/tapioca/compilers/dsl/protobuf.rb
@@ -192,7 +192,7 @@ module Tapioca
               name: descriptor.name,
               type: type,
               setter_type: descriptor.type == :enum ? "T.any(#{type}, Integer)" : type,
-              init_type: descriptor.type == :enum ? "T.any(#{type}, Integer)" : type,
+              init_type: descriptor.type == :enum ? "T.nilable(T.any(#{type}, Integer))" : type,
               default: "nil"
             )
           end

--- a/lib/tapioca/compilers/dsl/protobuf.rb
+++ b/lib/tapioca/compilers/dsl/protobuf.rb
@@ -79,9 +79,10 @@ module Tapioca
             elsif constant == Google::Protobuf::Map
               create_type_members(klass, "Key", "Value")
             else
-              descriptor = T.let(T.unsafe(constant).descriptor, T.any(Google::Protobuf::Descriptor, Google::Protobuf::EnumDescriptor))
+              descriptor = T.let(T.unsafe(constant).descriptor,
+                T.any(Google::Protobuf::Descriptor, Google::Protobuf::EnumDescriptor))
 
-              if descriptor.is_a? Google::Protobuf::EnumDescriptor
+              if descriptor.is_a?(Google::Protobuf::EnumDescriptor)
                 descriptor.to_h.each do |sym, val|
                   klass.create_constant(sym.to_s, value: val.to_s)
                 end

--- a/spec/tapioca/compilers/dsl/protobuf_spec.rb
+++ b/spec/tapioca/compilers/dsl/protobuf_spec.rb
@@ -173,13 +173,13 @@ class Tapioca::Compilers::Dsl::ProtobufSpec < DslSpec
         # typed: strong
 
         class Cart
-          sig { params(value_type: Symbol).void }
+          sig { params(value_type: T.any(Symbol, Integer)).void }
           def initialize(value_type: nil); end
 
           sig { returns(Symbol) }
           def value_type; end
 
-          sig { params(value: Symbol).returns(Symbol) }
+          sig { params(value: T.any(Symbol, Integer)).returns(Symbol) }
           def value_type=(value); end
         end
       RBI
@@ -194,8 +194,8 @@ class Tapioca::Compilers::Dsl::ProtobufSpec < DslSpec
         end
       RBI
 
-      assert_equal(expected, rbi_for(:Cart))
       assert_equal(expected_enum_rbi, rbi_for("Cart::VALUE_TYPE"))
+      assert_equal(expected, rbi_for(:Cart))
     end
 
     it("generates methods in RBI files for classes with Protobuf with enum field with defined type") do
@@ -224,20 +224,14 @@ class Tapioca::Compilers::Dsl::ProtobufSpec < DslSpec
         # typed: strong
 
         class Cart
-          sig { params(value_type: Symbol).void }
+          sig { params(value_type: T.any(Symbol, Integer)).void }
           def initialize(value_type: nil); end
 
           sig { returns(Symbol) }
           def value_type; end
 
-          sig { params(value: Symbol).returns(Symbol) }
+          sig { params(value: T.any(Symbol, Integer)).returns(Symbol) }
           def value_type=(value); end
-
-          module MYVALUETYPE
-            ACROSS = 0
-            EACH = 2
-            ONE = 1
-          end
         end
       RBI
 

--- a/spec/tapioca/compilers/dsl/protobuf_spec.rb
+++ b/spec/tapioca/compilers/dsl/protobuf_spec.rb
@@ -173,7 +173,7 @@ class Tapioca::Compilers::Dsl::ProtobufSpec < DslSpec
         # typed: strong
 
         class Cart
-          sig { params(value_type: T.any(Symbol, Integer)).void }
+          sig { params(value_type: T.nilable(T.any(Symbol, Integer))).void }
           def initialize(value_type: nil); end
 
           sig { returns(Symbol) }
@@ -224,7 +224,7 @@ class Tapioca::Compilers::Dsl::ProtobufSpec < DslSpec
         # typed: strong
 
         class Cart
-          sig { params(value_type: T.any(Symbol, Integer)).void }
+          sig { params(value_type: T.nilable(T.any(Symbol, Integer))).void }
           def initialize(value_type: nil); end
 
           sig { returns(Symbol) }

--- a/spec/tapioca/compilers/dsl/protobuf_spec.rb
+++ b/spec/tapioca/compilers/dsl/protobuf_spec.rb
@@ -68,13 +68,13 @@ class Tapioca::Compilers::Dsl::ProtobufSpec < DslSpec
           sig { returns(Integer) }
           def customer_id; end
 
-          sig { params(value: Integer).returns(Integer) }
+          sig { params(value: Integer).void }
           def customer_id=(value); end
 
           sig { returns(Integer) }
           def shop_id; end
 
-          sig { params(value: Integer).returns(Integer) }
+          sig { params(value: Integer).void }
           def shop_id=(value); end
         end
       RBI
@@ -105,7 +105,7 @@ class Tapioca::Compilers::Dsl::ProtobufSpec < DslSpec
           sig { returns(String) }
           def events; end
 
-          sig { params(value: String).returns(String) }
+          sig { params(value: String).void }
           def events=(value); end
         end
       RBI
@@ -139,7 +139,7 @@ class Tapioca::Compilers::Dsl::ProtobufSpec < DslSpec
           sig { returns(Google::Protobuf::UInt64Value) }
           def cart_item_index; end
 
-          sig { params(value: Google::Protobuf::UInt64Value).returns(Google::Protobuf::UInt64Value) }
+          sig { params(value: Google::Protobuf::UInt64Value).void }
           def cart_item_index=(value); end
         end
       RBI
@@ -179,7 +179,7 @@ class Tapioca::Compilers::Dsl::ProtobufSpec < DslSpec
           sig { returns(Symbol) }
           def value_type; end
 
-          sig { params(value: T.any(Symbol, Integer)).returns(Symbol) }
+          sig { params(value: T.any(Symbol, Integer)).void }
           def value_type=(value); end
         end
       RBI
@@ -230,7 +230,7 @@ class Tapioca::Compilers::Dsl::ProtobufSpec < DslSpec
           sig { returns(Symbol) }
           def value_type; end
 
-          sig { params(value: T.any(Symbol, Integer)).returns(Symbol) }
+          sig { params(value: T.any(Symbol, Integer)).void }
           def value_type=(value); end
         end
       RBI
@@ -264,13 +264,13 @@ class Tapioca::Compilers::Dsl::ProtobufSpec < DslSpec
           sig { returns(Google::Protobuf::RepeatedField[Integer]) }
           def customer_ids; end
 
-          sig { params(value: Google::Protobuf::RepeatedField[Integer]).returns(Google::Protobuf::RepeatedField[Integer]) }
+          sig { params(value: Google::Protobuf::RepeatedField[Integer]).void }
           def customer_ids=(value); end
 
           sig { returns(Google::Protobuf::RepeatedField[Google::Protobuf::UInt64Value]) }
           def indices; end
 
-          sig { params(value: Google::Protobuf::RepeatedField[Google::Protobuf::UInt64Value]).returns(Google::Protobuf::RepeatedField[Google::Protobuf::UInt64Value]) }
+          sig { params(value: Google::Protobuf::RepeatedField[Google::Protobuf::UInt64Value]).void }
           def indices=(value); end
         end
       RBI
@@ -304,13 +304,13 @@ class Tapioca::Compilers::Dsl::ProtobufSpec < DslSpec
           sig { returns(Google::Protobuf::Map[String, Integer]) }
           def customers; end
 
-          sig { params(value: Google::Protobuf::Map[String, Integer]).returns(Google::Protobuf::Map[String, Integer]) }
+          sig { params(value: Google::Protobuf::Map[String, Integer]).void }
           def customers=(value); end
 
           sig { returns(Google::Protobuf::Map[String, Google::Protobuf::UInt64Value]) }
           def stores; end
 
-          sig { params(value: Google::Protobuf::Map[String, Google::Protobuf::UInt64Value]).returns(Google::Protobuf::Map[String, Google::Protobuf::UInt64Value]) }
+          sig { params(value: Google::Protobuf::Map[String, Google::Protobuf::UInt64Value]).void }
           def stores=(value); end
         end
       RBI
@@ -345,47 +345,47 @@ class Tapioca::Compilers::Dsl::ProtobufSpec < DslSpec
       rbi_output = rbi_for(:Cart)
 
       assert_includes(rbi_output, indented(<<~RBI, 2))
-        sig { params(value: T::Boolean).returns(T::Boolean) }
+        sig { params(value: T::Boolean).void }
         def bool_value=(value); end
       RBI
 
       assert_includes(rbi_output, indented(<<~RBI, 2))
-        sig { params(value: String).returns(String) }
+        sig { params(value: String).void }
         def byte_value=(value); end
       RBI
 
       assert_includes(rbi_output, indented(<<~RBI, 2))
-        sig { params(value: Integer).returns(Integer) }
+        sig { params(value: Integer).void }
         def customer_id=(value); end
       RBI
 
       assert_includes(rbi_output, indented(<<~RBI, 2))
-        sig { params(value: Integer).returns(Integer) }
+        sig { params(value: Integer).void }
         def id=(value); end
       RBI
 
       assert_includes(rbi_output, indented(<<~RBI, 2))
-        sig { params(value: Integer).returns(Integer) }
+        sig { params(value: Integer).void }
         def item_id=(value); end
       RBI
 
       assert_includes(rbi_output, indented(<<~RBI, 2))
-        sig { params(value: Float).returns(Float) }
+        sig { params(value: Float).void }
         def money_value=(value); end
       RBI
 
       assert_includes(rbi_output, indented(<<~RBI, 2))
-        sig { params(value: Float).returns(Float) }
+        sig { params(value: Float).void }
         def number_value=(value); end
       RBI
 
       assert_includes(rbi_output, indented(<<~RBI, 2))
-        sig { params(value: Integer).returns(Integer) }
+        sig { params(value: Integer).void }
         def shop_id=(value); end
       RBI
 
       assert_includes(rbi_output, indented(<<~RBI, 2))
-        sig { params(value: String).returns(String) }
+        sig { params(value: String).void }
         def string_value=(value); end
       RBI
     end

--- a/spec/tapioca/compilers/dsl/protobuf_spec.rb
+++ b/spec/tapioca/compilers/dsl/protobuf_spec.rb
@@ -176,7 +176,7 @@ class Tapioca::Compilers::Dsl::ProtobufSpec < DslSpec
           sig { params(value_type: T.nilable(T.any(Symbol, Integer))).void }
           def initialize(value_type: nil); end
 
-          sig { returns(Symbol) }
+          sig { returns(T.any(Symbol, Integer)) }
           def value_type; end
 
           sig { params(value: T.any(Symbol, Integer)).void }
@@ -227,7 +227,7 @@ class Tapioca::Compilers::Dsl::ProtobufSpec < DslSpec
           sig { params(value_type: T.nilable(T.any(Symbol, Integer))).void }
           def initialize(value_type: nil); end
 
-          sig { returns(Symbol) }
+          sig { returns(T.any(Symbol, Integer)) }
           def value_type; end
 
           sig { params(value: T.any(Symbol, Integer)).void }

--- a/spec/tapioca/compilers/dsl/protobuf_spec.rb
+++ b/spec/tapioca/compilers/dsl/protobuf_spec.rb
@@ -62,7 +62,7 @@ class Tapioca::Compilers::Dsl::ProtobufSpec < DslSpec
         # typed: strong
 
         class Cart
-          sig { params(customer_id: Integer, shop_id: Integer).void }
+          sig { params(customer_id: T.nilable(Integer), shop_id: T.nilable(Integer)).void }
           def initialize(customer_id: nil, shop_id: nil); end
 
           sig { returns(Integer) }
@@ -99,7 +99,7 @@ class Tapioca::Compilers::Dsl::ProtobufSpec < DslSpec
         # typed: strong
 
         class Cart
-          sig { params(events: String).void }
+          sig { params(events: T.nilable(String)).void }
           def initialize(events: nil); end
 
           sig { returns(String) }
@@ -133,7 +133,7 @@ class Tapioca::Compilers::Dsl::ProtobufSpec < DslSpec
         # typed: strong
 
         class Cart
-          sig { params(cart_item_index: Google::Protobuf::UInt64Value).void }
+          sig { params(cart_item_index: T.nilable(Google::Protobuf::UInt64Value)).void }
           def initialize(cart_item_index: nil); end
 
           sig { returns(Google::Protobuf::UInt64Value) }
@@ -258,7 +258,7 @@ class Tapioca::Compilers::Dsl::ProtobufSpec < DslSpec
         # typed: strong
 
         class Cart
-          sig { params(customer_ids: T.any(Google::Protobuf::RepeatedField[Integer], T::Array[Integer]), indices: T.any(Google::Protobuf::RepeatedField[Google::Protobuf::UInt64Value], T::Array[Google::Protobuf::UInt64Value])).void }
+          sig { params(customer_ids: T.nilable(T.any(Google::Protobuf::RepeatedField[Integer], T::Array[Integer])), indices: T.nilable(T.any(Google::Protobuf::RepeatedField[Google::Protobuf::UInt64Value], T::Array[Google::Protobuf::UInt64Value]))).void }
           def initialize(customer_ids: Google::Protobuf::RepeatedField.new(:int32), indices: Google::Protobuf::RepeatedField.new(:message, Google::Protobuf::UInt64Value)); end
 
           sig { returns(Google::Protobuf::RepeatedField[Integer]) }
@@ -298,7 +298,7 @@ class Tapioca::Compilers::Dsl::ProtobufSpec < DslSpec
         # typed: strong
 
         class Cart
-          sig { params(customers: T.any(Google::Protobuf::Map[String, Integer], T::Hash[String, Integer]), stores: T.any(Google::Protobuf::Map[String, Google::Protobuf::UInt64Value], T::Hash[String, Google::Protobuf::UInt64Value])).void }
+          sig { params(customers: T.nilable(T.any(Google::Protobuf::Map[String, Integer], T::Hash[String, Integer])), stores: T.nilable(T.any(Google::Protobuf::Map[String, Google::Protobuf::UInt64Value], T::Hash[String, Google::Protobuf::UInt64Value]))).void }
           def initialize(customers: Google::Protobuf::Map.new(:string, :int32), stores: Google::Protobuf::Map.new(:string, :message, Google::Protobuf::UInt64Value)); end
 
           sig { returns(Google::Protobuf::Map[String, Integer]) }

--- a/spec/tapioca/compilers/dsl/protobuf_spec.rb
+++ b/spec/tapioca/compilers/dsl/protobuf_spec.rb
@@ -173,18 +173,29 @@ class Tapioca::Compilers::Dsl::ProtobufSpec < DslSpec
         # typed: strong
 
         class Cart
-          sig { params(value_type: Cart::VALUE_TYPE).void }
+          sig { params(value_type: Symbol).void }
           def initialize(value_type: nil); end
 
-          sig { returns(Cart::VALUE_TYPE) }
+          sig { returns(Symbol) }
           def value_type; end
 
-          sig { params(value: Cart::VALUE_TYPE).returns(Cart::VALUE_TYPE) }
+          sig { params(value: Symbol).returns(Symbol) }
           def value_type=(value); end
         end
       RBI
 
+      expected_enum_rbi = <<~RBI
+        # typed: strong
+
+        module Cart::VALUE_TYPE
+          FIXED_AMOUNT = 1
+          NULL = 0
+          PERCENTAGE = 2
+        end
+      RBI
+
       assert_equal(expected, rbi_for(:Cart))
+      assert_equal(expected_enum_rbi, rbi_for("Cart::VALUE_TYPE"))
     end
 
     it("generates methods in RBI files for classes with Protobuf with enum field with defined type") do
@@ -213,14 +224,20 @@ class Tapioca::Compilers::Dsl::ProtobufSpec < DslSpec
         # typed: strong
 
         class Cart
-          sig { params(value_type: Cart::MYVALUETYPE).void }
+          sig { params(value_type: Symbol).void }
           def initialize(value_type: nil); end
 
-          sig { returns(Cart::MYVALUETYPE) }
+          sig { returns(Symbol) }
           def value_type; end
 
-          sig { params(value: Cart::MYVALUETYPE).returns(Cart::MYVALUETYPE) }
+          sig { params(value: Symbol).returns(Symbol) }
           def value_type=(value); end
+
+          module MYVALUETYPE
+            ACROSS = 0
+            EACH = 2
+            ONE = 1
+          end
         end
       RBI
 


### PR DESCRIPTION
### Motivation

Fixes #604 

### Implementation

This PR is an update to #607 with a few extra commits to make the following changes:

- The return type of all setter methods is set to `void` because Ruby ignores return values from setter methods.
- The return type of enum value getter methods is changed to `T.any(Symbol, Integer)` to account for how Protobuf handles invalid enum values.

### Tests

Includes updated tests 👍 

