### PR TITLE
Check if OID is defined before referencing

### DIFF
--- a/lib/tapioca/dsl/helpers/active_record_column_type_helper.rb
+++ b/lib/tapioca/dsl/helpers/active_record_column_type_helper.rb
@@ -69,10 +69,10 @@ module Tapioca
             "::String"
           when ActiveRecord::Type::Serialized
             serialized_column_type(column_type)
-          when defined?(ActiveRecord::ConnectionAdapters::PostgreSQL) &&
+          when defined?(ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Hstore) &&
             ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Hstore
             "T::Hash[::String, ::String]"
-          when defined?(ActiveRecord::ConnectionAdapters::PostgreSQL) &&
+          when defined?(ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Array) &&
             ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Array
             "T::Array[#{type_for_activerecord_value(column_type.subtype)}]"
           else


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->

Resolves https://github.com/Shopify/tapioca/issues/1437

I was under the assumption if `ActiveRecord::ConnectionAdapters::PostgreSQL` is defined `OID` would be loaded too but that doesn't have to be the case if the connection adapter is loaded manually

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->

Now we check for the exact class we're referencing instead.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. --> Tested locally in a demo application 👍 
