### PR TITLE
Correct set_color's usage

### DIFF
--- a/lib/tapioca/commands/dsl.rb
+++ b/lib/tapioca/commands/dsl.rb
@@ -328,7 +328,7 @@ module Tapioca
 
           raise Thor::Error, <<~ERROR
             #{set_color("RBI files are out-of-date. In your development environment, please run:", :green)}
-              #{set_color("`#{default_command(command)}`", [:green, :bold])}
+              #{set_color("`#{default_command(command)}`", :green, :bold)}
             #{set_color("Once it is complete, be sure to commit and push any changes", :green)}
 
             #{set_color("Reason:", :red)}

--- a/lib/tapioca/commands/gem.rb
+++ b/lib/tapioca/commands/gem.rb
@@ -305,7 +305,7 @@ module Tapioca
 
           raise Thor::Error, <<~ERROR
             #{set_color("RBI files are out-of-date. In your development environment, please run:", :green)}
-              #{set_color("`#{default_command(command)}`", [:green, :bold])}
+              #{set_color("`#{default_command(command)}`", :green, :bold)}
             #{set_color("Once it is complete, be sure to commit and push any changes", :green)}
 
             #{set_color("Reason:", :red)}


### PR DESCRIPTION


### Motivation

Values should be passed separately instead of as an array: [doc](https://www.rubydoc.info/github/wycats/thor/Thor%2FShell%2FColor:set_color)

**before**
<img width="585" alt="before" src="https://user-images.githubusercontent.com/5079556/190362674-038b6f67-fdf1-4f93-b995-975ada7fd64c.png">

**after**

<img width="584" alt="after" src="https://user-images.githubusercontent.com/5079556/190362688-ab8dc78a-1b1f-424f-86af-9b9bac25c0f3.png">


### Implementation

Just changed the arguments

### Tests

It looks like we don't test colourised output for individual commands automatically, so we need to test this manually.

