### PR TITLE
Fix running `tapioca dsl` for Rails 5.x based applications

### DIFF
--- a/lib/tapioca/dsl/extensions/active_record.rb
+++ b/lib/tapioca/dsl/extensions/active_record.rb
@@ -23,7 +23,7 @@ module Tapioca
 
           attr_reader :__tapioca_secure_tokens
 
-          def has_secure_token(attribute = :token, length: ::ActiveRecord::SecureToken::MINIMUM_TOKEN_LENGTH)
+          def has_secure_token(attribute = :token, **)
             @__tapioca_secure_tokens ||= []
             @__tapioca_secure_tokens << attribute
 


### PR DESCRIPTION
### Motivation
This change fixes running `tapioca dsl` command for Rails 5 based applications: it fixes eager loading Rails applications.

Before the fix, `tapioca dsl` command could not eager load rails applications based on Rails 5.x. The command failed because of an uninitialized constant `ActiveRecord::SecureToken::MINIMUM_TOKEN_LENGTH` (it was added in Rails 6.1). Further, `has_secure_token` has only one parameter in Rails 5.x.

We don't use built-in ActiveRecord related dsl compilers, but we still have the problem. It seems the patch of `has_secure_token` method is loaded always.

### Implementation
The fix changes the definition of `has_secure_token` method inside `Tapioca::Dsl::Compilers::Extensions::ActiveRecord` module: `**` is used for `length` parameter, so the definition could be compatible with Rails 5.x.

### Tests
No tests. The change seems obvious.