### PR TITLE
Add `RelationType` to ActiveRecord

### DIFF
--- a/lib/tapioca/dsl/compilers/active_record_relations.rb
+++ b/lib/tapioca/dsl/compilers/active_record_relations.rb
@@ -242,6 +242,15 @@ module Tapioca
           create_relation_class(model)
           create_association_relation_class(model)
           create_collection_proxy_class(model)
+          
+          klass.create_type_alias(
+            'RelationType',
+            Types::Union.new([
+              RelationClassName,
+              AssociationRelationClassName,
+              RelationWhereChainClassName
+            ])
+          )
         end
 
         sig { params(model: RBI::Scope).void }


### PR DESCRIPTION
### Motivation
Many companies are trying to migrate away from sorbet-rails but they've committed large portions of their codebase to using `RelationType`.
Adding this alias would make migration much easier.

### Implementation
Generated the type alias with Parlour.

### Tests
Pending.
