### PR TITLE
Default to empty array in active support concern DSL compiler

### DIFF
--- a/lib/tapioca/dsl/compilers/active_support_concern.rb
+++ b/lib/tapioca/dsl/compilers/active_support_concern.rb
@@ -85,7 +85,7 @@ module Tapioca
 
           sig { params(concern: Module).returns(T::Array[Module]) }
           def dependencies_of(concern)
-            concern.instance_variable_get(:@_dependencies)
+            concern.instance_variable_get(:@_dependencies) || []
           end
         end
 


### PR DESCRIPTION
### Motivation

When running the `bundle exec tapioca dsl` command on another project, it would throw an error saying something about an unknown method `.empty?` on a nil object at line 82 in the active_support_concern.rb file. This was preventing the generation of RBI files for this project.

### Implementation

This simply returns an empty array if the result is nil.

I'm not sure why this only gets `nil` in certain circumstances or projects, but I think generally this approach provides the highest type safety.

### Tests

I have not added any direct tests other than running this on the repo it was failing on and it worked as intended. I generally believe this should be safe as the method signature defines it as non nilable array return.

I have also run the tests locally with `./bin/test` and all tests passed.

The one thing that I could see going wrong with the assumption that it should return a non-nilable array could be if another method relies on this method to return nil, however given that all tests have passed, this feels safe enough for me.

If anything else is needed for this PR, please let me know and I'll do my best to fix it. I also will not be offended if this is not the correct solution to this problem.

Thanks.
