### PR TITLE
map anonymous GraphQL InputObjects to T.untyped

### DIFF
--- a/lib/tapioca/dsl/helpers/graphql_type_helper.rb
+++ b/lib/tapioca/dsl/helpers/graphql_type_helper.rb
@@ -40,11 +40,9 @@ module Tapioca
             end
           when GraphQL::Schema::InputObject.singleton_class
             qualified_name_of(unwrapped_type)
-          else
-            "T.untyped"
           end
 
-          parsed_type = T.must(parsed_type)
+          return "T.untyped" if parsed_type.nil?
 
           if type.list?
             parsed_type = "T::Array[#{parsed_type}]"

--- a/spec/tapioca/dsl/compilers/graphql_input_object_spec.rb
+++ b/spec/tapioca/dsl/compilers/graphql_input_object_spec.rb
@@ -57,6 +57,7 @@ module Tapioca
                 class CreateCommentInput < GraphQL::Schema::InputObject
                   argument :body, String, required: true
                   argument :post_id, ID, required: true
+                  argument :signature, Class.new(GraphQL::Schema::InputObject), required: true
 
                   def resolve(body:, post_id:)
                     # ...
@@ -73,6 +74,9 @@ module Tapioca
 
                   sig { returns(::String) }
                   def post_id; end
+
+                  sig { returns(T.untyped) }
+                  def signature; end
                 end
               RBI
 


### PR DESCRIPTION
### Motivation

When run `tapioca dsl` against a GraphQLType that used an anonymous class inheriting from InputObject, I was seeing errors like these:

(when sorbet assertions are being enforced)
```
TypeError: Passed `nil` into T.must
            /home/spin/.bundle/tapioca/gems/sorbet-runtime-0.5.10326/lib/types/_types.rb:218:in `must'
            /home/spin/src/github.com/Shopify/tapioca/lib/tapioca/dsl/helpers/graphql_type_helper.rb:47:in `type_for'
            /home/spin/.bundle/tapioca/gems/sorbet-runtime-0.5.10326/lib/types/private/methods/call_validation_2_7.rb:106:in `bind_call'
            /home/spin/.bundle/tapioca/gems/sorbet-runtime-0.5.10326/lib/types/private/methods/call_validation_2_7.rb:106:in `block in create_validator_method_fast1'
            /home/spin/src/github.com/Shopify/tapioca/lib/tapioca/dsl/compilers/graphql_input_object.rb:55:in `block (2 levels) in decorate'
            /home/spin/src/github.com/Shopify/tapioca/lib/tapioca/dsl/compilers/graphql_input_object.rb:53:in `each'
            /home/spin/src/github.com/Shopify/tapioca/lib/tapioca/dsl/compilers/graphql_input_object.rb:53:in `block in decorate'
            /home/spin/src/github.com/Shopify/tapioca/lib/tapioca/rbi_ext/model.rb:40:in `block in create_class'
            <internal:kernel>:90:in `tap'
            /home/spin/src/github.com/Shopify/tapioca/lib/tapioca/rbi_ext/model.rb:39:in `create_class'
            /home/spin/.bundle/tapioca/gems/sorbet-runtime-0.5.10326/lib/types/private/methods/call_validation.rb:157:in `bind_call'
            /home/spin/.bundle/tapioca/gems/sorbet-runtime-0.5.10326/lib/types/private/methods/call_validation.rb:157:in `validate_call'
            /home/spin/.bundle/tapioca/gems/sorbet-runtime-0.5.10326/lib/types/private/methods/_methods.rb:270:in `block in _on_method_added'
            /home/spin/src/github.com/Shopify/tapioca/lib/tapioca/rbi_ext/model.rb:16:in `create_path'
            /home/spin/.bundle/tapioca/gems/sorbet-runtime-0.5.10326/lib/types/private/methods/call_validation.rb:157:in `bind_call'
            /home/spin/.bundle/tapioca/gems/sorbet-runtime-0.5.10326/lib/types/private/methods/call_validation.rb:157:in `validate_call'
            /home/spin/.bundle/tapioca/gems/sorbet-runtime-0.5.10326/lib/types/private/methods/_methods.rb:270:in `block in _on_method_added'
            /home/spin/src/github.com/Shopify/tapioca/lib/tapioca/dsl/compilers/graphql_input_object.rb:52:in `decorate'
            /home/spin/.bundle/tapioca/gems/sorbet-runtime-0.5.10326/lib/types/private/methods/call_validation.rb:157:in `bind_call'
            /home/spin/.bundle/tapioca/gems/sorbet-runtime-0.5.10326/lib/types/private/methods/call_validation.rb:157:in `validate_call'
            /home/spin/.bundle/tapioca/gems/sorbet-runtime-0.5.10326/lib/types/private/methods/_methods.rb:270:in `block in _on_method_added'
            /home/spin/src/github.com/Shopify/tapioca/lib/tapioca/helpers/test/dsl_compiler.rb:96:in `rbi_for'
            /home/spin/.bundle/tapioca/gems/sorbet-runtime-0.5.10326/lib/types/private/methods/call_validation.rb:157:in `bind_call'
            /home/spin/.bundle/tapioca/gems/sorbet-runtime-0.5.10326/lib/types/private/methods/call_validation.rb:157:in `validate_call'
            /home/spin/.bundle/tapioca/gems/sorbet-runtime-0.5.10326/lib/types/private/methods/_methods.rb:270:in `block in _on_method_added'
            /home/spin/src/github.com/Shopify/tapioca/lib/tapioca/helpers/test/dsl_compiler.rb:33:in `rbi_for'
            /home/spin/.bundle/tapioca/gems/sorbet-runtime-0.5.10326/lib/types/private/methods/call_validation.rb:157:in `bind_call'
            /home/spin/.bundle/tapioca/gems/sorbet-runtime-0.5.10326/lib/types/private/methods/call_validation.rb:157:in `validate_call'
            /home/spin/.bundle/tapioca/gems/sorbet-runtime-0.5.10326/lib/types/private/methods/_methods.rb:270:in `block in _on_method_added'
            /home/spin/src/github.com/Shopify/tapioca/spec/tapioca/dsl/compilers/graphql_input_object_spec.rb:80:in `block (3 levels) in <class:GraphqlInputObjectSpec>'
```

