### PR TITLE
Show full result when failing to match output in tests

### DIFF
--- a/spec/spec_with_project.rb
+++ b/spec/spec_with_project.rb
@@ -127,6 +127,16 @@ module Tapioca
       refute(result.status)
     end
 
+    sig { params(result: MockProject::ExecResult, snippet: String).void }
+    def assert_stdout_includes(result, snippet)
+      assert_includes(result.out, snippet, result.to_s)
+    end
+
+    sig { params(result: MockProject::ExecResult, snippet: String).void }
+    def assert_stderr_includes(result, snippet)
+      assert_includes(result.err, snippet, result.to_s)
+    end
+
     private
 
     sig { returns(String) }

--- a/spec/tapioca/cli/annotations_spec.rb
+++ b/spec/tapioca/cli/annotations_spec.rb
@@ -40,8 +40,8 @@ module Tapioca
 
         result = @project.tapioca("annotations --sources #{repo.path}")
 
-        assert_includes(result.out, "remove  sorbet/rbi/annotations/bar.rbi")
-        assert_includes(result.out, "remove  sorbet/rbi/annotations/foo.rbi")
+        assert_stdout_includes(result, "remove  sorbet/rbi/annotations/bar.rbi")
+        assert_stdout_includes(result, "remove  sorbet/rbi/annotations/foo.rbi")
         refute_includes(result.out, "remove  sorbet/rbi/annotations/rbi.rbi")
 
         assert_success_status(result)
@@ -70,8 +70,8 @@ module Tapioca
 
         result = @project.tapioca("annotations --sources #{repo.path}")
 
-        assert_includes(result.out, "create  sorbet/rbi/annotations/rbi.rbi")
-        assert_includes(result.out, "create  sorbet/rbi/annotations/spoom.rbi")
+        assert_stdout_includes(result, "create  sorbet/rbi/annotations/rbi.rbi")
+        assert_stdout_includes(result, "create  sorbet/rbi/annotations/spoom.rbi")
         refute_includes(result.out, "create  sorbet/rbi/annotations/foo.rbi")
 
         assert_project_annotation_equal("sorbet/rbi/annotations/rbi.rbi", <<~RBI)
@@ -103,16 +103,16 @@ module Tapioca
       it "gets index from the central repo using the default source" do
         result = @project.tapioca("annotations")
 
-        assert_includes(result.out, "Retrieving index from central repository... Done")
+        assert_stdout_includes(result, "Retrieving index from central repository... Done")
         assert_success_status(result)
       end
 
       it "recovers from a bad source" do
         result = @project.tapioca("annotations --sources #{Tapioca::CENTRAL_REPO_ROOT_URI} https://bad-source")
 
-        assert_includes(result.out, "Retrieving index from central repository #1... Done")
-        assert_includes(result.err, "Can't fetch file `index.json` from https://bad-source")
-        assert_includes(result.err, <<~ERROR)
+        assert_stdout_includes(result, "Retrieving index from central repository #1... Done")
+        assert_stderr_includes(result, "Can't fetch file `index.json` from https://bad-source")
+        assert_stderr_includes(result, <<~ERROR)
           Tapioca can't access the annotations at https://bad-source.
 
           Are you trying to access a private repository?
@@ -126,8 +126,8 @@ module Tapioca
       it "errors without a valid source" do
         result = @project.tapioca("annotations --sources https://bad-source")
 
-        assert_includes(result.err, "Can't fetch file `index.json` from https://bad-source")
-        assert_includes(result.err, "Can't fetch annotations without sources (no index fetched)")
+        assert_stderr_includes(result, "Can't fetch file `index.json` from https://bad-source")
+        assert_stderr_includes(result, "Can't fetch annotations without sources (no index fetched)")
         refute_success_status(result)
       end
 
@@ -142,7 +142,7 @@ module Tapioca
 
         result = @project.tapioca("annotations --sources #{repo.path}")
 
-        assert_includes(result.err, <<~ERR)
+        assert_stderr_includes(result, <<~ERR)
           Can't import RBI file for `spoom` as it contains errors:
               Error: unexpected token $end (-:4:0-4:0)
         ERR
