### PR TITLE
Use `ReqParam` instead `Param` because `Param` is an abstract class

### DIFF
--- a/lib/tapioca/gem/listeners/methods.rb
+++ b/lib/tapioca/gem/listeners/methods.rb
@@ -118,7 +118,7 @@ module Tapioca
           sanitized_parameters.each do |type, name|
             case type
             when :req
-              rbi_method << RBI::Param.new(name)
+              rbi_method << RBI::ReqParam.new(name)
             when :opt
               rbi_method << RBI::OptParam.new(name, "T.unsafe(nil)")
             when :rest

--- a/lib/tapioca/helpers/rbi_helper.rb
+++ b/lib/tapioca/helpers/rbi_helper.rb
@@ -40,7 +40,7 @@ module Tapioca
 
     sig { params(name: String, type: String).returns(RBI::TypedParam) }
     def create_param(name, type:)
-      create_typed_param(RBI::Param.new(name), type)
+      create_typed_param(RBI::ReqParam.new(name), type)
     end
 
     sig { params(name: String, type: String, default: String).returns(RBI::TypedParam) }

--- a/lib/tapioca/runtime/dynamic_mixin_compiler.rb
+++ b/lib/tapioca/runtime/dynamic_mixin_compiler.rb
@@ -145,7 +145,7 @@ module Tapioca
 
           class_attribute_writers.each do |attribute|
             mod << RBI::Method.new("#{attribute}=") do |method|
-              method << RBI::Param.new("value")
+              method << RBI::ReqParam.new("value")
             end
           end
 
@@ -162,7 +162,7 @@ module Tapioca
 
           instance_attribute_writers.each do |attribute|
             mod << RBI::Method.new("#{attribute}=") do |method|
-              method << RBI::Param.new("value")
+              method << RBI::ReqParam.new("value")
             end
           end
 


### PR DESCRIPTION
### Motivation

New version of Sorbet will prohibit initialising abstract classes directly ([related PR](https://github.com/sorbet/sorbet/pull/6273)), which means `Param` could not be directly used anymore. And as @Morriar pointed out in https://github.com/Shopify/rbi/pull/160#pullrequestreview-1371602446, we should use `ReqParam` for the current `Param` usages anyway. 

### Implementation

Replace `Param` invocations with `ReqParam`.

### Tests

I think existing tests should already cover those cases.

