### PR TITLE
Avoid raising when constantizing from paths

### DIFF
--- a/spec/tapioca/cli/dsl_spec.rb
+++ b/spec/tapioca/cli/dsl_spec.rb
@@ -804,8 +804,6 @@ module Tapioca
           OUT
 
           assert_equal(<<~ERR, result.err)
-
-            Warning: No constants found in: path/to/nowhere.rb
             No classes/modules can be matched for RBI generation.
             Please check that the requested classes/modules include processable DSL methods.
           ERR
@@ -818,6 +816,9 @@ module Tapioca
         it "does not generate anything but succeeds for real paths with no processable DSL" do
           @project.write("lib/models/post.rb", <<~RB)
             class Foo
+              class << self
+                BAR = nil
+              end
             end
           RB
 


### PR DESCRIPTION
### Motivation

#968 added support for generating DSL RBI via a path like `bin/tapioca dsl app/models`. The way it works is using `Static::SymbolLoader.symbols_from_paths` to find all constants defined in those paths and then acting as if you called `bin/tapioca dsl <those constants>`.

When testing this out for the first time, I realized that sometimes `symbols_from_paths` found constants that weren't actually loaded (or loadable) and would then raise an exception. Two common examples in our codebase:
1. A constant defined inside an eigenclass, for example
```ruby
class Foo
  class << self
    BAR = nil
  end
end
```
In this example, `Foo::BAR` is a constant returned from `symbols_from_paths` but you can't actually reference it outside the eigenclass.

2. Any constants (e.g. helper modules) defined in test folders. We use packwerk so my first command was something like `bin/tapioca dsl packs/xyz` which is a folder than contains both `app` and `spec` so it found a few constants from tests and blew up trying to load them.

### Implementation

When generating DSL for specific constants like `bin/tapioca dsl Some::Constant` we raise if that constant can't be resolved. This makes sense since you're explicitly asking us to generate DSL for a specific constant.

We previously had the same behavior for constants derived from given paths, however this PR changes that behavior so we'll simply ignore constants that cannot be resolved. This makes sense to me since by doing `bin/tapioca dsl some/path` you're essentially saying "generate RBI for whatever you can in `some/path`".

### Tests

Added a test for the eigenclass case and confirmed it failed before and passed after this change. I also tested out this branch of tapioca on Gusto's codebase and it worked as expected 👍 
