### PR TITLE
Bump tapioca gem version to 0.11.5

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 PATH
   remote: .
   specs:
-    tapioca (0.11.4)
+    tapioca (0.11.5)
       bundler (>= 2.2.25)
       netrc (>= 0.11.0)
       parallel (>= 1.21.0)

--- a/lib/tapioca/version.rb
+++ b/lib/tapioca/version.rb
@@ -2,5 +2,5 @@
 # frozen_string_literal: true
 
 module Tapioca
-  VERSION = "0.11.4"
+  VERSION = "0.11.5"
 end


### PR DESCRIPTION
### Motivation
Since the latest release of the 0.11.4 version, many changes have been shipped and are waiting to be deployed (https://github.com/Shopify/tapioca/compare/v0.11.4...main?expand=1), including bug fixes.

In this PR we bump the gem to v0.11.5 to cut a new release.

### Implementation
/

### Tests
/