### PR TITLE
Add Active Record secure token compiler

### DIFF
--- a/lib/tapioca/dsl/compilers/active_record_secure_token.rb
+++ b/lib/tapioca/dsl/compilers/active_record_secure_token.rb
@@ -1,0 +1,74 @@
+# typed: strict
+# frozen_string_literal: true
+
+begin
+  require "active_record"
+rescue LoadError
+  return
+end
+
+require "tapioca/dsl/helpers/active_record_constants_helper"
+
+module Tapioca
+  module Dsl
+    module Compilers
+      # `Tapioca::Dsl::Compilers::ActiveModelSecurePassword` decorates RBI files for all
+      # classes that use [`ActiveRecord::SecureToken`](https://api.rubyonrails.org/classes/ActiveRecord/SecureToken/ClassMethods.html).
+      #
+      # For example, with the following class:
+      #
+      # ~~~rb
+      # class User < ActiveRecord::Base
+      #   has_secure_token
+      #   has_secure_token :auth_token, length: 36
+      # end
+      # ~~~
+      #
+      # this compiler will produce an RBI file with the following content:
+      # ~~~rbi
+      # # typed: true
+      #
+      # class User
+      #   sig { returns(T::Boolean) }
+      #   def regenerate_token; end
+      #
+      #   sig { returns(T::Boolean) }
+      #   def regenerate_auth_token; end
+      # end
+      # ~~~
+      class ActiveRecordSecureToken < Compiler
+        extend T::Sig
+        include Helpers::ActiveRecordConstantsHelper
+
+        ConstantType = type_member { { fixed: T.all(T.class_of(ActiveRecord::Base), Extensions::ActiveRecord) } }
+
+        sig { override.void }
+        def decorate
+          return if constant.__tapioca_secure_tokens.nil?
+
+          root.create_path(constant) do |model|
+            model.create_module(SecureTokensModuleName) do |mod|
+              constant.__tapioca_secure_tokens.each do |attribute|
+                mod.create_method(
+                  "regenerate_#{attribute}",
+                  return_type: "T::Boolean",
+                )
+              end
+            end
+
+            model.create_include(SecureTokensModuleName)
+          end
+        end
+
+        class << self
+          extend T::Sig
+
+          sig { override.returns(T::Enumerable[Module]) }
+          def gather_constants
+            descendants_of(::ActiveRecord::Base).reject(&:abstract_class?)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/tapioca/dsl/extensions/active_record.rb
+++ b/lib/tapioca/dsl/extensions/active_record.rb
@@ -21,6 +21,15 @@ module Tapioca
             super
           end
 
+          attr_reader :__tapioca_secure_tokens
+
+          def has_secure_token(attribute = :token, length: ::ActiveRecord::SecureToken::MINIMUM_TOKEN_LENGTH)
+            @__tapioca_secure_tokens ||= []
+            @__tapioca_secure_tokens << attribute
+
+            super
+          end
+
           ::ActiveRecord::Base.singleton_class.prepend(self)
         end
       end

--- a/lib/tapioca/dsl/helpers/active_record_constants_helper.rb
+++ b/lib/tapioca/dsl/helpers/active_record_constants_helper.rb
@@ -14,6 +14,7 @@ module Tapioca
         AttributeMethodsModuleName = T.let("GeneratedAttributeMethods", String)
         AssociationMethodsModuleName = T.let("GeneratedAssociationMethods", String)
         DelegatedTypesModuleName = T.let("GeneratedDelegatedTypeMethods", String)
+        SecureTokensModuleName = T.let("GeneratedSecureTokenMethods", String)
 
         RelationMethodsModuleName = T.let("GeneratedRelationMethods", String)
         AssociationRelationMethodsModuleName = T.let("GeneratedAssociationRelationMethods", String)

