### PR TITLE
Make sure we can type GraphQL object with anonymous input fields

### DIFF
--- a/lib/tapioca/dsl/compilers/graphql_input_object.rb
+++ b/lib/tapioca/dsl/compilers/graphql_input_object.rb
@@ -47,12 +47,10 @@ module Tapioca
           arguments = constant.all_argument_definitions
           return if arguments.empty?
 
-          graphql_type_helper = Helpers::GraphqlTypeHelper.new
-
           root.create_path(constant) do |input_object|
             arguments.each do |argument|
               name = argument.keyword.to_s
-              input_object.create_method(name, return_type: graphql_type_helper.type_for(argument.type))
+              input_object.create_method(name, return_type: Helpers::GraphqlTypeHelper.type_for(argument.type))
             end
           end
         end

--- a/lib/tapioca/dsl/compilers/graphql_mutation.rb
+++ b/lib/tapioca/dsl/compilers/graphql_mutation.rb
@@ -54,12 +54,11 @@ module Tapioca
           return if arguments.empty?
 
           arguments_by_name = arguments.to_h { |a| [a.keyword.to_s, a] }
-          graphql_type_helper = Helpers::GraphqlTypeHelper.new
 
           params = compile_method_parameters_to_rbi(method_def).map do |param|
             name = param.param.name
             argument = arguments_by_name.fetch(name, nil)
-            create_typed_param(param.param, argument ? graphql_type_helper.type_for(argument.type) : "T.untyped")
+            create_typed_param(param.param, argument ? Helpers::GraphqlTypeHelper.type_for(argument.type) : "T.untyped")
           end
 
           root.create_path(constant) do |mutation|

--- a/lib/tapioca/dsl/helpers/graphql_type_helper.rb
+++ b/lib/tapioca/dsl/helpers/graphql_type_helper.rb
@@ -4,7 +4,9 @@
 module Tapioca
   module Dsl
     module Helpers
-      class GraphqlTypeHelper
+      module GraphqlTypeHelper
+        extend self
+
         extend T::Sig
         include RBIHelper
         include Runtime::Reflection

--- a/lib/tapioca/dsl/helpers/graphql_type_helper.rb
+++ b/lib/tapioca/dsl/helpers/graphql_type_helper.rb
@@ -8,8 +8,6 @@ module Tapioca
         extend self
 
         extend T::Sig
-        include RBIHelper
-        include Runtime::Reflection
 
         sig { params(type: GraphQL::Schema::Wrapper).returns(String) }
         def type_for(type)
@@ -50,7 +48,7 @@ module Tapioca
           end
 
           unless type.non_null?
-            parsed_type = as_nilable_type(parsed_type)
+            parsed_type = RBIHelper.as_nilable_type(parsed_type)
           end
 
           parsed_type
@@ -60,7 +58,7 @@ module Tapioca
 
         sig { params(constant: Module).returns(String) }
         def type_for_constant(constant)
-          qualified_name_of(constant) || "T.untyped"
+          Runtime::Reflection.qualified_name_of(constant) || "T.untyped"
         end
       end
     end

--- a/spec/tapioca/dsl/compilers/graphql_input_object_spec.rb
+++ b/spec/tapioca/dsl/compilers/graphql_input_object_spec.rb
@@ -78,6 +78,29 @@ module Tapioca
 
               assert_equal(expected, rbi_for(:CreateCommentInput))
             end
+
+            it "doesn't fail when input object is anonymous" do
+              add_ruby_file("create_comment_input.rb", <<~RUBY)
+                class CreateCommentInput < GraphQL::Schema::InputObject
+                  argument :transport, Class.new(GraphQL::Schema::InputObject), required: true
+
+                  def resolve(body:, post_id:)
+                    # ...
+                  end
+                end
+              RUBY
+
+              expected = <<~RBI
+                # typed: strong
+
+                class CreateCommentInput
+                  sig { returns(T.untyped) }
+                  def transport; end
+                end
+              RBI
+
+              assert_equal(expected, rbi_for(:CreateCommentInput))
+            end
           end
         end
       end


### PR DESCRIPTION
### Motivation
When the class is anonymous, `qualified_name_of` returns `nil`. This
means that `type_for` would raise an exception, causing the rbi generator
to fail.

### Implementation
Return `T.untyped` for the anonymous case

### Other info
Those commits are already applied to master (I used VSCode to sync the code and it end up pushing the changes), so this is only for the 0-10-stable branch.