### PR TITLE
Default to raising exception if Rails app cannot be loaded

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,36 +163,38 @@ Usage:
   tapioca gem [gem...]
 
 Options:
-  --out, -o,   [--outdir=directory]                             # The output directory for generated gem RBI files
-                                                                # Default: sorbet/rbi/gems
-               [--file-header], [--no-file-header]              # Add a "This file is generated" header on top of each generated RBI file
-                                                                # Default: true
-               [--all], [--no-all]                              # Regenerate RBI files for all gems
-  --pre, -b,   [--prerequire=file]                              # A file to be required before Bundler.require is called
-  --post, -a,  [--postrequire=file]                             # A file to be required after Bundler.require is called
-                                                                # Default: sorbet/tapioca/require.rb
-  -x,          [--exclude=gem [gem ...]]                        # Exclude the given gem(s) from RBI generation
-  --typed, -t, [--typed-overrides=gem:level [gem:level ...]]    # Override for typed sigils for generated gem RBIs
-                                                                # Default: {"activesupport"=>"false"}
-               [--verify], [--no-verify]                        # Verify RBIs are up-to-date
-               [--doc], [--no-doc]                              # Include YARD documentation from sources when generating RBIs. Warning: this might be slow
-                                                                # Default: true
-               [--loc], [--no-loc]                              # Include comments with source location when generating RBIs
-                                                                # Default: true
-               [--exported-gem-rbis], [--no-exported-gem-rbis]  # Include RBIs found in the `rbi/` directory of the gem
-                                                                # Default: true
-  -w,          [--workers=N]                                    # Number of parallel workers to use when generating RBIs (default: auto)
-               [--auto-strictness], [--no-auto-strictness]      # Autocorrect strictness in gem RBIs in case of conflict with the DSL RBIs
-                                                                # Default: true
-  --dsl-dir,   [--dsl-dir=directory]                            # The DSL directory used to correct gems strictnesses
-                                                                # Default: sorbet/rbi/dsl
-               [--rbi-max-line-length=N]                        # Set the max line length of generated RBIs. Signatures longer than the max line length will be wrapped
-                                                                # Default: 120
-  -e,          [--environment=ENVIRONMENT]                      # The Rack/Rails environment to use when generating RBIs
-                                                                # Default: development
-  -c,          [--config=<config file path>]                    # Path to the Tapioca configuration file
-                                                                # Default: sorbet/tapioca/config.yml
-  -V,          [--verbose], [--no-verbose]                      # Verbose output for debugging purposes
+  --out, -o,   [--outdir=directory]                                   # The output directory for generated gem RBI files
+                                                                      # Default: sorbet/rbi/gems
+               [--file-header], [--no-file-header]                    # Add a "This file is generated" header on top of each generated RBI file
+                                                                      # Default: true
+               [--all], [--no-all]                                    # Regenerate RBI files for all gems
+  --pre, -b,   [--prerequire=file]                                    # A file to be required before Bundler.require is called
+  --post, -a,  [--postrequire=file]                                   # A file to be required after Bundler.require is called
+                                                                      # Default: sorbet/tapioca/require.rb
+  -x,          [--exclude=gem [gem ...]]                              # Exclude the given gem(s) from RBI generation
+  --typed, -t, [--typed-overrides=gem:level [gem:level ...]]          # Override for typed sigils for generated gem RBIs
+                                                                      # Default: {"activesupport"=>"false"}
+               [--verify], [--no-verify]                              # Verify RBIs are up-to-date
+               [--doc], [--no-doc]                                    # Include YARD documentation from sources when generating RBIs. Warning: this might be slow
+                                                                      # Default: true
+               [--loc], [--no-loc]                                    # Include comments with source location when generating RBIs
+                                                                      # Default: true
+               [--exported-gem-rbis], [--no-exported-gem-rbis]        # Include RBIs found in the `rbi/` directory of the gem
+                                                                      # Default: true
+  -w,          [--workers=N]                                          # Number of parallel workers to use when generating RBIs (default: auto)
+               [--auto-strictness], [--no-auto-strictness]            # Autocorrect strictness in gem RBIs in case of conflict with the DSL RBIs
+                                                                      # Default: true
+  --dsl-dir,   [--dsl-dir=directory]                                  # The DSL directory used to correct gems strictnesses
+                                                                      # Default: sorbet/rbi/dsl
+               [--rbi-max-line-length=N]                              # Set the max line length of generated RBIs. Signatures longer than the max line length will be wrapped
+                                                                      # Default: 120
+  -e,          [--environment=ENVIRONMENT]                            # The Rack/Rails environment to use when generating RBIs
+                                                                      # Default: development
+               [--halt-upon-load-error], [--no-halt-upon-load-error]  # Halt upon a load error while loading the Rails application
+                                                                      # Default: true
+  -c,          [--config=<config file path>]                          # Path to the Tapioca configuration file
+                                                                      # Default: sorbet/tapioca/config.yml
+  -V,          [--verbose], [--no-verbose]                            # Verbose output for debugging purposes
 
 generate RBIs from gems
 ```
@@ -458,26 +460,28 @@ Usage:
   tapioca dsl [constant...]
 
 Options:
-  --out, -o, [--outdir=directory]                       # The output directory for generated DSL RBI files
-                                                        # Default: sorbet/rbi/dsl
-             [--file-header], [--no-file-header]        # Add a "This file is generated" header on top of each generated RBI file
-                                                        # Default: true
-             [--only=compiler [compiler ...]]           # Only run supplied DSL compiler(s)
-             [--exclude=compiler [compiler ...]]        # Exclude supplied DSL compiler(s)
-             [--verify], [--no-verify]                  # Verifies RBIs are up-to-date
-  -q,        [--quiet], [--no-quiet]                    # Suppresses file creation output
-  -w,        [--workers=N]                              # Number of parallel workers to use when generating RBIs (default: 2)
-                                                        # Default: 2
-             [--rbi-max-line-length=N]                  # Set the max line length of generated RBIs. Signatures longer than the max line length will be wrapped
-                                                        # Default: 120
-  -e,        [--environment=ENVIRONMENT]                # The Rack/Rails environment to use when generating RBIs
-                                                        # Default: development
-  -l,        [--list-compilers], [--no-list-compilers]  # List all loaded compilers
-             [--app-root=APP_ROOT]                      # The path to the Rails application
-                                                        # Default: .
-  -c,        [--config=<config file path>]              # Path to the Tapioca configuration file
-                                                        # Default: sorbet/tapioca/config.yml
-  -V,        [--verbose], [--no-verbose]                # Verbose output for debugging purposes
+  --out, -o, [--outdir=directory]                                   # The output directory for generated DSL RBI files
+                                                                    # Default: sorbet/rbi/dsl
+             [--file-header], [--no-file-header]                    # Add a "This file is generated" header on top of each generated RBI file
+                                                                    # Default: true
+             [--only=compiler [compiler ...]]                       # Only run supplied DSL compiler(s)
+             [--exclude=compiler [compiler ...]]                    # Exclude supplied DSL compiler(s)
+             [--verify], [--no-verify]                              # Verifies RBIs are up-to-date
+  -q,        [--quiet], [--no-quiet]                                # Suppresses file creation output
+  -w,        [--workers=N]                                          # Number of parallel workers to use when generating RBIs (default: 2)
+                                                                    # Default: 2
+             [--rbi-max-line-length=N]                              # Set the max line length of generated RBIs. Signatures longer than the max line length will be wrapped
+                                                                    # Default: 120
+  -e,        [--environment=ENVIRONMENT]                            # The Rack/Rails environment to use when generating RBIs
+                                                                    # Default: development
+  -l,        [--list-compilers], [--no-list-compilers]              # List all loaded compilers
+             [--app-root=APP_ROOT]                                  # The path to the Rails application
+                                                                    # Default: .
+             [--halt-upon-load-error], [--no-halt-upon-load-error]  # Halt upon a load error while loading the Rails application
+                                                                    # Default: true
+  -c,        [--config=<config file path>]                          # Path to the Tapioca configuration file
+                                                                    # Default: sorbet/tapioca/config.yml
+  -V,        [--verbose], [--no-verbose]                            # Verbose output for debugging purposes
 
 generate RBIs for dynamic methods
 ```