@@ -172,8 +172,8 @@ module Tapioca
 
         result = @project.tapioca("annotations --sources #{repo1.path} #{repo2.path}")
 
-        assert_includes(result.out, "create  sorbet/rbi/annotations/rbi.rbi")
-        assert_includes(result.out, "create  sorbet/rbi/annotations/spoom.rbi")
+        assert_stdout_includes(result, "create  sorbet/rbi/annotations/rbi.rbi")
+        assert_stdout_includes(result, "create  sorbet/rbi/annotations/spoom.rbi")
 
         assert_project_annotation_equal("sorbet/rbi/annotations/rbi.rbi", <<~RBI)
           # typed: true
@@ -226,7 +226,7 @@ module Tapioca
 
         result = @project.tapioca("annotations --sources #{repo1.path} #{repo2.path}")
 
-        assert_includes(result.out, "create  sorbet/rbi/annotations/rbi.rbi")
+        assert_stdout_includes(result, "create  sorbet/rbi/annotations/rbi.rbi")
 
         assert_project_annotation_equal("sorbet/rbi/annotations/rbi.rbi", <<~RBI)
           # typed: true
@@ -275,7 +275,7 @@ module Tapioca
 
         result = @project.tapioca("annotations --sources #{repo1.path} #{repo2.path}")
 
-        assert_includes(result.err, <<~ERR)
+        assert_stderr_includes(result, <<~ERR)
           Can't import RBI file for `spoom` as it contains conflicts:
               Conflicting definitions for `::AnnotationForSpoom#foo(x, y)`
               Conflicting definitions for `::AnnotationForSpoom#bar()`
@@ -291,7 +291,7 @@ module Tapioca
       it "errors if passing both --no-netrc and --netrc-file" do
         result = @project.tapioca("annotations --no-netrc --netrc-file some_file")
 
-        assert_includes(result.err, <<~ERR)
+        assert_stderr_includes(result, <<~ERR)
           Options `--no-netrc` and `--netrc-file` can't be used together
         ERR
 

--- a/spec/tapioca/cli/configure_spec.rb
+++ b/spec/tapioca/cli/configure_spec.rb
@@ -20,10 +20,10 @@ module Tapioca
       it "must create proper files" do
         result = @project.tapioca("configure")
 
-        assert_includes(result.out, "create  sorbet/config")
-        assert_includes(result.out, "create  sorbet/tapioca/config.yml")
-        assert_includes(result.out, "create  sorbet/tapioca/require.rb")
-        assert_includes(result.out, "create  bin/tapioca")
+        assert_stdout_includes(result, "create  sorbet/config")
+        assert_stdout_includes(result, "create  sorbet/tapioca/config.yml")
+        assert_stdout_includes(result, "create  sorbet/tapioca/require.rb")
+        assert_stdout_includes(result, "create  bin/tapioca")
 
         assert_equal(<<~CONFIG, @project.read("sorbet/config"))
           --dir
@@ -57,10 +57,10 @@ module Tapioca
 
         result = @project.tapioca("configure")
 
-        assert_includes(result.out, "skip  sorbet/config")
-        assert_includes(result.out, "skip  sorbet/tapioca/config.yml")
-        assert_includes(result.out, "skip  sorbet/tapioca/require.rb")
-        assert_includes(result.out, "force  bin/tapioca")
+        assert_stdout_includes(result, "skip  sorbet/config")
+        assert_stdout_includes(result, "skip  sorbet/tapioca/config.yml")
+        assert_stdout_includes(result, "skip  sorbet/tapioca/require.rb")
+        assert_stdout_includes(result, "force  bin/tapioca")
 
         assert_empty(@project.read("sorbet/config"))
         assert_empty(@project.read("sorbet/tapioca/require.rb"))
@@ -71,7 +71,7 @@ module Tapioca
 
       it "creates the Tapioca config file in a custom location" do
         result = @project.tapioca("configure --config sorbet/tapioca/custom_config.yml")
-        assert_includes(result.out, "create  sorbet/tapioca/custom_config.yml")
+        assert_stdout_includes(result, "create  sorbet/tapioca/custom_config.yml")
         assert_project_file_exist("sorbet/tapioca/custom_config.yml")
         assert_empty_stderr(result)
         assert_success_status(result)
