### PR TITLE
Start matching pathname directory prefixes more rigorously

### DIFF
--- a/lib/tapioca/gemfile.rb
+++ b/lib/tapioca/gemfile.rb
@@ -201,7 +201,7 @@ module Tapioca
         if default_gem?
           files.any? { |file| file.to_s == to_realpath(path) }
         else
-          to_realpath(path).start_with?(full_gem_path) || has_parent_gemspec?(path)
+          path_in_dir?(to_realpath(path), full_gem_path) || has_parent_gemspec?(path)
         end
       end
 

--- a/lib/tapioca/helpers/gem_helper.rb
+++ b/lib/tapioca/helpers/gem_helper.rb
@@ -5,15 +5,17 @@ module Tapioca
   module GemHelper
     extend T::Sig
 
-    sig { params(gemfile_dir: String, full_gem_path: String).returns(T::Boolean) }
-    def gem_in_app_dir?(gemfile_dir, full_gem_path)
-      !gem_in_bundle_path?(to_realpath(full_gem_path)) &&
-        full_gem_path.start_with?(to_realpath(gemfile_dir))
+    sig { params(app_dir: String, full_gem_path: String).returns(T::Boolean) }
+    def gem_in_app_dir?(app_dir, full_gem_path)
+      app_dir = to_realpath(app_dir)
+      full_gem_path = to_realpath(full_gem_path)
+
+      !gem_in_bundle_path?(full_gem_path) && path_in_dir?(full_gem_path, app_dir)
     end
 
     sig { params(full_gem_path: String).returns(T::Boolean) }
     def gem_in_bundle_path?(full_gem_path)
-      full_gem_path.start_with?(Bundler.bundle_path.to_s, Bundler.app_cache.to_s)
+      path_in_dir?(full_gem_path, Bundler.bundle_path) || path_in_dir?(full_gem_path, Bundler.app_cache)
     end
 
     sig { params(path: T.any(String, Pathname)).returns(String) }
@@ -21,6 +23,16 @@ module Tapioca
       path_string = path.to_s
       path_string = File.realpath(path_string) if File.exist?(path_string)
       path_string
+    end
+
+    private
+
+    sig { params(path: T.any(Pathname, String), dir: T.any(Pathname, String)).returns(T::Boolean) }
+    def path_in_dir?(path, dir)
+      dir = Pathname.new(dir)
+      path = Pathname.new(path)
+
+      path.ascend.any?(dir)
     end
   end
 end

--- a/spec/spec_with_project.rb
+++ b/spec/spec_with_project.rb
@@ -72,11 +72,12 @@ module Tapioca
         name: String,
         version: String,
         dependencies: T::Array[String],
+        path: String,
         block: T.nilable(T.proc.params(gem: MockGem).bind(MockGem).void),
       ).returns(MockGem)
     end
-    def mock_gem(name, version, dependencies: [], &block)
-      gem = MockGem.new("#{TEST_TMP_PATH}/#{spec_name}/gems/#{name}", name, version, dependencies)
+    def mock_gem(name, version, dependencies: [], path: default_gem_path(name), &block)
+      gem = MockGem.new(path, name, version, dependencies)
       gem.gemspec(gem.default_gemspec_contents)
       gem.instance_exec(gem, &block) if block
       gem
@@ -138,6 +139,11 @@ module Tapioca
     end
 
     private
+
+    sig { params(name: String).returns(String) }
+    def default_gem_path(name)
+      "#{TEST_TMP_PATH}/#{spec_name}/gems/#{name}"
+    end
 
     sig { returns(String) }
     def spec_name

--- a/spec/tapioca/cli/gem_spec.rb
+++ b/spec/tapioca/cli/gem_spec.rb
@@ -710,6 +710,20 @@ module Tapioca
           assert_success_status(result)
         end
 
+        it "must generate RBIs for gems whose folder location starts with the same prefix as project folder" do
+          # Set the gem path so that the project folder is a prefix of the gem folder
+          gem_path = @project.path + "-gem/foo"
+          gem = mock_gem("foo", "0.0.1", path: gem_path)
+
+          @project.require_mock_gem(gem)
+
+          result = @project.tapioca("gem foo")
+
+          assert_stdout_includes(result, "Compiled foo")
+          assert_empty_stderr(result)
+          assert_success_status(result)
+        end
+
         it "must respect exclude option" do
           @project.require_mock_gem(mock_gem("foo", "0.0.1"))
           @project.require_mock_gem(mock_gem("bar", "0.3.0"))


### PR DESCRIPTION
Fixes #1174

### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
The simplistic `start_with?` check was not sufficient to match that a given file/folder was under a given folder, since we were not explicitly checking for full folder name matches. For example, if `path = "/foo/bar-gem/baz"` and `folder = "/foo/bar"`, then `path.start_with?(folder)` would return `true`, but `path` is not under the `folder` directory.

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
This commit fixes the problem by matching `folder` to any of the parent directories of `path` by using the `Pathname#ascend` method to get all parent directory prefixes of a `path`.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->
Added a test that fails without the fix.
