### PR TITLE
Avoid installing prerelease bundler for mock project

### DIFF
--- a/spec/helpers/mock_project.rb
+++ b/spec/helpers/mock_project.rb
@@ -92,8 +92,18 @@ module Tapioca
       opts = {}
       opts[:chdir] = path
       Bundler.with_unbundled_env do
-        ::Gem.install("bundler", bundler_version)
-        out, err, status = Open3.capture3(["bundle", "_#{bundler_version}_", "install"].join(" "), opts)
+        cmd =
+          # prerelease versions are not always available on rubygems.org
+          # so in this case, we install whichever is the latest
+          if ::Gem::Version.new(bundler_version).prerelease?
+            ::Gem.install("bundler")
+            "bundle install"
+          else
+            ::Gem.install("bundler", bundler_version)
+            "bundle _#{bundler_version}_ install"
+          end
+
+        out, err, status = Open3.capture3(cmd, opts)
         ExecResult.new(out: out, err: err, status: T.must(status.success?))
       end
     end


### PR DESCRIPTION
### Motivation

Currently, our test suites with Ruby 3.2 are failing ([example](https://github.com/Shopify/tapioca/actions/runs/3337789715/jobs/5524586722)). This is because we try to install `bundler` `2.4.0.dev` based on the value of `Bundler::VERSION`, which is not released on rubygems.org yet.

### Implementation

Before installing `bundler` for our mock projects, check if the target bundler version is a prerelease. If it is, skip that version and just install the latest available version.

### Tests

This PR is to fix CI builds, so it doesn't need extra tests other than existing ones.

