### PR TITLE
Test with supported versions of Rails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,30 @@ env:
   SRB_SKIP_GEM_RBIS: true
 
 jobs:
-  build:
+  linters:
+    runs-on: ubuntu-latest
+    name: Linters
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.1"
+          bundler-cache: true
+      - name: Run type check
+        run: bin/typecheck
+      - name: Lint Ruby files
+        run: bin/style
+      - name: Verify documentation
+        run: bin/docs
+      - name: Verify README
+        run: bin/readme
+      - name: Verify gem RBIs are up-to-date
+        run: bundle exec exe/tapioca gem --verify
+      - name: Verify duplicates in shims
+        run: bundle exec exe/tapioca check-shims
+
+  tests:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -36,29 +59,16 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
-      - name: Run type check
-        run: bin/typecheck
-      - name: Lint Ruby files
-        run: bin/style
-      - name: Verify documentation
-        run: bin/docs
-      - name: Verify README
-        run: bin/readme
       - name: Run tests
         run: bin/test
         continue-on-error: ${{ matrix.experimental }}
-      - name: Verify gem RBIs are up-to-date
-        run: bundle exec exe/tapioca gem --verify
-        if: ${{ matrix.gemfile == 'Gemfile' }}
-      - name: Verify duplicates in shims
-        run: bundle exec exe/tapioca check-shims
 
   buildall:
     if: ${{ always() && github.event.pull_request }}
     runs-on: ubuntu-latest
     name: Build (matrix)
-    needs: build
+    needs: [linters, tests]
     steps:
       - name: Check build matrix status
-        if: ${{ needs.build.result != 'success' }}
+        if: ${{ needs.tests.result != 'success' || needs.linters.result != 'success' }}
         run: exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,3 +52,13 @@ jobs:
         if: ${{ matrix.gemfile == 'Gemfile' }}
       - name: Verify duplicates in shims
         run: bundle exec exe/tapioca check-shims
+
+  buildall:
+    if: ${{ always() && github.event.pull_request }}
+    runs-on: ubuntu-latest
+    name: Build (matrix)
+    needs: build
+    steps:
+      - name: Check build matrix status
+        if: ${{ needs.build.result != 'success' }}
+        run: exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,24 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ "2.7", "3.0", "3.1" ]
-    name: Ruby ${{ matrix.ruby }}
+        ruby: ["2.7", "3.0", "3.1"]
+        experimental: [false]
+        gemfile:
+          - Gemfile
+          - gemfiles/Gemfile-rails-6-1
+        include:
+          - gemfile: gemfiles/Gemfile-rails-main
+            ruby: "2.7"
+            experimental: true
+          - gemfile: gemfiles/Gemfile-rails-main
+            ruby: "3.0"
+            experimental: true
+          - gemfile: gemfiles/Gemfile-rails-main
+            ruby: "3.1"
+            experimental: true
+    name: Ruby ${{ matrix.ruby }} - ${{ matrix.gemfile }}
+    env:
+      BUNDLE_GEMFILE: ${{ matrix.gemfile }}
     steps:
       - uses: actions/checkout@v2
       - name: Set up Ruby
@@ -30,7 +46,9 @@ jobs:
         run: bin/readme
       - name: Run tests
         run: bin/test
+        continue-on-error: ${{ matrix.experimental }}
       - name: Verify gem RBIs are up-to-date
         run: bundle exec exe/tapioca gem --verify
+        if: ${{ matrix.gemfile == 'Gemfile' }}
       - name: Verify duplicates in shims
         run: bundle exec exe/tapioca check-shims

--- a/bin/test
+++ b/bin/test
@@ -6,6 +6,7 @@ ENV["DEFAULT_TEST"] = "spec/**/*_spec.rb"
 
 require "bundler/setup"
 
+require "active_support" # Remove this when we drop support to Rails 6.
 require "rails/test_unit/runner"
 
 Rails::TestUnit::Runner.parse_options(ARGV)

