### PR TITLE
Add missing bundle install in test

### DIFF
--- a/spec/tapioca/cli/dsl_spec.rb
+++ b/spec/tapioca/cli/dsl_spec.rb
@@ -37,6 +37,7 @@ module Tapioca
       end
 
       it "shows an error message for unknown options" do
+        @project.bundle_install
         result = @project.tapioca("dsl --unknown-option")
 
         assert_empty_stdout(result)


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->

The missing `bundle_install` would make this flaky when it would run before any other test had a chance to do a bundle install on the project.

An example of such a failure can be [seen here][0].

[0]: https://github.com/Shopify/tapioca/actions/runs/3199842402/jobs/5226068916#step:4:28

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
Add the `bundle_install`.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->
Updated test.
