### PR TITLE
Silence warnings in all CLI output

### DIFF
--- a/lib/tapioca/cli.rb
+++ b/lib/tapioca/cli.rb
@@ -281,7 +281,10 @@ module Tapioca
         payload: options[:payload],
         number_of_workers: options[:workers],
       )
-      command.execute
+
+      Tapioca.silence_warnings do
+        command.execute
+      end
     end
 
     desc "annotations", "Pull gem RBI annotations from remote sources"
@@ -307,7 +310,10 @@ module Tapioca
         netrc_file: netrc_file(options),
         typed_overrides: options[:typed_overrides],
       )
-      command.execute
+
+      Tapioca.silence_warnings do
+        command.execute
+      end
     end
 
     map ["--version", "-v"] => :__print_version


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
We should wrap all command executions inside `Tapioca.silence_warnings` so that we can suppress warnings in the CLI output, like the ones from the parser gem that fails out 3.2-head tests.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->
Expect existing tests to pass on 3.2 builds
