### PR TITLE
Generate clear_foo methods for protobuf compiler

### DIFF
--- a/lib/tapioca/dsl/compilers/protobuf.rb
+++ b/lib/tapioca/dsl/compilers/protobuf.rb
@@ -284,6 +284,11 @@ module Tapioca
             return_type: "void",
           )
 
+          klass.create_method(
+            "clear_#{field.name}",
+            return_type: "void",
+          )
+
           field
         end
 

--- a/spec/tapioca/dsl/compilers/protobuf_spec.rb
+++ b/spec/tapioca/dsl/compilers/protobuf_spec.rb
@@ -60,6 +60,12 @@ module Tapioca
                   sig { params(customer_id: T.nilable(Integer), shop_id: T.nilable(Integer)).void }
                   def initialize(customer_id: nil, shop_id: nil); end
 
+                  sig { void }
+                  def clear_customer_id; end
+
+                  sig { void }
+                  def clear_shop_id; end
+
                   sig { returns(Integer) }
                   def customer_id; end
 
@@ -96,6 +102,9 @@ module Tapioca
                 class Cart
                   sig { params(events: T.nilable(String)).void }
                   def initialize(events: nil); end
+
+                  sig { void }
+                  def clear_events; end
 
                   sig { returns(String) }
                   def events; end
@@ -136,6 +145,9 @@ module Tapioca
 
                   sig { params(value: T.nilable(Google::Protobuf::UInt64Value)).void }
                   def cart_item_index=(value); end
+
+                  sig { void }
+                  def clear_cart_item_index; end
                 end
               RBI
 
@@ -170,6 +182,9 @@ module Tapioca
                 class Cart
                   sig { params(value_type: T.nilable(T.any(Symbol, Integer))).void }
                   def initialize(value_type: nil); end
+
+                  sig { void }
+                  def clear_value_type; end
 
                   sig { returns(T.any(Symbol, Integer)) }
                   def value_type; end
@@ -233,6 +248,9 @@ module Tapioca
                   sig { params(value_type: T.nilable(T.any(Symbol, Integer))).void }
                   def initialize(value_type: nil); end
 
+                  sig { void }
+                  def clear_value_type; end
+
                   sig { returns(T.any(Symbol, Integer)) }
                   def value_type; end
 
@@ -266,6 +284,12 @@ module Tapioca
                 class Cart
                   sig { params(customer_ids: T.nilable(T.any(Google::Protobuf::RepeatedField[Integer], T::Array[Integer])), indices: T.nilable(T.any(Google::Protobuf::RepeatedField[Google::Protobuf::UInt64Value], T::Array[Google::Protobuf::UInt64Value]))).void }
                   def initialize(customer_ids: Google::Protobuf::RepeatedField.new(:int32), indices: Google::Protobuf::RepeatedField.new(:message, Google::Protobuf::UInt64Value)); end
+
+                  sig { void }
+                  def clear_customer_ids; end
+
+                  sig { void }
+                  def clear_indices; end
 
                   sig { returns(Google::Protobuf::RepeatedField[Integer]) }
                   def customer_ids; end
@@ -306,6 +330,12 @@ module Tapioca
                 class Cart
                   sig { params(customers: T.nilable(T.any(Google::Protobuf::Map[String, Integer], T::Hash[String, Integer])), stores: T.nilable(T.any(Google::Protobuf::Map[String, Google::Protobuf::UInt64Value], T::Hash[String, Google::Protobuf::UInt64Value]))).void }
                   def initialize(customers: Google::Protobuf::Map.new(:string, :int32), stores: Google::Protobuf::Map.new(:string, :message, Google::Protobuf::UInt64Value)); end
+
+                  sig { void }
+                  def clear_customers; end
+
+                  sig { void }
+                  def clear_stores; end
 
                   sig { returns(Google::Protobuf::Map[String, Integer]) }
                   def customers; end
@@ -428,6 +458,12 @@ module Tapioca
 
                   sig { params(value: String).void }
                   def ShopName=(value); end
+
+                  sig { void }
+                  def clear_ShopID; end
+
+                  sig { void }
+                  def clear_ShopName; end
                 end
               RBI
 
@@ -453,6 +489,13 @@ module Tapioca
               rbi_output = rbi_for(:Cart)
 
               assert_includes(rbi_output, indented(<<~RBI, 2))
+
+                sig { void }
+                def clear_email; end
+
+                sig { void }
+                def clear_phone_number; end
+
                 sig { returns(T.nilable(Symbol)) }
                 def contact_info; end
               RBI


### PR DESCRIPTION
Protobuf: Add support for `clear_*` methods

### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->

[Per the docs](https://developers.google.com/protocol-buffers/docs/reference/ruby-generated#checking-presence), Protobuf generates a method for every field that clears it. We should have sigs declared for those.

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->

Just added to the existing `create_descriptor_method` 

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->
Yep

