### PR TITLE
Add types for postgres hstore & arrays

### DIFF
--- a/sorbet/rbi/shims/activerecord_postgresql.rbi
+++ b/sorbet/rbi/shims/activerecord_postgresql.rbi
@@ -1,0 +1,5 @@
+# typed: strict
+
+# These constants are dynamically loaded only when connecting to postgresql
+module ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Array; end
+module ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Hstore; end


### PR DESCRIPTION
A new PR for https://github.com/Shopify/tapioca/pull/1268 because I don't have push permissions to the fork.

### Motivation
When using an hstore column in postgres, tapioca generates "T.untyped". Both keys and values in hstore are strings.

### Implementation
Added a case for hstore to the existing case statement.

### Tests
Testing this is hard because we can't use postgres columns with sqlite. Open to other testing suggestions