### PR TITLE
Fix rubocop-rspec dependencies

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -274,7 +274,7 @@ GEM
     rubocop-ast (1.21.0)
       parser (>= 3.1.1.0)
     rubocop-rspec (2.13.1)
-      rubocop (~> 1.35)
+      rubocop (~> 1.33)
     rubocop-shopify (2.10.1)
       rubocop (~> 1.35)
     rubocop-sorbet (0.6.11)


### PR DESCRIPTION
Tapioca is failing `bundle install` with the following error:

```
Downloading rubocop-rspec-2.13.1 revealed dependencies not in the API or the lockfile (rubocop (~> 1.33)).

Either installing with `--full-index` or running `bundle update rubocop-rspec` should fix the problem.
```

This PR is the result of running `bundle update rubocop-rspec`.
