### PR TITLE
Decorate ActiveRecord::SignedId finder methods

### DIFF
--- a/lib/tapioca/dsl/compilers/active_record_relations.rb
+++ b/lib/tapioca/dsl/compilers/active_record_relations.rb
@@ -217,6 +217,7 @@ module Tapioca
           T::Array[Symbol],
         )
         FINDER_METHODS = T.let(ActiveRecord::FinderMethods.instance_methods(false), T::Array[Symbol])
+        SIGNED_FINDER_METHODS = T.let(ActiveRecord::SignedId::ClassMethods.instance_methods(false), T::Array[Symbol])
         CALCULATION_METHODS = T.let(ActiveRecord::Calculations.instance_methods(false), T::Array[Symbol])
         ENUMERABLE_QUERY_METHODS = T.let([:any?, :many?, :none?, :one?], T::Array[Symbol])
         FIND_OR_CREATE_METHODS = T.let(
@@ -589,6 +590,31 @@ module Tapioca
                 method_name,
                 common_relation_methods_module,
                 return_type: return_type,
+              )
+            end
+          end
+
+          SIGNED_FINDER_METHODS.each do |method_name|
+            case method_name
+            when :find_signed
+              create_common_method(
+                "find_signed",
+                common_relation_methods_module,
+                parameters: [
+                  create_param("signed_id", type: "T.untyped"),
+                  create_kw_opt_param("purpose", type: "T.untyped", default: "nil"),
+                ],
+                return_type: as_nilable_type(constant_name),
+              )
+            when :find_signed!
+              create_common_method(
+                "find_signed!",
+                common_relation_methods_module,
+                parameters: [
+                  create_param("signed_id", type: "T.untyped"),
+                  create_kw_opt_param("purpose", type: "T.untyped", default: "nil"),
+                ],
+                return_type: constant_name,
               )
             end
           end

--- a/spec/tapioca/dsl/compilers/active_record_relations_spec.rb
+++ b/spec/tapioca/dsl/compilers/active_record_relations_spec.rb
@@ -109,6 +109,12 @@ module Tapioca
                     sig { params(attributes: T.untyped, block: T.nilable(T.proc.params(object: ::Post).void)).returns(::Post) }
                     def find_or_initialize_by(attributes, &block); end
 
+                    sig { params(signed_id: T.untyped, purpose: T.untyped).returns(T.nilable(::Post)) }
+                    def find_signed(signed_id, purpose: nil); end
+
+                    sig { params(signed_id: T.untyped, purpose: T.untyped).returns(::Post) }
+                    def find_signed!(signed_id, purpose: nil); end
+
                 <% if rails_version(">= 7.0") %>
                     sig { params(arg: T.untyped, args: T.untyped).returns(::Post) }
                     def find_sole_by(arg, *args); end


### PR DESCRIPTION
### Motivation
Noticed I missed typing for these. https://api.rubyonrails.org/classes/ActiveRecord/SignedId/ClassMethods.html was added in Rails 6.1.

### Implementation
Similar to existing finder methods.

### Tests
Tests added.

