### PR TITLE
Configure::spec can also return a Gem::Specification

### DIFF
--- a/lib/tapioca/commands/configure.rb
+++ b/lib/tapioca/commands/configure.rb
@@ -92,7 +92,7 @@ module Tapioca
         @installer ||= Bundler::Installer.new(Bundler.root, Bundler.definition)
       end
 
-      sig { returns(Bundler::StubSpecification) }
+      sig { returns(T.any(Bundler::StubSpecification, ::Gem::Specification)) }
       def spec
         @spec ||= Bundler.definition.specs.find { |s| s.name == "tapioca" }
       end


### PR DESCRIPTION
### Motivation

It seems the type of the spec actually depends on what is in the Gemfile.

* We're getting a `Bundler::StubSpecification` if we use `gem("tapioca")` and `bundle`
* We're getting a `Gem::Specification` if we use `gem("tapioca", path: "path/to/tapioca")` or no `bundle`

Found with #1287.

### Implementation

Let's return a `T.any` of both types?