### PR TITLE
Fix typo in boilerplate

### DIFF
--- a/lib/tapioca/commands/configure.rb
+++ b/lib/tapioca/commands/configure.rb
@@ -70,7 +70,7 @@ module Tapioca
           # typed: true
           # frozen_string_literal: true
 
-          # Add your extra requires here (`#{default_command(:require)}` can be used to boostrap this list)
+          # Add your extra requires here (`#{default_command(:require)}` can be used to bootstrap this list)
         CONTENT
       end
 

--- a/spec/tapioca/cli/configure_spec.rb
+++ b/spec/tapioca/cli/configure_spec.rb
@@ -35,7 +35,7 @@ module Tapioca
           # typed: true
           # frozen_string_literal: true
 
-          # Add your extra requires here (`bin/tapioca require` can be used to boostrap this list)
+          # Add your extra requires here (`bin/tapioca require` can be used to bootstrap this list)
         RB
 
         assert_project_file_exist("bin/tapioca")


### PR DESCRIPTION
Noticed when working on `ruby-lsp`:

https://github.com/Shopify/ruby-lsp/blob/20f7a9798cc7e0e94d164906e04c0372b7260d20/sorbet/tapioca/require.rb#L4