@@ -827,6 +831,7 @@ dsl:
   environment: development
   list_compilers: false
   app_root: "."
+  halt_upon_load_error: true
 gem:
   outdir: sorbet/rbi/gems
   file_header: true
@@ -845,6 +850,7 @@ gem:
   dsl_dir: sorbet/rbi/dsl
   rbi_max_line_length: 120
   environment: development
+  halt_upon_load_error: true
 check_shims:
   gem_rbi_dir: sorbet/rbi/gems
   dsl_rbi_dir: sorbet/rbi/dsl

--- a/lib/tapioca/cli.rb
+++ b/lib/tapioca/cli.rb
@@ -130,6 +130,10 @@ module Tapioca
       type: :string,
       desc: "The path to the Rails application",
       default: "."
+    option :halt_upon_load_error,
+      type: :boolean,
+      desc: "Halt upon a load error while loading the Rails application",
+      default: true
     def dsl(*constant_or_paths)
       set_environment(options)
 
@@ -150,6 +154,7 @@ module Tapioca
         number_of_workers: options[:workers],
         rbi_formatter: rbi_formatter(options),
         app_root: options[:app_root],
+        halt_upon_load_error: options[:halt_upon_load_error],
       )
 
       Tapioca.silence_warnings do
@@ -235,6 +240,10 @@ module Tapioca
       type: :string,
       desc: "The Rack/Rails environment to use when generating RBIs",
       default: DEFAULT_ENVIRONMENT