@@ -79,7 +79,7 @@ module Tapioca
 
       it "creates the Tapioca post-require file in a custom location" do
         result = @project.tapioca("configure --postrequire sorbet/tapioca/custom_require.rb")
-        assert_includes(result.out, "create  sorbet/tapioca/custom_require.rb")
+        assert_stdout_includes(result, "create  sorbet/tapioca/custom_require.rb")
         assert_project_file_exist("sorbet/tapioca/custom_require.rb")
         assert_empty_stderr(result)
         assert_success_status(result)

--- a/spec/tapioca/cli/dsl_spec.rb
+++ b/spec/tapioca/cli/dsl_spec.rb
@@ -1190,8 +1190,8 @@ module Tapioca
 
           OUT
 
-          assert_includes(result.err, "Error: `PostCompilerThatRaises` failed to generate RBI for `Post`")
-          assert_includes(result.err, "Some unexpected error happened")
+          assert_stderr_includes(result, "Error: `PostCompilerThatRaises` failed to generate RBI for `Post`")
+          assert_stderr_includes(result, "Some unexpected error happened")
 
           refute_project_file_exist("sorbet/rbi/dsl/post.rbi")
           refute_success_status(result)
@@ -1313,7 +1313,7 @@ module Tapioca
           @project.tapioca("dsl")
           result = @project.tapioca("dsl --verify")
 
-          assert_includes(result.out, <<~OUT)
+          assert_stdout_includes(result, <<~OUT)
             Nothing to do, all RBIs are up-to-date.
           OUT
 
@@ -1463,7 +1463,7 @@ module Tapioca
 
           result = @project.tapioca("dsl Post")
 
-          assert_includes(result.out, <<~OUT)
+          assert_stdout_includes(result, <<~OUT)
             Checking generated RBI files...  Done
 
               Changed strictness of sorbet/rbi/gems/bar@1.0.0.rbi to `typed: false` (conflicting with DSL files)

--- a/spec/tapioca/cli/gem_spec.rb
+++ b/spec/tapioca/cli/gem_spec.rb
@@ -140,7 +140,7 @@ module Tapioca
 
         result = @project.tapioca("gems foo")
 
-        assert_includes(result.out, <<~OUT)
+        assert_stdout_includes(result, <<~OUT)
           Compiled foo
                 create  sorbet/rbi/gems/foo@0.0.1.rbi
         OUT
@@ -213,7 +213,7 @@ module Tapioca
 
           result = @project.tapioca("gem foo")
 
-          assert_includes(result.out, <<~OUT)
+          assert_stdout_includes(result, <<~OUT)
             Compiled foo
                   create  sorbet/rbi/gems/foo@0.0.1.rbi
           OUT
@@ -241,7 +241,7 @@ module Tapioca
 
           result = @project.tapioca("gem #{gem_name}")
 
-          assert_includes(result.out, <<~OUT)
+          assert_stdout_includes(result, <<~OUT)
             Compiled #{gem_name}
                   create  sorbet/rbi/gems/#{gem_name}@#{gem_version}.rbi
           OUT
@@ -263,7 +263,7 @@ module Tapioca
 
           result = @project.tapioca("gem foo --outdir rbis/")
 
-          assert_includes(result.out, <<~OUT)
+          assert_stdout_includes(result, <<~OUT)
             Compiled foo
           OUT
 
@@ -304,7 +304,7 @@ module Tapioca
 
           result = @project.tapioca("gem foo")
 
-          assert_includes(result.out, "create  sorbet/rbi/gems/foo@0.0.1.rbi")
+          assert_stdout_includes(result, "create  sorbet/rbi/gems/foo@0.0.1.rbi")
 
           assert_project_file_equal("sorbet/rbi/gems/foo@0.0.1.rbi", <<~RBI)
             # typed: true
@@ -362,7 +362,7 @@ module Tapioca
 
           result = @project.tapioca("gem foo --no-exported-gem-rbis")
 
