### PR TITLE
Disable TracePoints when running the check-shims command

### DIFF
--- a/lib/tapioca.rb
+++ b/lib/tapioca.rb
@@ -6,6 +6,18 @@ require "sorbet-runtime"
 module Tapioca
   extend T::Sig
 
+  @traces = T.let([], T::Array[TracePoint])
+
+  sig { params(trace_name: Symbol, block: T.proc.params(arg0: TracePoint).void).void }
+  def self.register_trace(trace_name, &block)
+    @traces << TracePoint.trace(trace_name, &block)
+  end
+
+  sig { void }
+  def self.disable_traces
+    @traces.each(&:disable)
+  end
+
   sig do
     type_parameters(:Result)
       .params(blk: T.proc.returns(T.type_parameter(:Result)))

--- a/lib/tapioca/cli.rb
+++ b/lib/tapioca/cli.rb
@@ -260,6 +260,8 @@ module Tapioca
     option :payload, type: :boolean, desc: "Check shims against Sorbet's payload", default: true
     option :workers, aliases: ["-w"], type: :numeric, desc: "Number of parallel workers (default: auto)"
     def check_shims
+      Tapioca.disable_traces
+
       command = Commands::CheckShims.new(
         gem_rbi_dir: options[:gem_rbi_dir],
         dsl_rbi_dir: options[:dsl_rbi_dir],

--- a/lib/tapioca/runtime/trackers/constant_definition.rb
+++ b/lib/tapioca/runtime/trackers/constant_definition.rb
@@ -20,7 +20,7 @@ module Tapioca
         @class_files = {}.compare_by_identity
 
         # Immediately activated upon load. Observes class/module definition.
-        TracePoint.trace(:class) do |tp|
+        Tapioca.register_trace(:class) do |tp|
           next if tp.self.singleton_class?
 
           key = tp.self
@@ -40,7 +40,7 @@ module Tapioca
           (@class_files[key] ||= Set.new) << loc
         end
 
-        TracePoint.trace(:c_return) do |tp|
+        Tapioca.register_trace(:c_return) do |tp|
           next unless tp.method_id == :new
           next unless Module === tp.return_value
 


### PR DESCRIPTION
When profiling why this command was taking so much time, I found out that in the specific application I was working on 37% of the time was spent in the `TracePoint#method_id` method.

Since we don't need this TracePoint enabled in this command, this patch disables it.

## Profiling before
![Screen Shot 2022-07-28 at 2 28 31 PM](https://user-images.githubusercontent.com/47848/181611445-5018dff4-fc20-4fa2-875f-48d65ef25f8c.png)

## Profiling after
![Screen Shot 2022-07-28 at 2 29 06 PM](https://user-images.githubusercontent.com/47848/181611555-3a6b43da-73ca-48e6-b338-3efd445cb1b5.png)

Total time went down from 3:50min to 1:20min