+    option :halt_upon_load_error,
+      type: :boolean,
+      desc: "Halt upon a load error while loading the Rails application",
+      default: true
     def gem(*gems)
       Tapioca.silence_warnings do
         set_environment(options)
@@ -257,6 +266,7 @@ module Tapioca
           auto_strictness: options[:auto_strictness],
           dsl_dir: options[:dsl_dir],
           rbi_formatter: rbi_formatter(options),
+          halt_upon_load_error: options[:halt_upon_load_error],
         )
 
         raise MalformattedArgumentError, "Options '--all' and '--verify' are mutually exclusive" if all && verify

--- a/lib/tapioca/commands/dsl.rb
+++ b/lib/tapioca/commands/dsl.rb
@@ -24,6 +24,7 @@ module Tapioca
           gem_dir: String,
           rbi_formatter: RBIFormatter,
           app_root: String,
+          halt_upon_load_error: T::Boolean,
         ).void
       end
       def initialize(
@@ -41,7 +42,8 @@ module Tapioca
         auto_strictness: true,
         gem_dir: DEFAULT_GEM_DIR,
         rbi_formatter: DEFAULT_RBI_FORMATTER,
-        app_root: "."
+        app_root: ".",
+        halt_upon_load_error: true
       )
         @requested_constants = requested_constants
         @requested_paths = requested_paths
@@ -58,6 +60,7 @@ module Tapioca
         @gem_dir = gem_dir
         @rbi_formatter = rbi_formatter
         @app_root = app_root
+        @halt_upon_load_error = halt_upon_load_error
 
         super()
       end
@@ -68,6 +71,7 @@ module Tapioca
           tapioca_path: @tapioca_path,
           eager_load: @requested_constants.empty? && @requested_paths.empty?,
           app_root: @app_root,
+          halt_upon_load_error: @halt_upon_load_error,
         )
 
         pipeline = create_pipeline
@@ -95,6 +99,7 @@ module Tapioca
           tapioca_path: @tapioca_path,
           eager_load: @requested_constants.empty? && @requested_paths.empty?,
           app_root: @app_root,
+          halt_upon_load_error: @halt_upon_load_error,
         )
 
         if @should_verify

--- a/lib/tapioca/commands/gem.rb
+++ b/lib/tapioca/commands/gem.rb
@@ -23,6 +23,7 @@ module Tapioca
           auto_strictness: T::Boolean,
           dsl_dir: String,
           rbi_formatter: RBIFormatter,
