### PR TITLE
Revert "Make ActiveRecord#find return value typed"

### DIFF
--- a/lib/tapioca/dsl/compilers/active_record_relations.rb
+++ b/lib/tapioca/dsl/compilers/active_record_relations.rb
@@ -522,7 +522,7 @@ module Tapioca
                 parameters: [
                   create_rest_param("args", type: "T.untyped"),
                 ],
-                return_type: "T.any(#{constant_name}, T::Array[#{constant_name}])"
+                return_type: "T.untyped"
               )
             when :find_by
               create_common_method(

--- a/spec/tapioca/dsl/compilers/active_record_relations_spec.rb
+++ b/spec/tapioca/dsl/compilers/active_record_relations_spec.rb
@@ -93,7 +93,7 @@ module Tapioca
                     sig { returns(::Post) }
                     def fifth!; end
 
-                    sig { params(args: T.untyped).returns(T.any(::Post, T::Array[::Post])) }
+                    sig { params(args: T.untyped).returns(T.untyped) }
                     def find(*args); end
 
                     sig { params(args: T.untyped).returns(T.nilable(::Post)) }


### PR DESCRIPTION
Reverts Shopify/tapioca#1089

The PR was merged, but the implementation is flawed and will not work in real applications. 

Union types as return values don't work the way folks imagine them to work:
```ruby
user = User.find(1)

user.name # Method name does not exist on T::Array[User] component of T.any(T::Array[User], User)
```