### PR TITLE
Only run pending migrations check if necessary

### DIFF
--- a/lib/tapioca/loaders/dsl.rb
+++ b/lib/tapioca/loaders/dsl.rb
@@ -20,7 +20,6 @@ module Tapioca
       def load
         load_dsl_extensions
         load_application
-        abort_if_pending_migrations!
         load_dsl_compilers
       end
 
@@ -69,17 +68,6 @@ module Tapioca
         )
 
         say("Done", :green)
-      end
-
-      sig { void }
-      def abort_if_pending_migrations!
-        return unless File.exist?("#{@app_root}/config/application.rb")
-        return unless defined?(::Rake)
-
-        Rails.application.load_tasks
-        if Rake::Task.task_defined?("db:abort_if_pending_migrations")
-          Rake::Task["db:abort_if_pending_migrations"].invoke
-        end
       end
     end
   end

--- a/spec/tapioca/cli/dsl_spec.rb
+++ b/spec/tapioca/cli/dsl_spec.rb
@@ -1211,64 +1211,65 @@ module Tapioca
           RBI
         end
 
-        it "aborts if there are pending migrations" do
-          @project.require_real_gem("rake", "13.0.6")
-          @project.bundle_install
-
-          @project.write("lib/post.rb", <<~RB)
-            require "smart_properties"
-
-            class Post
-              include SmartProperties
-              property :title, accepts: String
-            end
-          RB
-
-          @project.write("db/migrate/202001010000_create_articles.rb", <<~RB)
-            class CreateArticles < ActiveRecord::Migration[6.1]
-              def change
-                create_table(:articles) do |t|
-                  t.timestamps
-                end
-              end
-            end
-          RB
-
-          @project.write("lib/database.rb", <<~RB)
-            require "rake"
-
-            namespace :db do
-              task :abort_if_pending_migrations do
-                pending_migrations = Dir["\#{Kernel.__dir__}/../db/migrate/*.rb"]
-
-                if pending_migrations.any?
-                  Kernel.puts "You have \#{pending_migrations.size} pending migration:"
-
-                  pending_migrations.each do |pending_migration|
-                    name = pending_migration.split("/").last
-                    Kernel.puts name
+        describe "pending migrations" do
+          before do
+            @project.write("db/migrate/202001010000_create_articles.rb", <<~RB)
+              class CreateArticles < ActiveRecord::Migration[6.1]
+                def change
+                  create_table(:articles) do |t|
+                    t.timestamps
                   end
-
-                  Kernel.abort(%{Run `bin/rails db:migrate` to update your database then try again.})
                 end
               end
-            end
-          RB
+            RB
 
-          result = @project.tapioca("dsl")
+            @project.write("lib/database.rb", <<~RB)
+              require "rake"
 
-          # FIXME: print the error to the correct stream
-          assert_equal(<<~OUT, result.out)
-            Loading Rails application... Done
-            You have 1 pending migration:
-            202001010000_create_articles.rb
-          OUT
+              namespace :db do
+                task :abort_if_pending_migrations do
+                  pending_migrations = Dir["\#{Kernel.__dir__}/../db/migrate/*.rb"]
 
-          assert_equal(<<~ERR, result.err)
-            Run `bin/rails db:migrate` to update your database then try again.
-          ERR
+                  if pending_migrations.any?
+                    Kernel.puts "You have \#{pending_migrations.size} pending migration:"
 
-          refute_success_status(result)
+                    pending_migrations.each do |pending_migration|
+                      name = pending_migration.split("/").last
+                      Kernel.puts name
+                    end
+
+                    Kernel.abort(%{Run `bin/rails db:migrate` to update your database then try again.})
+                  end
+                end
+              end
+            RB
+
+            @project.require_real_gem("rake", "13.0.6")
+            @project.require_real_gem("activerecord")
+            @project.bundle_install
+          end
+
+          it "aborts if there are pending migrations" do
+            @project.write("lib/post.rb", <<~RB)
+              class Post < ActiveRecord::Base
+              end
+            RB
+
+            result = @project.tapioca("dsl")
+
+            # FIXME: print the error to the correct stream
+            assert_equal(<<~OUT, result.out)
+              Loading Rails application... Done
+              You have 1 pending migration:
+              202001010000_create_articles.rb
+            OUT
+
+            assert_equal(<<~ERR, result.err)
+              Run `bin/rails db:migrate` to update your database then try again.
+            ERR
+
+            refute_success_status(result)
+          end
         end
 
         it "overwrites existing RBIs without user input" do


### PR DESCRIPTION
### Motivation

A point of friction we've experienced is getting blocked from running DSL generation due to pending migration even when we're not generating RBI for ActiveRecord models (e.g. when doing something like `bin/tapioca dsl Some::Sidekiq::Worker Some::Graphql::Mutation`) . The pending migration check is valuable to ensure we don't generate ActiveRecord RBI with a stale schema, but it's irrelevant when generating RBI for things like sidekiq workers, graphql mutations, or other non-ActiveRecord things.

### Implementation

Since we want to conditionalize running the pending migrations check, we need to be at a point where we have the constants we're going to process in memory.  This means we need to pull the pending migrations check out from the `Loaders::Dsl` further down into the `Dsl::Pipeline`. We then check to see if any of the constants we're going to process subclass ActiveRecord::Base and only check for pending migrations then.

This handles both the case where you don't give specific classes (`bin/tapioca dsl`) or you give some (`bin/tapioca dsl Something`) and there are test cases for both scenarios.

A small side-benefit here is that previously even a command like `bin/tapiocs dsl --list-compilers` would fail due to pending migrations since that check happened when loading rails. Since it now only runs if necessary, that command would succeed.

### Tests

I refactored the existing pending migration test to reuse some pieces (see first commit) and then added some specific test cases for this.
