### PR TITLE
Relax constraint for `actions/checkout`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Linters
     steps:
-      - uses: actions/checkout@v3.5.2
+      - uses: actions/checkout@v3
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
@@ -46,7 +46,7 @@ jobs:
     env:
       BUNDLE_GEMFILE: ${{ matrix.gemfile }}
     steps:
-      - uses: actions/checkout@v3.5.2
+      - uses: actions/checkout@v3
       - if: ${{ matrix.ruby == '3.2' }}
         run: "rm -f ${{ matrix.gemfile }}.lock"
       - name: Set up Ruby


### PR DESCRIPTION
### Motivation

To reduce Dependabot noise such as https://github.com/Shopify/tapioca/pull/1478

### Implementation

Specify only the major version, so that GH uses the latest available within the major range.

