### PR TITLE
Handle `all_argument_definitions` not being defined in `graphql` `< 1.13`

### DIFF
--- a/lib/tapioca/dsl/compilers/graphql_input_object.rb
+++ b/lib/tapioca/dsl/compilers/graphql_input_object.rb
@@ -44,7 +44,7 @@ module Tapioca
 
         sig { override.void }
         def decorate
-          arguments = constant.all_argument_definitions
+          arguments = constant.arguments.values
           return if arguments.empty?
 
           root.create_path(constant) do |input_object|

--- a/lib/tapioca/dsl/compilers/graphql_mutation.rb
+++ b/lib/tapioca/dsl/compilers/graphql_mutation.rb
@@ -50,7 +50,7 @@ module Tapioca
           method_def = constant.instance_method(:resolve)
           return if signature_of(method_def) # Skip if the mutation already has an inline sig
 
-          arguments = constant.all_argument_definitions
+          arguments = constant.arguments.values
           return if arguments.empty?
 
           arguments_by_name = arguments.to_h { |a| [a.keyword.to_s, a] }


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->

We use [`GraphQL::Schema::Member::HasArguments.all_argument_definitions`](https://github.com/rmosolgo/graphql-ruby/blob/28bb4362c19c6ca6b2fab35edb48bf2627cd9b3f/lib/graphql/schema/member/has_arguments.rb#L141) in the DSL compiler for GraphQL mutations. This method was [introduced in `graphql@1.13`](https://github.com/rmosolgo/graphql-ruby/commit/6e5fe3731d81b5d22d869e3de51ded9a7d831b40), which means our implementation breaks in versions prior to that.

Therefore, we either need a workaround, or to restrict the versions we're compatible with.

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->

This first pass tries to switch to the `arguments` method, which returns a `Hash` whose `values` we can extract, which hopefully has the same semantics.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->

Currently seeing if existing tests pass.

### After Merging
- [ ] Backport to `0-10-stable`, which introduced GraphQL DSL compilation
