### PR TITLE
in_batches/find_in_batches/find_each cannot return nil

### DIFF
--- a/lib/tapioca/dsl/compilers/active_record_relations.rb
+++ b/lib/tapioca/dsl/compilers/active_record_relations.rb
@@ -699,7 +699,7 @@ module Tapioca
                   *(create_kw_opt_param("order", type: "Symbol", default: ":asc") if order),
                   create_block_param("block", type: "T.nilable(T.proc.params(object: #{constant_name}).void)"),
                 ],
-                return_type: "T.nilable(T::Enumerator[#{constant_name}])",
+                return_type: "T::Enumerator[#{constant_name}]",
               )
             when :find_in_batches
               order = ActiveRecord::Batches.instance_method(:find_in_batches).parameters.include?([:key, :order])
@@ -716,7 +716,7 @@ module Tapioca
                     type: "T.nilable(T.proc.params(object: T::Array[#{constant_name}]).void)",
                   ),
                 ],
-                return_type: "T.nilable(T::Enumerator[T::Enumerator[#{constant_name}]])",
+                return_type: "T::Enumerator[T::Enumerator[#{constant_name}]]",
               )
             when :in_batches
               order = ActiveRecord::Batches.instance_method(:in_batches).parameters.include?([:key, :order])
@@ -733,7 +733,7 @@ module Tapioca
                   *(create_kw_opt_param("use_ranges", type: "T.untyped", default: "nil") if use_ranges),
                   create_block_param("block", type: "T.nilable(T.proc.params(object: #{RelationClassName}).void)"),
                 ],
-                return_type: "T.nilable(::ActiveRecord::Batches::BatchEnumerator)",
+                return_type: "::ActiveRecord::Batches::BatchEnumerator",
               )
             end
           end

--- a/spec/tapioca/dsl/compilers/active_record_relations_spec.rb
+++ b/spec/tapioca/dsl/compilers/active_record_relations_spec.rb
@@ -100,10 +100,10 @@ module Tapioca
                     sig { params(args: T.untyped).returns(::Post) }
                     def find_by!(*args); end
 
-                    sig { params(start: T.untyped, finish: T.untyped, batch_size: Integer, error_on_ignore: T.untyped, order: Symbol, block: T.nilable(T.proc.params(object: ::Post).void)).returns(T.nilable(T::Enumerator[::Post])) }
+                    sig { params(start: T.untyped, finish: T.untyped, batch_size: Integer, error_on_ignore: T.untyped, order: Symbol, block: T.nilable(T.proc.params(object: ::Post).void)).returns(T::Enumerator[::Post]) }
                     def find_each(start: nil, finish: nil, batch_size: 1000, error_on_ignore: nil, order: :asc, &block); end
 
-                    sig { params(start: T.untyped, finish: T.untyped, batch_size: Integer, error_on_ignore: T.untyped, order: Symbol, block: T.nilable(T.proc.params(object: T::Array[::Post]).void)).returns(T.nilable(T::Enumerator[T::Enumerator[::Post]])) }
+                    sig { params(start: T.untyped, finish: T.untyped, batch_size: Integer, error_on_ignore: T.untyped, order: Symbol, block: T.nilable(T.proc.params(object: T::Array[::Post]).void)).returns(T::Enumerator[T::Enumerator[::Post]]) }
                     def find_in_batches(start: nil, finish: nil, batch_size: 1000, error_on_ignore: nil, order: :asc, &block); end
 
                     sig { params(attributes: T.untyped, block: T.nilable(T.proc.params(object: ::Post).void)).returns(::Post) }
@@ -148,10 +148,10 @@ module Tapioca
                     def ids; end
 
                 <% if rails_version(">= 7.1.alpha") %>
-                    sig { params(of: Integer, start: T.untyped, finish: T.untyped, load: T.untyped, error_on_ignore: T.untyped, order: Symbol, use_ranges: T.untyped, block: T.nilable(T.proc.params(object: PrivateRelation).void)).returns(T.nilable(::ActiveRecord::Batches::BatchEnumerator)) }
+                    sig { params(of: Integer, start: T.untyped, finish: T.untyped, load: T.untyped, error_on_ignore: T.untyped, order: Symbol, use_ranges: T.untyped, block: T.nilable(T.proc.params(object: PrivateRelation).void)).returns(::ActiveRecord::Batches::BatchEnumerator) }
                     def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, order: :asc, use_ranges: nil, &block); end
                 <% else %>
-                    sig { params(of: Integer, start: T.untyped, finish: T.untyped, load: T.untyped, error_on_ignore: T.untyped, order: Symbol, block: T.nilable(T.proc.params(object: PrivateRelation).void)).returns(T.nilable(::ActiveRecord::Batches::BatchEnumerator)) }
+                    sig { params(of: Integer, start: T.untyped, finish: T.untyped, load: T.untyped, error_on_ignore: T.untyped, order: Symbol, block: T.nilable(T.proc.params(object: PrivateRelation).void)).returns(::ActiveRecord::Batches::BatchEnumerator) }
                     def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, order: :asc, &block); end
                 <% end %>
 


### PR DESCRIPTION
### Motivation
* Based on https://api.rubyonrails.org/classes/ActiveRecord/Batches.html#method-i-in_batches, all 3 batch methods cannot return nil.

### Implementation
* Removed the `nilable` part. Tested it in our app and it works as it should.

### Tests
* Updated the tests

