### PR TITLE
More accurately type ActiveRecordRelations calculation methods

### DIFF
--- a/lib/tapioca/dsl/helpers/active_record_constants_helper.rb
+++ b/lib/tapioca/dsl/helpers/active_record_constants_helper.rb
@@ -22,8 +22,10 @@ module Tapioca
         CommonRelationMethodsModuleName = T.let("CommonRelationMethods", String)
 
         RelationClassName = T.let("PrivateRelation", String)
+        RelationGroupChainClassName = T.let("PrivateRelationGroupChain", String)
         RelationWhereChainClassName = T.let("PrivateRelationWhereChain", String)
         AssociationRelationClassName = T.let("PrivateAssociationRelation", String)
+        AssociationRelationGroupChainClassName = T.let("PrivateAssociationRelationGroupChain", String)
         AssociationRelationWhereChainClassName = T.let("PrivateAssociationRelationWhereChain", String)
         AssociationsCollectionProxyClassName = T.let("PrivateCollectionProxy", String)
       end

--- a/spec/tapioca/dsl/compilers/active_record_relations_spec.rb
+++ b/spec/tapioca/dsl/compilers/active_record_relations_spec.rb
@@ -69,16 +69,16 @@ module Tapioca
                     sig { params(block: T.nilable(T.proc.params(record: ::Post).returns(T.untyped))).returns(T::Boolean) }
                     def any?(&block); end
 
-                    sig { params(column_name: T.any(String, Symbol)).returns(T.untyped) }
+                    sig { params(column_name: T.any(String, Symbol)).returns(Numeric) }
                     def average(column_name); end
 
                     sig { params(attributes: T.untyped, block: T.nilable(T.proc.params(object: ::Post).void)).returns(::Post) }
                     def build(attributes = nil, &block); end
 
-                    sig { params(operation: Symbol, column_name: T.any(String, Symbol)).returns(T.untyped) }
+                    sig { params(operation: Symbol, column_name: T.any(String, Symbol)).returns(Numeric) }
                     def calculate(operation, column_name); end
 
-                    sig { params(column_name: T.untyped).returns(T.untyped) }
+                    sig { params(column_name: T.untyped).returns(Integer) }
                     def count(column_name = nil); end
 
                     sig { params(attributes: T.untyped, block: T.nilable(T.proc.params(object: ::Post).void)).returns(::Post) }
@@ -229,7 +229,7 @@ module Tapioca
                     def sole; end
 
                 <% end %>
-                    sig { params(column_name: T.nilable(T.any(String, Symbol)), block: T.nilable(T.proc.params(record: T.untyped).returns(T.untyped))).returns(T.untyped) }
+                    sig { params(column_name: T.nilable(T.any(String, Symbol)), block: T.nilable(T.proc.params(record: T.untyped).returns(T.untyped))).returns(Numeric) }
                     def sum(column_name = nil, &block); end
 
                     sig { params(limit: NilClass).returns(T.nilable(::Post)) }
@@ -288,7 +288,7 @@ module Tapioca
                     sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
                     def from(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
+                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelationGroupChain) }
                     def group(*args, &blk); end
 
                     sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
@@ -459,7 +459,7 @@ module Tapioca
                     sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
                     def from(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
+                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelationGroupChain) }
                     def group(*args, &blk); end
 
                     sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
@@ -589,6 +589,31 @@ module Tapioca
                     def to_ary; end
                   end
 
+                  class PrivateAssociationRelationGroupChain < PrivateAssociationRelation
+                    Elem = type_member { { fixed: ::Post } }
+
+                    sig { params(column_name: T.any(String, Symbol)).returns(T::Hash[T.untyped, Numeric]) }
+                    def average(column_name); end
+
+                    sig { params(operation: Symbol, column_name: T.any(String, Symbol)).returns(T::Hash[T.untyped, Numeric]) }
+                    def calculate(operation, column_name); end
+
+                    sig { params(column_name: T.untyped).returns(T::Hash[T.untyped, Integer]) }
+                    def count(column_name = nil); end
+
+                    sig { params(args: T.untyped, blk: T.untyped).returns(T.self_type) }
+                    def having(*args, &blk); end
+
+                    sig { params(column_name: T.any(String, Symbol)).returns(T::Hash[T.untyped, T.untyped]) }
+                    def maximum(column_name); end
+
+                    sig { params(column_name: T.any(String, Symbol)).returns(T::Hash[T.untyped, T.untyped]) }
+                    def minimum(column_name); end
+
+                    sig { params(column_name: T.nilable(T.any(String, Symbol)), block: T.nilable(T.proc.params(record: T.untyped).returns(T.untyped))).returns(T::Hash[T.untyped, Numeric]) }
+                    def sum(column_name = nil, &block); end
+                  end
+
                   class PrivateAssociationRelationWhereChain < PrivateAssociationRelation
                     Elem = type_member { { fixed: ::Post } }
 
@@ -664,6 +689,31 @@ module Tapioca
 
                     sig { returns(T::Array[::Post]) }
                     def to_ary; end
+                  end
+
+                  class PrivateRelationGroupChain < PrivateRelation
+                    Elem = type_member { { fixed: ::Post } }
+
+                    sig { params(column_name: T.any(String, Symbol)).returns(T::Hash[T.untyped, Numeric]) }
+                    def average(column_name); end
+
+                    sig { params(operation: Symbol, column_name: T.any(String, Symbol)).returns(T::Hash[T.untyped, Numeric]) }
+                    def calculate(operation, column_name); end
+
+                    sig { params(column_name: T.untyped).returns(T::Hash[T.untyped, Integer]) }
+                    def count(column_name = nil); end
+
+                    sig { params(args: T.untyped, blk: T.untyped).returns(T.self_type) }
+                    def having(*args, &blk); end
+
+                    sig { params(column_name: T.any(String, Symbol)).returns(T::Hash[T.untyped, T.untyped]) }
+                    def maximum(column_name); end
+
+                    sig { params(column_name: T.any(String, Symbol)).returns(T::Hash[T.untyped, T.untyped]) }
+                    def minimum(column_name); end
+
+                    sig { params(column_name: T.nilable(T.any(String, Symbol)), block: T.nilable(T.proc.params(record: T.untyped).returns(T.untyped))).returns(T::Hash[T.untyped, Numeric]) }
+                    def sum(column_name = nil, &block); end
                   end
 
                   class PrivateRelationWhereChain < PrivateRelation


### PR DESCRIPTION
### Motivation

Currently the calculation methods like `sum` and `count` return `T.untyped`. For some methods we cannot know the type (e.g. `minimum`) but for others we at least know it's numeric (e.g. `sum`) and for `count` we know it's an Integer.

However, I'm assuming these are untyped because if they're used with `group` the return value is actually a hash where the keys cannot be typed but the values will be the types mentioned above. This PR updates the `ActiveRecordRelations` compiler to type these correctly.

### Implementation

I first updated the return values of the calculation methods where possible. Then I largely copied from the code around `PrivateRelationWhereChain` to add a `PrivateRelationGroupChain` module which defines the calculation methods with the hash return values.

Some callouts:
- Unlike "WhereChain", there's no such analogous `GroupChain` runtime class available so this is solely made for RBI. From looking at the source it looks like when a query uses `group` some metadata is added to it.
- Technically a `group` anywhere in the query chain produces this behavior but to avoid needing to re-type every query method inside this module we make a simplifying assumption that the calculation method is called immediately after the group (e.g. `group().count` and not `group().where().count`). The one exception is `group().having().count` which is fairly idiomatic so that gets handled without breaking the chain.

### Tests

Updated the existing specs.