### PR TITLE
Update `fixture_names` type to include `String`

### DIFF
--- a/lib/tapioca/dsl/compilers/active_record_fixtures.rb
+++ b/lib/tapioca/dsl/compilers/active_record_fixtures.rb
@@ -31,7 +31,7 @@ module Tapioca
       # # test_case.rbi
       # # typed: true
       # class ActiveSupport::TestCase
-      #   sig { params(fixture_names: Symbol).returns(T.untyped) }
+      #   sig { params(fixture_names: T.any(String, Symbol)).returns(T.untyped) }
       #   def posts(*fixture_names); end
       # end
       # ~~~
@@ -99,7 +99,7 @@ module Tapioca
         def create_fixture_method(mod, name)
           mod.create_method(
             name,
-            parameters: [create_rest_param("fixture_names", type: "Symbol")],
+            parameters: [create_rest_param("fixture_names", type: "T.any(String, Symbol)")],
             return_type: "T.untyped"
           )
         end

--- a/manual/compiler_activerecordfixtures.md
+++ b/manual/compiler_activerecordfixtures.md
@@ -18,7 +18,7 @@ The generated RBI by this compiler will produce the following
 # test_case.rbi
 # typed: true
 class ActiveSupport::TestCase
-  sig { params(fixture_names: Symbol).returns(T.untyped) }
+  sig { params(fixture_names: T.any(String, Symbol)).returns(T.untyped) }
   def posts(*fixture_names); end
 end
 ~~~

--- a/spec/tapioca/dsl/compilers/active_record_fixtures_spec.rb
+++ b/spec/tapioca/dsl/compilers/active_record_fixtures_spec.rb
@@ -68,7 +68,7 @@ module Tapioca
                 # typed: strong
 
                 class ActiveSupport::TestCase
-                  sig { params(fixture_names: Symbol).returns(T.untyped) }
+                  sig { params(fixture_names: T.any(String, Symbol)).returns(T.untyped) }
                   def posts(*fixture_names); end
                 end
               RBI
@@ -97,10 +97,10 @@ module Tapioca
                 # typed: strong
 
                 class ActiveSupport::TestCase
-                  sig { params(fixture_names: Symbol).returns(T.untyped) }
+                  sig { params(fixture_names: T.any(String, Symbol)).returns(T.untyped) }
                   def posts(*fixture_names); end
 
-                  sig { params(fixture_names: Symbol).returns(T.untyped) }
+                  sig { params(fixture_names: T.any(String, Symbol)).returns(T.untyped) }
                   def users(*fixture_names); end
                 end
               RBI


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->

Currently, the `fixture_names` argument to the Rails fixture accessors is typed as `Symbol`s. However, fixtures are actually keyed by `String`s, but the helpers also accept `Symbol`s, which are converted to `String`s internally.

Therefore, the param type should be `T.any(String, Symbol)`, not `Symbol`.

See https://github.com/rails/rails/blob/ab67599c47f4f74a7be55420dc3ae93000e19af6/activerecord/lib/active_record/test_fixtures.rb#L261


### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->

I searched for all occurrences of `fixture_names`, and update the type.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->

The type updates included the tests.
