### PR TITLE
Compiler for controller actions

### DIFF
--- a/lib/tapioca/dsl/compilers/controller_actions.rb
+++ b/lib/tapioca/dsl/compilers/controller_actions.rb
@@ -1,0 +1,75 @@
+# typed: strict
+# frozen_string_literal: true
+
+begin
+  require "action_controller"
+rescue LoadError
+  return
+end
+
+module Tapioca
+  module Dsl
+    module Compilers
+      # `Tapioca::Dsl::Compilers::ControllerActions` generates RBI files for classes that include
+      # [`ActionController::Base`](https://api.rubyonrails.org/classes/ActionController/Base.html).
+      #
+      # For example, with the following class that includes `ActionController::Base`:
+      #
+      # ~~~rb
+      # class PostsController < ApplicationController
+      #  def index
+      #   # ...
+      #  end
+      #
+      #  def create
+      #    # ...
+      #  end
+      # end
+      # ~~~
+      #
+      # this compiler will produce the RBI file `posts_controller.rbi` with the following content:
+      #
+      # ~~~rbi
+      # # posts_controller.rbi
+      # # typed: strong
+      # class PostsController
+      #   sig { void }
+      #   def index; end
+      #
+      #   sig { void }
+      #   def create; end
+      # end
+      # ~~~
+      class ControllerActions < Compiler
+        extend T::Sig
+
+        ConstantType = type_member { { fixed: T.class_of(::ActionController::Base) } }
+
+        sig { override.void }
+        def decorate
+          public_methods = constant.instance_methods(false)
+          return if public_methods.empty?
+
+          root.create_path(constant) do |klass|
+            public_methods.each do |method_name|
+              method = constant.instance_method(method_name)
+              signature = signature_of(method)
+              next if signature
+
+              klass.create_method(method_name.to_s, return_type: "void")
+            end
+          end
+        end
+
+        class << self
+          extend T::Sig
+
+          sig { override.returns(T::Enumerable[Module]) }
+          def gather_constants
+            all_classes.select { |c| c < ActionController::Base }
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/tapioca/dsl/compilers/controller_actions.rb
+++ b/lib/tapioca/dsl/compilers/controller_actions.rb
@@ -47,11 +47,11 @@ module Tapioca
 
         sig { override.void }
         def decorate
-          public_methods = constant.instance_methods(false)
-          return if public_methods.empty?
+          action_methods = constant.action_methods
+          return if action_methods.empty?
 
           root.create_path(constant) do |klass|
-            public_methods.each do |method_name|
+            action_methods.each do |method_name|
               method = constant.instance_method(method_name)
               signature = signature_of(method)
               next if signature

