### PR TITLE
Print backtrace information

### DIFF
--- a/lib/tapioca/loaders/loader.rb
+++ b/lib/tapioca/loaders/loader.rb
@@ -48,11 +48,15 @@ module Tapioca
         eager_load_rails_app if eager_load
       rescue LoadError, StandardError => e
         say(
-          "Tapioca attempted to load the Rails application after encountering a `config/application.rb` file, " \
+          "\nTapioca attempted to load the Rails application after encountering a `config/application.rb` file, " \
             "but it failed. If your application uses Rails please ensure it can be loaded correctly before " \
             "generating RBIs.\n#{e}",
           :yellow,
         )
+        if e.backtrace
+          backtrace = T.must(e.backtrace).join("\n")
+          say(backtrace, :cyan) # TODO: Check verbose flag to print backtrace.
+        end
         say("Continuing RBI generation without loading the Rails application.")
       end
 

--- a/spec/tapioca/cli/dsl_spec.rb
+++ b/spec/tapioca/cli/dsl_spec.rb
@@ -2088,10 +2088,10 @@ module Tapioca
 
         out = "Tapioca attempted to load the Rails application after encountering a `config/application.rb` file, " \
           "but it failed. If your application uses Rails please ensure it can be loaded correctly before " \
-          "generating RBIs."
+          "generating RBIs.\nError during application loading"
         assert_includes(res.out, out)
+        assert_includes(res.out, "tapioca/tests/dsl_spec/project/config/application.rb:5:in `<class:Application>'")
         assert_includes(res.out, <<~OUT)
-          Error during application loading
           Continuing RBI generation without loading the Rails application.
           Done
           Loading DSL compiler classes... Done


### PR DESCRIPTION
### Motivation
Tapioca does not show the place where the error happen,
when it tries to load rails application.

Current solution:

```
Loading Rails application... Tapioca attempted to load the Rails application after encountering a `config/application.rb` file, but it failed. If your application uses Rails please ensure it can be loaded correctly before generating RBIs.
undefined method `active_record' for ...
Continuing RBI generation without loading the Rails application.
```

Proposed:

```
Loading Rails application... 
Tapioca attempted to load the Rails application after encountering a `config/application.rb` file, but it failed. If your application uses Rails please ensure it can be loaded correctly before generating RBIs.
undefined method `active_record' for ...
/app/vendor/bundle/ruby/3.2.0/gems/railties-7.0.4.2/lib/rails/railtie/configuration.rb:96:in `method_missing'
```

### Implementation
Add backtrace output. But it would be nice to show backtrace only when Verbose mode enabled.
