### PR TITLE
Add test to ensure scope for enum attributes are generated

### DIFF
--- a/spec/tapioca/dsl/compilers/active_record_scope_spec.rb
+++ b/spec/tapioca/dsl/compilers/active_record_scope_spec.rb
@@ -266,6 +266,38 @@ module Tapioca
                 assert_equal(expected, rbi_for(:Post))
               end
 
+              it "generates scopes defined by enum attributes" do
+                add_ruby_file("post.rb", <<~RUBY)
+                  class Post < ActiveRecord::Base
+                    enum status: [ :active, :archived ]
+                  end
+                RUBY
+
+                expected = <<~RBI
+                  # typed: strong
+
+                  class Post
+                    extend GeneratedRelationMethods
+
+                    module GeneratedRelationMethods
+                      sig { params(args: T.untyped, blk: T.untyped).returns(T.untyped) }
+                      def active(*args, &blk); end
+
+                      sig { params(args: T.untyped, blk: T.untyped).returns(T.untyped) }
+                      def archived(*args, &blk); end
+
+                      sig { params(args: T.untyped, blk: T.untyped).returns(T.untyped) }
+                      def not_active(*args, &blk); end
+
+                      sig { params(args: T.untyped, blk: T.untyped).returns(T.untyped) }
+                      def not_archived(*args, &blk); end
+                    end
+                  end
+                RBI
+
+                assert_equal(expected, rbi_for(:Post))
+              end
+
               it "generates relation includes from non-abstract parent models" do
                 add_ruby_file("post.rb", <<~RUBY)
                   class Post < ActiveRecord::Base


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
Add a test case for #1081, which shows (and ensures) that the scopes are generated.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->
Added a test case for `ActiveRecordScope` generator that ensures the expected scopes are generated for enum attributes
