### PR TITLE
Properly discover methods added to `<main>` object

### DIFF
--- a/lib/tapioca/gem/pipeline.rb
+++ b/lib/tapioca/gem/pipeline.rb
@@ -355,7 +355,7 @@ module Tapioca
       def get_file_candidates(constant)
         wrapped_module = Pry::WrappedModule.new(constant)
 
-        wrapped_module.candidates.map(&:file).to_a.compact
+        wrapped_module.send(:method_candidates).flatten.filter_map(&:source_file).uniq
       rescue ArgumentError, NameError
         []
       end

--- a/spec/tapioca/gem/pipeline_spec.rb
+++ b/spec/tapioca/gem/pipeline_spec.rb
@@ -293,7 +293,7 @@ class Tapioca::Gem::PipelineSpec < Minitest::HooksSpec
       assert_equal(output, compile)
     end
 
-    it "compiles extensions to BasicObject and Object" do
+    it "compiles extensions to BasicObject, Object and <main> object" do
       add_ruby_file("ext.rb", <<~RUBY)
         class BasicObject
           def hello
@@ -303,6 +303,11 @@ class Tapioca::Gem::PipelineSpec < Minitest::HooksSpec
         class Object
           def hello
           end
+        end
+
+        # Addition to <main> object,
+        # which should be a private method on Object
+        def log
         end
       RUBY
 
@@ -317,6 +322,10 @@ class Tapioca::Gem::PipelineSpec < Minitest::HooksSpec
           include ::Kernel
 
           def hello; end
+
+          private
+
+          def log; end
         end
       RBI
 


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
Address https://github.com/Shopify/rbi-central/pull/94 in Tapioca for more resilience.

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
This PR changes how we get file candidates for a given constant which allows us to attribute the constant to a gem or not. We use the `Pry::WrappedModule` class to help us do that, so that we don't have to reimplement that logic ourselves.

While that's been working really fine so far, it turns out that Pry does a lot of extra work to get a list of candidates for a given wrapped module. One of these extra things is to attribute the methods that are introspected to the constant that defines them in the source file. This is not only a performance issue, but it was also failing for methods added to `Object` by being defined at the top level, and was resolving their `file`s as `nil`.

Since we don't need the machinery that the `candidates` method gives us, we can just rely on the `method_candidates` method (alas, it is a private method), to grab the unique file names that have defined methods on the wrapped module.

The `method_candidates` returns an array of arrays of `Pry::Method` objects. We flatten it into a single list, grab unique source file names from it. This should give us the proper list of file candidates.

This also reduces our dependency on `Pry:WrappedModule` and allows us to reimplement it inside Tapioca in the near future.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->
Extended an existing test to test for extension to `<main>` object that fails before this PR and passes after.
