### PR TITLE
Check-shims should not error with different superclasses

### DIFF
--- a/lib/tapioca/helpers/rbi_files_helper.rb
+++ b/lib/tapioca/helpers/rbi_files_helper.rb
@@ -175,7 +175,15 @@ module Tapioca
       return false if shims_or_todos.empty?
 
       shims_or_todos_empty_scopes = extract_empty_scopes(shims_or_todos)
-      return true unless shims_or_todos_empty_scopes.empty?
+      shims_or_todos_empty_scopes.each do |shim_or_todo|
+        return true unless shim_or_todo.is_a?(RBI::Class)
+
+        nodes.each do |node|
+          return true unless node.is_a?(RBI::Class)
+          next if node == shim_or_todo
+          return true if node.superclass_name == shim_or_todo.superclass_name
+        end
+      end
 
       mixins = extract_mixins(shims_or_todos)
       return true unless mixins.empty?


### PR DESCRIPTION
### Motivation
While looking at https://github.com/Shopify/rbi-central/pull/143 I noticed check-shims command doesn't take the superclass information into account.

### Implementation
Compare `superclass_name` fields if we are dealing with empty `RBI::Class` nodes. If the node isn't an empty `RBI::Scope` then we continue to check the body for duplicates.

### Tests
Added.

