### PR TITLE
Revert "Make scopes available for abstract classes"

### DIFF
--- a/lib/tapioca/dsl/compilers/active_record_relations.rb
+++ b/lib/tapioca/dsl/compilers/active_record_relations.rb
@@ -175,7 +175,7 @@ module Tapioca
 
           sig { override.returns(T::Enumerable[Module]) }
           def gather_constants
-            descendants_of(ActiveRecord::Base).reject(&:abstract_class?)
+            ActiveRecord::Base.descendants.reject(&:abstract_class?)
           end
         end
 

--- a/lib/tapioca/dsl/compilers/active_record_scope.rb
+++ b/lib/tapioca/dsl/compilers/active_record_scope.rb
@@ -83,7 +83,7 @@ module Tapioca
         class << self
           sig { override.returns(T::Enumerable[Module]) }
           def gather_constants
-            descendants_of(::ActiveRecord::Base)
+            descendants_of(::ActiveRecord::Base).reject(&:abstract_class?)
           end
         end
 

--- a/spec/tapioca/dsl/compilers/active_record_scope_spec.rb
+++ b/spec/tapioca/dsl/compilers/active_record_scope_spec.rb
@@ -13,7 +13,7 @@ module Tapioca
               assert_empty(gathered_constants)
             end
 
-            it "gathers ActiveRecord constants including abstract classes" do
+            it "gathers only ActiveRecord constants with no abstract classes" do
               add_ruby_file("conversation.rb", <<~RUBY)
                 class Post < ActiveRecord::Base
                 end
@@ -26,7 +26,7 @@ module Tapioca
                 end
               RUBY
 
-              assert_equal(["Post", "Product"], gathered_constants)
+              assert_equal(["Post"], gathered_constants)
             end
           end
 
@@ -174,25 +174,7 @@ module Tapioca
                   end
                 RUBY
 
-                expected_application_record = <<~RBI
-                  # typed: strong
-
-                  class ApplicationRecord
-                    extend GeneratedRelationMethods
-
-                    module GeneratedAssociationRelationMethods
-                      sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
-                      def app_scope(*args, &blk); end
-                    end
-
-                    module GeneratedRelationMethods
-                      sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
-                      def app_scope(*args, &blk); end
-                    end
-                  end
-                RBI
-
-                expected_post = <<~RBI
+                expected = <<~RBI
                   # typed: strong
 
                   class Post
@@ -216,8 +198,7 @@ module Tapioca
                   end
                 RBI
 
-                assert_equal(expected_application_record, rbi_for(:ApplicationRecord))
-                assert_equal(expected_post, rbi_for(:Post))
+                assert_equal(expected, rbi_for(:Post))
               end
             end
 
@@ -367,20 +348,7 @@ module Tapioca
                   end
                 RUBY
 
-                expected_application_record = <<~RBI
-                  # typed: strong
-
-                  class ApplicationRecord
-                    extend GeneratedRelationMethods
-
-                    module GeneratedRelationMethods
-                      sig { params(args: T.untyped, blk: T.untyped).returns(T.untyped) }
-                      def app_scope(*args, &blk); end
-                    end
-                  end
-                RBI
-
-                expected_post = <<~RBI
+                expected = <<~RBI
                   # typed: strong
 
                   class Post
@@ -396,8 +364,7 @@ module Tapioca
                   end
                 RBI
 
-                assert_equal(expected_application_record, rbi_for(:ApplicationRecord))
-                assert_equal(expected_post, rbi_for(:Post))
+                assert_equal(expected, rbi_for(:Post))
               end
             end
           end


### PR DESCRIPTION
Reverts Shopify/tapioca#1250

I've been thinking about the problem that this change has been causing with AR relations (as pointed out by #1413 that was trying to fix this forward), and I've come to the conclusion that it is better for Tapioca to NOT support this case at all, for a few reasons. 

I will explain my reasons based on the following code example (adapted from the one in the original PR #1250)

```ruby
ActiveRecord::Schema.define do
  create_table :posts, force: true do |t|
    t.datetime :deleted_at, nilable: true
  end

  create_table :comments, force: true do |t|
    t.integer :post_id
  end
end

class ApplicationRecord < ActiveRecord::Base
  self.abstract_class = true

  scope :deleted, -> { where.not(deleted_at: nil) }

  def self.count_deleted
    deleted.count
  end
end

class Post < ApplicationRecord
  has_many :comments
end

class SubPost < Post
end

class Comment < ApplicationRecord
  belongs_to :post
end
```

1. Given the current level of RBI signature generation there is no good way to type the return value of the `deleted` method. It is supposed to the an `ActiveRecord::Relation` subtype, but the actual type would depend on what it was called on. For example:
    ```ruby
    Post.deleted.class    #=> Post::ActiveRecord_Relation
    Foo.deleted.class     #=> Foo::ActiveRecord_Relation
    Comment.deleted.class #=> Comment::ActiveRecord_Relation
    ```
    and we are not able to currently type this appropriately.
2. More importantly than the previous point, there is not generic way to type the `deleted` call being made inside the `count_deleted` method, since depending on what model type `count_deleted` is being called on, it could be returning any of the types listed in the previous point. As a result, the `deleted` call being made inside that method is not type safe anyway, and I would really prefer if that was explicit using a `T.unsafe` explicitly.
3. Finally, and probably, most importantly, I think the pattern that is being suggested is unsafe to begin with. You can easily see that by trying to make a `Comment.count_deleted` call and seeing that it raises an error with the message `no such column: comments.deleted_at`. Since the abstract base class cannot enforce the definition of a set of columns on child models, it should not try to act like it can ensure that it can make these kinds of queries either. If applications still want to use this pattern, it is better for them to explicitly use `T.unsafe` to communicate that the method could be unsafe in this respect as well.

So, I think it is best to revert the original PR and disallow abstract base classes from DSL generation for scopes.