### PR TITLE
Thor: Love (❤️ ) and Thunder (⚡)

### DIFF
--- a/lib/tapioca/cli.rb
+++ b/lib/tapioca/cli.rb
@@ -286,8 +286,7 @@ module Tapioca
       default: {}
     def annotations
       if !options[:netrc] && options[:netrc_file]
-        say_error("Options `--no-netrc` and `--netrc-file` can't be used together", :bold, :red)
-        exit(1)
+        raise Thor::Error, set_color("Options `--no-netrc` and `--netrc-file` can't be used together", :bold, :red)
       end
 
       command = Commands::Annotations.new(

--- a/lib/tapioca/commands/annotations.rb
+++ b/lib/tapioca/commands/annotations.rb
@@ -88,8 +88,7 @@ module Tapioca
         end
 
         if indexes.empty?
-          say_error("\nCan't fetch annotations without sources (no index fetched)", :bold, :red)
-          exit(1)
+          raise Thor::Error, set_color("Can't fetch annotations without sources (no index fetched)", :bold, :red)
         end
 
         indexes
@@ -117,7 +116,8 @@ module Tapioca
 
         if fetchable_gems.empty?
           say(" Nothing to do")
-          exit(0)
+
+          return []
         end
 
         say("\n")

--- a/lib/tapioca/commands/check_shims.rb
+++ b/lib/tapioca/commands/check_shims.rb
@@ -44,7 +44,8 @@ module Tapioca
 
         if (!Dir.exist?(@shim_rbi_dir) || Dir.empty?(@shim_rbi_dir)) && !File.exist?(@todo_rbi_file)
           say("No shim RBIs to check", :green)
-          exit(0)
+
+          return
         end
 
         payload_path = T.let(nil, T.nilable(String))
@@ -56,18 +57,20 @@ module Tapioca
               result = sorbet("--no-config --print=payload-sources:#{payload_path}")
 
               unless result.status
-                say_error("Sorbet failed to dump payload")
-                say_error(result.err)
-                exit(1)
+                raise Thor::Error, <<~ERROR
+                  "Sorbet failed to dump payload"
+                  #{result.err}
+                ERROR
               end
 
               index_rbis(index, "payload", payload_path, number_of_workers: @number_of_workers)
             end
           else
-            say_error("The version of Sorbet used in your Gemfile.lock does not support `--print=payload-sources`")
-            say_error("Current: v#{SORBET_GEM_SPEC.version}")
-            say_error("Required: #{FEATURE_REQUIREMENTS[:print_payload_sources]}")
-            exit(1)
+            raise Thor::Error, <<~ERROR
+              The version of Sorbet used in your Gemfile.lock does not support `--print=payload-sources`
+              Current: v#{SORBET_GEM_SPEC.version}
+              Required: #{FEATURE_REQUIREMENTS[:print_payload_sources]}
+            ERROR
           end
         end
 
@@ -78,23 +81,31 @@ module Tapioca
         index_rbis(index, "annotation", @annotations_rbi_dir, number_of_workers: @number_of_workers)
 
         duplicates = duplicated_nodes_from_index(index, shim_rbi_dir: @shim_rbi_dir, todo_rbi_file: @todo_rbi_file)
+
         unless duplicates.empty?
+          messages = []
+
           duplicates.each do |key, nodes|
-            say_error("\nDuplicated RBI for #{key}:", :red)
+            messages << set_color("\nDuplicated RBI for #{key}:", :red)
+
             nodes.each do |node|
               node_loc = node.loc
+
               next unless node_loc
 
               loc_string = location_to_payload_url(node_loc, path_prefix: payload_path)
-              say_error(" * #{loc_string}", :red)
+              messages << set_color(" * #{loc_string}", :red)
             end
           end
-          say_error("\nPlease remove the duplicated definitions from #{@shim_rbi_dir} and #{@todo_rbi_file}", :red)
-          exit(1)
+
+          messages << set_color(
+            "\nPlease remove the duplicated definitions from #{@shim_rbi_dir} and #{@todo_rbi_file}", :red
+          )
+
+          raise Thor::Error, messages.join("\n")
         end
 
         say("\nNo duplicates found in shim RBIs", :green)
-        exit(0)
       end
     end
   end

--- a/lib/tapioca/helpers/rbi_files_helper.rb
+++ b/lib/tapioca/helpers/rbi_files_helper.rb
@@ -100,14 +100,16 @@ module Tapioca
 
       if errors.empty?
         say("  No errors found\n\n", [:green, :bold])
+
         return
       end
 
       parse_errors = errors.select { |error| error.code < 4000 }
 
-      if parse_errors.any?
-        say_error(<<~ERR, :red)
+      error_messages = []
 
+      if parse_errors.any?
+        error_messages << set_color(<<~ERR, :red)
           ##### INTERNAL ERROR #####
 
           There are parse errors in the generated RBI files.
@@ -119,27 +121,23 @@ module Tapioca
 
           Command:
             #{command}
-
         ERR
 
-        say_error(<<~ERR, :red) if gems.any?
+        error_messages << set_color(<<~ERR, :red) if gems.any?
           Gems:
           #{gems.map { |gem| "  #{gem.name} (#{gem.version})" }.join("\n")}
-
         ERR
 
-        say_error(<<~ERR, :red) if compilers.any?
+        error_messages << set_color(<<~ERR, :red) if compilers.any?
           Compilers:
           #{compilers.map { |compiler| "  #{compiler.name}" }.join("\n")}
-
         ERR
 
-        say_error(<<~ERR, :red)
+        error_messages << set_color(<<~ERR, :red)
           Errors:
           #{parse_errors.map { |error| "  #{error}" }.join("\n")}
 
           ##########################
-
         ERR
       end
 
@@ -148,7 +146,7 @@ module Tapioca
         update_gem_rbis_strictnesses(redef_errors, gem_dir)
       end
 
-      Kernel.exit(1) if parse_errors.any?
+      Kernel.raise Thor::Error, error_messages.join("\n") if parse_errors.any?
     end
 
     private

--- a/spec/tapioca/cli/check_shims_spec.rb
+++ b/spec/tapioca/cli/check_shims_spec.rb
@@ -106,19 +106,16 @@ module Tapioca
 
           result = @project.tapioca("check-shims --no-payload")
 
-          assert_includes(result.err, <<~ERR)
+          assert_equal(<<~ERR, result.err)
+
             Duplicated RBI for ::Bar#bar:
              * sorbet/rbi/shims/bar.rbi:2:2-2:14
              * sorbet/rbi/dsl/bar.rbi:2:2-2:14
-          ERR
 
-          assert_includes(result.err, <<~ERR)
             Duplicated RBI for ::Foo#foo:
              * sorbet/rbi/shims/foo.rbi:2:2-2:18
              * sorbet/rbi/gems/foo@1.0.0.rbi:2:2-2:18
-          ERR
 
-          assert_includes(result.err, <<~ERR)
             Please remove the duplicated definitions from sorbet/rbi/shims and sorbet/rbi/todo.rbi
           ERR
 
@@ -191,13 +188,12 @@ module Tapioca
 
           result = @project.tapioca("check-shims --no-payload")
 
-          assert_includes(result.err, <<~ERR)
+          assert_equal(<<~ERR, result.err)
+
             Duplicated RBI for ::Foo#foo:
              * sorbet/rbi/shims/foo.rbi:3:2-3:20
              * sorbet/rbi/gems/foo@1.0.0.rbi:3:2-3:20
-          ERR
 
-          assert_includes(result.err, <<~ERR)
             Please remove the duplicated definitions from sorbet/rbi/shims and sorbet/rbi/todo.rbi
           ERR
 
@@ -222,13 +218,12 @@ module Tapioca
 
           result = @project.tapioca("check-shims --no-payload")
 
-          assert_includes(result.err, <<~ERR)
+          assert_equal(<<~ERR, result.err)
+
             Duplicated RBI for ::Foo#foo:
              * sorbet/rbi/shims/foo.rbi:2:2-2:24
              * sorbet/rbi/gems/foo@1.0.0.rbi:2:2-2:18
-          ERR
 
-          assert_includes(result.err, <<~ERR)
             Please remove the duplicated definitions from sorbet/rbi/shims and sorbet/rbi/todo.rbi
           ERR
 
@@ -277,7 +272,8 @@ module Tapioca
 
           result = @project.tapioca("check-shims --no-payload")
 
-          assert_includes(result.err, <<~ERR)
+          assert_equal(<<~ERR, result.err)
+
             Duplicated RBI for ::Foo.include(Bar):
              * sorbet/rbi/shims/foo.rbi:2:2-2:13
              * sorbet/rbi/gems/foo@1.0.0.rbi:4:2-4:13
@@ -293,9 +289,7 @@ module Tapioca
             Duplicated RBI for ::Foo.requires_ancestor(Bar):
              * sorbet/rbi/shims/foo.rbi:5:2-5:27
              * sorbet/rbi/gems/foo@1.0.0.rbi:7:2-7:27
-          ERR
 
-          assert_includes(result.err, <<~ERR)
             Please remove the duplicated definitions from sorbet/rbi/shims and sorbet/rbi/todo.rbi
           ERR
 
@@ -327,27 +321,22 @@ module Tapioca
 
           result = @project.tapioca("check-shims --no-payload")
 
-          assert_includes(result.err, <<~ERR)
+          assert_equal(<<~ERR, result.err)
+
             Duplicated RBI for ::Foo#foo:
              * sorbet/rbi/shims/foo.rbi:2:2-2:24
              * sorbet/rbi/shims/foo.rbi:3:2-3:14
              * sorbet/rbi/gems/foo@1.0.0.rbi:2:2-2:18
-          ERR
 
-          assert_includes(result.err, <<~ERR)
             Duplicated RBI for ::Foo::Baz:
              * sorbet/rbi/shims/foo.rbi:5:2-5:16
              * sorbet/rbi/gems/foo@1.0.0.rbi:4:2-4:16
-          ERR
 
-          assert_includes(result.err, <<~ERR)
             Duplicated RBI for ::Bar:
              * sorbet/rbi/shims/foo.rbi:8:0-8:14
              * sorbet/rbi/shims/foo.rbi:9:0-9:14
              * sorbet/rbi/gems/foo@1.0.0.rbi:7:0-7:14
-          ERR
 
-          assert_includes(result.err, <<~ERR)
             Please remove the duplicated definitions from sorbet/rbi/shims and sorbet/rbi/todo.rbi
           ERR
 
@@ -379,19 +368,18 @@ module Tapioca
 
           result = @project.tapioca("check-shims")
 
-          assert_includes(strip_timer(result.out), <<~OUT)
+          assert_equal(<<~OUT, strip_timer(result.out))
             Loading Sorbet payload...  Done
             Loading shim RBIs from sorbet/rbi/shims...  Done
             Looking for duplicates...  Done
           OUT
 
-          assert_includes(result.err, <<~ERR)
+          assert_equal(<<~ERR, result.err)
+
             Duplicated RBI for ::Object:
              * https://github.com/sorbet/sorbet/tree/master/rbi/core/object.rbi#L27
              * sorbet/rbi/shims/core/object.rbi:1:0-1:17
-          ERR
 
-          assert_includes(result.err, <<~ERR)
             Duplicated RBI for ::String#capitalize:
              * https://github.com/sorbet/sorbet/tree/master/rbi/core/string.rbi#L406
              * sorbet/rbi/shims/core/string.rbi:3:2-3:23
@@ -399,9 +387,7 @@ module Tapioca
             Duplicated RBI for ::Base64::decode64:
              * https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/base64.rbi#L37
              * sorbet/rbi/shims/stdlib/base64.rbi:3:2-3:29
-          ERR
 
-          assert_includes(result.err, <<~ERR)
             Please remove the duplicated definitions from sorbet/rbi/shims and sorbet/rbi/todo.rbi
           ERR
 
@@ -443,25 +429,20 @@ module Tapioca
               "--todo-rbi-file=rbi/todo.rbi --no-payload"
           )
 
