### PR TITLE
Fix eager loading for DSL

### DIFF
--- a/lib/tapioca/loaders/dsl.rb
+++ b/lib/tapioca/loaders/dsl.rb
@@ -11,7 +11,7 @@ module Tapioca
 
         sig { params(tapioca_path: String, eager_load: T::Boolean, app_root: String).void }
         def load_application(tapioca_path:, eager_load: true, app_root: ".")
-          loader = new(tapioca_path: tapioca_path, app_root: app_root)
+          loader = new(tapioca_path: tapioca_path, eager_load: eager_load, app_root: app_root)
           loader.load
         end
       end


### PR DESCRIPTION
### Motivation

It appears that #1072 introduced a bug where the `eager_load:` option was not fully threaded through to the `Tapioca::Loaders::Dsl.new` so it was always falling back to the default value of `true`.

### Implementation

Pass the given argument to `Tapioca::Loaders::Dsl.new`

### Tests

There's no indication eager loading is/isn't used so there's not a straightforward way to test this specifically, but it's a one-line change that's pretty obvious.
