### PR TITLE
protobuf: Handle AbstractMessage descendants

### DIFF
--- a/lib/tapioca/dsl/compilers/protobuf.rb
+++ b/lib/tapioca/dsl/compilers/protobuf.rb
@@ -145,7 +145,9 @@ module Tapioca
                   klass.create_method("initialize", parameters: [kwargs_parameter], return_type: "void")
                 end
               else
-                raise TypeError, "Unexpected descriptor class `#{descriptor.class.name}` for constant `#{constant}`"
+                add_error(<<~MSG.strip)
+                  Unexpected descriptor class `#{descriptor.class.name}` for `#{constant}`
+                MSG
               end
             end
           end

--- a/spec/tapioca/dsl/compilers/protobuf_spec.rb
+++ b/spec/tapioca/dsl/compilers/protobuf_spec.rb
@@ -501,6 +501,23 @@ module Tapioca
                 def contact_info; end
               RBI
             end
+
+            it "shows an error for an unexpected descriptor class" do
+              expect_dsl_compiler_errors!
+
+              add_ruby_file("protobuf.rb", <<~RUBY)
+                Cart = Class.new(::Google::Protobuf.const_get(:AbstractMessage))
+              RUBY
+
+              rbi_output = rbi_for(:Cart)
+
+              assert_equal(<<~RBI, rbi_output)
+                # typed: strong
+
+                class Cart; end
+              RBI
+              assert_equal(["Unexpected descriptor class `NilClass` for `Cart`"], generated_errors)
+            end
           end
         end
       end


### PR DESCRIPTION
### Motivation

This fixes the issue described in https://github.com/Shopify/tapioca/issues/1410.

`AbstractMessage` is [not new](https://github.com/protocolbuffers/protobuf/pull/10281) ~and I don't quite know yet why this is causing problems _now_ (and why it didn't seem to cause problems for other services)~—ah, it looks like they only added it to the most recent minor release.

### Implementation

We changed the `gather_constants` method of the Protobuf compiler to check if `Google::Protobuf::AbstractMessage` is defined:
- if it isn't, we preserve the old behaviour
- if it is, we skip that class but gather its descendants

This has been tested with the repository used to report this bug.