--- a/manual/compiler_activerecordsecuretoken.md
+++ b/manual/compiler_activerecordsecuretoken.md
@@ -1,0 +1,26 @@
+## ActiveRecordSecureToken
+
+`Tapioca::Dsl::Compilers::ActiveModelSecurePassword` decorates RBI files for all
+classes that use [`ActiveRecord::SecureToken`](https://api.rubyonrails.org/classes/ActiveRecord/SecureToken/ClassMethods.html).
+
+For example, with the following class:
+
+~~~rb
+class User < ActiveRecord::Base
+  has_secure_token
+  has_secure_token :auth_token, length: 36
+end
+~~~
+
+this compiler will produce an RBI file with the following content:
+~~~rbi
+# typed: true
+
+class User
+  sig { returns(T::Boolean) }
+  def regenerate_token; end
+
+  sig { returns(T::Boolean) }
+  def regenerate_auth_token; end
+end
+~~~

--- a/manual/compilers.md
+++ b/manual/compilers.md
@@ -16,6 +16,7 @@ In the following section you will find all available DSL compilers:
 * [ActiveRecordFixtures](compiler_activerecordfixtures.md)
 * [ActiveRecordRelations](compiler_activerecordrelations.md)
 * [ActiveRecordScope](compiler_activerecordscope.md)
+* [ActiveRecordSecureToken](compiler_activerecordsecuretoken.md)
 * [ActiveRecordTypedStore](compiler_activerecordtypedstore.md)
 * [ActiveResource](compiler_activeresource.md)
 * [ActiveStorage](compiler_activestorage.md)

--- a/spec/tapioca/cli/dsl_spec.rb
+++ b/spec/tapioca/cli/dsl_spec.rb
@@ -1873,6 +1873,7 @@ module Tapioca
               Tapioca::Dsl::Compilers::ActiveRecordEnum                enabled
               Tapioca::Dsl::Compilers::ActiveRecordRelations           enabled
               Tapioca::Dsl::Compilers::ActiveRecordScope               enabled
+              Tapioca::Dsl::Compilers::ActiveRecordSecureToken         enabled
               Tapioca::Dsl::Compilers::ActiveSupportConcern            enabled
               Tapioca::Dsl::Compilers::ActiveSupportCurrentAttributes  enabled
               Tapioca::Dsl::Compilers::MixedInClassAttributes          enabled
@@ -1902,6 +1903,7 @@ module Tapioca
               Tapioca::Dsl::Compilers::ActiveRecordEnum                disabled
               Tapioca::Dsl::Compilers::ActiveRecordRelations           enabled
               Tapioca::Dsl::Compilers::ActiveRecordScope               enabled
+              Tapioca::Dsl::Compilers::ActiveRecordSecureToken         enabled
               Tapioca::Dsl::Compilers::ActiveSupportConcern            enabled
               Tapioca::Dsl::Compilers::ActiveSupportCurrentAttributes  enabled
               Tapioca::Dsl::Compilers::MixedInClassAttributes          enabled
@@ -1931,6 +1933,7 @@ module Tapioca
               Tapioca::Dsl::Compilers::ActiveRecordEnum                enabled
               Tapioca::Dsl::Compilers::ActiveRecordRelations           disabled
               Tapioca::Dsl::Compilers::ActiveRecordScope               disabled
+              Tapioca::Dsl::Compilers::ActiveRecordSecureToken         disabled
               Tapioca::Dsl::Compilers::ActiveSupportConcern            disabled
               Tapioca::Dsl::Compilers::ActiveSupportCurrentAttributes  disabled
               Tapioca::Dsl::Compilers::MixedInClassAttributes          disabled

--- a/spec/tapioca/dsl/compilers/active_record_secure_token_spec.rb
+++ b/spec/tapioca/dsl/compilers/active_record_secure_token_spec.rb
@@ -1,0 +1,127 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Tapioca
+  module Dsl
+    module Compilers
+      class ActiveRecordSecureTokenSpec < ::DslSpec
+        describe "Tapioca::Dsl::Compilers::ActiveRecordSecureTokenSpec" do
+          sig { void }
+          def before_setup
+            require "tapioca/dsl/extensions/active_record"
+          end
+
+          describe "initialize" do
+            it "gathers no constants if there are no ActiveRecord subclasses" do
+              assert_empty(gathered_constants)
+            end
+
+            it "gathers only ActiveRecord subclasses" do
+              add_ruby_file("user.rb", <<~RUBY)
+                class User
+                end
+
+                class UserRecord < ActiveRecord::Base
+                end
+              RUBY
+
+              assert_equal(["UserRecord"], gathered_constants)
+            end
+          end
+
+          describe "decorate" do
+            it "generates empty RBI file if there are no calls to has_secure_token" do
+              add_ruby_file("user.rb", <<~RUBY)
+                class User < ActiveRecord::Base
+                end
+              RUBY
+
+              expected = <<~RBI
+                # typed: strong
+              RBI
+
+              assert_equal(expected, rbi_for(:User))
+            end
+
+            it "generates default secure password methods" do
+              add_ruby_file("user.rb", <<~RUBY)
+                class User < ActiveRecord::Base
+                  has_secure_token
+                end
+              RUBY
+
+              expected = template(<<~RBI)
+                # typed: strong
+
+                class User
+                  include GeneratedSecureTokenMethods
+
+                  module GeneratedSecureTokenMethods
+                    sig { returns(T::Boolean) }
+                    def regenerate_token; end
+                  end
+                end
+              RBI
+
+              assert_equal(expected, rbi_for(:User))
+            end
+
+            it "generates custom secure password methods" do
+              add_ruby_file("user.rb", <<~RUBY)
+                class User < ActiveRecord::Base
+
+                  has_secure_token :auth_token
+                end
+              RUBY
+
+              expected = template(<<~RBI)
+                # typed: strong
+
+                class User
+                  include GeneratedSecureTokenMethods
+
+                  module GeneratedSecureTokenMethods
+                    sig { returns(T::Boolean) }
+                    def regenerate_auth_token; end
+                  end
+                end
+              RBI
+
+              assert_equal(expected, rbi_for(:User))
+            end
+
+            it "generates multiple secure token methods" do
+              add_ruby_file("user.rb", <<~RUBY)
+                class User < ActiveRecord::Base
+
+                  has_secure_token :auth_token
+                  has_secure_token
+                end
+              RUBY
+
+              expected = template(<<~RBI)
+                # typed: strong
+
+                class User
+                  include GeneratedSecureTokenMethods
+
+                  module GeneratedSecureTokenMethods
+                    sig { returns(T::Boolean) }
+                    def regenerate_auth_token; end
+
+                    sig { returns(T::Boolean) }
+                    def regenerate_token; end
+                  end
+                end
+              RBI
+
+              assert_equal(expected, rbi_for(:User))
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Motivation
Found myself having to write a couple of shims for this, so here's a small compiler for https://api.rubyonrails.org/classes/ActiveRecord/SecureToken/ClassMethods.html which was added in Rails 5.

![It ain't much but it's honest work.](https://i.kym-cdn.com/entries/icons/original/000/028/021/work.jpg)

### Implementation
Used the same extension used for delegated types.

### Tests
Added tests