+          halt_upon_load_error: T::Boolean,
         ).void
       end
       def initialize(
@@ -39,7 +40,8 @@ module Tapioca
         number_of_workers: nil,
         auto_strictness: true,
         dsl_dir: DEFAULT_DSL_DIR,
-        rbi_formatter: DEFAULT_RBI_FORMATTER
+        rbi_formatter: DEFAULT_RBI_FORMATTER,
+        halt_upon_load_error: true
       )
         @gem_names = gem_names
         @exclude = exclude
@@ -61,6 +63,7 @@ module Tapioca
         @include_doc = T.let(include_doc, T::Boolean)
         @include_loc = T.let(include_loc, T::Boolean)
         @include_exported_rbis = include_exported_rbis
+        @halt_upon_load_error = halt_upon_load_error
       end
 
       sig { override.void }
@@ -70,6 +73,7 @@ module Tapioca
           prerequire: @prerequire,
           postrequire: @postrequire,
           default_command: default_command(:require),
+          halt_upon_load_error: @halt_upon_load_error,
         )
 
         gem_queue = gems_to_generate(@gem_names).reject { |gem| @exclude.include?(gem.name) }
@@ -245,6 +249,7 @@ module Tapioca
               prerequire: @prerequire,
               postrequire: @postrequire,
               default_command: default_command(:require),
+              halt_upon_load_error: @halt_upon_load_error,
             )
 
             Executor.new(gems, number_of_workers: @number_of_workers).run_in_parallel do |gem_name|

--- a/lib/tapioca/loaders/dsl.rb
+++ b/lib/tapioca/loaders/dsl.rb
@@ -9,9 +9,16 @@ module Tapioca
       class << self
         extend T::Sig
 
-        sig { params(tapioca_path: String, eager_load: T::Boolean, app_root: String).void }
-        def load_application(tapioca_path:, eager_load: true, app_root: ".")
-          loader = new(tapioca_path: tapioca_path, eager_load: eager_load, app_root: app_root)
+        sig do
+          params(tapioca_path: String, eager_load: T::Boolean, app_root: String, halt_upon_load_error: T::Boolean).void
+        end
+        def load_application(tapioca_path:, eager_load: true, app_root: ".", halt_upon_load_error: true)
+          loader = new(
+            tapioca_path: tapioca_path,
+            eager_load: eager_load,
+            app_root: app_root,
+            halt_upon_load_error: halt_upon_load_error,
+          )
           loader.load
         end
       end
@@ -25,13 +32,16 @@ module Tapioca
 
       protected
 
-      sig { params(tapioca_path: String, eager_load: T::Boolean, app_root: String).void }
-      def initialize(tapioca_path:, eager_load: true, app_root: ".")
+      sig do
+        params(tapioca_path: String, eager_load: T::Boolean, app_root: String, halt_upon_load_error: T::Boolean).void
+      end
+      def initialize(tapioca_path:, eager_load: true, app_root: ".", halt_upon_load_error: true)
         super()
 
         @tapioca_path = tapioca_path
         @eager_load = eager_load
         @app_root = app_root
+        @halt_upon_load_error = halt_upon_load_error
       end
 
       sig { void }
@@ -65,6 +75,7 @@ module Tapioca
           environment_load: true,
           eager_load: @eager_load,
           app_root: @app_root,
+          halt_upon_load_error: @halt_upon_load_error,
         )
 
         say("Done", :green)

--- a/lib/tapioca/loaders/gem.rb
+++ b/lib/tapioca/loaders/gem.rb
@@ -15,14 +15,16 @@ module Tapioca
             prerequire: T.nilable(String),
             postrequire: String,
             default_command: String,
+            halt_upon_load_error: T::Boolean,
           ).void
         end
-        def load_application(bundle:, prerequire:, postrequire:, default_command:)
+        def load_application(bundle:, prerequire:, postrequire:, default_command:, halt_upon_load_error:)
           loader = new(
             bundle: bundle,
             prerequire: prerequire,
             postrequire: postrequire,
             default_command: default_command,
+            halt_upon_load_error: halt_upon_load_error,
           )
           loader.load
         end
@@ -41,22 +43,24 @@ module Tapioca
           prerequire: T.nilable(String),
           postrequire: String,
           default_command: String,
+          halt_upon_load_error: T::Boolean,
         ).void
       end
