### PR TITLE
Protobuf DSL: generate namespaced enum constants on root

### DIFF
--- a/lib/tapioca/dsl/compilers/protobuf.rb
+++ b/lib/tapioca/dsl/compilers/protobuf.rb
@@ -95,7 +95,18 @@ module Tapioca
               case descriptor
               when Google::Protobuf::EnumDescriptor
                 descriptor.to_h.each do |sym, val|
-                  klass.create_constant(sym.to_s, value: val.to_s)
+                  # For each enum value, create a namespaced constant on the root rather than an un-namespaced
+                  # constant within the class. This is because un-namespaced constants might conflict with reserved
+                  # Ruby words, such as "BEGIN." By namespacing them, we avoid this problem.
+                  #
+                  # Invalid syntax:
+                  # class Foo
+                  #   BEGIN = 3
+                  # end
+                  #
+                  # Valid syntax:
+                  # Foo::BEGIN = 3
+                  root.create_constant("#{constant}::#{sym}", value: val.to_s)
                 end
 
                 klass.create_method(

--- a/spec/tapioca/dsl/compilers/protobuf_spec.rb
+++ b/spec/tapioca/dsl/compilers/protobuf_spec.rb
@@ -193,11 +193,11 @@ module Tapioca
                     sig { params(symbol: Symbol).returns(T.nilable(Integer)) }
                     def resolve(symbol); end
                   end
-
-                  FIXED_AMOUNT = 1
-                  NULL = 0
-                  PERCENTAGE = 2
                 end
+
+                Cart::VALUE_TYPE::FIXED_AMOUNT = 1
+                Cart::VALUE_TYPE::NULL = 0
+                Cart::VALUE_TYPE::PERCENTAGE = 2
               RBI
 
               assert_equal(expected_enum_rbi, rbi_for("Cart::VALUE_TYPE"))


### PR DESCRIPTION
### Motivation
Closes #1236.

The Protobuf DSL compiler was causing errors by generating un-namespaced constants for enums that conflicted with reserved Ruby words.

e.g. if there is an enum member called `BEGIN`, the DSL compiler will generate something like:

```
class Foo
  BEGIN = 3
end
```

This is invalid Ruby syntax because `BEGIN` is a reserved word in Ruby.

### Implementation
@Morriar and I changed the implementation of the Protobuf DSL compiler to add a namespaced version of these constants to the root of the RBI file, which prevents them from having the same name as a reserved word in Ruby.

e.g.

```
class Foo; end

Foo::BEGIN = 3
```

### Tests
Automated tests have been updated to reflect this change.