-          assert_includes(result.err, <<~ERR)
-            Duplicated RBI for ::Foo#bar:
-             * rbi/shim/foo.rbi:3:2-3:14
-             * rbi/dsl/foo.rbi:2:2-2:14
-          ERR
+          assert_equal(<<~ERR, result.err)
 
-          assert_includes(result.err, <<~ERR)
-            Duplicated RBI for ::Foo#foo:
-             * rbi/shim/foo.rbi:2:2-2:14
-             * rbi/gem/foo@1.0.0.rbi:2:2-2:14
-          ERR
-
-          assert_includes(result.err, <<~ERR)
             Duplicated RBI for ::Baz#baz:
              * rbi/todo.rbi:2:2-2:14
              * rbi/shim/foo.rbi:7:2-7:14
-          ERR
 
-          assert_includes(result.err, <<~ERR)
+            Duplicated RBI for ::Foo#foo:
+             * rbi/shim/foo.rbi:2:2-2:14
+             * rbi/gem/foo@1.0.0.rbi:2:2-2:14
+
+            Duplicated RBI for ::Foo#bar:
+             * rbi/shim/foo.rbi:3:2-3:14
+             * rbi/dsl/foo.rbi:2:2-2:14
+
             Please remove the duplicated definitions from rbi/shim and rbi/todo.rbi
           ERR
 