-      def initialize(bundle:, prerequire:, postrequire:, default_command:)
+      def initialize(bundle:, prerequire:, postrequire:, default_command:, halt_upon_load_error:)
         super()
 
         @bundle = bundle
         @prerequire = prerequire
         @postrequire = postrequire
         @default_command = default_command
+        @halt_upon_load_error = halt_upon_load_error
       end
 
       sig { void }
       def require_gem_file
         say("Requiring all gems to prepare for compiling... ")
         begin
-          load_bundle(@bundle, @prerequire, @postrequire)
+          load_bundle(@bundle, @prerequire, @postrequire, @halt_upon_load_error)
         rescue LoadError => e
           explain_failed_require(@postrequire, e)
           exit(1)

--- a/spec/tapioca/cli/dsl_spec.rb
+++ b/spec/tapioca/cli/dsl_spec.rb
@@ -2135,60 +2135,64 @@ module Tapioca
           assert_success_status(result)
         end
       end
-    end
 
-    describe "cli::dsl::custom application.rb" do
-      before(:all) do
-        @project.write("config/environment.rb", <<~RB)
-          require_relative "application.rb"
-        RB
+      describe "halt-upon-load-error" do
+        before(:all) do
+          @project.write("config/environment.rb", <<~RB)
+            require_relative "application.rb"
+          RB
 
-        @project.write("config/application.rb", <<~RB)
-          require "rails"
+          @project.write("config/application.rb", <<~RB)
+            require "rails"
 
-          module Test
-            class Application < Rails::Application
-              raise "Error during application loading"
+            module Test
+              class Application < Rails::Application
+                raise "Error during application loading"
+              end
             end
-          end
-        RB
+          RB
 
-        @project.require_real_gem("rails")
-        @project.bundle_install
-      end
+          @project.require_real_gem("rails")
+          @project.bundle_install
+        end
 
-      it "halts upon load errors when rails application cannot be loaded" do
-        res = @project.tapioca("dsl")
+        after(:all) do
+          @project.remove("config/application.rb")
+        end
 
-        out = "Tapioca attempted to load the Rails application after encountering a `config/application.rb` file, " \
-          "but it failed. If your application uses Rails please ensure it can be loaded correctly before " \
-          "generating RBIs. If your application does not use Rails and you wish to continue RBI generation " \
-          "please pass `--no-halt-upon-load-error` to the tapioca command in sorbet/tapioca/config.yml or in CLI." \
-          "\nError during application loading"
-        assert_stdout_includes(res, out)
-        err = "tapioca/tests/dsl_spec/project/config/application.rb:5:in `<class:Application>': Error during " \
-          "application loading (RuntimeError)"
-        assert_stderr_includes(res, err)
-        refute_success_status(res)
-      end
+        it "halts upon load errors when rails application cannot be loaded" do
+          res = @project.tapioca("dsl")
 
-      it "output errors when rails application cannot be loaded with --no-halt-upon-load-error flag" do
-        res = @project.tapioca("dsl --no-halt-upon-load-error")
+          out = "Tapioca attempted to load the Rails application after encountering a `config/application.rb` file, " \
+            "but it failed. If your application uses Rails please ensure it can be loaded correctly before " \
+            "generating RBIs. If your application does not use Rails and you wish to continue RBI generation " \
+            "please pass `--no-halt-upon-load-error` to the tapioca command in sorbet/tapioca/config.yml or in CLI." \
+            "\nError during application loading"
+          assert_stdout_includes(res, out)
+          err = "tapioca/tests/dsl_spec/project/config/application.rb:5:in `<class:Application>': Error during " \
+            "application loading (RuntimeError)"
+          assert_stderr_includes(res, err)
+          refute_success_status(res)
+        end
 
