### PR TITLE
Handle constants with nil value

### DIFF
--- a/lib/tapioca/dsl/pipeline.rb
+++ b/lib/tapioca/dsl/pipeline.rb
@@ -146,6 +146,7 @@ module Tapioca
         constants_by_name
           .keys
           .map { |name| T.cast(Runtime::Reflection.constantize(name), Module) }
+          .select { |mod| Runtime::Reflection.constant_defined?(mod) }
           .to_set
       end
 

--- a/lib/tapioca/gem/listeners/subconstants.rb
+++ b/lib/tapioca/gem/listeners/subconstants.rb
@@ -26,7 +26,7 @@ module Tapioca
             # Don't compile modules of Object because Object::Foo == Foo
             # Don't compile modules of BasicObject because BasicObject::BasicObject == BasicObject
             next if (Object == constant || BasicObject == constant) && Module === subconstant
-            next unless subconstant
+            next unless Runtime::Reflection.constant_defined?(subconstant)
 
             @pipeline.push_constant(name, subconstant)
           end

--- a/lib/tapioca/runtime/reflection.rb
+++ b/lib/tapioca/runtime/reflection.rb
@@ -19,8 +19,14 @@ module Tapioca
       PROTECTED_INSTANCE_METHODS_METHOD = T.let(Module.instance_method(:protected_instance_methods), UnboundMethod)
       PRIVATE_INSTANCE_METHODS_METHOD = T.let(Module.instance_method(:private_instance_methods), UnboundMethod)
       METHOD_METHOD = T.let(Kernel.instance_method(:method), UnboundMethod)
+      UNDEFINED_CONSTANT = T.let(Module.new.freeze, Module)
 
       REQUIRED_FROM_LABELS = T.let(["<top (required)>", "<main>"].freeze, T::Array[String])
+
+      T::Sig::WithoutRuntime.sig { params(constant: BasicObject).returns(T::Boolean) }
+      def constant_defined?(constant)
+        !UNDEFINED_CONSTANT.eql?(constant)
+      end
 
       sig do
         params(
@@ -32,7 +38,7 @@ module Tapioca
       def constantize(symbol, inherit: false, namespace: Object)
         namespace.const_get(symbol, inherit)
       rescue NameError, LoadError, RuntimeError, ArgumentError, TypeError
-        nil
+        UNDEFINED_CONSTANT
       end
 
       sig { params(object: BasicObject).returns(Class).checked(:never) }

--- a/spec/tapioca/gem/pipeline_spec.rb
+++ b/spec/tapioca/gem/pipeline_spec.rb
@@ -4090,5 +4090,20 @@ class Tapioca::Gem::PipelineSpec < Minitest::HooksSpec
 
       assert_equal(output, compile(include_doc: true, include_loc: true))
     end
+
+    it "compiles constants with nil values" do
+      add_ruby_file("foo.rb", <<~RUBY)
+        class Foo
+          BAR = nil
+        end
+      RUBY
+
+      output = template(<<~RBI)
+        class Foo; end
+        Foo::BAR = T.let(T.unsafe(nil), T.untyped)
+      RBI
+
+      assert_equal(output, compile)
+    end
   end
 end


### PR DESCRIPTION
### Motivation

I noticed that Tapioca was not generating RBIs for constants that have their value set to nil. E.g.:
```ruby
FOO = nil # => ignored by Tapioca
```
The reason is because inside `constantize`, applying `const_get` will return `nil` and then we skip that constant. I'm not sure if that was intentional, so I appreciate feedback on the implementation.

### Implementation

Basically, moved part of the implementation of `constantize` to only skip constants that are not defined and include the ones that have their value set to `nil`.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->

Added an example.