### PR TITLE
Don't skip over abstract FrozenRecord classes

### DIFF
--- a/lib/tapioca/dsl/compilers/frozen_record.rb
+++ b/lib/tapioca/dsl/compilers/frozen_record.rb
@@ -90,7 +90,7 @@ module Tapioca
 
         sig { override.returns(T::Enumerable[Module]) }
         def self.gather_constants
-          descendants_of(::FrozenRecord::Base).reject(&:abstract_class?)
+          descendants_of(::FrozenRecord::Base)
         end
 
         private


### PR DESCRIPTION
### Motivation

On `shop-server`, we have an `abstract!` base class that derives from `FrozenRecord::Base`.

Currently, this class doesn't have an RBI file generated, because the FrozenRecord Tapioca compiler is explicitly skipping over abstract classes.

I don't think there's a reason *not* to include these, so let's just do it.

### Tests

There wasn't a test to check that `abstract` classes are skipped. If there was one, I would have deleted it. I don't think there's a need to add a test to verify that's we're not not including abstract files, but LMK if you think I should add one anyway :)
