### PR TITLE
Ensure that trackers stay enabled until after `gem` command is run

### DIFF
--- a/lib/tapioca/cli.rb
+++ b/lib/tapioca/cli.rb
@@ -25,9 +25,12 @@ module Tapioca
 
     desc "init", "get project ready for type checking"
     def init
-      invoke(:configure)
-      invoke(:annotations)
-      invoke(:gem)
+      # We need to make sure that trackers stay enabled until the `gem` command is invoked
+      Runtime::Trackers.with_trackers_enabled do
+        invoke(:configure)
+        invoke(:annotations)
+        invoke(:gem)
+      end
       invoke(:todo)
 
       print_init_next_steps

--- a/lib/tapioca/runtime/trackers.rb
+++ b/lib/tapioca/runtime/trackers.rb
@@ -13,6 +13,23 @@ module Tapioca
       class << self
         extend T::Sig
 
+        sig do
+          type_parameters(:Return)
+            .params(blk: T.proc.returns(T.type_parameter(:Return)))
+            .returns(T.type_parameter(:Return))
+        end
+        def with_trackers_enabled(&blk)
+          # Currently this is a dirty hack to ensure disabling trackers
+          # doesn't work while in the block passed to this method.
+          disable_all_method = method(:disable_all!)
+          define_singleton_method(:disable_all!) {}
+          blk.call
+        ensure
+          if disable_all_method
+            define_singleton_method(:disable_all!, disable_all_method)
+          end
+        end
+
         sig { void }
         def disable_all!
           @trackers.each(&:disable!)


### PR DESCRIPTION

### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
Fixes #1325

Since all commands other than `gem` and `dsl` commands now inherit from `CommandWithoutTracker`, as soon as we invoke the `configure` command inside `init`, we ended up disabling the trackers. This meant that by the time the `gem` command got to run, the trackers were already disabled and that we generated the RBIs with missing information.

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
The fix is to create a block in which trackers can't be disabled and using that up to and past the point where the `gem` command is run.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->
No additional tests, since it is quite time consuming to test the `init` command. Ultimately, we should find a way around that.

I did top-hat this in a fresh Rails app though and it works as expected, whereas it was broken before.
