### PR TITLE
Backport "Only load GraphQL compilers for versions >= 1.13"

### DIFF
--- a/lib/tapioca/dsl/compilers/graphql_input_object.rb
+++ b/lib/tapioca/dsl/compilers/graphql_input_object.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 begin
+  gem("graphql", ">= 1.13")
   require "graphql"
 rescue LoadError
   return

--- a/lib/tapioca/dsl/compilers/graphql_mutation.rb
+++ b/lib/tapioca/dsl/compilers/graphql_mutation.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 begin
+  gem("graphql", ">= 1.13")
   require "graphql"
 rescue LoadError
   return


### PR DESCRIPTION
This is a backport of #1184.