### PR TITLE
Fix DSL RBI missing PrivateRelation on abstract_class ActiveRecord

### DIFF
--- a/lib/tapioca/dsl/compilers/active_record_scope.rb
+++ b/lib/tapioca/dsl/compilers/active_record_scope.rb
@@ -55,7 +55,7 @@ module Tapioca
           return if method_names.empty?
 
           root.create_path(constant) do |model|
-            relations_enabled = compiler_enabled?("ActiveRecordRelations")
+            relations_enabled = compiler_enabled?("ActiveRecordRelations") && !constant.abstract_class?
 
             relation_methods_module = model.create_module(RelationMethodsModuleName)
             assoc_relation_methods_mod = model.create_module(AssociationRelationMethodsModuleName) if relations_enabled

--- a/spec/tapioca/dsl/compilers/active_record_scope_spec.rb
+++ b/spec/tapioca/dsl/compilers/active_record_scope_spec.rb
@@ -181,8 +181,12 @@ module Tapioca
                     extend GeneratedRelationMethods
 
                     module GeneratedRelationMethods
-                      sig { params(args: T.untyped, blk: T.untyped).returns(T.untyped) }
+                      sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
                       def app_scope(*args, &blk); end
+                    end
+
+                    class PrivateRelation < ::ActiveRecord::Relation
+                      include GeneratedRelationMethods
                     end
                   end
                 RBI

--- a/spec/tapioca/dsl/compilers/active_record_scope_spec.rb
+++ b/spec/tapioca/dsl/compilers/active_record_scope_spec.rb
@@ -180,13 +180,8 @@ module Tapioca
                   class ApplicationRecord
                     extend GeneratedRelationMethods
 
-                    module GeneratedAssociationRelationMethods
-                      sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
-                      def app_scope(*args, &blk); end
-                    end
-
                     module GeneratedRelationMethods
-                      sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
+                      sig { params(args: T.untyped, blk: T.untyped).returns(T.untyped) }
                       def app_scope(*args, &blk); end
                     end
                   end


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
In the current tapioca 0.11 scoped methods on abstract classes will end up with a return type of `PrivateRelation` and `PrivateAssociationRelation`. However, those will not exist in the DSL for those ActiveRecords as they are abstract classes.

This PR forces abstract classes to use `T.untyped` as the return type.

Please see the related PR for more context: https://github.com/Shopify/tapioca/pull/1250

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
Another option I looked into was to add `PrivateRelation` and `PrivateAssociationRelation` to the DSL of the model but I'm not sure that makes sense. I think this fix is a good way forward to at least for a patch  semver release.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->
I've fixed the existing test. If my reasoning is correct then the test was asserting with the wrong return type.