-          assert_includes(result.out, "create  sorbet/rbi/gems/foo@0.0.1.rbi")
+          assert_stdout_includes(result, "create  sorbet/rbi/gems/foo@0.0.1.rbi")
           assert_project_file_equal("sorbet/rbi/gems/foo@0.0.1.rbi", FOO_RBI)
           assert_empty_stderr(result)
           assert_success_status(result)
@@ -382,11 +382,11 @@ module Tapioca
 
           result = @project.tapioca("gem foo")
 
-          assert_includes(result.out, "create  sorbet/rbi/gems/foo@0.0.1.rbi")
+          assert_stdout_includes(result, "create  sorbet/rbi/gems/foo@0.0.1.rbi")
 
-          assert_includes(result.err, "RBIs exported by `foo` contain errors and can't be used:")
-          assert_includes(result.err, "Cause: unexpected token $end")
-          assert_includes(result.err, "foo/rbi/foo.rbi:2:0-2:0")
+          assert_stderr_includes(result, "RBIs exported by `foo` contain errors and can't be used:")
+          assert_stderr_includes(result, "Cause: unexpected token $end")
+          assert_stderr_includes(result, "foo/rbi/foo.rbi:2:0-2:0")
 
           assert_project_file_equal("sorbet/rbi/gems/foo@0.0.1.rbi", FOO_RBI)
 
@@ -415,13 +415,13 @@ module Tapioca
 
           result = @project.tapioca("gem foo")
 
-          assert_includes(result.out, "create  sorbet/rbi/gems/foo@0.0.1.rbi")
+          assert_stdout_includes(result, "create  sorbet/rbi/gems/foo@0.0.1.rbi")
 
-          assert_includes(result.err, "RBIs exported by `foo` contain conflicts and can't be used:")
-          assert_includes(result.err, "Conflicting definitions for `::RBI::Foo#foo(a, b, c)`")
-          assert_includes(result.err, "Found at:")
-          assert_includes(result.err, "foo/rbi/bar.rbi:2:2-2:23")
-          assert_includes(result.err, "foo/rbi/foo.rbi:2:2-2:17")
+          assert_stderr_includes(result, "RBIs exported by `foo` contain conflicts and can't be used:")
+          assert_stderr_includes(result, "Conflicting definitions for `::RBI::Foo#foo(a, b, c)`")
+          assert_stderr_includes(result, "Found at:")
+          assert_stderr_includes(result, "foo/rbi/bar.rbi:2:2-2:23")
+          assert_stderr_includes(result, "foo/rbi/foo.rbi:2:2-2:17")
 
           assert_project_file_equal("sorbet/rbi/gems/foo@0.0.1.rbi", FOO_RBI)
 
@@ -446,7 +446,7 @@ module Tapioca
 
           result = @project.tapioca("gem foo")
 
-          assert_includes(result.out, "create  sorbet/rbi/gems/foo@0.0.1.rbi")
+          assert_stdout_includes(result, "create  sorbet/rbi/gems/foo@0.0.1.rbi")
           assert_project_file_equal("sorbet/rbi/gems/foo@0.0.1.rbi", FOO_RBI)
           assert_empty_stderr(result)
           assert_success_status(result)
@@ -465,7 +465,7 @@ module Tapioca
 
           result = @project.tapioca("gem --all")
 
-          assert_includes(result.out, "remove  sorbet/rbi/gems/outdated@5.0.0.rbi\n")
+          assert_stdout_includes(result, "remove  sorbet/rbi/gems/outdated@5.0.0.rbi\n")
           refute_includes(result.out, "create sorbet/rbi/gems/foo@0.0.1.rbi")
           refute_includes(result.out, "create sorbet/rbi/gems/bar@0.3.0.rbi")
           refute_includes(result.out, "create sorbet/rbi/gems/baz@0.0.2.rbi")
@@ -495,7 +495,7 @@ module Tapioca
 
           result = @project.tapioca("gem foo")
 
-          assert_includes(result.out, <<~OUT)
+          assert_stdout_includes(result, <<~OUT)
             Compiled foo
           OUT
 
@@ -536,7 +536,7 @@ module Tapioca
             Compiled bar
           OUT
 
