### PR TITLE
Filter backtrace locations in test errors

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,7 +16,12 @@ require "spec_reporter"
 require "dsl_spec_helper"
 require "spec_with_project"
 
-Minitest::Reporters.use!(SpecReporter.new(color: true))
+backtrace_filter = Minitest::ExtensibleBacktraceFilter.default_filter
+backtrace_filter.add_filter(%r{gems/sorbet-runtime})
+backtrace_filter.add_filter(%r{gems/railties})
+backtrace_filter.add_filter(%r{tapioca/helpers/test/})
+
+Minitest::Reporters.use!(SpecReporter.new(color: true), ENV, backtrace_filter)
 
 module Minitest
   class Test


### PR DESCRIPTION

### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
Our test backtrace messages are too noisy and include frames from Sorbet runtime, the Railties runner and our test helpers like the `Isolation` helper module.


### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
This commit filters out those frames from the backtrace, leaving only the frames pertinent to the test failure.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->
No new tests
