### PR TITLE
Remove support for old Bundler API in materialize_deps

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ PATH
   remote: .
   specs:
     tapioca (0.11.2)
-      bundler (>= 1.17.3)
+      bundler (>= 2.2.25)
       netrc (>= 0.11.0)
       parallel (>= 1.21.0)
       rbi (~> 0.0.0, >= 0.0.16)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -392,4 +392,4 @@ DEPENDENCIES
   xpath
 
 BUNDLED WITH
-   2.3.26
+   2.4.9

--- a/lib/tapioca/gemfile.rb
+++ b/lib/tapioca/gemfile.rb
@@ -105,14 +105,13 @@ module Tapioca
     sig { returns([T::Enumerable[Spec], T::Array[String]]) }
     def materialize_deps
       deps = definition.locked_gems.dependencies.values
-      missing_specs = T::Array[String].new
-      materialized_dependencies = if definition.resolve.method(:materialize).arity == 1 # Support bundler >= v2.2.25
-        md = definition.resolve.materialize(deps)
-        missing_spec_names = md.missing_specs.map(&:name)
-        missing_specs = T.cast(md.missing_specs.map { |spec| "#{spec.name} (#{spec.version})" }, T::Array[String])
-        md.to_a.reject { |spec| missing_spec_names.include?(spec.name) }
-      else
-        definition.resolve.materialize(deps, missing_specs)
+      materialized_dependencies = definition.resolve.materialize(deps)
+      missing_spec_names = materialized_dependencies.missing_specs.map(&:name).to_set
+      missing_specs = materialized_dependencies.missing_specs.map do |spec|
+        "#{spec.name} (#{spec.version})"
+      end
+      materialized_dependencies = materialized_dependencies.to_a.reject do |spec|
+        missing_spec_names.include?(spec.name)
       end
       [materialized_dependencies, missing_specs]
     end

--- a/spec/tapioca/cli/gem_spec.rb
+++ b/spec/tapioca/cli/gem_spec.rb
@@ -596,6 +596,7 @@ module Tapioca
         end
 
         it "must not include `rbi` definitions into `tapioca` RBI" do
+          @project.bundle_install
           result = @project.tapioca("gem tapioca")
 
           assert_stdout_includes(result, <<~OUT)
@@ -686,24 +687,6 @@ module Tapioca
           refute_includes(result.out, "Compiled ruby2_keywords")
 
           assert_empty_stderr(result)
-          assert_success_status(result)
-        end
-
-        it "must not generate RBIs for missing gem specs on Bundler 2.2.22" do
-          @project.gemfile(<<~GEMFILE, append: true)
-            platform :rbx do
-              gem "ruby2_keywords", "0.0.5"
-            end
-          GEMFILE
-
-          @project.bundle_install(version: "2.2.22")
-
-          result = @project.tapioca("gem --all")
-
-          assert_stdout_includes(result, "completed with missing specs: ruby2_keywords (0.0.5)")
-          refute_includes(result.out, "Compiled ruby2_keywords")
-
-          # StdErr will have some messages about incompatibilities, so we don't check for clean err
           assert_success_status(result)
         end
 

--- a/tapioca.gemspec
+++ b/tapioca.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
 
   spec.metadata["allowed_push_host"] = "https://rubygems.org"
 
-  spec.add_dependency("bundler", ">= 1.17.3")
+  spec.add_dependency("bundler", ">= 2.2.25")
   spec.add_dependency("netrc", ">= 0.11.0")
   spec.add_dependency("parallel", ">= 1.21.0")
   spec.add_dependency("rbi", "~> 0.0.0", ">= 0.0.16")


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->

This piece of code was brittle and causes an error in the latest bundler version.

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
Instead of supporting different method arity's which could keep changing in the future we can remove support for the old Bundler API. [v2.2.25](https://github.com/rubygems/rubygems/releases/tag/bundler-v2.2.25) has been out since July 2021. Users with old versions of Bundler will not be able to use future Tapioca versions.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->

Locally tested using `BUNDLER_VERSION=2.4.9 bundle exec tapioca gem --verify` and bumped the version used in tapioca to trigger CI run with latest bundler.