-          assert_includes(result.out, <<~OUT)
+          assert_stdout_includes(result, <<~OUT)
             Compiled foo
           OUT
 
@@ -566,7 +566,7 @@ module Tapioca
 
           result = @project.tapioca("gem foo")
 
-          assert_includes(result.err, <<~ERR)
+          assert_stderr_includes(result, <<~ERR)
             LoadError: cannot load such file -- foo/will_fail
 
             Tapioca could not load all the gems required by your application.
@@ -582,7 +582,7 @@ module Tapioca
         it "must not include `rbi` definitions into `tapioca` RBI" do
           result = @project.tapioca("gem tapioca")
 
-          assert_includes(result.out, <<~OUT)
+          assert_stdout_includes(result, <<~OUT)
             Compiled tapioca
           OUT
 
@@ -613,8 +613,8 @@ module Tapioca
 
           result = @project.tapioca("gem foo bar")
 
-          assert_includes(result.out, "Compiled foo")
-          assert_includes(result.out, "Compiled bar")
+          assert_stdout_includes(result, "Compiled foo")
+          assert_stdout_includes(result, "Compiled bar")
           assert_project_file_equal("sorbet/rbi/gems/foo@0.0.1.rbi", FOO_RBI)
           assert_project_file_equal("sorbet/rbi/gems/bar@0.3.0.rbi", BAR_RBI)
           refute_project_file_exist("sorbet/rbi/gems/baz@0.0.2.rbi")
@@ -643,9 +643,9 @@ module Tapioca
 
           result = @project.tapioca("gem --all")
 
-          assert_includes(result.out, "Compiled bar")
-          assert_includes(result.out, "Compiled baz")
-          assert_includes(result.out, "Compiled foo")
+          assert_stdout_includes(result, "Compiled bar")
+          assert_stdout_includes(result, "Compiled baz")
+          assert_stdout_includes(result, "Compiled foo")
 
           assert_project_file_equal("sorbet/rbi/gems/foo@0.0.1.rbi", FOO_RBI)
           assert_project_file_equal("sorbet/rbi/gems/bar@0.3.0.rbi", BAR_RBI)
@@ -666,7 +666,7 @@ module Tapioca
 
           result = @project.tapioca("gem --all")
 
-          assert_includes(result.out, "completed with missing specs: ruby2_keywords (0.0.5)")
+          assert_stdout_includes(result, "completed with missing specs: ruby2_keywords (0.0.5)")
           refute_includes(result.out, "Compiled ruby2_keywords")
 
           assert_empty_stderr(result)
@@ -684,7 +684,7 @@ module Tapioca
 
           result = @project.tapioca("gem --all")
 
-          assert_includes(result.out, "completed with missing specs: ruby2_keywords (0.0.5)")
+          assert_stdout_includes(result, "completed with missing specs: ruby2_keywords (0.0.5)")
           refute_includes(result.out, "Compiled ruby2_keywords")
 
           # StdErr will have some messages about incompatibilities, so we don't check for clean err
@@ -700,7 +700,7 @@ module Tapioca
 
           result = @project.tapioca("gem faraday")
 
