### PR TITLE
ActionControllerHelpers DSL compiler should not call `name` directly

### DIFF
--- a/lib/tapioca/dsl/compilers/action_controller_helpers.rb
+++ b/lib/tapioca/dsl/compilers/action_controller_helpers.rb
@@ -156,7 +156,7 @@ module Tapioca
         sig { params(mod: Module).returns(T::Array[String]) }
         def gather_includes(mod)
           mod.ancestors
-            .reject { |ancestor| ancestor.is_a?(Class) || ancestor == mod || ancestor.name.nil? }
+            .reject { |ancestor| ancestor.is_a?(Class) || ancestor == mod || name_of(ancestor).nil? }
             .map { |ancestor| T.must(qualified_name_of(ancestor)) }
             .reverse
         end


### PR DESCRIPTION
### Motivation

Avoid crashing if the ActionController helper redefines the `name` method.

Here's an example doing so: https://github.com/ViewComponent/lookbook/blob/daa8c903a34e0f051f6f40907ab583478e5959f4/lib/lookbook/support/utils/utils.rb#L10.

### Implementation

We can use our own helper `name_of` to get the same information without crashing.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->

See included test.
