### PR TITLE
Don't ignore default gems if Ruby vendored in app

### DIFF
--- a/lib/tapioca/helpers/gem_helper.rb
+++ b/lib/tapioca/helpers/gem_helper.rb
@@ -10,12 +10,17 @@ module Tapioca
       app_dir = to_realpath(app_dir)
       full_gem_path = to_realpath(full_gem_path)
 
-      !gem_in_bundle_path?(full_gem_path) && path_in_dir?(full_gem_path, app_dir)
+      !gem_in_bundle_path?(full_gem_path) && !gem_in_ruby_path?(full_gem_path) && path_in_dir?(full_gem_path, app_dir)
     end
 
     sig { params(full_gem_path: String).returns(T::Boolean) }
     def gem_in_bundle_path?(full_gem_path)
       path_in_dir?(full_gem_path, Bundler.bundle_path) || path_in_dir?(full_gem_path, Bundler.app_cache)
+    end
+
+    sig { params(full_gem_path: String).returns(T::Boolean) }
+    def gem_in_ruby_path?(full_gem_path)
+      path_in_dir?(full_gem_path, RbConfig::CONFIG["rubylibprefix"])
     end
 
     sig { params(path: T.any(String, Pathname)).returns(String) }

--- a/spec/tapioca/gemfile_spec.rb
+++ b/spec/tapioca/gemfile_spec.rb
@@ -125,6 +125,20 @@ module Tapioca
       end
     end
 
+    it "ignore? returns false for gems within Ruby even when Ruby is installed inside the project" do
+      # Imitate Ruby being installed inside the project
+      original_rubylibprefix = RbConfig::CONFIG["rubylibprefix"]
+      mock_rubylibprefix = "#{File.realpath(@project.path)}/vendor/ruby/lib"
+      RbConfig::CONFIG["rubylibprefix"] = mock_rubylibprefix
+
+      foo_gem = mock_gem("foo", "0.0.1", path: "#{mock_rubylibprefix}/ruby/gems")
+      foo_spec = make_spec(foo_gem)
+
+      refute(foo_spec.ignore?(@project.path))
+    ensure
+      RbConfig::CONFIG["rubylibprefix"] = original_rubylibprefix
+    end
+
     private
 
     sig { params(gem: MockGem).returns(Gemfile::GemSpec) }
@@ -153,6 +167,11 @@ module Tapioca
     sig { returns(T::Array[String]) }
     def full_require_paths
       []
+    end
+
+    sig { returns(String) }
+    def name
+      ""
     end
   end
 end


### PR DESCRIPTION
### Motivation

This is similar in spirit to https://github.com/Shopify/tapioca/pull/34, except that it's probably a much less common scenario.

At GitHub we vendor a Ruby build within our app directory, which means that our default gems meet the conditions of the `gem_in_app_dir?` method—they are within the app, but not in the bundle directory. That results in these default gems getting ignored.

We also sometimes generate PRs via GitHub actions, using Ruby from the setup-ruby action. In these scenarios the default gems are not within the app, and are thus not ignored. To get around having PRs that continuously add and remove these rbis, we ended up explicitly excluding them.

This PR aims to make the behavior consistent regardless of where Ruby is installed.

### Implementation

This PR checks if the gem in question is within Ruby (similar to how it checks whether it is in the bundle path). The `full_gem_path` for default gems will start with something like `<root>/lib/ruby/gems`. `RbConfig::CONFIG["rubylibprefix"]`, which returns something like `<root>/lib/ruby`, seems to be the narrowest value that still covers such gem paths.

### Tests

~I did not add a test mostly because I have no idea how I'd go about it, but also since I'm not sure how much value it would offer for this likely unusual edge case. But I'm open to suggestion!~

I added a test. It's a bit coupled to the implementation, but I couldn't think of
another simple way to test Ruby being installed inside the project.