-        out = "Tapioca attempted to load the Rails application after encountering a `config/application.rb` file, " \
-          "but it failed. If your application uses Rails please ensure it can be loaded correctly before " \
-          "generating RBIs. If your application does not use Rails and you wish to continue RBI generation " \
-          "please pass `--no-halt-upon-load-error` to the tapioca command in sorbet/tapioca/config.yml or in CLI." \
-          "\nError during application loading"
-        assert_stdout_includes(res, out)
-        assert_stdout_includes(res, "tapioca/tests/dsl_spec/project/config/application.rb:5:in `<class:Application>'")
-        assert_stdout_includes(res, <<~OUT)
-          Continuing RBI generation without loading the Rails application.
-          Done
-          Loading DSL compiler classes... Done
-          Compiling DSL RBI files...
-        OUT
-        assert_success_status(res)
+        it "output errors when rails application cannot be loaded with --no-halt-upon-load-error flag" do
+          res = @project.tapioca("dsl --no-halt-upon-load-error")
+
+          out = "Tapioca attempted to load the Rails application after encountering a `config/application.rb` file, " \
+            "but it failed. If your application uses Rails please ensure it can be loaded correctly before " \
+            "generating RBIs. If your application does not use Rails and you wish to continue RBI generation " \
+            "please pass `--no-halt-upon-load-error` to the tapioca command in sorbet/tapioca/config.yml or in CLI." \
+            "\nError during application loading"
+          assert_stdout_includes(res, out)
+          assert_stdout_includes(res, "tapioca/tests/dsl_spec/project/config/application.rb:5:in `<class:Application>'")
+          assert_stdout_includes(res, <<~OUT)
+            Continuing RBI generation without loading the Rails application.
+            Done
+            Loading DSL compiler classes... Done
+            Compiling DSL RBI files...
+          OUT
+          assert_success_status(res)
+        end
       end
     end
   end

--- a/spec/tapioca/cli/dsl_spec.rb
+++ b/spec/tapioca/cli/dsl_spec.rb
@@ -2138,7 +2138,7 @@ module Tapioca
     end
 
     describe "cli::dsl::custom application.rb" do
-      it "output errors when rails application cannot be loaded" do
+      before(:all) do
         @project.write("config/environment.rb", <<~RB)
           require_relative "application.rb"
         RB
@@ -2155,14 +2155,34 @@ module Tapioca
 
         @project.require_real_gem("rails")
         @project.bundle_install
+      end
+
+      it "halts upon load errors when rails application cannot be loaded" do
         res = @project.tapioca("dsl")
 
         out = "Tapioca attempted to load the Rails application after encountering a `config/application.rb` file, " \
           "but it failed. If your application uses Rails please ensure it can be loaded correctly before " \
-          "generating RBIs.\nError during application loading"
-        assert_includes(res.out, out)
-        assert_includes(res.out, "tapioca/tests/dsl_spec/project/config/application.rb:5:in `<class:Application>'")
-        assert_includes(res.out, <<~OUT)
+          "generating RBIs. If your application does not use Rails and you wish to continue RBI generation " \
+          "please pass `--no-halt-upon-load-error` to the tapioca command in sorbet/tapioca/config.yml or in CLI." \
+          "\nError during application loading"
+        assert_stdout_includes(res, out)
+        err = "tapioca/tests/dsl_spec/project/config/application.rb:5:in `<class:Application>': Error during " \
+          "application loading (RuntimeError)"
+        assert_stderr_includes(res, err)
+        refute_success_status(res)
+      end
+
+      it "output errors when rails application cannot be loaded with --no-halt-upon-load-error flag" do
+        res = @project.tapioca("dsl --no-halt-upon-load-error")
+
+        out = "Tapioca attempted to load the Rails application after encountering a `config/application.rb` file, " \
+          "but it failed. If your application uses Rails please ensure it can be loaded correctly before " \
+          "generating RBIs. If your application does not use Rails and you wish to continue RBI generation " \
+          "please pass `--no-halt-upon-load-error` to the tapioca command in sorbet/tapioca/config.yml or in CLI." \
+          "\nError during application loading"
+        assert_stdout_includes(res, out)
+        assert_stdout_includes(res, "tapioca/tests/dsl_spec/project/config/application.rb:5:in `<class:Application>'")
+        assert_stdout_includes(res, <<~OUT)
           Continuing RBI generation without loading the Rails application.
           Done
           Loading DSL compiler classes... Done