@@ -489,17 +470,14 @@ module Tapioca
 
           result = @project.tapioca("check-shims --no-payload")
 
-          assert_includes(result.err, <<~ERR)
-            Warning: Unsupported block node type `foo` (sorbet/rbi/shims/foo.rbi:2:2-2:13)
-          ERR
+          assert_equal(<<~ERR, result.err)
 
-          assert_includes(result.err, <<~ERR)
+            Warning: Unsupported block node type `foo` (sorbet/rbi/shims/foo.rbi:2:2-2:13)
+
             Duplicated RBI for ::Foo#foo:
              * sorbet/rbi/shims/bar.rbi:2:2-2:14
              * sorbet/rbi/gems/foo@1.0.0.rbi:2:2-2:18
-          ERR
 
-          assert_includes(result.err, <<~ERR)
             Please remove the duplicated definitions from sorbet/rbi/shims and sorbet/rbi/todo.rbi
           ERR
 
@@ -541,25 +519,20 @@ module Tapioca
 
           result = @project.tapioca("check-shims --no-payload")
 
-          assert_includes(result.err, <<~ERR)
+          assert_equal(<<~ERR, result.err)
+
             Duplicated RBI for ::Bar#bar:
              * sorbet/rbi/shims/bar.rbi:2:2-2:14
              * sorbet/rbi/annotations/bar.rbi:2:2-2:14
