### PR TITLE
Add global callbacks to AASM compiler

### DIFF
--- a/lib/tapioca/dsl/compilers/aasm.rb
+++ b/lib/tapioca/dsl/compilers/aasm.rb
@@ -58,6 +58,22 @@ module Tapioca
             T::Array[String],
           )
 
+        # Taken directly from the AASM::Base class, here:
+        # https://github.com/aasm/aasm/blob/0e03746a2b86558ee1bf7bd7db873938cbb3b29b/lib/aasm/base.rb#L145-L171
+        GLOBAL_CALLBACKS =
+          T.let(
+            [
+              "after_all_transitions",
+              "after_all_transactions",
+              "before_all_transactions",
+              "before_all_events",
+              "after_all_events",
+              "error_on_all_events",
+              "ensure_on_all_events",
+            ].freeze,
+            T::Array[String],
+          )
+
         ConstantType = type_member { { fixed: T.all(::AASM::ClassMethods, Class) } }
 
         sig { override.void }
@@ -129,6 +145,16 @@ module Tapioca
                   create_block_param("block", type: "T.proc.bind(PrivateAASMEvent).void"),
                 ],
               )
+
+              GLOBAL_CALLBACKS.each do |method|
+                machine.create_method(
+                  method,
+                  parameters: [
+                    create_opt_param("symbol", type: "T.nilable(Symbol)", default: "nil"),
+                    create_block_param("block", type: "T.nilable(T.proc.bind(#{name_of(constant)}).void)"),
+                  ],
+                )
+              end
 
               # Create a private event class that we can pass around for the
               # purpose of binding all of the callbacks without having to

--- a/spec/tapioca/dsl/compilers/aasm_spec.rb
+++ b/spec/tapioca/dsl/compilers/aasm_spec.rb
@@ -94,6 +94,27 @@ module Tapioca
                   end
 
                   class PrivateAASMMachine < AASM::Base
+                    sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
+                    def after_all_events(symbol = nil, &block); end
+
+                    sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
+                    def after_all_transactions(symbol = nil, &block); end
+
+                    sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
+                    def after_all_transitions(symbol = nil, &block); end
+
+                    sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
+                    def before_all_events(symbol = nil, &block); end
+
+                    sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
+                    def before_all_transactions(symbol = nil, &block); end
+
+                    sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
+                    def ensure_on_all_events(symbol = nil, &block); end
+
+                    sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
+                    def error_on_all_events(symbol = nil, &block); end
+
                     sig { params(name: T.untyped, options: T.untyped, block: T.proc.bind(PrivateAASMEvent).void).returns(T.untyped) }
                     def event(name, options = nil, &block); end
 
@@ -197,6 +218,27 @@ module Tapioca
                   end
 
                   class PrivateAASMMachine < AASM::Base
+                    sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
+                    def after_all_events(symbol = nil, &block); end
+
+                    sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
+                    def after_all_transactions(symbol = nil, &block); end
+
+                    sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
+                    def after_all_transitions(symbol = nil, &block); end
+
+                    sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
+                    def before_all_events(symbol = nil, &block); end
+
+                    sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
+                    def before_all_transactions(symbol = nil, &block); end
+
+                    sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
+                    def ensure_on_all_events(symbol = nil, &block); end
+
+                    sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
+                    def error_on_all_events(symbol = nil, &block); end
+
                     sig { params(name: T.untyped, options: T.untyped, block: T.proc.bind(PrivateAASMEvent).void).returns(T.untyped) }
                     def event(name, options = nil, &block); end
 
@@ -303,6 +345,27 @@ module Tapioca
                   end
 
                   class PrivateAASMMachine < AASM::Base
+                    sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
+                    def after_all_events(symbol = nil, &block); end
+
+                    sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
+                    def after_all_transactions(symbol = nil, &block); end
+
+                    sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
+                    def after_all_transitions(symbol = nil, &block); end
+
+                    sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
+                    def before_all_events(symbol = nil, &block); end
+
+                    sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
+                    def before_all_transactions(symbol = nil, &block); end
+
+                    sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
+                    def ensure_on_all_events(symbol = nil, &block); end
+
+                    sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
+                    def error_on_all_events(symbol = nil, &block); end
+
                     sig { params(name: T.untyped, options: T.untyped, block: T.proc.bind(PrivateAASMEvent).void).returns(T.untyped) }
                     def event(name, options = nil, &block); end
 


### PR DESCRIPTION
### Motivation
AASM state machines allow registering global callbacks like after_all_transitions, before_all_transactions, and so on. They accept a block that runs in the context of the record. The gem compiler creates these callbacks, but the block is of course bound to T.untyped. This requires the application code to always include a cast in global callback blocks.

### Implementation
This change extends the AASM compiler to also generate the global callbacks (in addition to the event callbacks it already generates). Since the resulting methods are typed with blocks bound to the record class, the correct type appears in application code.

### Tests
I updated the existing AASM spec to expect the global callbacks to be generated with the correct types.
