### PR TITLE
Add types for postgres hstore

### DIFF
--- a/lib/tapioca/dsl/helpers/active_record_column_type_helper.rb
+++ b/lib/tapioca/dsl/helpers/active_record_column_type_helper.rb
@@ -19,33 +19,7 @@ module Tapioca
 
           column_type = @constant.attribute_types[column_name]
 
-          getter_type =
-            case column_type
-            when defined?(MoneyColumn) && MoneyColumn::ActiveRecordType
-              "::Money"
-            when ActiveRecord::Type::Integer
-              "::Integer"
-            when ActiveRecord::Type::String
-              "::String"
-            when ActiveRecord::Type::Date
-              "::Date"
-            when ActiveRecord::Type::Decimal
-              "::BigDecimal"
-            when ActiveRecord::Type::Float
-              "::Float"
-            when ActiveRecord::Type::Boolean
-              "T::Boolean"
-            when ActiveRecord::Type::DateTime, ActiveRecord::Type::Time
-              "::Time"
-            when ActiveRecord::AttributeMethods::TimeZoneConversion::TimeZoneConverter
-              "::ActiveSupport::TimeWithZone"
-            when ActiveRecord::Enum::EnumType
-              "::String"
-            when ActiveRecord::Type::Serialized
-              serialized_column_type(column_type)
-            else
-              handle_unknown_type(column_type)
-            end
+          getter_type = type_for_activerecord_value column_type
 
           column = @constant.columns_hash[column_name]
           setter_type =
@@ -70,6 +44,40 @@ module Tapioca
         end
 
         private
+
+        sig {params(column_type: T.untyped).returns(String)}
+        def type_for_activerecord_value(column_type)
+          case column_type
+          when defined?(MoneyColumn) && MoneyColumn::ActiveRecordType
+            "::Money"
+          when ActiveRecord::Type::Integer
+            "::Integer"
+          when ActiveRecord::Type::String
+            "::String"
+          when ActiveRecord::Type::Date
+            "::Date"
+          when ActiveRecord::Type::Decimal
+            "::BigDecimal"
+          when ActiveRecord::Type::Float
+            "::Float"
+          when ActiveRecord::Type::Boolean
+            "T::Boolean"
+          when defined?(ActiveRecord::ConnectionAdapters::PostgreSQL) && ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Hstore
+            "T::Hash[::String, ::String]"
+          when defined?(ActiveRecord::ConnectionAdapters::PostgreSQL) && ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Array
+            "T::Array[#{type_for_activerecord_value column_type.subtype}]"
+          when ActiveRecord::Type::DateTime, ActiveRecord::Type::Time
+            "::Time"
+          when ActiveRecord::AttributeMethods::TimeZoneConversion::TimeZoneConverter
+            "::ActiveSupport::TimeWithZone"
+          when ActiveRecord::Enum::EnumType
+            "::String"
+          when ActiveRecord::Type::Serialized
+            serialized_column_type(column_type)
+          else
+            handle_unknown_type(column_type)
+          end
+        end
 
         sig { params(constant: Module).returns(T::Boolean) }
         def do_not_generate_strong_types?(constant)

--- a/lib/tapioca/dsl/helpers/active_record_column_type_helper.rb
+++ b/lib/tapioca/dsl/helpers/active_record_column_type_helper.rb
@@ -48,8 +48,6 @@ module Tapioca
         sig {params(column_type: T.untyped).returns(String)}
         def type_for_activerecord_value(column_type)
           case column_type
-          when defined?(MoneyColumn) && MoneyColumn::ActiveRecordType
-            "::Money"
           when ActiveRecord::Type::Integer
             "::Integer"
           when ActiveRecord::Type::String
@@ -62,10 +60,6 @@ module Tapioca
             "::Float"
           when ActiveRecord::Type::Boolean
             "T::Boolean"
-          when defined?(ActiveRecord::ConnectionAdapters::PostgreSQL) && ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Hstore
-            "T::Hash[::String, ::String]"
-          when defined?(ActiveRecord::ConnectionAdapters::PostgreSQL) && ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Array
-            "T::Array[#{type_for_activerecord_value column_type.subtype}]"
           when ActiveRecord::Type::DateTime, ActiveRecord::Type::Time
             "::Time"
           when ActiveRecord::AttributeMethods::TimeZoneConversion::TimeZoneConverter
@@ -74,6 +68,12 @@ module Tapioca
             "::String"
           when ActiveRecord::Type::Serialized
             serialized_column_type(column_type)
+          when defined?(ActiveRecord::ConnectionAdapters::PostgreSQL) && ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Hstore
+            "T::Hash[::String, ::String]"
+          when defined?(ActiveRecord::ConnectionAdapters::PostgreSQL) && ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Array
+            "T::Array[#{type_for_activerecord_value column_type.subtype}]"
+          when defined?(MoneyColumn) && MoneyColumn::ActiveRecordType
+            "::Money"
           else
             handle_unknown_type(column_type)
           end

--- a/sorbet/rbi/shims/activerecord_postgresql.rbi
+++ b/sorbet/rbi/shims/activerecord_postgresql.rbi
@@ -1,0 +1,5 @@
+# typed: strict
+
+# These constants are dynamically loaded only when connecting to postgresql
+module ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Array; end
+module ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Hstore; end


### PR DESCRIPTION
### Motivation
When using an hstore column in postgres, tapioca generates "T.untyped". Both keys and values in `hstore` are strings.

### Implementation
Added a case for hstore to the existing case statement.

### Tests
No tests, but hopefully it's pretty clear what it does. Checked it on a codebase that uses hstore.

