### PR TITLE
Simplify check for `Google::Protobuf::Map` type - redux

### DIFF
--- a/lib/tapioca/dsl/compilers/protobuf.rb
+++ b/lib/tapioca/dsl/compilers/protobuf.rb
@@ -206,7 +206,7 @@ module Tapioca
             # > field, even if it was not defined in the enum.
             "T.any(Symbol, Integer)"
           when :message
-            descriptor.subtype.msgclass.name
+            descriptor.subtype.msgclass.name || "T.untyped"
           when :int32, :int64, :uint32, :uint64
             "Integer"
           when :double, :float

--- a/lib/tapioca/dsl/compilers/protobuf.rb
+++ b/lib/tapioca/dsl/compilers/protobuf.rb
@@ -78,7 +78,7 @@ module Tapioca
 
         extend T::Sig
 
-        ConstantType = type_member { { fixed: Module } }
+        ConstantType = type_member { { fixed: T::Class[T.anything] } }
 
         FIELD_RE = /^[a-z_][a-zA-Z0-9_]*$/
 
@@ -225,14 +225,24 @@ module Tapioca
           descriptor.label == :optional && descriptor.type == :message
         end
 
+        sig { params(descriptor: Google::Protobuf::FieldDescriptor).returns(T::Boolean) }
+        def map_type?(descriptor)
+          # Defensively make sure that we are dealing with a repeated field
+          return false unless descriptor.label == :repeated
+
+          # Try to create a new instance with the field that maps to the descriptor name
+          # being assinged a hash value. If this goes through, then it's a map type.
+          constant.new(**{ descriptor.name => {} })
+          true
+        rescue ArgumentError
+          # This means the descriptor is not a map type
+          false
+        end
+
         sig { params(descriptor: Google::Protobuf::FieldDescriptor).returns(Field) }
         def field_of(descriptor)
           if descriptor.label == :repeated
-            # Here we're going to check if the submsg_name is named according to
-            # how Google names map entries.
-            # https://github.com/protocolbuffers/protobuf/blob/f82e26/ruby/ext/google/protobuf_c/defs.c#L1963-L1966
-            if descriptor.submsg_name.to_s.end_with?("_MapEntry_#{descriptor.name}") ||
-                descriptor.submsg_name.to_s.end_with?("FieldsEntry")
+            if map_type?(descriptor)
               key = descriptor.subtype.lookup("key")
               value = descriptor.subtype.lookup("value")
 


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
Fix #1533

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
The realization is that you can't assign an array type to `Map` fields and that you can't assign a hash type to `Repeated` fields. So we can use that to detect the type of the field.

We try to instantiate a new instance of the constant type, setting the value of the current descriptor field to an empty hash. If the type is `Map`, then it will succeed. If it's `Repeated`, it will fail.

Another small change in this PR makes it so that when we fail to read the type of the descriptor for repeated/map fields, we won't end up generating invalid RBI files, due to the message class not having a name.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->
Added failing tests that pass after the changes.