--- a/manual/compiler_controlleractions.md
+++ b/manual/compiler_controlleractions.md
@@ -1,0 +1,32 @@
+## ControllerActions
+
+`Tapioca::Dsl::Compilers::ControllerActions` generates RBI files for classes that include
+[`ActionController::Base`](https://api.rubyonrails.org/classes/ActionController/Base.html).
+
+For example, with the following class that includes `ActionController::Base`:
+
+~~~rb
+class PostsController < ApplicationController
+ def index
+  # ...
+ end
+
+ def create
+   # ...
+ end
+end
+~~~
+
+this compiler will produce the RBI file `posts_controller.rbi` with the following content:
+
+~~~rbi
+# posts_controller.rbi
+# typed: strong
+class PostsController
+  sig { void }
+  def index; end
+
+  sig { void }
+  def create; end
+end
+~~~

--- a/manual/compilers.md
+++ b/manual/compilers.md
@@ -23,6 +23,7 @@ In the following section you will find all available DSL compilers:
 * [ActiveSupportConcern](compiler_activesupportconcern.md)
 * [ActiveSupportCurrentAttributes](compiler_activesupportcurrentattributes.md)
 * [Config](compiler_config.md)
+* [ControllerActions](compiler_controlleractions.md)
 * [FrozenRecord](compiler_frozenrecord.md)
 * [GraphqlInputObject](compiler_graphqlinputobject.md)
 * [GraphqlMutation](compiler_graphqlmutation.md)

--- a/spec/tapioca/dsl/compilers/controller_actions_spec.rb
+++ b/spec/tapioca/dsl/compilers/controller_actions_spec.rb
@@ -1,0 +1,115 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Tapioca
+  module Dsl
+    module Compilers
+      class ControllerActionsSpec < ::DslSpec
+        describe "Tapioca::Dsl::Compilers::ActionController" do
+          describe "initialize" do
+            it "gathers no constants if there are no ActionController::Base subclasses" do
+              assert_empty(gathered_constants)
+            end
+
+            it "gathers only ActionController::Base subclasses" do
+              add_ruby_file("content.rb", <<~RUBY)
+                class UsersController < ActionController::Base
+                end
+
+                class User
+                end
+              RUBY
+
+              assert_equal(["UsersController"], gathered_constants)
+            end
+
+            it "gathers subclasses of ActionController::Base subclasses" do
+              add_ruby_file("content.rb", <<~RUBY)
+                class UserController < ActionController::Base
+                end
+
+                class LoginController < UserController
+                end
+              RUBY
+
+              assert_equal(["LoginController", "UserController"], gathered_constants)
+            end
+          end
+
+          describe "decorate" do
+            it "generates an empty RBI file if there is no actions" do
+              add_ruby_file("job.rb", <<~RUBY)
+                class UserController < ActionController::Base
+                end
+              RUBY
+
+              expected = <<~RBI
+                # typed: strong
+              RBI
+
+              assert_equal(expected, rbi_for(:UserController))
+            end
+
+            it "generates correct RBI file for subclass with methods" do
+              add_ruby_file("job.rb", <<~RUBY)
+                class UserController < ActionController::Base
+                  def index
+                  end
+                  def show
+                  end
+
+                  private
+                  def private_index
+                  end
+                end
+              RUBY
+
+              expected = <<~RBI
+                # typed: strong
+
+                class UserController
+                  sig { void }
+                  def index; end
+
+                  sig { void }
+                  def show; end
+                end
+              RBI
+
+              assert_equal(expected, rbi_for(:UserController))
+            end
+
+            it "generates correct RBI file for subclass with method signatures" do
+              add_ruby_file("job.rb", <<~RUBY)
+                class UserController < ActionController::Base
+                  extend T::Sig
+                  sig { void }
+                  def index
+                    # ...
+                  end
+
+                  def show
+                    # ...
+                  end
+                end
+              RUBY
+
+              expected = <<~RBI
+                # typed: strong
+
+                class UserController
+                  sig { void }
+                  def show; end
+                end
+              RBI
+
+              assert_equal(expected, rbi_for(:UserController))
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/tapioca/dsl/compilers/controller_actions_spec.rb
+++ b/spec/tapioca/dsl/compilers/controller_actions_spec.rb
@@ -52,7 +52,7 @@ module Tapioca
               assert_equal(expected, rbi_for(:UserController))
             end
 
-            it "generates correct RBI file for subclass with methods" do
+            it "generates correct RBI file for subclass with private methods" do
               add_ruby_file("job.rb", <<~RUBY)
                 class UserController < ActionController::Base
                   def index
@@ -62,6 +62,35 @@ module Tapioca
 
                   private
                   def private_index
+                  end
+                end
+              RUBY
+
+              expected = <<~RBI
+                # typed: strong
+
+                class UserController
+                  sig { void }
+                  def index; end
+
+                  sig { void }
+                  def show; end
+                end
+              RBI
+
+              assert_equal(expected, rbi_for(:UserController))
+            end
+
+            it "generates correct RBI file for subclass with protected methods" do
+              add_ruby_file("job.rb", <<~RUBY)
+                class UserController < ActionController::Base
+                  def index
+                  end
+                  def show
+                  end
+
+                  protected
+                  def protected_index
                   end
                 end
               RUBY


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
This is trying to resolve https://github.com/Shopify/tapioca/issues/1484, where we want signatures for controller actions.  


### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
Wrote a compiler with the help of @vinistock to create a `sig { void }` for all public controller actions.
  
Things to look out for: Is there something in Shopify core or another big project that might break because of this?  

### Tests

There are some tests added and dsl docs generated. 
