### PR TITLE
Handle keyword argument splats correctly

### DIFF
--- a/lib/tapioca/dsl/compiler.rb
+++ b/lib/tapioca/dsl/compiler.rb
@@ -98,10 +98,11 @@ module Tapioca
         # keyword parameters types
         signature.kwarg_types.each { |_, kwarg_type| params << kwarg_type.to_s }
 
-        # rest and keyrest parameter types
-        ["", "key"].each do |prefix|
-          params << signature.public_send("#{prefix}rest_type").to_s if signature.public_send("has_#{prefix}rest")
-        end
+        # rest parameter type
+        params << signature.rest_type.to_s if signature.has_rest
+
+        # keyrest parameter type
+        params << signature.keyrest_type.to_s if signature.has_keyrest
 
         # special case `.void` in a proc
         unless signature.block_name.nil?


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
Currently, keyword argument splats aren't handled in the base compiler class so methods like the below don't work
```ruby
sig { params(arg1: Symbol, kwargs: Symbol).returns(Symbol) }
def my_methods(arg1, **kwargs) = arg1
```

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
This PR adds support for keyword argument splats by relying on the `keyrest_type` method from the signature

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->
There are no tests for the base class.  
Theoretically, the change could be covered in `spec/tapioca/cli/dsl_spec.rb` but I couldn't make it work so I will invest more into this

