### PR TITLE
Make YARD documentation idempotent

### DIFF
--- a/lib/tapioca/gem/listeners/yard_doc.rb
+++ b/lib/tapioca/gem/listeners/yard_doc.rb
@@ -25,6 +25,7 @@ module Tapioca
 
         sig { params(pipeline: Pipeline).void }
         def initialize(pipeline)
+          YARD::Registry.clear
           super(pipeline)
           pipeline.gem.parse_yard_docs
         end


### PR DESCRIPTION
### Motivation
Resolves https://github.com/Shopify/tapioca/issues/1345

**Problem**: `YARD.parse` stores parsed documentation into a registry that's persisted. So depending on the parsing order of the gems documentation may change. If a previous gem has documentation for a constant/method definition it'll be included in the current gem's documentation too. However, in another run if that previous gem is parsed too late its documentation won't be available. 

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->

In this PR we reset the YARD registry everytime we parse a gem's documentation to ensure only the documentation from that gem is included in the output. This means parsing order has no effect in the RBIs created and that documentation generation is idempotent.

As a result of this change duplicated RBI entries will not contain as much documentation as before. For example, when a gem defines a method on the global namespace tapioca would define `class Object` on the gem RBI. If a previously processed gem had documentation for `Object` it'd get imported into that gem, [example](https://github.com/Shopify/tapioca/blob/6d7f9a776f37afc01000379e0a1682fb999b66f6/sorbet/rbi/gems/rainbow%403.1.1.rbi#L17-L33). In some cases like the example the documentation didn't even make sense. It's coming from [Rails](https://github.com/rails/rails/blob/7cf65bc335bf1cd49cf94462ddbd8ae1adda6025/activesupport/lib/active_support/core_ext/object/duplicable.rb#L4-L19).

We initially tried to keep the documentation for each gem by parsing the documentation of all gems before any RBI generation. However, this increases the runtime since parsing isn't done in parallel anymore. 

### Tests
Included