### PR TITLE
Make ActiveRecord#find return value typed

### DIFF
--- a/lib/tapioca/dsl/compilers/active_record_relations.rb
+++ b/lib/tapioca/dsl/compilers/active_record_relations.rb
@@ -522,7 +522,7 @@ module Tapioca
                 parameters: [
                   create_rest_param("args", type: "T.untyped"),
                 ],
-                return_type: "T.untyped"
+                return_type: "T.any(#{constant_name}, T::Array[#{constant_name}])"
               )
             when :find_by
               create_common_method(

--- a/spec/tapioca/dsl/compilers/active_record_relations_spec.rb
+++ b/spec/tapioca/dsl/compilers/active_record_relations_spec.rb
@@ -93,7 +93,7 @@ module Tapioca
                     sig { returns(::Post) }
                     def fifth!; end
 
-                    sig { params(args: T.untyped).returns(T.untyped) }
+                    sig { params(args: T.untyped).returns(T.any(::Post, T::Array[::Post])) }
                     def find(*args); end
 
                     sig { params(args: T.untyped).returns(T.nilable(::Post)) }


### PR DESCRIPTION
### Motivation
Currently the return value of e.g. `Post#find` gets generated as untyped. We could catch some subtle bugs if it was typed.

Imagine a novice Rails dev who's not familiar with which finder method would return `nil` and which would raise exception if no record was found. Sorbet could warn e.g. if we tried to `nil` check on the return value of a `find`.

![image](https://user-images.githubusercontent.com/6256480/181925238-f39ad658-8a5c-4f00-b40e-cd2c41d59713.png)

### Implementation
I first thought that `find` always returns with a model, but it turned out it can be used to [query multiple record at once](https://api.rubyonrails.org/v7.0.3/classes/ActiveRecord/FinderMethods.html#method-i-find) so I went with a union type: either the model or an array of the models is returned.

(Some more background: `rails-sorbet` chose to [support only the one model retrieval for `find`](https://github.com/chanzuckerberg/sorbet-rails#find-first-and-last) and introduced a new method for the multiple record use case.)

### Tests
I've modified the existing test for the generated signature for `#find`.