### PR TITLE
Fix ActiveRecordScope Compiler to not duplicate relation methods of superclass

### DIFF
--- a/lib/tapioca/dsl/compilers/active_record_scope.rb
+++ b/lib/tapioca/dsl/compilers/active_record_scope.rb
@@ -105,7 +105,7 @@ module Tapioca
             constant = T.cast(superclass, T.class_of(ActiveRecord::Base))
           end
 
-          scope_methods
+          scope_methods.uniq
         end
 
         sig do


### PR DESCRIPTION
### Motivation

We encountered a strange situation where CI was reporting that a rbi file has changed and needs to be regenerated, but running `bin/tapioca dsl` locally on the dev environment would not generate any changes.

It seems on the CI build, a method in one of the rbi files is generated twice while on dev environment not, leading to CI failing all the time we regenerate the rbis. It is unclear why this is happening, the same version of tapioca is used in both cases and there is no obvious reason why it is happening.

As a workaround we had to undo the changes to that rbi file on each branch, leading to confusion within the team.

After investigation I found that the ActiveRecordScope Compiler gathers scope methods until it hits "ActiveRecord::Base" and concatenates the methods in an array. The problem is it does not remove duplicates, if a method is defined twice along the class hierarchy chain.

Given the class hierarchy

```
class ApplicationRecord < ActiveRecord::Base
  self.abstract_class = true

  default_scope { max_execution_time(100) }
end

class ConfigurationRecord < ApplicationRecord
  self.abstract_class = true

  scope :post_scope, -> { where.not(kind: 'private') }

  default_scope { max_execution_time(200) }
end

class Post < ConfigurationRecord
  scope :post_scope, -> { where.not(kind: 'private') }
end
```

Before this PR:

```
class Post
  extend GeneratedRelationMethods

  module GeneratedAssociationRelationMethods
    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
    def post_scope(*args, &blk); end

    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
    def post_scope(*args, &blk); end
  end

  module GeneratedRelationMethods
    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
    def post_scope(*args, &blk); end

    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
    def post_scope(*args, &blk); end
  end
end
```

After this PR:

```
class Post
  extend GeneratedRelationMethods

  module GeneratedAssociationRelationMethods
    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
    def post_scope(*args, &blk); end
  end

  module GeneratedRelationMethods
    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
    def post_scope(*args, &blk); end
  end
end
```

### Implementation

Removed duplicates from ActiveRecordScope Compiler while gathering scope methods of the class hierarchy chain.

### Tests
Added a test that asserts that no methods defined twice in the class hierarchy are duplicated in the rbi file.
