### PR TITLE
Fix CI flakyness with respect to `Bundler`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,8 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
+      - name: Install latest Bundler version
+        run: gem install bundler
       - name: Run tests
         run: bin/test
         continue-on-error: ${{ !!matrix.experimental }}

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -393,4 +393,4 @@ DEPENDENCIES
   xpath
 
 BUNDLED WITH
-   2.3.23
+   2.3.26


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
As mentioned in #1306, we'd been observing some tests failures with message `rubygems/specification.rb:2121:in 'method_missing': undefined method 'identifier' for #<Gem::Specification:0x0000562ed629c100> (NoMethodError)`. We investigated this with @Morriar and were not able to reproduce the error locally or on Spin however hard we've tried.

What does not make sense about the whole thing is that at that point in the code where the failures always happen, there shouldn't be any instances of `Gem::Specification` anywhere, all entries should be `Bundler::StubSpecification` instances. So the error is quite unexpected.

We ultimately noticed 2 important things about our CI:
1. Our CI runs for non-main `Gemfile`s do not install a recent enough Bundler version. Since there is no lockfile associated with those gemfiles, Ruby setup does not know which Bundler version was used to create a lockfile, so just uses the Bundler that comes with Ruby. This has the possibility to make our tests non-deterministic.
2. Our main lockfile was locked to a slightly older Bundler version. This might have meant that we were running into an edge case on that version.

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->

The implementation in this PR addresses the 2 points above:
1. We have a new step for every test job that installs the latest Bundler version possible. This ensures that the test runs are more deterministic, at least.
2. We've update the lockfile to be bundled with `2.3.26` instead of `2.3.23`.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->
Ran the test suite 10 times on this branch and the only failures that we are observing is the other issue about `PP::ObjectMixin`, so we are pretty confident the Bundler issue is resolved with these changes.
