### PR TITLE
Make scopes available for abstract classes

### DIFF
--- a/lib/tapioca/dsl/compilers/active_record_relations.rb
+++ b/lib/tapioca/dsl/compilers/active_record_relations.rb
@@ -175,7 +175,7 @@ module Tapioca
 
           sig { override.returns(T::Enumerable[Module]) }
           def gather_constants
-            ActiveRecord::Base.descendants.reject(&:abstract_class?)
+            descendants_of(ActiveRecord::Base).reject(&:abstract_class?)
           end
         end
 

--- a/lib/tapioca/dsl/compilers/active_record_scope.rb
+++ b/lib/tapioca/dsl/compilers/active_record_scope.rb
@@ -83,7 +83,7 @@ module Tapioca
         class << self
           sig { override.returns(T::Enumerable[Module]) }
           def gather_constants
-            descendants_of(::ActiveRecord::Base).reject(&:abstract_class?)
+            descendants_of(::ActiveRecord::Base)
           end
         end
 

--- a/spec/tapioca/dsl/compilers/active_record_scope_spec.rb
+++ b/spec/tapioca/dsl/compilers/active_record_scope_spec.rb
@@ -13,7 +13,7 @@ module Tapioca
               assert_empty(gathered_constants)
             end
 
-            it "gathers only ActiveRecord constants with no abstract classes" do
+            it "gathers ActiveRecord constants including abstract classes" do
               add_ruby_file("conversation.rb", <<~RUBY)
                 class Post < ActiveRecord::Base
                 end
@@ -26,7 +26,7 @@ module Tapioca
                 end
               RUBY
 
-              assert_equal(["Post"], gathered_constants)
+              assert_equal(["Post", "Product"], gathered_constants)
             end
           end
 
@@ -174,7 +174,25 @@ module Tapioca
                   end
                 RUBY
 
-                expected = <<~RBI
+                expected_application_record = <<~RBI
+                  # typed: strong
+
+                  class ApplicationRecord
+                    extend GeneratedRelationMethods
+
+                    module GeneratedAssociationRelationMethods
+                      sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
+                      def app_scope(*args, &blk); end
+                    end
+
+                    module GeneratedRelationMethods
+                      sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
+                      def app_scope(*args, &blk); end
+                    end
+                  end
+                RBI
+
+                expected_post = <<~RBI
                   # typed: strong
 
                   class Post
@@ -198,7 +216,8 @@ module Tapioca
                   end
                 RBI
 
-                assert_equal(expected, rbi_for(:Post))
+                assert_equal(expected_application_record, rbi_for(:ApplicationRecord))
+                assert_equal(expected_post, rbi_for(:Post))
               end
             end
 
@@ -348,7 +367,20 @@ module Tapioca
                   end
                 RUBY
 
-                expected = <<~RBI
+                expected_application_record = <<~RBI
+                  # typed: strong
+
+                  class ApplicationRecord
+                    extend GeneratedRelationMethods
+
+                    module GeneratedRelationMethods
+                      sig { params(args: T.untyped, blk: T.untyped).returns(T.untyped) }
+                      def app_scope(*args, &blk); end
+                    end
+                  end
+                RBI
+
+                expected_post = <<~RBI
                   # typed: strong
 
                   class Post
@@ -364,7 +396,8 @@ module Tapioca
                   end
                 RBI
 
-                assert_equal(expected, rbi_for(:Post))
+                assert_equal(expected_application_record, rbi_for(:ApplicationRecord))
+                assert_equal(expected_post, rbi_for(:Post))
               end
             end
           end


### PR DESCRIPTION
### Motivation
At the moment sorbet can't figure out that classes, that are marked as abstract, have access to scopes. The following example illustrates this:

```ruby
class A < ApplicationRecord
  extend T::Sig
  abstract_class = true

  scope :deleted, -> { where.not(deleted_at: nil) }

  class << self
    extend T::Sig

    sig { returns(Integer) }
    def count_deleted
        # Method `deleted` does not exist on `T.class_of(A)`
        deleted.count
    end
  end
end
```

Since those scopes can be used, I think it makes sense to generate the rbi files accordingly.

### Implementation
I removed the filter for abstract classes in `ActiveRecordScope` and did the same thing in `ActiveRecordRelations` to make the generated relation methods work.

### Tests
Tests for `ActiveRecordScope` have been extended.