--- a/gemfiles/Gemfile-rails-6-1
+++ b/gemfiles/Gemfile-rails-6-1
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+source("https://rubygems.org")
+
+gemspec path: ".."
+
+gem("minitest")
+gem("minitest-hooks")
+gem("minitest-reporters")
+gem("pry-byebug")
+gem("rubocop-shopify", require: false)
+gem("rubocop-sorbet", ">= 0.4.1")
+gem("rubocop-rspec", require: false)
+gem("ruby-lsp", require: false)
+
+group(:deployment, :development) do
+  gem("rake")
+end
+
+group(:development, :test) do
+  gem("smart_properties", require: false)
+  gem("frozen_record", require: false)
+  gem("sprockets", require: false)
+  gem("rails", "~> 6.1.0", require: false)
+  gem("state_machines", require: false)
+  gem("activerecord-typedstore", require: false)
+  gem("sqlite3")
+  gem("identity_cache", require: false)
+  gem(
+    "cityhash",
+    git: "https://github.com/csfrancis/cityhash.git",
+    ref: "3cfc7d01f333c01811d5e834f1495eaa29f87c36",
+    require: false
+  )
+  gem("activeresource", require: false)
+  gem("google-protobuf", require: false)
+  gem("shopify-money", require: false)
+  gem("sidekiq", require: false)
+  gem("nokogiri", require: false)
+  gem("config", github: "rubyconfig/config", branch: "master", require: false)
+  gem("aasm", require: false)
+  gem("bcrypt", require: false)
+  gem("xpath", require: false)
+
+  # net-smtp was removed from default gems in Ruby 3.1, but is used by the `mail` gem.
+  # So we need to add it as a dependency until `mail` is fixed:
+  # https://github.com/rails/rails/blob/0919aa97260ab8240150278d3b07a1547489e3fd/Gemfile#L178-L191
+  gem("net-smtp", "0.3.1", require: false)
+end
+
+group :test do
+  gem("webmock")
+end
+
+gem "kramdown", "~> 2.4"

--- a/gemfiles/Gemfile-rails-main
+++ b/gemfiles/Gemfile-rails-main
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+source("https://rubygems.org")
+
+gemspec path: ".."
+
+gem("minitest")
+gem("minitest-hooks")
+gem("minitest-reporters")
+gem("pry-byebug")
+gem("rubocop-shopify", require: false)
+gem("rubocop-sorbet", ">= 0.4.1")
+gem("rubocop-rspec", require: false)
+gem("ruby-lsp", require: false)
+
+group(:deployment, :development) do
+  gem("rake")
+end
+
+group(:development, :test) do
+  gem("smart_properties", require: false)
+  gem("frozen_record", require: false)
+  gem("sprockets", require: false)
+  gem("rails", github: "rails/rails", branch: "main", require: false)
+  gem("state_machines", require: false)
+  gem("activerecord-typedstore", require: false)
+  gem("sqlite3")
+  gem("identity_cache", require: false)
+  gem(
+    "cityhash",
+    git: "https://github.com/csfrancis/cityhash.git",
+    ref: "3cfc7d01f333c01811d5e834f1495eaa29f87c36",
+    require: false
+  )
+  gem("activeresource", require: false)
+  gem("google-protobuf", require: false)
+  gem("shopify-money", require: false)
+  gem("sidekiq", require: false)
+  gem("nokogiri", require: false)
+  gem("config", github: "rubyconfig/config", branch: "master", require: false)
+  gem("aasm", require: false)
+  gem("bcrypt", require: false)
+  gem("xpath", require: false)
+
+  # net-smtp was removed from default gems in Ruby 3.1, but is used by the `mail` gem.
+  # So we need to add it as a dependency until `mail` is fixed:
+  # https://github.com/rails/rails/blob/0919aa97260ab8240150278d3b07a1547489e3fd/Gemfile#L178-L191
+  gem("net-smtp", "0.3.1", require: false)
+end
+
+group :test do
+  gem("webmock")
+end
+
+gem "kramdown", "~> 2.4"

--- a/spec/tapioca/dsl/compilers/active_record_columns_spec.rb
+++ b/spec/tapioca/dsl/compilers/active_record_columns_spec.rb
@@ -269,8 +269,9 @@ module Tapioca
                   class Post < ActiveRecord::Base
                     money_column(:money_column, currency: "USD")
                     serialize :serialized_column, JSON
-                    enum :integer_enum_column, [ :active, :archived ]
-                    enum :string_enum_column, { high: 'high', low: 'low' }
+                    # Change enum calls to new syntax when we drop support to Rails 6.
+                    enum integer_enum_column: [ :active, :archived ]
+                    enum string_enum_column: { high: 'high', low: 'low' }
                   end
                 RUBY
 

--- a/spec/tapioca/dsl/compilers/active_record_relations_spec.rb
+++ b/spec/tapioca/dsl/compilers/active_record_relations_spec.rb
@@ -111,9 +111,11 @@ module Tapioca
                     sig { params(attributes: T.untyped, block: T.nilable(T.proc.params(object: ::Post).void)).returns(::Post) }
                     def find_or_initialize_by(attributes, &block); end
 
+                <% if rails_version(">= 7.0") %>
                     sig { params(arg: T.untyped, args: T.untyped).returns(::Post) }
                     def find_sole_by(arg, *args); end
 
+                <% end %>
                     sig { params(limit: T.untyped).returns(T.untyped) }
                     def first(limit = nil); end
 
@@ -183,9 +185,11 @@ module Tapioca
                     sig { returns(::Post) }
                     def second_to_last!; end
 
+                <% if rails_version(">= 7.0") %>
                     sig { returns(::Post) }
                     def sole; end
 
