### PR TITLE
ignore tmp directory when initializing sorbet config

### DIFF
--- a/lib/tapioca/commands/configure.rb
+++ b/lib/tapioca/commands/configure.rb
@@ -41,6 +41,7 @@ module Tapioca
         create_file(@sorbet_config, <<~CONTENT, skip: true, force: false)
           --dir
           .
+          --ignore=tmp/
           --ignore=vendor/
         CONTENT
       end


### PR DESCRIPTION
### Motivation

- Potentially speed up `dev tc` on local envs which can accumulate alot of stuff in tmp
- Avoid random errors from `tmp` directory

For https://github.com/Shopify/shopify/pull/399463


