### PR TITLE
Stop regenerating all value constants for reopened types

### DIFF
--- a/spec/tapioca/gem/pipeline_spec.rb
+++ b/spec/tapioca/gem/pipeline_spec.rb
@@ -3639,7 +3639,7 @@ class Tapioca::Gem::PipelineSpec < Minitest::HooksSpec
       assert_equal(output, compile)
     end
 
-    it "handles class_env created classes and modules" do
+    it "handles class_eval created classes and modules" do
       add_ruby_file("container.rb", <<~RUBY)
         class Container
           class_eval <<~EOF
@@ -3651,12 +3651,18 @@ class Tapioca::Gem::PipelineSpec < Minitest::HooksSpec
 
             Bar = 42
           EOF
+
+          class_eval <<~EOF, __FILE__, __LINE__ + 1
+            class Baz
+            end
+          EOF
         end
       RUBY
 
       output = template(<<~RBI)
         class Container; end
         Container::Bar = T.let(T.unsafe(nil), Integer)
+        class Container::Baz; end
         class Container::FooClass; end
         module Container::FooModule; end
       RBI


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
Fixes #1326 

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
When we are generating value constants (i.e. constants that have a value that is not a module), we didn't have a good way to filter them based on where they were defined, since we couldn't ask them before.

However, since Ruby 2.7, we have access to `const_source_location` so we can check to see if a value constant has been defined by the current gem or not. So the implementation uses that.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->
Updated existing tests to test for this specific case where the `bar` gem is reopening a constant defined by the `foo` gem and adds a value constant under it. The expectation is that only the subconstant added in `bar` gem is generated in `bar.rbi` and none of the other subconstants defined in `foo`.

I also tested this against Core and it works without problems (and gets rid of a lot of unnecessary constant definitions on gem RBI files).