### PR TITLE
Replace synthetic relation class names with real relation names.

### DIFF
--- a/lib/tapioca/dsl/helpers/active_record_constants_helper.rb
+++ b/lib/tapioca/dsl/helpers/active_record_constants_helper.rb
@@ -18,11 +18,11 @@ module Tapioca
         AssociationRelationMethodsModuleName = T.let("GeneratedAssociationRelationMethods", String)
         CommonRelationMethodsModuleName = T.let("CommonRelationMethods", String)
 
-        RelationClassName = T.let("PrivateRelation", String)
+        RelationClassName = T.let("ActiveRecord_Relation", String)
         RelationWhereChainClassName = T.let("PrivateRelationWhereChain", String)
-        AssociationRelationClassName = T.let("PrivateAssociationRelation", String)
+        AssociationRelationClassName = T.let("ActiveRecord_AssociationRelation", String)
         AssociationRelationWhereChainClassName = T.let("PrivateAssociationRelationWhereChain", String)
-        AssociationsCollectionProxyClassName = T.let("PrivateCollectionProxy", String)
+        AssociationsCollectionProxyClassName = T.let("ActiveRecord_Associations_CollectionProxy", String)
       end
     end
   end


### PR DESCRIPTION
### Motivation

The synthetic classes that are generated by the Tapioca DSL compilers to support ActiveRecord relations (`PrivateRelation`, etc.) are widely used in generated RBI files, but don't exist at runtime and therefore can't be referenced in method signatures in Ruby files or used in runtime type checking. This limits how well code that passes around around relations can be annotated with types.

### Implementation

This PR changes the names of three of these synthetic constants to match the names of the [real runtime classes that are dynamically generated by Rails](https://github.com/rails/rails/blob/7fdcbe747f7ab5ef664b894f73c8e0ada04c5c50/activerecord/lib/active_record/relation/delegation.rb#L13-L31). Since these are real classes, they can be referenced in both RBI and Ruby files:

- `PrivateRelation` 👉 `ActiveRecord_Relation`
- `PrivateAssociationRelation` 👉 `ActiveRecord_AssociationRelation`
- `PrivateCollectionProxy` 👉  `ActiveRecord_Associations_CollectionProxy`

The remaining constants do not have any obvious model-specific analogies, so they continue to be synthetic types.

The real classes that are referenced by the generated RBI files after this change are private to the model where they are defined, but users can directly reference them on models within the model class or – assuming they want to take on the risk of doing so – expose them with a call to `public_constant :ActiveRecord_Relation`.

In experimenting with this change, I've found that keeping them private, but defining public type aliases that make use them is a very effective middle ground, e.g.

``` ruby
class MyModel < ApplicationRecord
  AnyRelation = T.type_alias do
    T.any(
      ActiveRecord_Relation,
      ActiveRecord_AssociationRelation,
      ActiveRecord_Associations_CollectionProxy,
    )
  end
end
```

A similar change has been discussed previously, e.g.

- https://github.com/Shopify/tapioca/issues/1140

It's was [suggested in that thread that using `ActiveRecord::Relation` as the type for relations is the correct approach](https://github.com/Shopify/tapioca/issues/1140#issuecomment-1234432926), but this loses any model-specific type information and therefore limits Sorbet's ability to type check any code that deals with relations.

For example, consider a method that applies some filters to a given relation:

``` ruby
class UserFilter
  sig { params(base_relation: ActiveRecord::Relation).returns(ActiveRecord::Relation) }
  def apply_to(base_relation)
    base_relation.where(conditions)
  end
end
```

Typing this return value as an `ActiveRecord::Relation` has two downsides:

- We can't use model-specific scopes and class methods on the result, e.g.

    ``` ruby
    UserFilter.new.apply_to(User.all).admins  # ❌ error: Method `admins` does not exist on `ActiveRecord::Relation`
    ```

- We lose type information entirely on the records loaded by the relation, e.g.

    ``` ruby
    UserFilter.new.apply_to(User.all).map do |u|
      T.reveal_type(u) # ℹ️ Revealed type: `T.untyped`
    end
    ```

- We cannot statically validate inputs are of the correct type, e.g.

    ``` ruby
    UserFilter.new.apply_to(BlogPost.all)  # ✅ Sorbet is fine with this
    ```

Replacing `ActiveRecord::Relation` with `User::AnyRelation` (as described above) gives us more expected results:

- We can use model-specific scopes and class methods on the result,
- Sorbet knows the type of the records loaded by the relation, and
- we get static validation in situations where we only want to accept a relation for a specific model.

### Tests

🚨 There are tests that definitely won't pass with this change, and documentation that will need updating too. I wanted to float the idea of making the change in principle before doing all of the detailed work of updating tests and docs.

I have manually tested this version of Tapioca on the GitHub Rails monolith, and updated all of our sigs that contained types like `ActiveRecord::Relation` to use model-specific type aliases like the one I described above. The extra type information was very useful: I found a couple of minor issues as a result of having model-specific relation types.