### PR TITLE
feat: consistently define `fetch_multi_by`

### DIFF
--- a/lib/tapioca/dsl/compilers/identity_cache.rb
+++ b/lib/tapioca/dsl/compilers/identity_cache.rb
@@ -172,7 +172,6 @@ module Tapioca
           ).void
         end
         def create_index_fetch_by_methods(field, klass)
-          field_length = field.key_fields.length
           fields_name = field.key_fields.join("_and_")
           name = "fetch_by_#{fields_name}"
           parameters = field.key_fields.map do |arg|
@@ -205,17 +204,15 @@ module Tapioca
             )
           end
 
-          if field_length == 1
-            klass.create_method(
-              "fetch_multi_by_#{fields_name}",
-              class_method: true,
-              parameters: [
-                create_param("index_values", type: "T::Enumerable[T.untyped]"),
-                create_kw_opt_param("includes", default: "nil", type: "T.untyped"),
-              ],
-              return_type: COLLECTION_TYPE.call(constant),
-            )
-          end
+          klass.create_method(
+            "fetch_multi_by_#{fields_name}",
+            class_method: true,
+            parameters: [
+              create_param("index_values", type: "T::Enumerable[T.untyped]"),
+              create_kw_opt_param("includes", default: "nil", type: "T.untyped"),
+            ],
+            return_type: COLLECTION_TYPE.call(constant),
+          )
         end
 
         sig do

--- a/spec/tapioca/dsl/compilers/identity_cache_spec.rb
+++ b/spec/tapioca/dsl/compilers/identity_cache_spec.rb
@@ -214,6 +214,9 @@ module Tapioca
                     sig { params(index_values: T::Enumerable[T.untyped], includes: T.untyped).returns(T::Array[::Post]) }
                     def fetch_multi_by_title(index_values, includes: nil); end
 
+                    sig { params(index_values: T::Enumerable[T.untyped], includes: T.untyped).returns(T::Array[::Post]) }
+                    def fetch_multi_by_title_and_review_date(index_values, includes: nil); end
+
                     sig { params(keys: T::Enumerable[T.untyped]).returns(T::Array[::Integer]) }
                     def fetch_multi_id_by_title(keys); end
                   end


### PR DESCRIPTION
### Motivation

Following https://github.com/Shopify/identity_cache/pull/534, IdentityCache will define `fetch_multi_by` for `cache_index` invocations regardless of the number of keys included in the index. (Previously only single-index keys were supported.)

We should lift the `field_length` restriction accordingly.

### Implementation
Removes the `field_length == 1` restriction (as well as the `field_length` variable designation, which is now useless).

### Tests
~Nothing changed.~

Updated a unit test implicitly testing this behavior in https://github.com/Shopify/tapioca/pull/1468/commits/64983d4af1eaaf4b383e1506c617e0cfbac0bbf9.