### PR TITLE
Stop marking Ruby 3.2 test suite experimental

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,8 +42,6 @@ jobs:
         include:
           - gemfile: gemfiles/Gemfile-rails-main
             experimental: true
-          - ruby: "3.2"
-            experimental: true
     name: Ruby ${{ matrix.ruby }} - ${{ matrix.gemfile }}
     env:
       BUNDLE_GEMFILE: ${{ matrix.gemfile }}


### PR DESCRIPTION
Now that Ruby 3.2 is officially released and our tests are passing with it, we shouldn't need to mark it as experimental.
