### PR TITLE
Teach ActiveRecordColumns compiler about virtual attributes

### DIFF
--- a/lib/tapioca/dsl/compilers/active_record_columns.rb
+++ b/lib/tapioca/dsl/compilers/active_record_columns.rb
@@ -16,7 +16,8 @@ module Tapioca
       # `Tapioca::Dsl::Compilers::ActiveRecordColumns` refines RBI files for subclasses of
       # [`ActiveRecord::Base`](https://api.rubyonrails.org/classes/ActiveRecord/Base.html).
       # This compiler is only responsible for defining the attribute methods that would be
-      # created for the columns that are defined in the Active Record model.
+      # created for columns and virtual attributes that are defined in the Active Record
+      # model.
       #
       # For example, with the following model class:
       # ~~~rb
@@ -109,8 +110,7 @@ module Tapioca
 
           root.create_path(constant) do |model|
             model.create_module(AttributeMethodsModuleName) do |mod|
-              constant.columns_hash.each_key do |column_name|
-                column_name = column_name.to_s
+              constant.attribute_names.each do |column_name|
                 add_methods_for_attribute(mod, column_name)
               end
 

--- a/manual/compiler_activerecordcolumns.md
+++ b/manual/compiler_activerecordcolumns.md
@@ -3,7 +3,8 @@
 `Tapioca::Dsl::Compilers::ActiveRecordColumns` refines RBI files for subclasses of
 [`ActiveRecord::Base`](https://api.rubyonrails.org/classes/ActiveRecord/Base.html).
 This compiler is only responsible for defining the attribute methods that would be
-created for the columns that are defined in the Active Record model.
+created for columns and virtual attributes that are defined in the Active Record
+model.
 
 For example, with the following model class:
 ~~~rb

--- a/spec/tapioca/dsl/compilers/active_record_columns_spec.rb
+++ b/spec/tapioca/dsl/compilers/active_record_columns_spec.rb
@@ -663,6 +663,94 @@ module Tapioca
                 assert_includes(output, expected)
               end
 
+              it "generates methods for virtual attributes" do
+                add_ruby_file("schema.rb", <<~RUBY)
+                  ActiveRecord::Migration.suppress_messages do
+                    ActiveRecord::Schema.define do
+                      create_table :posts do |t|
+                      end
+                    end
+                  end
+                RUBY
+
+                add_ruby_file("post.rb", <<~RUBY)
+                  class Post < ActiveRecord::Base
+                    attribute :publication_date, :date
+                  end
+                RUBY
+
+                output = rbi_for(:Post)
+
+                expected = indented(<<~RBI, 4)
+                  sig { returns(::Date) }
+                  def publication_date; end
+
+                  sig { params(value: ::Date).returns(::Date) }
+                  def publication_date=(value); end
+
+                  sig { returns(T::Boolean) }
+                  def publication_date?; end
+
+                  sig { returns(T.nilable(::Date)) }
+                  def publication_date_before_last_save; end
+
+                  sig { returns(T.untyped) }
+                  def publication_date_before_type_cast; end
+
+                  sig { returns(T::Boolean) }
+                  def publication_date_came_from_user?; end
+
+                  sig { returns(T.nilable([::Date, ::Date])) }
+                  def publication_date_change; end
+
+                  sig { returns(T.nilable([::Date, ::Date])) }
+                  def publication_date_change_to_be_saved; end
+
+                  sig { returns(T::Boolean) }
+                  def publication_date_changed?; end
+
+                  sig { returns(T.nilable(::Date)) }
+                  def publication_date_in_database; end
+
+                  sig { returns(T.nilable([::Date, ::Date])) }
+                  def publication_date_previous_change; end
+
+                  sig { returns(T::Boolean) }
+                  def publication_date_previously_changed?; end
+
+                  sig { returns(T.nilable(::Date)) }
+                  def publication_date_previously_was; end
+
+                  sig { returns(T.nilable(::Date)) }
+                  def publication_date_was; end
+
+                  sig { void }
+                  def publication_date_will_change!; end
+                RBI
+                assert_includes(output, expected)
+
+                expected = indented(<<~RBI, 4)
+                  sig { void }
+                  def restore_publication_date!; end
+                RBI
+                assert_includes(output, expected)
+
+                expected = indented(<<~RBI, 4)
+                  sig { returns(T.nilable([::Date, ::Date])) }
+                  def saved_change_to_publication_date; end
+
+                  sig { returns(T::Boolean) }
+                  def saved_change_to_publication_date?; end
+                RBI
+                assert_includes(output, expected)
+
+                expected = indented(<<~RBI, 4)
+                  sig { returns(T::Boolean) }
+                  def will_save_change_to_publication_date?; end
+                RBI
+                assert_includes(output, expected)
+              end
+
               it "discovers custom type from signature on deserialize method" do
                 add_ruby_file("schema.rb", <<~RUBY)
                   ActiveRecord::Migration.suppress_messages do


### PR DESCRIPTION
### Motivation
Closes https://github.com/Shopify/tapioca/issues/1351

### Implementation
`_default_attributes` contains the contents of `columns_hash` and virtual attributes, see
- https://github.com/rails/rails/blob/v7.0.4/activerecord/lib/active_record/model_schema.rb#L486-L489
- https://github.com/rails/rails/blob/v7.0.4/activerecord/lib/active_record/attributes.rb#L288

### Tests
Test added.

