### PR TITLE
Do not pass `Post` as value to `dsl --only`

### DIFF
--- a/spec/tapioca/cli/dsl_spec.rb
+++ b/spec/tapioca/cli/dsl_spec.rb
@@ -1285,7 +1285,7 @@ module Tapioca
             end
           RB
 
-          result = @project.tapioca("dsl --only=ActiveRecordTypedStore Post")
+          result = @project.tapioca("dsl Post --only=ActiveRecordTypedStore")
 
           assert_equal(<<~OUT, result.out)
             Loading Rails application... Done


### PR DESCRIPTION
### Motivation

Found with #1287. This one is also very funny.

Since the `dsl --only` [option accepts an array](https://github.com/Shopify/tapioca/blob/main/lib/tapioca/cli.rb#L89), `Post` was considered as the name of a compiler rather than the class to produce the RBI for.

### Implementation

Since we only have one class, passing explicitly `Post` doesn't change much but I inverted the argument and option as to keep the original meaning.