(when sorbet assertions are **not** being enforced)
```
tapioca/lib/tapioca/helpers/rbi_helper.rb:100:in `as_nilable_type': NoMethodError: undefined method `start_with?' for nil:NilClass (Parallel::UndumpableException)

      if type.start_with?("T.nilable(", "::T.nilable(") || type == "T.untyped" || type == "::T.untyped"
             ^^^^^^^^^^^^
	from /Users/ryanquanz/src/github.com/Shopify/tapioca/lib/tapioca/dsl/helpers/graphql_type_helper.rb:54:in `type_for'
	from /Users/ryanquanz/.gem/ruby/3.1.2/gems/sorbet-runtime-0.5.10346/lib/types/private/methods/_methods.rb:272:in `bind_call'
	from /Users/ryanquanz/.gem/ruby/3.1.2/gems/sorbet-runtime-0.5.10346/lib/types/private/methods/_methods.rb:272:in `block in _on_method_added'
	from /Users/ryanquanz/src/github.com/Shopify/tapioca/lib/tapioca/dsl/compilers/graphql_input_object.rb:55:in `block (2 levels) in decorate'
	from /Users/ryanquanz/src/github.com/Shopify/tapioca/lib/tapioca/dsl/compilers/graphql_input_object.rb:53:in `each'
	from /Users/ryanquanz/src/github.com/Shopify/tapioca/lib/tapioca/dsl/compilers/graphql_input_object.rb:53:in `block in decorate'
	from /Users/ryanquanz/src/github.com/Shopify/tapioca/lib/tapioca/rbi_ext/model.rb:40:in `block in create_class'
	from <internal:kernel>:90:in `tap'
	from /Users/ryanquanz/src/github.com/Shopify/tapioca/lib/tapioca/rbi_ext/model.rb:39:in `create_class'
	from /Users/ryanquanz/src/github.com/Shopify/tapioca/lib/tapioca/rbi_ext/model.rb:16:in `create_path'
	from /Users/ryanquanz/src/github.com/Shopify/tapioca/lib/tapioca/dsl/compilers/graphql_input_object.rb:52:in `decorate'
	from /Users/ryanquanz/.gem/ruby/3.1.2/gems/sorbet-runtime-0.5.10346/lib/types/private/methods/_methods.rb:272:in `bind_call'
	from /Users/ryanquanz/.gem/ruby/3.1.2/gems/sorbet-runtime-0.5.10346/lib/types/private/methods/_methods.rb:272:in `block in _on_method_added'
	from /Users/ryanquanz/src/github.com/Shopify/tapioca/lib/tapioca/dsl/pipeline.rb:160:in `block in rbi_for_constant'
	from /Users/ryanquanz/src/github.com/Shopify/tapioca/lib/tapioca/dsl/pipeline.rb:156:in `each'
	from /Users/ryanquanz/src/github.com/Shopify/tapioca/lib/tapioca/dsl/pipeline.rb:156:in `rbi_for_constant'
	from /Users/ryanquanz/src/github.com/Shopify/tapioca/lib/tapioca/dsl/pipeline.rb:68:in `block in run'
	from /Users/ryanquanz/.gem/ruby/3.1.2/gems/parallel-1.22.1/lib/parallel.rb:587:in `call_with_index'
	from /Users/ryanquanz/.gem/ruby/3.1.2/gems/parallel-1.22.1/lib/parallel.rb:557:in `process_incoming_jobs'
	from /Users/ryanquanz/.gem/ruby/3.1.2/gems/parallel-1.22.1/lib/parallel.rb:537:in `block in worker'
	from /Users/ryanquanz/.gem/ruby/3.1.2/gems/parallel-1.22.1/lib/parallel.rb:528:in `fork'
	from /Users/ryanquanz/.gem/ruby/3.1.2/gems/parallel-1.22.1/lib/parallel.rb:528:in `worker'
	from /Users/ryanquanz/.gem/ruby/3.1.2/gems/parallel-1.22.1/lib/parallel.rb:519:in `block in create_workers'
	from /Users/ryanquanz/.gem/ruby/3.1.2/gems/parallel-1.22.1/lib/parallel.rb:518:in `each'
	from /Users/ryanquanz/.gem/ruby/3.1.2/gems/parallel-1.22.1/lib/parallel.rb:518:in `each_with_index'
	from /Users/ryanquanz/.gem/ruby/3.1.2/gems/parallel-1.22.1/lib/parallel.rb:518:in `create_workers'
	from /Users/ryanquanz/.gem/ruby/3.1.2/gems/parallel-1.22.1/lib/parallel.rb:457:in `work_in_processes'
	from /Users/ryanquanz/.gem/ruby/3.1.2/gems/parallel-1.22.1/lib/parallel.rb:294:in `map'
	from /Users/ryanquanz/src/github.com/Shopify/tapioca/lib/tapioca/executor.rb:31:in `run_in_parallel'
	from /Users/ryanquanz/.gem/ruby/3.1.2/gems/sorbet-runtime-0.5.10346/lib/types/private/methods/_methods.rb:272:in `bind_call'
	from /Users/ryanquanz/.gem/ruby/3.1.2/gems/sorbet-runtime-0.5.10346/lib/types/private/methods/_methods.rb:272:in `block in _on_method_added'
	from /Users/ryanquanz/src/github.com/Shopify/tapioca/lib/tapioca/dsl/pipeline.rb:67:in `run'
	from /Users/ryanquanz/.gem/ruby/3.1.2/gems/sorbet-runtime-0.5.10346/lib/types/private/methods/_methods.rb:272:in `bind_call'
	from /Users/ryanquanz/.gem/ruby/3.1.2/gems/sorbet-runtime-0.5.10346/lib/types/private/methods/_methods.rb:272:in `block in _on_method_added'
	from /Users/ryanquanz/src/github.com/Shopify/tapioca/lib/tapioca/commands/dsl.rb:104:in `execute'
	from /Users/ryanquanz/.gem/ruby/3.1.2/gems/sorbet-runtime-0.5.10346/lib/types/private/methods/_methods.rb:272:in `bind_call'
	from /Users/ryanquanz/.gem/ruby/3.1.2/gems/sorbet-runtime-0.5.10346/lib/types/private/methods/_methods.rb:272:in `block in _on_method_added'
	from /Users/ryanquanz/src/github.com/Shopify/tapioca/lib/tapioca/cli.rb:144:in `block in dsl'
	from /Users/ryanquanz/src/github.com/Shopify/tapioca/lib/tapioca.rb:33:in `block in silence_warnings'
	from /opt/rubies/3.1.2/lib/ruby/3.1.0/rubygems/user_interaction.rb:46:in `use_ui'
	from /Users/ryanquanz/src/github.com/Shopify/tapioca/lib/tapioca.rb:32:in `silence_warnings'
	from /Users/ryanquanz/.gem/ruby/3.1.2/gems/sorbet-runtime-0.5.10346/lib/types/private/methods/_methods.rb:272:in `bind_call'
	from /Users/ryanquanz/.gem/ruby/3.1.2/gems/sorbet-runtime-0.5.10346/lib/types/private/methods/_methods.rb:272:in `block in _on_method_added'
	from /Users/ryanquanz/src/github.com/Shopify/tapioca/lib/tapioca/cli.rb:140:in `dsl'
	from /Users/ryanquanz/.gem/ruby/3.1.2/gems/thor-1.2.1/lib/thor/command.rb:27:in `run'
	from /Users/ryanquanz/.gem/ruby/3.1.2/gems/thor-1.2.1/lib/thor/invocation.rb:127:in `invoke_command'
	from /Users/ryanquanz/.gem/ruby/3.1.2/gems/thor-1.2.1/lib/thor.rb:392:in `dispatch'
	from /Users/ryanquanz/.gem/ruby/3.1.2/gems/thor-1.2.1/lib/thor/base.rb:485:in `start'
	from /Users/ryanquanz/src/github.com/Shopify/tapioca/exe/tapioca:23:in `<top (required)>'
	from bin/tapioca:29:in `load'
	from bin/tapioca:29:in `<main>'
```


The problem appears to be that `Tapioca::Dsl::Helpers::GraphqlTypeHelper#type_for` when receiving a descendant of `GraphQL::Schema::InputObject` assumes it will have a name, but with anonymous classes that is not the case:

https://github.com/Shopify/tapioca/blob/9c6e11567f14dd59ece81567cfd969d21df78abc/lib/tapioca/dsl/helpers/graphql_type_helper.rb#L16-L47



### Implementation

I replace the `T.must` with a guard to return `T.untyped`, I'm not sure if we could make a more precise type determination?

### Tests

I have augmented a test - hopefully it suffices as replication instructions.