--- a/spec/tapioca/cli/gem_spec.rb
+++ b/spec/tapioca/cli/gem_spec.rb
@@ -210,6 +210,7 @@ module Tapioca
           project.remove("sorbet/rbi")
           project.remove("../gems")
           project.remove("sorbet/tapioca/require.rb")
+          project.remove("config/application.rb")
         end
 
         it "must generate a single gem RBI" do
@@ -2077,67 +2078,70 @@ module Tapioca
           OUT
         end
       end
-    end
 
-    describe "custom application.rb" do
-      before(:all) do
-        @project.write("config/environment.rb", <<~RB)
-          require_relative "application.rb"
-        RB
+      describe "halt-upon-load-error" do
+        before(:all) do
+          @project.write("config/environment.rb", <<~RB)
+            require_relative "application.rb"
+          RB
 
-        @project.write("config/application.rb", <<~RB)
-          require "rails"
+          @project.write("config/application.rb", <<~RB)
+            require "rails"
 
-          module Test
-            class Application < Rails::Application
-              raise "Error during application loading"
+            module Test
+              class Application < Rails::Application
+                raise "Error during application loading"
+              end
             end
-          end
-        RB
+          RB
 
-        foo = mock_gem("foo", "0.0.1") do
-          write("lib/foo.rb", FOO_RB)
+          foo = mock_gem("foo", "0.0.1") do
+            write("lib/foo.rb", FOO_RB)
+          end
+
+          @project.require_mock_gem(foo)
+          @project.require_real_gem("rails")
+          @project.bundle_install
         end
 
-        @project.require_mock_gem(foo)
-        @project.require_real_gem("rails")
-        @project.bundle_install
-      end
+        after(:all) do
+          @project.remove("config/application.rb")
+        end
 
-      it "halts upon load errors when rails application cannot be loaded" do
-        result = @project.tapioca("gem foo")
+        it "halts upon load errors when rails application cannot be loaded" do
+          result = @project.tapioca("gem foo")
 
-        out = "Tapioca attempted to load the Rails application after encountering a `config/application.rb` file, " \
-          "but it failed. If your application uses Rails please ensure it can be loaded correctly before " \
-          "generating RBIs. If your application does not use Rails and you wish to continue RBI generation " \
-          "please pass `--no-halt-upon-load-error` to the tapioca command in sorbet/tapioca/config.yml or in CLI." \
-          "\nError during application loading"
-        assert_stdout_includes(result, out)
-        err = "/tmp/tapioca/tests/gem_spec/project/config/application.rb:5:in `<class:Application>': Error during " \
-          "application loading (RuntimeError)"
-        assert_stderr_includes(result, err)
-        refute_success_status(result)
-      end
+          out = "Tapioca attempted to load the Rails application after encountering a `config/application.rb` file, " \
+            "but it failed. If your application uses Rails please ensure it can be loaded correctly before " \
+            "generating RBIs. If your application does not use Rails and you wish to continue RBI generation " \
+            "please pass `--no-halt-upon-load-error` to the tapioca command in sorbet/tapioca/config.yml or in CLI." \
+            "\nError during application loading"
+          assert_stdout_includes(result, out)
+          err = "/tmp/tapioca/tests/gem_spec/project/config/application.rb:5:in `<class:Application>': Error during " \
+            "application loading (RuntimeError)"
+          assert_stderr_includes(result, err)
+          refute_success_status(result)
+        end
 
-      it "output errors when rails application cannot be loaded with --no-halt-upon-load-error flag" do
-        result = @project.tapioca("gem foo --no-halt-upon-load-error")
+        it "output errors when rails application cannot be loaded with --no-halt-upon-load-error flag" do
+          result = @project.tapioca("gem foo --no-halt-upon-load-error")
 
