### PR TITLE
Type the rails find method

### DIFF
--- a/lib/tapioca/dsl/compilers/active_record_relations.rb
+++ b/lib/tapioca/dsl/compilers/active_record_relations.rb
@@ -526,7 +526,7 @@ module Tapioca
                 parameters: [
                   create_rest_param("args", type: "T.untyped"),
                 ],
-                return_type: "T.untyped"
+                return_type: "T.any(#{constant_name}, T::Enumerable[#{constant_name}])"
               )
             when :find_by
               create_common_method(

--- a/spec/tapioca/dsl/compilers/active_record_relations_spec.rb
+++ b/spec/tapioca/dsl/compilers/active_record_relations_spec.rb
@@ -93,7 +93,7 @@ module Tapioca
                     sig { returns(::Post) }
                     def fifth!; end
 
-                    sig { params(args: T.untyped).returns(T.untyped) }
+                    sig { params(args: T.untyped).returns(T.any(::Post, T::Enumerable[::Post])) }
                     def find(*args); end
 
                     sig { params(args: T.untyped).returns(T.nilable(::Post)) }


### PR DESCRIPTION
### Motivation

For find_by, we have no problem inferring that it will return
T.nilable(constant_name), however we eject from trying to type find. Per
https://github.com/rails/rails/blob/33100212244efbd1adf21587e1e37090fdd3591d/activerecord/lib/active_record/relation/finder_methods.rb#L13-L19
(current main revision at time of authoriship)

We should be able to provide something a bit better, even if developers
have to T.cast when they know they're not getting an array back.

I have _zero_ idea if there was a specific reason for T.untyped in this
regard, but I thought I'd contribute this as a suggestion if this is
tenable, or a question if it is not so I can better understand.

### Motivation

### Implementation
Instead of having ActiveRecord::Base::find return T.untyped, have it return the constant it belongs to similar to find_by, or an array of those constants per the documentation and code on rails/rails

### Tests
I added the test I thought relevant, the tests take a while so I'll check branch CI for anything else I've missed.
