### PR TITLE
Backport "Use correct type for `GraphQL::Types::ISO8601DateTime`"

### DIFF
--- a/lib/tapioca/dsl/helpers/graphql_type_helper.rb
+++ b/lib/tapioca/dsl/helpers/graphql_type_helper.rb
@@ -25,7 +25,7 @@ module Tapioca
           when GraphQL::Types::ISO8601Date.singleton_class
             type_for_constant(Date)
           when GraphQL::Types::ISO8601DateTime.singleton_class
-            type_for_constant(DateTime)
+            type_for_constant(Time)
           when GraphQL::Types::JSON.singleton_class
             "T::Hash[::String, T.untyped]"
           when GraphQL::Schema::Enum.singleton_class

--- a/spec/tapioca/dsl/compilers/graphql_mutation_spec.rb
+++ b/spec/tapioca/dsl/compilers/graphql_mutation_spec.rb
@@ -138,7 +138,7 @@ module Tapioca
                 # typed: strong
 
                 class CreateComment
-                  sig { params(boolean: T::Boolean, float: ::Float, id: ::String, int: ::Integer, date: ::Date, datetime: ::DateTime, json: T::Hash[::String, T.untyped], string: ::String, enum_a: ::String, enum_b: T.any(::String, ::Symbol), input_object: ::CreateCommentInput, custom_scalar: T.untyped).returns(T.untyped) }
+                  sig { params(boolean: T::Boolean, float: ::Float, id: ::String, int: ::Integer, date: ::Date, datetime: ::Time, json: T::Hash[::String, T.untyped], string: ::String, enum_a: ::String, enum_b: T.any(::String, ::Symbol), input_object: ::CreateCommentInput, custom_scalar: T.untyped).returns(T.untyped) }
                   def resolve(boolean:, float:, id:, int:, date:, datetime:, json:, string:, enum_a:, enum_b:, input_object:, custom_scalar:); end
                 end
               RBI


### PR DESCRIPTION
This backports #1196 to `0-10-stable`, as `0.10` introduced the bug.