### PR TITLE
Support Rails 6.0 which has no `SignedId` class defined

### DIFF
--- a/lib/tapioca/dsl/compilers/active_record_relations.rb
+++ b/lib/tapioca/dsl/compilers/active_record_relations.rb
@@ -217,7 +217,10 @@ module Tapioca
           T::Array[Symbol],
         )
         FINDER_METHODS = T.let(ActiveRecord::FinderMethods.instance_methods(false), T::Array[Symbol])
-        SIGNED_FINDER_METHODS = T.let(ActiveRecord::SignedId::ClassMethods.instance_methods(false), T::Array[Symbol])
+        SIGNED_FINDER_METHODS = T.let(
+          defined?(ActiveRecord::SignedId) ? ActiveRecord::SignedId::ClassMethods.instance_methods(false) : [],
+          T::Array[Symbol],
+        )
         CALCULATION_METHODS = T.let(ActiveRecord::Calculations.instance_methods(false), T::Array[Symbol])
         ENUMERABLE_QUERY_METHODS = T.let([:any?, :many?, :none?, :one?], T::Array[Symbol])
         FIND_OR_CREATE_METHODS = T.let(


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
Fixes #1324 

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
By making sure that the `SignedId` class is defined, we can support Rails 6.0 and not try to generate any signed id finder methods.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->
No tests added since we don't test against Rails 6.0. This is a best-effort support for that Rails version with minimal code changes.
