### PR TITLE
Use correct type for `GraphQL::Types::ISO8601DateTime`

### DIFF
--- a/lib/tapioca/dsl/helpers/graphql_type_helper.rb
+++ b/lib/tapioca/dsl/helpers/graphql_type_helper.rb
@@ -25,7 +25,7 @@ module Tapioca
           when GraphQL::Types::ISO8601Date.singleton_class
             type_for_constant(Date)
           when GraphQL::Types::ISO8601DateTime.singleton_class
-            type_for_constant(DateTime)
+            type_for_constant(Time)
           when GraphQL::Types::JSON.singleton_class
             "T::Hash[::String, T.untyped]"
           when GraphQL::Schema::Enum.singleton_class

--- a/spec/tapioca/dsl/compilers/graphql_mutation_spec.rb
+++ b/spec/tapioca/dsl/compilers/graphql_mutation_spec.rb
@@ -138,7 +138,7 @@ module Tapioca
                 # typed: strong
 
                 class CreateComment
-                  sig { params(boolean: T::Boolean, float: ::Float, id: ::String, int: ::Integer, date: ::Date, datetime: ::DateTime, json: T::Hash[::String, T.untyped], string: ::String, enum_a: ::String, enum_b: T.any(::String, ::Symbol), input_object: ::CreateCommentInput, custom_scalar: T.untyped).returns(T.untyped) }
+                  sig { params(boolean: T::Boolean, float: ::Float, id: ::String, int: ::Integer, date: ::Date, datetime: ::Time, json: T::Hash[::String, T.untyped], string: ::String, enum_a: ::String, enum_b: T.any(::String, ::Symbol), input_object: ::CreateCommentInput, custom_scalar: T.untyped).returns(T.untyped) }
                   def resolve(boolean:, float:, id:, int:, date:, datetime:, json:, string:, enum_a:, enum_b:, input_object:, custom_scalar:); end
                 end
               RBI


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->

GraphQL deserializes this type into a `Time`, not a `DateTime`.[^1]

[^1]: [See the implementation of `ISO8601DateTime`](https://github.com/rmosolgo/graphql-ruby/blob/2515f2ad938265c7e3adc6d9f127539fd15bd76a/lib/graphql/types/iso_8601_date_time.rb#L55)

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->

The type is updated and the test is too.

I've backported this to `0-10-stable` in #1197.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->

✅ 

