### PR TITLE
Fix `Reflection#inherited_ancestors_of` method for modules

### DIFF
--- a/lib/tapioca/runtime/reflection.rb
+++ b/lib/tapioca/runtime/reflection.rb
@@ -113,7 +113,7 @@ module Tapioca
         if Class === constant
           ancestors_of(superclass_of(constant) || Object)
         else
-          Module.ancestors
+          Module.new.ancestors
         end
       end
 


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
As reported by @searls on the Sorbet Slack, Tapioca would remove `include Kernel` lines from a module when generating the RBI file for the gem.

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
It turns out the problems stems from the implementation of `Reflection#inherited_ancestors_of` method doing the wrong thing for modules. For classes we look at the ancestors of the class' superclass (or `Object` if no explicit superclass is set), but for modules we used to look at the ancestors of `Module`. However, a module is an instance of `Module`, so the ancestors of `Module` would not be in the original module's ancestor list anyway. What we needed to check was the ancestors of a newly created `Module` instance, and strip those out.

This ends up affecting only `Kernel` mixed into a module, since `Module`'s ancestors only has `Kernel` as a mixin, all the other ancestors are classes like `Object` and `BasicObject`. That's probably why this behaviour was not caught earlier.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->
Added a test for module mixins that exhibits the wrong behaviour and passes after the change.
