### PR TITLE
Refactor AR relations compiler to pass less parameters around

### DIFF
--- a/lib/tapioca/rbi_ext/model.rb
+++ b/lib/tapioca/rbi_ext/model.rb
@@ -5,7 +5,7 @@ module RBI
   class Tree
     extend T::Sig
 
-    sig { params(constant: ::Module, block: T.nilable(T.proc.params(scope: Scope).void)).void }
+    sig { params(constant: ::Module, block: T.nilable(T.proc.params(scope: Scope).void)).returns(Scope) }
     def create_path(constant, &block)
       constant_name = Tapioca::Runtime::Reflection.name_of(constant)
       raise "given constant does not have a name" unless constant_name

--- a/sorbet/rbi/gems/rbi@0.0.16.rbi
+++ b/sorbet/rbi/gems/rbi@0.0.16.rbi
@@ -13,7 +13,7 @@ module RBI; end
 class RBI::ASTVisitor
   abstract!
 
-  # source://sorbet-runtime/0.5.10572/lib/types/private/abstract/declare.rb#37
+  # source://sorbet-runtime/0.5.10634/lib/types/private/abstract/declare.rb#37
   def initialize(*args, **_arg1, &blk); end
 
   # @abstract
@@ -1761,7 +1761,7 @@ class RBI::Rewriters::Merge::Conflict < ::T::Struct
   def to_s; end
 
   class << self
-    # source://sorbet-runtime/0.5.10572/lib/types/struct.rb#13
+    # source://sorbet-runtime/0.5.10634/lib/types/struct.rb#13
     def inherited(s); end
   end
 end
@@ -1978,7 +1978,7 @@ class RBI::Rewriters::RemoveKnownDefinitions::Operation < ::T::Struct
   def to_s; end
 
   class << self
-    # source://sorbet-runtime/0.5.10572/lib/types/struct.rb#13
+    # source://sorbet-runtime/0.5.10634/lib/types/struct.rb#13
     def inherited(s); end
   end
 end
@@ -2018,7 +2018,7 @@ class RBI::Scope < ::RBI::Tree
 
   abstract!
 
-  # source://sorbet-runtime/0.5.10572/lib/types/private/abstract/declare.rb#37
+  # source://sorbet-runtime/0.5.10634/lib/types/private/abstract/declare.rb#37
   def initialize(*args, **_arg1, &blk); end
 
   # source://rbi//lib/rbi/printer.rb#240
@@ -2644,7 +2644,7 @@ class RBI::Tree < ::RBI::NodeWithComments
   sig { params(annotation: ::String, annotate_scopes: T::Boolean, annotate_properties: T::Boolean).void }
   def annotate!(annotation, annotate_scopes: T.unsafe(nil), annotate_properties: T.unsafe(nil)); end
 
-  # source://tapioca/0.10.3/lib/tapioca/rbi_ext/model.rb#38
+  # source://tapioca/0.10.5/lib/tapioca/rbi_ext/model.rb#38
   sig do
     params(
       name: ::String,
@@ -2654,19 +2654,19 @@ class RBI::Tree < ::RBI::NodeWithComments
   end
   def create_class(name, superclass_name: T.unsafe(nil), &block); end
 
-  # source://tapioca/0.10.3/lib/tapioca/rbi_ext/model.rb#45
+  # source://tapioca/0.10.5/lib/tapioca/rbi_ext/model.rb#45
   sig { params(name: ::String, value: ::String).void }
   def create_constant(name, value:); end
 
-  # source://tapioca/0.10.3/lib/tapioca/rbi_ext/model.rb#55
+  # source://tapioca/0.10.5/lib/tapioca/rbi_ext/model.rb#55
   sig { params(name: ::String).void }
   def create_extend(name); end
 
-  # source://tapioca/0.10.3/lib/tapioca/rbi_ext/model.rb#50
+  # source://tapioca/0.10.5/lib/tapioca/rbi_ext/model.rb#50
   sig { params(name: ::String).void }
   def create_include(name); end
 
-  # source://tapioca/0.10.3/lib/tapioca/rbi_ext/model.rb#89
+  # source://tapioca/0.10.5/lib/tapioca/rbi_ext/model.rb#89
   sig do
     params(
       name: ::String,
@@ -2679,19 +2679,19 @@ class RBI::Tree < ::RBI::NodeWithComments
   end
   def create_method(name, parameters: T.unsafe(nil), return_type: T.unsafe(nil), class_method: T.unsafe(nil), visibility: T.unsafe(nil), comments: T.unsafe(nil)); end
 
-  # source://tapioca/0.10.3/lib/tapioca/rbi_ext/model.rb#60
+  # source://tapioca/0.10.5/lib/tapioca/rbi_ext/model.rb#60
   sig { params(name: ::String).void }
   def create_mixes_in_class_methods(name); end
 
-  # source://tapioca/0.10.3/lib/tapioca/rbi_ext/model.rb#25
+  # source://tapioca/0.10.5/lib/tapioca/rbi_ext/model.rb#25
   sig { params(name: ::String, block: T.nilable(T.proc.params(scope: ::RBI::Scope).void)).returns(::RBI::Scope) }
   def create_module(name, &block); end
 
-  # source://tapioca/0.10.3/lib/tapioca/rbi_ext/model.rb#9
-  sig { params(constant: ::Module, block: T.nilable(T.proc.params(scope: ::RBI::Scope).void)).void }
+  # source://tapioca/0.10.5/lib/tapioca/rbi_ext/model.rb#9
+  sig { params(constant: ::Module, block: T.nilable(T.proc.params(scope: ::RBI::Scope).void)).returns(::RBI::Scope) }
   def create_path(constant, &block); end
 
-  # source://tapioca/0.10.3/lib/tapioca/rbi_ext/model.rb#74
+  # source://tapioca/0.10.5/lib/tapioca/rbi_ext/model.rb#74
   sig do
     params(
       name: ::String,
@@ -2753,11 +2753,11 @@ class RBI::Tree < ::RBI::NodeWithComments
 
   private
 
-  # source://tapioca/0.10.3/lib/tapioca/rbi_ext/model.rb#111
+  # source://tapioca/0.10.5/lib/tapioca/rbi_ext/model.rb#116
   sig { params(node: ::RBI::Node).returns(::RBI::Node) }
   def create_node(node); end
 
-  # source://tapioca/0.10.3/lib/tapioca/rbi_ext/model.rb#106
+  # source://tapioca/0.10.5/lib/tapioca/rbi_ext/model.rb#111
   sig { returns(T::Hash[::String, ::RBI::Node]) }
   def nodes_cache; end
 end
@@ -2993,7 +2993,7 @@ end
 class RBI::Visitor
   abstract!
 
-  # source://sorbet-runtime/0.5.10572/lib/types/private/abstract/declare.rb#37
+  # source://sorbet-runtime/0.5.10634/lib/types/private/abstract/declare.rb#37
   def initialize(*args, **_arg1, &blk); end
 
   # @abstract


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
Relying on lazily evaluated instance variables instead of passing around initialized module scopes makes the code much more readable and easier to understand.

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
Simple refactor.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->
No added tests.
