### PR TITLE
Only load GraphQL compilers for versions >= 1.13

### DIFF
--- a/lib/tapioca/dsl/compilers/graphql_input_object.rb
+++ b/lib/tapioca/dsl/compilers/graphql_input_object.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 begin
+  gem("graphql", ">= 1.13")
   require "graphql"
 rescue LoadError
   return

--- a/lib/tapioca/dsl/compilers/graphql_mutation.rb
+++ b/lib/tapioca/dsl/compilers/graphql_mutation.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 begin
+  gem("graphql", ">= 1.13")
   require "graphql"
 rescue LoadError
   return


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->

`Tapioca::Dsl::Compilers::GraphqlInputObject` depends on a method introduced in 1.13. As per @rafaelfranca's comment in https://github.com/Shopify/tapioca/pull/1164#issuecomment-1254251540, we will add a version restriction.

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->

For consistency, we treat all GraphQL compilers as a unit and require the same version in all of them. If the version requirement is not satisfied, we simply skip generating the RBIs entirely.


### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->

There are two parts of this we _could_ test:

- What happens if we use a version < 1.13?
  _This would require adding another gemfile._
- What happens if we use the minimum supported version (1.13) rather than latest?
  _This would also require adding another gemfile._

I can add either or both of those if we think we should.

----

Closes #1164