### PR TITLE
ci: regenerate Gemfile.lock when running on ruby head

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,8 @@ jobs:
       BUNDLE_GEMFILE: ${{ matrix.gemfile }}
     steps:
       - uses: actions/checkout@v3.1.0
+      - if: ${{ matrix.ruby == '3.2' }}
+        run: "rm -f ${{ matrix.gemfile }}.lock"
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
### Motivation

Experimental Ruby 3.2 builds are failing because Nokogiri's precompiled native platform gem only supports up to Ruby 3.1.

Example failure: https://github.com/Shopify/tapioca/actions/runs/3283616191/jobs/5408560879#step:3:41

### Implementation

CI should regenerate the lockfile when running on an unreleased version of Ruby.

### Tests

Ruby 3.2 should run as expected.
