### PR TITLE
dev: clean up Gemfile.lock platforms

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -341,8 +341,8 @@ GEM
     zeitwerk (2.6.0)
 
 PLATFORMS
-  arm64-darwin-21
-  universal-darwin-22
+  arm64-darwin
+  x86_64-darwin
   x86_64-linux
 
 DEPENDENCIES


### PR DESCRIPTION
### Motivation

Updating the Gemfile.lock platforms to be in line with what we expect development environments to be.

- remove `universal-darwin-22` because this only applies to the Apple-installed version of Ruby which nobody should be using to develop Tapioca
- add `x86_64-darwin` for our friends without M1s
- change `arm64-darwin-21` to the more generic `arm64-darwin`

Note that none of the gems locked in this bundle have changed.

### Implementation

See above.

### Tests

No functional change, existing tests are sufficient.
