### PR TITLE
New approach to finding attached class

### DIFF
--- a/lib/tapioca/gem/listeners/foreign_constants.rb
+++ b/lib/tapioca/gem/listeners/foreign_constants.rb
@@ -35,10 +35,10 @@ module Tapioca
               # base constant. Then, generate RBIs as if the base constant is extending the mixin,
               # which is functionally equivalent to including or prepending to the singleton class.
               if !name && constant.singleton_class?
-                name = constant_name_from_singleton_class(constant)
-                next unless name
+                attached_class = attached_class_of(constant)
+                next unless attached_class
 
-                constant = T.cast(constantize(name), Module)
+                constant = attached_class
               end
 
               @pipeline.push_foreign_constant(name, constant) if name

--- a/lib/tapioca/runtime/reflection.rb
+++ b/lib/tapioca/runtime/reflection.rb
@@ -168,15 +168,14 @@ module Tapioca
         resolved_loc.absolute_path || ""
       end
 
-      sig { params(constant: Module).returns(T.nilable(String)) }
-      def constant_name_from_singleton_class(constant)
-        constant.to_s.match("#<Class:(.+)>")&.captures&.first
-      end
+      sig { params(singleton_class: Module).returns(T.nilable(Module)) }
+      def attached_class_of(singleton_class)
+        # https://stackoverflow.com/a/36622320/98634
+        result = ObjectSpace.each_object(singleton_class).find do |klass|
+          singleton_class_of(T.cast(klass, Module)) == singleton_class
+        end
 
-      sig { params(constant: Module).returns(T.nilable(BasicObject)) }
-      def constant_from_singleton_class(constant)
-        constant_name = constant_name_from_singleton_class(constant)
-        constantize(constant_name) if constant_name
+        T.cast(result, Module)
       end
     end
   end

--- a/lib/tapioca/runtime/trackers/mixin.rb
+++ b/lib/tapioca/runtime/trackers/mixin.rb
@@ -103,7 +103,7 @@ class Module
     # this mixin can be found whether searching for an include/prepend on the singleton class
     # or an extend on the attached class.
     def register_extend_on_attached_class(constant)
-      attached_class = Tapioca::Runtime::Reflection.constant_from_singleton_class(constant)
+      attached_class = Tapioca::Runtime::Reflection.attached_class_of(constant)
 
       Tapioca::Runtime::Trackers::Mixin.register(
         T.cast(attached_class, Module),


### PR DESCRIPTION
Closes #1097.

### Motivation
Historically, to identify the attached class of a singleton class, we've parsed the name (result of the`#inspect` method) of the singleton class and then constantized the result. However, this doesn't work when the `#inspect` method of a singleton class is overridden because the return value of `#inspect` no longer conforms to the structure we expected.

### Implementation
We can fix this problem by searching `ObjectSpace` for the class that has the correct singleton class. This is less performant but more correct.

### Tests
Added a test that fails without the changes and passes with them. Existing tests continue to pass.
