### PR TITLE
Do not generate file fixture methods

### DIFF
--- a/lib/tapioca/dsl/compilers/active_record_fixtures.rb
+++ b/lib/tapioca/dsl/compilers/active_record_fixtures.rb
@@ -75,7 +75,11 @@ module Tapioca
           @fixture_loader ||= T.let(
             Class.new do
               T.unsafe(self).include(ActiveRecord::TestFixtures)
+
               T.unsafe(self).fixture_path = Rails.root.join("test", "fixtures")
+              # https://github.com/rails/rails/blob/7c70791470fc517deb7c640bead9f1b47efb5539/activerecord/lib/active_record/test_fixtures.rb#L46
+              singleton_class.define_method(:file_fixture_path) { Rails.root.join("test", "fixtures", "files") }
+
               T.unsafe(self).fixtures(:all)
             end,
             T.nilable(Class),

--- a/spec/tapioca/dsl/compilers/active_record_fixtures_spec.rb
+++ b/spec/tapioca/dsl/compilers/active_record_fixtures_spec.rb
@@ -107,6 +107,22 @@ module Tapioca
 
               assert_equal(expected, rbi_for("ActiveSupport::TestCase"))
             end
+
+            it "generates no methods for file fixtures" do
+              add_content_file("test/fixtures/files/posts.yml", <<~YAML)
+                super_post:
+                  title: An incredible Ruby post
+                  author: Johnny Developer
+                  created_at: 2021-09-08 11:00:00
+                  updated_at: 2021-09-08 11:00:00
+              YAML
+
+              expected = <<~RBI
+                # typed: strong
+              RBI
+
+              assert_equal(expected, rbi_for("ActiveSupport::TestCase"))
+            end
           end
         end
 


### PR DESCRIPTION
### Motivation

Tapioca currently erroneously generates methods for file fixtures.

For example if one were to create the following file in a Rails app

```yaml
# test/fixtures/files/greetings.yml
Hello: there
```

Tapioca would generate the following RBI:

```ruby
class ActiveSupport::TestCase
  sig { params(fixture_names: T.any(String, Symbol)).returns(T.untyped) }
  def files_greetings(*fixture_names); end
end
```

But that method does not exist.

### Implementation

By defining `file_fixture_path`, `ActiveRecord::TestFixtures` skips over the directory.

See https://github.com/rails/rails/blob/7c70791470fc517deb7c640bead9f1b47efb5539/activerecord/lib/active_record/test_fixtures.rb#L46


### Tests

A test is which includes a file fixture and asserts no method is defined for it.