-          ERR
 
-          assert_includes(result.err, <<~ERR)
-            Duplicated RBI for ::Foo#foo:
-             * sorbet/rbi/shims/foo.rbi:2:2-2:18
-             * sorbet/rbi/annotations/foo.rbi:2:2-2:18
-          ERR
-
-          assert_includes(result.err, <<~ERR)
             Duplicated RBI for ::Baz:
              * sorbet/rbi/shims/baz.rbi:1:0-1:15
              * sorbet/rbi/annotations/baz.rbi:1:0-1:15
-          ERR
 
-          assert_includes(result.err, <<~ERR)
+            Duplicated RBI for ::Foo#foo:
+             * sorbet/rbi/shims/foo.rbi:2:2-2:18
+             * sorbet/rbi/annotations/foo.rbi:2:2-2:18
+
             Please remove the duplicated definitions from sorbet/rbi/shims and sorbet/rbi/todo.rbi
           ERR
 
@@ -595,25 +568,20 @@ module Tapioca
 
           result = @project.tapioca("check-shims --no-payload")
 
-          assert_includes(result.err, <<~ERR)
-            Duplicated RBI for ::Bar#bar:
-             * sorbet/rbi/todo.rbi:8:2-8:14
-             * sorbet/rbi/dsl/bar.rbi:2:2-2:14
-          ERR
+          assert_equal(<<~ERR, result.err)
 
-          assert_includes(result.err, <<~ERR)
             Duplicated RBI for ::Foo#foo:
              * sorbet/rbi/todo.rbi:2:2-2:18
              * sorbet/rbi/gems/foo@1.0.0.rbi:2:2-2:18
-          ERR
 
-          assert_includes(result.err, <<~ERR)
             Duplicated RBI for ::Foo::Baz:
              * sorbet/rbi/todo.rbi:4:2-4:16
              * sorbet/rbi/gems/foo@1.0.0.rbi:4:2-4:16
