### PR TITLE
`GemHelper#gem_in_app_dir?` accepts a Pathname

### DIFF
--- a/lib/tapioca/helpers/gem_helper.rb
+++ b/lib/tapioca/helpers/gem_helper.rb
@@ -5,7 +5,7 @@ module Tapioca
   module GemHelper
     extend T::Sig
 
-    sig { params(app_dir: String, full_gem_path: String).returns(T::Boolean) }
+    sig { params(app_dir: T.any(String, Pathname), full_gem_path: String).returns(T::Boolean) }
     def gem_in_app_dir?(app_dir, full_gem_path)
       app_dir = to_realpath(app_dir)
       full_gem_path = to_realpath(full_gem_path)


### PR DESCRIPTION
### Motivation

Found by #1287.

The variable `project_path` defined at https://github.com/Shopify/tapioca/blob/main/lib/tapioca/loaders/loader.rb#L85 is actually a `Pathname`.

### Implementation

Let's accept both `String` and `Pathname`.
