### PR TITLE
Continue to support `pry`

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,6 +14,7 @@ require "tapioca/helpers/test/isolation"
 require "spec_reporter"
 require "dsl_spec_helper"
 require "spec_with_project"
+require "pry"
 
 backtrace_filter = Minitest::ExtensibleBacktraceFilter.default_filter
 backtrace_filter.add_filter(%r{gems/sorbet-runtime})


### PR DESCRIPTION
### Motivation

After some internal discussion, we will continue to support `pry`, but not `pry-byebug`.

