### PR TITLE
Include base controller helpers when possible

### DIFF
--- a/lib/tapioca/dsl/compilers/action_controller_helpers.rb
+++ b/lib/tapioca/dsl/compilers/action_controller_helpers.rb
@@ -84,6 +84,13 @@ module Tapioca
 
             # Create helper method module
             controller.create_module(helper_methods_name) do |helper_methods|
+              # If the controller has the same helpers module as the superclass
+              # just include superclass helpers
+              if helpers_module == constant.superclass._helpers
+                superclass_helper_methods = constant.superclass.const_get(helper_methods_name)
+                next helper_methods.create_include(qualified_name_of(superclass_helper_methods))
+              end
+
               # If the controller has no helper defined, then it just inherits
               # the Action Controlller base helper methods module, so we should
               # just add that as an include and stop doing more processing.

--- a/spec/tapioca/dsl/compilers/action_controller_helpers_spec.rb
+++ b/spec/tapioca/dsl/compilers/action_controller_helpers_spec.rb
@@ -160,13 +160,7 @@ module Tapioca
                   def helpers; end
 
                   module HelperMethods
-                    include ::ActionController::Base::HelperMethods
-
-                    sig { returns(T.untyped) }
-                    def current_user_name; end
-
-                    sig { params(user_id: ::Integer).void }
-                    def notify_user(user_id); end
+                    include ::BaseController::HelperMethods
                   end
 
                   class HelperProxy < ::ActionView::Base


### PR DESCRIPTION
### Motivation
In a Rails project is common to have helpers defined in a base controller. Currently those helpers are declared on every `.rbi` file for descendant controllers unless those controllers define new helpers. The problem with this approach is that whenever a slight change is made on the base controller helpers, most `.rbi` files for descendants get updated making reviews of PRs annoying.

### Implementation
If the helpers module of a controller is the same helpers module of it superclass then it's guaranteed that the helpers methods are the same. So, instead of generating the helpers methods, use the helper methods module generated for the parent class.

### Tests
There was already a test with the case I described, so I updated the test to check that the subclass module just includes the parent's class module.