-        out = "Tapioca attempted to load the Rails application after encountering a `config/application.rb` file, " \
-          "but it failed. If your application uses Rails please ensure it can be loaded correctly before " \
-          "generating RBIs. If your application does not use Rails and you wish to continue RBI generation " \
-          "please pass `--no-halt-upon-load-error` to the tapioca command in sorbet/tapioca/config.yml or in CLI." \
-          "\nError during application loading"
-        assert_stdout_includes(result, out)
-        assert_stdout_includes(
-          result,
-          "/tmp/tapioca/tests/gem_spec/project/config/application.rb:5:in `<class:Application>'",
-        )
-        assert_stdout_includes(result, <<~OUT)
-          Continuing RBI generation without loading the Rails application.
-           Done
-        OUT
-        puts result.err
-        assert_success_status(result)
+          out = "Tapioca attempted to load the Rails application after encountering a `config/application.rb` file, " \
+            "but it failed. If your application uses Rails please ensure it can be loaded correctly before " \
+            "generating RBIs. If your application does not use Rails and you wish to continue RBI generation " \
+            "please pass `--no-halt-upon-load-error` to the tapioca command in sorbet/tapioca/config.yml or in CLI." \
+            "\nError during application loading"
+          assert_stdout_includes(result, out)
+          assert_stdout_includes(
+            result,
+            "/tmp/tapioca/tests/gem_spec/project/config/application.rb:5:in `<class:Application>'",
+          )
+          assert_stdout_includes(result, <<~OUT)
+            Continuing RBI generation without loading the Rails application.
+             Done
+          OUT
+          assert_success_status(result)
+        end
       end
     end
   end

--- a/spec/tapioca/cli/gem_spec.rb
+++ b/spec/tapioca/cli/gem_spec.rb
@@ -2078,5 +2078,67 @@ module Tapioca
         end
       end
     end
+
+    describe "custom application.rb" do
+      before(:all) do
+        @project.write("config/environment.rb", <<~RB)
+          require_relative "application.rb"
+        RB
+
+        @project.write("config/application.rb", <<~RB)
+          require "rails"
+
+          module Test
+            class Application < Rails::Application
+              raise "Error during application loading"
+            end
+          end
+        RB
+
+        foo = mock_gem("foo", "0.0.1") do
+          write("lib/foo.rb", FOO_RB)
+        end
+
+        @project.require_mock_gem(foo)
+        @project.require_real_gem("rails")
+        @project.bundle_install
+      end
+
+      it "halts upon load errors when rails application cannot be loaded" do
+        result = @project.tapioca("gem foo")
+
+        out = "Tapioca attempted to load the Rails application after encountering a `config/application.rb` file, " \
+          "but it failed. If your application uses Rails please ensure it can be loaded correctly before " \
+          "generating RBIs. If your application does not use Rails and you wish to continue RBI generation " \
+          "please pass `--no-halt-upon-load-error` to the tapioca command in sorbet/tapioca/config.yml or in CLI." \
+          "\nError during application loading"
+        assert_stdout_includes(result, out)
+        err = "/tmp/tapioca/tests/gem_spec/project/config/application.rb:5:in `<class:Application>': Error during " \
+          "application loading (RuntimeError)"
+        assert_stderr_includes(result, err)
+        refute_success_status(result)
+      end
+
+      it "output errors when rails application cannot be loaded with --no-halt-upon-load-error flag" do
+        result = @project.tapioca("gem foo --no-halt-upon-load-error")
+
+        out = "Tapioca attempted to load the Rails application after encountering a `config/application.rb` file, " \
+          "but it failed. If your application uses Rails please ensure it can be loaded correctly before " \
+          "generating RBIs. If your application does not use Rails and you wish to continue RBI generation " \
+          "please pass `--no-halt-upon-load-error` to the tapioca command in sorbet/tapioca/config.yml or in CLI." \
+          "\nError during application loading"
+        assert_stdout_includes(result, out)
+        assert_stdout_includes(
+          result,
+          "/tmp/tapioca/tests/gem_spec/project/config/application.rb:5:in `<class:Application>'",
+        )
+        assert_stdout_includes(result, <<~OUT)
+          Continuing RBI generation without loading the Rails application.
+           Done
+        OUT
+        puts result.err
+        assert_success_status(result)
+      end
+    end
   end
 end


### PR DESCRIPTION
Resolves https://github.com/Shopify/tapioca/issues/1500

Apps that want the previous functionality can use --no-halt-upon-load-error

### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
Current behaviour is hiding legitimate errors and requires inspecting the logs

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->

Raise the exception thrown from `config/application.rb` if the new `halt-upon-load-error` flag is set

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->

Included.