### PR TITLE
Handle anonymous GraphQL input classes

### DIFF
--- a/lib/tapioca/dsl/helpers/graphql_type_helper.rb
+++ b/lib/tapioca/dsl/helpers/graphql_type_helper.rb
@@ -39,7 +39,7 @@ module Tapioca
               "T.any(#{value_types.join(", ")})"
             end
           when GraphQL::Schema::InputObject.singleton_class
-            qualified_name_of(unwrapped_type)
+            qualified_name_of(unwrapped_type) || "T.untyped"
           else
             "T.untyped"
           end


### PR DESCRIPTION
### Motivation

When defining GraphQL input objects from a schema, anonymous classes are generated to define them in Ruby. This means that invoking `qualified_name_of` returns `nil` and we end up breaking in `rbi_helper` when trying to turn it into a nilable type.

For example, loading this GraphQL schema
```graphql
input CommentInput {
  body: CommentBodyInput
}

input CommentBodyInput {
  content: String!
}
```

### Implementation

Started returning `T.untyped` if the GraphQL input object's name is nil. Not sure if we can do better than this.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->

I tried writing tests by adding a content file with the schema and then loading it, but marshal loading for our isolation test runner was failing when loading the anonymous class. If you have a better idea on how to test this, please let me know.