+                <% end %>
                     sig { params(column_name: T.nilable(T.any(String, Symbol)), block: T.nilable(T.proc.params(record: T.untyped).returns(T.untyped))).returns(T.untyped) }
                     def sum(column_name = nil, &block); end
 
@@ -230,9 +234,11 @@ module Tapioca
                     sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
                     def except(*args, &blk); end
 
+                <% if rails_version(">= 7.0") %>
                     sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
                     def excluding(*args, &blk); end
 
+                <% end %>
                     sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
                     def extending(*args, &blk); end
 
@@ -248,9 +254,11 @@ module Tapioca
                     sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
                     def having(*args, &blk); end
 
+                <% if rails_version(">= 7.0") %>
                     sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
                     def in_order_of(*args, &blk); end
 
+                <% end %>
                     sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
                     def includes(*args, &blk); end
 
@@ -266,9 +274,11 @@ module Tapioca
                     sig { params(attributes: T::Array[Hash], returning: T.nilable(T.any(T::Array[Symbol], FalseClass))).returns(ActiveRecord::Result) }
                     def insert_all!(attributes, returning: nil); end
 
+                <% if rails_version(">= 7.0") %>
                     sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
                     def invert_where(*args, &blk); end
 
+                <% end %>
                     sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
                     def joins(*args, &blk); end
 
@@ -332,9 +342,11 @@ module Tapioca
                     sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
                     def strict_loading(*args, &blk); end
 
+                <% if rails_version(">= 7.0") %>
                     sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
                     def structurally_compatible?(*args, &blk); end
 
+                <% end %>
                     sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
                     def uniq!(*args, &blk); end
 
@@ -349,9 +361,11 @@ module Tapioca
 
                     sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelationWhereChain) }
                     def where(*args, &blk); end
+                <% if rails_version(">= 7.0") %>
 
                     sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
                     def without(*args, &blk); end
+                <% end %>
                   end
 
                   module GeneratedRelationMethods
@@ -376,9 +390,11 @@ module Tapioca
                     sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
                     def except(*args, &blk); end
 
+                <% if rails_version(">= 7.0") %>
                     sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
                     def excluding(*args, &blk); end
 
+                <% end %>
                     sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
                     def extending(*args, &blk); end
 
@@ -394,15 +410,19 @@ module Tapioca
                     sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
                     def having(*args, &blk); end
 
+                <% if rails_version(">= 7.0") %>
                     sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
                     def in_order_of(*args, &blk); end
 
+                <% end %>
                     sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
                     def includes(*args, &blk); end
 
+                <% if rails_version(">= 7.0") %>
                     sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
                     def invert_where(*args, &blk); end
 
+                <% end %>
                     sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
                     def joins(*args, &blk); end
 
@@ -466,9 +486,11 @@ module Tapioca
                     sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
                     def strict_loading(*args, &blk); end
 
+                <% if rails_version(">= 7.0") %>
                     sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
                     def structurally_compatible?(*args, &blk); end
 
+                <% end %>
                     sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
                     def uniq!(*args, &blk); end
 
@@ -477,9 +499,11 @@ module Tapioca
 
                     sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelationWhereChain) }
                     def where(*args, &blk); end
+                <% if rails_version(">= 7.0") %>
 
                     sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
                     def without(*args, &blk); end
+                <% end %>
                   end
 
                   class PrivateAssociationRelation < ::ActiveRecord::AssociationRelation
@@ -495,9 +519,11 @@ module Tapioca
                   class PrivateAssociationRelationWhereChain < PrivateAssociationRelation
                     Elem = type_member { { fixed: ::Post } }
 
+                <% if rails_version(">= 7.0") %>
                     sig { params(args: T.untyped).returns(PrivateAssociationRelation) }
                     def associated(*args); end
 
+                <% end %>
                     sig { params(args: T.untyped).returns(PrivateAssociationRelation) }
                     def missing(*args); end
 
@@ -564,9 +590,11 @@ module Tapioca
                   class PrivateRelationWhereChain < PrivateRelation
                     Elem = type_member { { fixed: ::Post } }
 
+                <% if rails_version(">= 7.0") %>
                     sig { params(args: T.untyped).returns(PrivateRelation) }
                     def associated(*args); end
 
+                <% end %>
                     sig { params(args: T.untyped).returns(PrivateRelation) }
                     def missing(*args); end
 
@@ -579,6 +607,13 @@ module Tapioca
               assert_equal(expected, rbi_for(:Post))
             end
           end
+        end
+
+        private
+
+        sig { params(selector: String).returns(T::Boolean) }
+        def rails_version(selector)
+          ::Gem::Requirement.new(selector).satisfied_by?(ActiveSupport.gem_version)
         end
       end
     end


### PR DESCRIPTION
Some of our DSL generators depend on Rails code, which might change between versions.

Since Rails is an important dependency and people might be still in an old version. It is better to test against all of them.