### PR TITLE
Disable trackers in commands that don't need them

### DIFF
--- a/lib/tapioca.rb
+++ b/lib/tapioca.rb
@@ -11,16 +11,6 @@ module Tapioca
   class << self
     extend T::Sig
 
-    sig { params(trace_name: Symbol, block: T.proc.params(arg0: TracePoint).void).void }
-    def register_trace(trace_name, &block)
-      @traces << TracePoint.trace(trace_name, &block)
-    end
-
-    sig { void }
-    def disable_traces
-      @traces.each(&:disable)
-    end
-
     sig do
       type_parameters(:Result)
         .params(blk: T.proc.returns(T.type_parameter(:Result)))

--- a/lib/tapioca/cli.rb
+++ b/lib/tapioca/cli.rb
@@ -269,8 +269,6 @@ module Tapioca
     option :payload, type: :boolean, desc: "Check shims against Sorbet's payload", default: true
     option :workers, aliases: ["-w"], type: :numeric, desc: "Number of parallel workers (default: auto)"
     def check_shims
-      Tapioca.disable_traces
-
       command = Commands::CheckShims.new(
         gem_rbi_dir: options[:gem_rbi_dir],
         dsl_rbi_dir: options[:dsl_rbi_dir],

--- a/lib/tapioca/commands.rb
+++ b/lib/tapioca/commands.rb
@@ -4,6 +4,7 @@
 module Tapioca
   module Commands
     autoload :Command, "tapioca/commands/command"
+    autoload :CommandWithoutTracker, "tapioca/commands/command_without_tracker"
     autoload :Annotations, "tapioca/commands/annotations"
     autoload :CheckShims, "tapioca/commands/check_shims"
     autoload :Dsl, "tapioca/commands/dsl"

--- a/lib/tapioca/commands/annotations.rb
+++ b/lib/tapioca/commands/annotations.rb
@@ -3,7 +3,7 @@
 
 module Tapioca
   module Commands
-    class Annotations < Command
+    class Annotations < CommandWithoutTracker
       extend T::Sig
 
       sig do

--- a/lib/tapioca/commands/check_shims.rb
+++ b/lib/tapioca/commands/check_shims.rb
@@ -3,7 +3,7 @@
 
 module Tapioca
   module Commands
-    class CheckShims < Command
+    class CheckShims < CommandWithoutTracker
       extend T::Sig
       include SorbetHelper
       include RBIFilesHelper

--- a/lib/tapioca/commands/command_without_tracker.rb
+++ b/lib/tapioca/commands/command_without_tracker.rb
@@ -1,0 +1,18 @@
+# typed: strict
+# frozen_string_literal: true
+
+module Tapioca
+  module Commands
+    class CommandWithoutTracker < Command
+      extend T::Helpers
+
+      abstract!
+
+      sig { void }
+      def initialize
+        Tapioca::Runtime::Trackers.disable_all!
+        super
+      end
+    end
+  end
+end

--- a/lib/tapioca/commands/configure.rb
+++ b/lib/tapioca/commands/configure.rb
@@ -3,7 +3,7 @@
 
 module Tapioca
   module Commands
-    class Configure < Command
+    class Configure < CommandWithoutTracker
       sig do
         params(
           sorbet_config: String,

--- a/lib/tapioca/commands/dsl.rb
+++ b/lib/tapioca/commands/dsl.rb
@@ -3,7 +3,7 @@
 
 module Tapioca
   module Commands
-    class Dsl < Command
+    class Dsl < CommandWithoutTracker
       include SorbetHelper
       include RBIFilesHelper
 

--- a/lib/tapioca/commands/require.rb
+++ b/lib/tapioca/commands/require.rb
@@ -3,7 +3,7 @@
 
 module Tapioca
   module Commands
-    class Require < Command
+    class Require < CommandWithoutTracker
       sig do
         params(
           requires_path: String,

--- a/lib/tapioca/commands/todo.rb
+++ b/lib/tapioca/commands/todo.rb
@@ -3,7 +3,7 @@
 
 module Tapioca
   module Commands
-    class Todo < Command
+    class Todo < CommandWithoutTracker
       include SorbetHelper
 
       sig do

--- a/lib/tapioca/runtime/trackers.rb
+++ b/lib/tapioca/runtime/trackers.rb
@@ -1,5 +1,31 @@
-# typed: strict
+# typed: true
 # frozen_string_literal: true
+
+require "tapioca/runtime/trackers/tracker"
+
+module Tapioca
+  module Runtime
+    module Trackers
+      extend T::Sig
+
+      @trackers = T.let([], T::Array[Tracker])
+
+      class << self
+        extend T::Sig
+
+        sig { void }
+        def disable_all!
+          @trackers.each(&:disable!)
+        end
+
+        sig { params(tracker: Tracker).void }
+        def register_tracker(tracker)
+          @trackers << tracker
+        end
+      end
+    end
+  end
+end
 
 # The load order below is important:
 # ----------------------------------

--- a/lib/tapioca/runtime/trackers/autoload.rb
+++ b/lib/tapioca/runtime/trackers/autoload.rb
@@ -5,6 +5,7 @@ module Tapioca
   module Runtime
     module Trackers
       module Autoload
+        extend Tracker
         extend T::Sig
 
         NOOP_METHOD = ->(*_args, **_kwargs, &_block) {}
@@ -28,6 +29,8 @@ module Tapioca
 
           sig { params(constant_name: String).void }
           def register(constant_name)
+            return unless enabled?
+
             @constant_names_registered_for_autoload << constant_name
           end
 

--- a/lib/tapioca/runtime/trackers/mixin.rb
+++ b/lib/tapioca/runtime/trackers/mixin.rb
@@ -5,11 +5,11 @@ module Tapioca
   module Runtime
     module Trackers
       module Mixin
+        extend Tracker
         extend T::Sig
 
         @constants_to_mixin_locations = {}.compare_by_identity
         @mixins_to_constants = {}.compare_by_identity
-        @enabled = true
 
         class Type < T::Enum
           enums do
@@ -28,11 +28,7 @@ module Tapioca
               .returns(T.type_parameter(:Result))
           end
           def with_disabled_registration(&block)
-            @enabled = false
-
-            block.call
-          ensure
-            @enabled = true
+            with_disabled_tracker(&block)
           end
 
           sig do
@@ -43,7 +39,7 @@ module Tapioca
             ).void
           end
           def register(constant, mixin, mixin_type)
-            return unless @enabled
+            return unless enabled?
 
             location = Reflection.resolve_loc(caller_locations)
 

--- a/lib/tapioca/runtime/trackers/required_ancestor.rb
+++ b/lib/tapioca/runtime/trackers/required_ancestor.rb
@@ -5,6 +5,7 @@ module Tapioca
   module Runtime
     module Trackers
       module RequiredAncestor
+        extend Tracker
         @required_ancestors_map = {}.compare_by_identity
 
         class << self
@@ -12,6 +13,8 @@ module Tapioca
 
           sig { params(requiring: T::Helpers, block: T.proc.void).void }
           def register(requiring, block)
+            return unless enabled?
+
             ancestors = @required_ancestors_map[requiring] ||= []
             ancestors << block
           end

--- a/lib/tapioca/runtime/trackers/tracker.rb
+++ b/lib/tapioca/runtime/trackers/tracker.rb
@@ -1,0 +1,45 @@
+# typed: true
+# frozen_string_literal: true
+
+module Tapioca
+  module Runtime
+    module Trackers
+      module Tracker
+        extend T::Sig
+        extend T::Helpers
+
+        abstract!
+
+        class << self
+          extend T::Sig
+
+          sig { params(base: T.all(Tracker, Module)).void }
+          def extended(base)
+            Trackers.register_tracker(base)
+            base.instance_exec do
+              @enabled = true
+            end
+          end
+        end
+
+        sig { void }
+        def disable!
+          @enabled = false
+        end
+
+        def enabled?
+          @enabled
+        end
+
+        def with_disabled_tracker(&block)
+          original_state = @enabled
+          @enabled = false
+
+          block.call
+        ensure
+          @enabled = original_state
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
Related to: #1181 

Most of our commands don't need the overhead of Tapioca runtime trackers constantly running in the background and doing processing. This PR implements and makes use of a mechanism to disable all trackers for commands that don't need them.

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
1. Add a `Tracker` module that is responsible for registration and disabling of an individual tracker module.
2. Make all trackers use that `Tracker` module and respect the `enabled?` state.
3. Add a `CommandWithoutTracker` base class that disables all trackers during initialization.
4. Make all commands that don't need trackers (basically all commands except `GemCommand`) subclass from `CommandWithoutTracker`.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->
No added tests.
