### PR TITLE
Add flag to list compilers for DSL command

### DIFF
--- a/README.md
+++ b/README.md
@@ -458,22 +458,23 @@ Usage:
   tapioca dsl [constant...]
 
 Options:
-  --out, -o, [--outdir=directory]              # The output directory for generated DSL RBI files
-                                               # Default: sorbet/rbi/dsl
-          [--file-header], [--no-file-header]  # Add a "This file is generated" header on top of each generated RBI file
-                                               # Default: true
-          [--only=compiler [compiler ...]]     # Only run supplied DSL compiler(s)
-          [--exclude=compiler [compiler ...]]  # Exclude supplied DSL compiler(s)
-          [--verify], [--no-verify]            # Verifies RBIs are up-to-date
-  -q, [--quiet], [--no-quiet]                  # Suppresses file creation output
-  -w, [--workers=N]                            # Number of parallel workers to use when generating RBIs (default: auto)
-          [--rbi-max-line-length=N]            # Set the max line length of generated RBIs. Signatures longer than the max line length will be wrapped
-                                               # Default: 120
-  -e, [--environment=ENVIRONMENT]              # The Rack/Rails environment to use when generating RBIs
-                                               # Default: development
-  -c, [--config=<config file path>]            # Path to the Tapioca configuration file
-                                               # Default: sorbet/tapioca/config.yml
-  -V, [--verbose], [--no-verbose]              # Verbose output for debugging purposes
+  --out, -o, [--outdir=directory]                # The output directory for generated DSL RBI files
+                                                 # Default: sorbet/rbi/dsl
+          [--file-header], [--no-file-header]    # Add a "This file is generated" header on top of each generated RBI file
+                                                 # Default: true
+          [--only=compiler [compiler ...]]       # Only run supplied DSL compiler(s)
+          [--exclude=compiler [compiler ...]]    # Exclude supplied DSL compiler(s)
+          [--verify], [--no-verify]              # Verifies RBIs are up-to-date
+  -q, [--quiet], [--no-quiet]                    # Suppresses file creation output
+  -w, [--workers=N]                              # Number of parallel workers to use when generating RBIs (default: auto)
+          [--rbi-max-line-length=N]              # Set the max line length of generated RBIs. Signatures longer than the max line length will be wrapped
+                                                 # Default: 120
+  -e, [--environment=ENVIRONMENT]                # The Rack/Rails environment to use when generating RBIs
+                                                 # Default: development
+  -l, [--list-compilers], [--no-list-compilers]  # List all loaded compilers
+  -c, [--config=<config file path>]              # Path to the Tapioca configuration file
+                                                 # Default: sorbet/tapioca/config.yml
+  -V, [--verbose], [--no-verbose]                # Verbose output for debugging purposes
 
 generate RBIs for dynamic methods
 ```
@@ -819,6 +820,7 @@ dsl:
   workers: 1
   rbi_max_line_length: 120
   environment: development
+  list_compilers: false
 gem:
   outdir: sorbet/rbi/gems
   file_header: true

--- a/lib/tapioca/cli.rb
+++ b/lib/tapioca/cli.rb
@@ -115,6 +115,11 @@ module Tapioca
       type: :string,
       desc: "The Rack/Rails environment to use when generating RBIs",
       default: DEFAULT_ENVIRONMENT
+    option :list_compilers,
+      aliases: ["-l"],
+      type: :boolean,
+      desc: "List all loaded compilers",
+      default: false
     def dsl(*constants)
       set_environment(options)
 
@@ -133,7 +138,11 @@ module Tapioca
       )
 
       Tapioca.silence_warnings do
-        command.execute
+        if options[:list_compilers]
+          command.list_compilers
+        else
+          command.execute
+        end
       end
     end
 

--- a/spec/tapioca/cli/dsl_spec.rb
+++ b/spec/tapioca/cli/dsl_spec.rb
@@ -1767,6 +1767,107 @@ module Tapioca
           OUT
         end
       end
+
+      describe "list compilers" do
+        before(:all) do
+          @project.tapioca("configure")
+          @project.require_real_gem("smart_properties")
+          @project.require_real_gem("sidekiq")
+          @project.require_real_gem("activerecord")
+          @project.bundle_install
+
+          @project.write("lib/compilers/post_compiler.rb", <<~RB)
+            require "tapioca/dsl"
+
+            class PostCompiler < Tapioca::Dsl::Compiler
+            end
+          RB
+        end
+
+        it "lists all Tapioca bundled compilers" do
+          result = @project.tapioca("dsl --list-compilers")
+
+          assert_equal(<<~OUT, result.out)
+            Loading Rails application... Done
+            Loading DSL compiler classes... Done
+
+            Loaded DSL compiler classes:
+
+              PostCompiler                                             enabled
+              Tapioca::Dsl::Compilers::ActiveModelAttributes           enabled
+              Tapioca::Dsl::Compilers::ActiveModelSecurePassword       enabled
+              Tapioca::Dsl::Compilers::ActiveRecordAssociations        enabled
+              Tapioca::Dsl::Compilers::ActiveRecordColumns             enabled
+              Tapioca::Dsl::Compilers::ActiveRecordEnum                enabled
+              Tapioca::Dsl::Compilers::ActiveRecordRelations           enabled
+              Tapioca::Dsl::Compilers::ActiveRecordScope               enabled
+              Tapioca::Dsl::Compilers::ActiveSupportConcern            enabled
+              Tapioca::Dsl::Compilers::ActiveSupportCurrentAttributes  enabled
+              Tapioca::Dsl::Compilers::MixedInClassAttributes          enabled
+              Tapioca::Dsl::Compilers::SidekiqWorker                   enabled
+              Tapioca::Dsl::Compilers::SmartProperties                 enabled
+          OUT
+
+          assert_empty_stderr(result)
+          assert_success_status(result)
+        end
+
+        it "lists excluded compilers" do
+          result = @project.tapioca("dsl --list-compilers --exclude SmartProperties ActiveRecordEnum")
+
+          assert_equal(<<~OUT, result.out)
+            Loading Rails application... Done
+            Loading DSL compiler classes... Done
+
+            Loaded DSL compiler classes:
+
+              PostCompiler                                             enabled
+              Tapioca::Dsl::Compilers::ActiveModelAttributes           enabled
+              Tapioca::Dsl::Compilers::ActiveModelSecurePassword       enabled
+              Tapioca::Dsl::Compilers::ActiveRecordAssociations        enabled
+              Tapioca::Dsl::Compilers::ActiveRecordColumns             enabled
+              Tapioca::Dsl::Compilers::ActiveRecordEnum                disabled
+              Tapioca::Dsl::Compilers::ActiveRecordRelations           enabled
+              Tapioca::Dsl::Compilers::ActiveRecordScope               enabled
+              Tapioca::Dsl::Compilers::ActiveSupportConcern            enabled
+              Tapioca::Dsl::Compilers::ActiveSupportCurrentAttributes  enabled
+              Tapioca::Dsl::Compilers::MixedInClassAttributes          enabled
+              Tapioca::Dsl::Compilers::SidekiqWorker                   enabled
+              Tapioca::Dsl::Compilers::SmartProperties                 disabled
+          OUT
+
+          assert_empty_stderr(result)
+          assert_success_status(result)
+        end
+
+        it "lists enabled compilers" do
+          result = @project.tapioca("dsl --list-compilers --only SmartProperties ActiveRecordEnum")
+
+          assert_equal(<<~OUT, result.out)
+            Loading Rails application... Done
+            Loading DSL compiler classes... Done
+
+            Loaded DSL compiler classes:
+
+              PostCompiler                                             disabled
+              Tapioca::Dsl::Compilers::ActiveModelAttributes           disabled
+              Tapioca::Dsl::Compilers::ActiveModelSecurePassword       disabled
+              Tapioca::Dsl::Compilers::ActiveRecordAssociations        disabled
+              Tapioca::Dsl::Compilers::ActiveRecordColumns             disabled
+              Tapioca::Dsl::Compilers::ActiveRecordEnum                enabled
+              Tapioca::Dsl::Compilers::ActiveRecordRelations           disabled
+              Tapioca::Dsl::Compilers::ActiveRecordScope               disabled
+              Tapioca::Dsl::Compilers::ActiveSupportConcern            disabled
+              Tapioca::Dsl::Compilers::ActiveSupportCurrentAttributes  disabled
+              Tapioca::Dsl::Compilers::MixedInClassAttributes          disabled
+              Tapioca::Dsl::Compilers::SidekiqWorker                   disabled
+              Tapioca::Dsl::Compilers::SmartProperties                 enabled
+          OUT
+
+          assert_empty_stderr(result)
+          assert_success_status(result)
+        end
+      end
     end
 
     describe "cli::dsl::custom application.rb" do


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
Since we are now loading all compilers from any loaded gem that exports a DSL compiler, the full set of DSL compilers in play might be a little confusing.

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
Thus, this PR adds a way to ask Tapioca to list the set of DSL compilers and get a tabular output that shows them as well as their enabled/disabled status.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->
Added CLI tests for the feature.