-          assert_includes(result.out, "Compiled faraday")
+          assert_stdout_includes(result, "Compiled faraday")
 
           assert_project_file_exist(
             "sorbet/rbi/gems/faraday@2.0.0.alpha.pre.4-23e249563613971ced8f851230c46b9eeeefe931.rbi"
@@ -719,7 +719,7 @@ module Tapioca
           result = @project.tapioca("gem --all --exclude foo bar")
 
           refute_includes(result.out, "Compiled bar")
-          assert_includes(result.out, "Compiled baz")
+          assert_stdout_includes(result, "Compiled baz")
           refute_includes(result.out, "Compiled foo")
 
           refute_project_file_exist("sorbet/rbi/gems/foo@0.0.1.rbi")
@@ -745,7 +745,7 @@ module Tapioca
 
           result = @project.tapioca("gem foo")
 
-          assert_includes(result.out, "Compiled foo")
+          assert_stdout_includes(result, "Compiled foo")
           assert_project_file_exist("sorbet/rbi/gems/foo@0.0.1.rbi")
           assert_project_file_equal("sorbet/rbi/gems/foo@0.0.1.rbi", FOO_RBI)
 
@@ -759,8 +759,8 @@ module Tapioca
 
           result = @project.tapioca("gem foo")
 
-          assert_includes(result.out, "Compiled foo (empty output)")
-          assert_includes(result.out, "create  sorbet/rbi/gems/foo@0.0.1.rbi\n")
+          assert_stdout_includes(result, "Compiled foo (empty output)")
+          assert_stdout_includes(result, "create  sorbet/rbi/gems/foo@0.0.1.rbi\n")
 
           assert_project_file_equal("sorbet/rbi/gems/foo@0.0.1.rbi", <<~RBI)
             # typed: true
@@ -1484,8 +1484,8 @@ module Tapioca
 
           result = @project.tapioca("gem --exclude foo bar")
 
-          assert_includes(result.out, "remove  sorbet/rbi/gems/foo@0.0.1.rbi\n")
-          assert_includes(result.out, "remove  sorbet/rbi/gems/bar@0.3.0.rbi\n")
+          assert_stdout_includes(result, "remove  sorbet/rbi/gems/foo@0.0.1.rbi\n")
+          assert_stdout_includes(result, "remove  sorbet/rbi/gems/bar@0.3.0.rbi\n")
           refute_includes(result.out, "remove  sorbet/rbi/gems/baz@0.0.2.rbi\n")
           refute_includes(result.out, "create sorbet/rbi/gems/foo@0.0.1.rbi")
           refute_includes(result.out, "create sorbet/rbi/gems/bar@0.3.0.rbi")
@@ -1508,7 +1508,7 @@ module Tapioca
 
           result = @project.tapioca("gem")
 
-          assert_includes(result.out, "remove  sorbet/rbi/gems/outdated@5.0.0.rbi\n")
+          assert_stdout_includes(result, "remove  sorbet/rbi/gems/outdated@5.0.0.rbi\n")
           refute_includes(result.out, "create sorbet/rbi/gems/foo@0.0.1.rbi")
           refute_includes(result.out, "create sorbet/rbi/gems/bar@0.3.0.rbi")
           refute_includes(result.out, "create sorbet/rbi/gems/baz@0.0.2.rbi")
@@ -1528,12 +1528,12 @@ module Tapioca
 
           result = @project.tapioca("gem")
 
-          assert_includes(result.out, "create  sorbet/rbi/gems/bar@0.3.0.rbi\n")
-          assert_includes(result.out, "create  sorbet/rbi/gems/baz@0.0.2.rbi\n")
+          assert_stdout_includes(result, "create  sorbet/rbi/gems/bar@0.3.0.rbi\n")
+          assert_stdout_includes(result, "create  sorbet/rbi/gems/baz@0.0.2.rbi\n")
           refute_includes(result.out, "remove ")
           refute_includes(result.out, "-> Moving:")
 
-          assert_includes(result.out, <<~OUT)
+          assert_stdout_includes(result, <<~OUT)
             Removing RBI files of gems that have been removed:
 
               Nothing to do.
@@ -1554,13 +1554,13 @@ module Tapioca
 
           result = @project.tapioca("gem")
 
-          assert_includes(result.out, "-> Moving: sorbet/rbi/gems/bar@0.0.1.rbi to sorbet/rbi/gems/bar@0.3.0.rbi\n")
-          assert_includes(result.out, "force  sorbet/rbi/gems/bar@0.3.0.rbi\n")
-          assert_includes(result.out, "-> Moving: sorbet/rbi/gems/baz@0.0.1.rbi to sorbet/rbi/gems/baz@0.0.2.rbi\n")
-          assert_includes(result.out, "force  sorbet/rbi/gems/baz@0.0.2.rbi\n")
+          assert_stdout_includes(result, "-> Moving: sorbet/rbi/gems/bar@0.0.1.rbi to sorbet/rbi/gems/bar@0.3.0.rbi\n")
+          assert_stdout_includes(result, "force  sorbet/rbi/gems/bar@0.3.0.rbi\n")
+          assert_stdout_includes(result, "-> Moving: sorbet/rbi/gems/baz@0.0.1.rbi to sorbet/rbi/gems/baz@0.0.2.rbi\n")
+          assert_stdout_includes(result, "force  sorbet/rbi/gems/baz@0.0.2.rbi\n")
           refute_includes(result.out, "remove ")
 
-          assert_includes(result.out, <<~OUT)
+          assert_stdout_includes(result, <<~OUT)
             Removing RBI files of gems that have been removed:
 
               Nothing to do.
@@ -1733,7 +1733,7 @@ module Tapioca
         it "must turn the strictness of files with errors to false" do
           result = @project.tapioca("gem --all")
 
-          assert_includes(result.out, <<~OUT)
+          assert_stdout_includes(result, <<~OUT)
             Checking generated RBI files...  Done
 
               Changed strictness of sorbet/rbi/gems/bar@0.3.0.rbi to `typed: false` (conflicting with DSL files)
@@ -1761,7 +1761,7 @@ module Tapioca
 
           result = @project.tapioca("gem --dsl-dir sorbet/rbi/shims")
 
-          assert_includes(result.out, <<~OUT)
+          assert_stdout_includes(result, <<~OUT)
             Checking generated RBI files...  Done
 
               Changed strictness of sorbet/rbi/gems/foo@0.0.1.rbi to `typed: false` (conflicting with DSL files)
@@ -1814,7 +1814,7 @@ module Tapioca
 
           result = @project.tapioca("gem foo")
 
-          assert_includes(result.err, <<~ERR)
+          assert_stderr_includes(result, <<~ERR)
             ##### INTERNAL ERROR #####
 
             There are parse errors in the generated RBI files.
@@ -1830,9 +1830,9 @@ module Tapioca
             Gems:
           ERR
 
-          assert_includes(result.err, "foo (0.0.1)")
+          assert_stderr_includes(result, "foo (0.0.1)")
 
-          assert_includes(result.err, <<~ERR)
+          assert_stderr_includes(result, <<~ERR)
             Errors:
               sorbet/rbi/gems/bar@1.0.0.rbi:5: unexpected token tRCURLY (2001)
               sorbet/rbi/gems/bar@1.0.0.rbi:6: unexpected token "end" (2001)
@@ -1864,7 +1864,7 @@ module Tapioca
 
           result = @project.tapioca("gem")
 
-          assert_includes(result.out, <<~OUT)
+          assert_stdout_includes(result, <<~OUT)
             Compiled type_variable
                   create  sorbet/rbi/gems/type_variable@0.0.1.rbi
           OUT
@@ -1920,7 +1920,7 @@ module Tapioca
 
           result = @project.tapioca("gem")
 
-          assert_includes(result.out, <<~OUT)
+          assert_stdout_includes(result, <<~OUT)
             Compiled type_variable
                   create  sorbet/rbi/gems/type_variable@0.0.1.rbi
           OUT


### PR DESCRIPTION
We seem to have a [flaky test in `main`](https://github.com/Shopify/tapioca/runs/7813457788?check_suite_focus=true#step:4:650); the test failure only tells us that the output is empty, but it doesn't show anything about stderr or about the overall success.

This PR introduces and uses two new assertions that might make it easier to debug such test failures:

* `assert_stdout_includes`
* `assert_stderr_includes`

If I manually setup a failure on that flaky test, this is what we get now:

```
cli
  gem
    generate
      it must not include `rbi` definitions into `tapioca` RBI        FAIL (1.61s)
        ########## STDOUT ##########
        Requiring all gems to prepare for compiling...  Done
        
        Removing RBI files of gems that have been removed:
        
          Nothing to do.
        
          Compiled tapioca
              create  sorbet/rbi/gems/tapioca@0.9.2.rbi
        
        Checking generated RBI files...  Done
        
          Changed strictness of sorbet/rbi/gems/tapioca@0.9.2.rbi to `typed: false` (conflicting with DSL files)
        
        All operations performed in working directory.
        Please review changes and commit them.
        
        ########## STDERR ##########
        <empty>
        ########## STATUS: true ##########
```