### PR TITLE
Implement support for `has_attached_class!` method

### DIFF
--- a/lib/tapioca/sorbet_ext/generic_name_patch.rb
+++ b/lib/tapioca/sorbet_ext/generic_name_patch.rb
@@ -49,6 +49,21 @@ module T
           Tapioca::Runtime::GenericTypeRegistry.register_type_variable(self, type_variable)
         end
       end
+
+      def has_attached_class!(variance = :invariant, &bounds_proc)
+        Tapioca::Runtime::GenericTypeRegistry.register_type_variable(
+          self,
+          Tapioca::TypeVariableModule.new(
+            T.cast(self, Module),
+            Tapioca::TypeVariableModule::Type::HasAttachedClass,
+            variance,
+            nil,
+            nil,
+            nil,
+            bounds_proc,
+          ),
+        )
+      end
     end
 
     prepend TypeStoragePatch
@@ -140,8 +155,12 @@ module Tapioca
       enums do
         Member = new("type_member")
         Template = new("type_template")
+        HasAttachedClass = new("has_attached_class!")
       end
     end
+
+    sig { returns(Type) }
+    attr_reader :type
 
     # rubocop:disable Metrics/ParameterLists
     sig do

--- a/spec/tapioca/gem/pipeline_spec.rb
+++ b/spec/tapioca/gem/pipeline_spec.rb
@@ -2786,6 +2786,20 @@ class Tapioca::Gem::PipelineSpec < Minitest::HooksSpec
         end
       RUBY
 
+      add_ruby_file("class_methods.rb", <<~RUBY)
+        module ClassMethods
+          extend(T::Generic)
+
+          has_attached_class!
+        end
+
+        module ClassMethodsWithVariance
+          extend(T::Generic)
+
+          has_attached_class!(:out) { {upper: String} }
+        end
+      RUBY
+
       add_ruby_file("generic.rb", <<~RUBY)
         module Generics
           class ComplexGenericType
@@ -2910,6 +2924,18 @@ class Tapioca::Gem::PipelineSpec < Minitest::HooksSpec
           const :foo, ::Integer
           prop :bar, ::String
           const :baz, T.proc.params(arg0: ::String).void
+        end
+
+        module ClassMethods
+          extend T::Generic
+
+          has_attached_class!
+        end
+
+        module ClassMethodsWithVariance
+          extend T::Generic
+
+          has_attached_class!(:out) { { upper: String } }
         end
 
         class Foo


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
Fixes #1513 

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
As implemented `has_attached_class!` is a generic construct, is defined on `T::Generic`, accepts the same parameters as `type_member`/`type_template` calls. So for all intents and purposes it is type variable without a name (or rather with an implicit, internal, name).

Thus, I implemented it as yet another type variable type, which gets serialized differently. The sorting order of `has_attached_class!` calls might not be grouped with `type_member`/`type_template` calls, but that is not important for supporting this feature.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->
Added test cases for the next syntax