-          ERR
 
-          assert_includes(result.err, <<~ERR)
+            Duplicated RBI for ::Bar#bar:
+             * sorbet/rbi/todo.rbi:8:2-8:14
+             * sorbet/rbi/dsl/bar.rbi:2:2-2:14
+
             Please remove the duplicated definitions from sorbet/rbi/shims and sorbet/rbi/todo.rbi
           ERR
 
@@ -651,25 +619,20 @@ module Tapioca
 
           result = @project.tapioca("check-shims --no-payload")
 
-          assert_includes(result.err, <<~ERR)
-            Duplicated RBI for ::Bar#bar:
-             * sorbet/rbi/todo.rbi:6:2-6:14
-             * sorbet/rbi/shims/bar.rbi:2:2-2:14
-          ERR
+          assert_equal(<<~ERR, result.err)
 
-          assert_includes(result.err, <<~ERR)
             Duplicated RBI for ::Foo#foo:
              * sorbet/rbi/todo.rbi:2:2-2:18
              * sorbet/rbi/shims/foo.rbi:2:2-2:18
-          ERR
 
-          assert_includes(result.err, <<~ERR)
+            Duplicated RBI for ::Bar#bar:
+             * sorbet/rbi/todo.rbi:6:2-6:14
+             * sorbet/rbi/shims/bar.rbi:2:2-2:14
+
             Duplicated RBI for ::Baz:
              * sorbet/rbi/todo.rbi:9:0-9:15
              * sorbet/rbi/shims/baz.rbi:1:0-1:15
-          ERR
 
-          assert_includes(result.err, <<~ERR)
             Please remove the duplicated definitions from sorbet/rbi/shims and sorbet/rbi/todo.rbi
           ERR
 
@@ -725,7 +688,7 @@ module Tapioca
 
           result = @project.tapioca("check-shims")
 
-          assert_includes(result.err, <<~ERR)
+          assert_equal(<<~ERR, result.err)
             The version of Sorbet used in your Gemfile.lock does not support `--print=payload-sources`
             Current: v0.5.9760
             Required: >= 0.5.9818

--- a/spec/tapioca/cli/dsl_spec.rb
+++ b/spec/tapioca/cli/dsl_spec.rb
@@ -146,7 +146,7 @@ module Tapioca
             Error: Cannot find constant 'NonExistent::Baz'
           OUT
 
-          assert_empty_stderr(result) # FIXME: Shouldn't the errors be printed here?
+          assert_equal("\n", result.err)
 
           refute_project_file_exist("sorbet/rbi/dsl/non_existent/foo.rbi")
           refute_project_file_exist("sorbet/rbi/dsl/non_existent/bar.rbi")
@@ -173,7 +173,7 @@ module Tapioca
                   remove  sorbet/rbi/dsl/non_existent/baz.rbi
           OUT
 
-          assert_empty_stderr(result) # FIXME: Shouldn't the errors be printed here?
+          assert_equal("\n", result.err)
 
           refute_project_file_exist("sorbet/rbi/dsl/non_existent/foo.rbi")
           refute_project_file_exist("sorbet/rbi/dsl/non_existent/baz.rbi")
@@ -859,10 +859,12 @@ module Tapioca
             Loading DSL compiler classes... Done
             Compiling DSL RBI files...
 
-            Error: Cannot find compiler 'NonexistentCompiler'
           OUT
 
-          assert_empty_stderr(result) # FIXME: Shouldn't the errors be printed here?
+          assert_equal(<<~ERROR, result.err)
+            Error: Cannot find compiler 'NonexistentCompiler'
+          ERROR
+
           refute_success_status(result)
         end
 
@@ -944,10 +946,12 @@ module Tapioca
             Loading DSL compiler classes... Done
             Compiling DSL RBI files...
 
-            Error: Cannot find compiler 'NonexistentCompiler'
           OUT
 
-          assert_empty_stderr(result) # FIXME: Shouldn't the errors be printed here?
+          assert_equal(<<~ERROR, result.err)
+            Error: Cannot find compiler 'NonexistentCompiler'
+          ERROR
+
           refute_success_status(result)
         end
 
