### PR TITLE
Prepare for 0.10.1 release

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,7 +17,7 @@ GIT
 PATH
   remote: .
   specs:
-    tapioca (0.10.0)
+    tapioca (0.10.1)
       bundler (>= 1.17.3)
       netrc (>= 0.11.0)
       parallel (>= 1.21.0)

--- a/lib/tapioca/version.rb
+++ b/lib/tapioca/version.rb
@@ -2,5 +2,5 @@
 # frozen_string_literal: true
 
 module Tapioca
-  VERSION = "0.10.0"
+  VERSION = "0.10.1"
 end


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->

This PR bumps the gem version ahead of releasing 0.10.1

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->

The `VERSION` constant was incremented and `bundle install` was run to update `Gemfile.lock`.

I have drafted [release notes](https://github.com/Shopify/tapioca/releases/edit/untagged-b1110106e7588135b7a8).

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->

Not applicable.