@@ -1327,6 +1331,9 @@ module Tapioca
             Checking for out-of-date RBIs...
 
 
+          OUT
+
+          assert_equal(<<~ERROR, result.err)
             RBI files are out-of-date. In your development environment, please run:
               `bin/tapioca dsl`
             Once it is complete, be sure to commit and push any changes
@@ -1334,9 +1341,8 @@ module Tapioca
             Reason:
               File(s) removed:
               - sorbet/rbi/dsl/post.rbi
-          OUT
+          ERROR
 
-          assert_empty_stderr(result) # FIXME: Shouldn't the errors be printed here?
           refute_success_status(result)
         end
 
@@ -1361,6 +1367,9 @@ module Tapioca
             Checking for out-of-date RBIs...
 
 
+          OUT
+
+          assert_equal(<<~ERROR, result.err)
             RBI files are out-of-date. In your development environment, please run:
               `bin/tapioca dsl`
             Once it is complete, be sure to commit and push any changes
@@ -1368,9 +1377,8 @@ module Tapioca
             Reason:
               File(s) added:
               - sorbet/rbi/dsl/image.rbi
-          OUT
+          ERROR
 
-          assert_empty_stderr(result) # FIXME: Shouldn't the errors be printed here?
           refute_success_status(result)
 
           @project.remove("lib/image.rb")
@@ -1406,6 +1414,9 @@ module Tapioca
             Checking for out-of-date RBIs...
 
 
+          OUT
+
+          assert_equal(<<~ERROR, result.err)
             RBI files are out-of-date. In your development environment, please run:
               `bin/tapioca dsl`
             Once it is complete, be sure to commit and push any changes
@@ -1413,9 +1424,8 @@ module Tapioca
             Reason:
               File(s) changed:
               - sorbet/rbi/dsl/post.rbi
-          OUT
+          ERROR
 
-          assert_empty_stderr(result) # FIXME: Shouldn't the errors be printed here?
           refute_success_status(result)
         end
       end
@@ -1635,7 +1645,7 @@ module Tapioca
 
           result = @project.tapioca("dsl Post")
 
-          assert_includes(result.err, <<~ERR)
+          assert_equal(<<~ERR, result.err)
             ##### INTERNAL ERROR #####
 
             There are parse errors in the generated RBI files.

--- a/spec/tapioca/cli/gem_spec.rb
+++ b/spec/tapioca/cli/gem_spec.rb
@@ -1619,6 +1619,14 @@ module Tapioca
           assert_equal(<<~OUT, result.out)
             Checking for out-of-date RBIs...
 
+          OUT
+
+          # Does not actually modify anything
+          refute_project_file_exist("sorbet/rbi/gems/foo@0.0.1.rbi")
+          assert_project_file_exist("sorbet/rbi/gems/outdated@5.0.0.rbi")
+          assert_project_file_exist("sorbet/rbi/gems/bar@0.2.0.rbi")
+
+          assert_equal(<<~ERROR, result.err)
             RBI files are out-of-date. In your development environment, please run:
               `bin/tapioca gem`
             Once it is complete, be sure to commit and push any changes
@@ -1630,14 +1638,8 @@ module Tapioca
               - sorbet/rbi/gems/bar@0.3.0.rbi
               File(s) removed:
               - sorbet/rbi/gems/outdated@5.0.0.rbi
-          OUT
+          ERROR
 
-          # Does not actually modify anything
-          refute_project_file_exist("sorbet/rbi/gems/foo@0.0.1.rbi")
-          assert_project_file_exist("sorbet/rbi/gems/outdated@5.0.0.rbi")
-          assert_project_file_exist("sorbet/rbi/gems/bar@0.2.0.rbi")
-
-          assert_empty_stderr(result)
           refute_success_status(result)
         end
       end


### PR DESCRIPTION
### Motivation
When working in profiling the `check-shims` command I was being surprised my profiling data wasn't be written to the disk. I found that it was because we were exiting the process from inside the `Command` class.

Thor already knows how to deal with `exit` status, so it is better to use the mechanism so we can make easier to profile out commands.

### Implementation
Avoid `exit` call in the command classes and instead using `Thor::Error` to provide the messages to STDERR, and exit with the right status.
