### PR TITLE
Simplify protobuf compiler default field values

### DIFF
--- a/lib/tapioca/dsl/compilers/protobuf.rb
+++ b/lib/tapioca/dsl/compilers/protobuf.rb
@@ -250,27 +250,21 @@ module Tapioca
               value_type = type_of(value)
               type = "Google::Protobuf::Map[#{key_type}, #{value_type}]"
 
-              default_args = [key.type.inspect, value.type.inspect]
-              default_args << value_type if [:enum, :message].include?(value.type)
-
               Field.new(
                 name: descriptor.name,
                 type: type,
                 init_type: "T.nilable(T.any(#{type}, T::Hash[#{key_type}, #{value_type}]))",
-                default: "Google::Protobuf::Map.new(#{default_args.join(", ")})",
+                default: "T.unsafe(nil)",
               )
             else
               elem_type = type_of(descriptor)
               type = "Google::Protobuf::RepeatedField[#{elem_type}]"
 
-              default_args = [descriptor.type.inspect]
-              default_args << elem_type if [:enum, :message].include?(descriptor.type)
-
               Field.new(
                 name: descriptor.name,
                 type: type,
                 init_type: "T.nilable(T.any(#{type}, T::Array[#{elem_type}]))",
-                default: "Google::Protobuf::RepeatedField.new(#{default_args.join(", ")})",
+                default: "T.unsafe(nil)",
               )
             end
           else

--- a/spec/tapioca/dsl/compilers/protobuf_spec.rb
+++ b/spec/tapioca/dsl/compilers/protobuf_spec.rb
@@ -284,7 +284,7 @@ module Tapioca
 
                 class Cart
                   sig { params(customer_ids: T.nilable(T.any(Google::Protobuf::RepeatedField[Integer], T::Array[Integer])), indices: T.nilable(T.any(Google::Protobuf::RepeatedField[Google::Protobuf::UInt64Value], T::Array[Google::Protobuf::UInt64Value]))).void }
-                  def initialize(customer_ids: Google::Protobuf::RepeatedField.new(:int32), indices: Google::Protobuf::RepeatedField.new(:message, Google::Protobuf::UInt64Value)); end
+                  def initialize(customer_ids: T.unsafe(nil), indices: T.unsafe(nil)); end
 
                   sig { void }
                   def clear_customer_ids; end
@@ -330,7 +330,7 @@ module Tapioca
 
                 class Cart
                   sig { params(customers: T.nilable(T.any(Google::Protobuf::Map[String, Integer], T::Hash[String, Integer])), stores: T.nilable(T.any(Google::Protobuf::Map[String, Google::Protobuf::UInt64Value], T::Hash[String, Google::Protobuf::UInt64Value]))).void }
-                  def initialize(customers: Google::Protobuf::Map.new(:string, :int32), stores: Google::Protobuf::Map.new(:string, :message, Google::Protobuf::UInt64Value)); end
+                  def initialize(customers: T.unsafe(nil), stores: T.unsafe(nil)); end
 
                   sig { void }
                   def clear_customers; end
@@ -529,7 +529,7 @@ module Tapioca
 
                 class Google::Protobuf::Struct
                   sig { params(fields: T.nilable(T.any(Google::Protobuf::Map[String, Google::Protobuf::Value], T::Hash[String, Google::Protobuf::Value]))).void }
-                  def initialize(fields: Google::Protobuf::Map.new(:string, :message, Google::Protobuf::Value)); end
+                  def initialize(fields: T.unsafe(nil)); end
 
                   sig { void }
                   def clear_fields; end
@@ -573,7 +573,7 @@ module Tapioca
 
                 class Cart
                   sig { params(items: T.nilable(T.any(Google::Protobuf::RepeatedField[T.untyped], T::Array[T.untyped])), tables: T.nilable(T.any(Google::Protobuf::Map[String, T.untyped], T::Hash[String, T.untyped]))).void }
-                  def initialize(items: Google::Protobuf::RepeatedField.new(:message, T.untyped), tables: Google::Protobuf::Map.new(:string, :message, T.untyped)); end
+                  def initialize(items: T.unsafe(nil), tables: T.unsafe(nil)); end
 
                   sig { void }
                   def clear_items; end
@@ -642,7 +642,7 @@ module Tapioca
 
                 class Cart
                   sig { params(progress: T.nilable(T.any(Google::Protobuf::Map[String, Cart::Progress], T::Hash[String, Cart::Progress]))).void }
-                  def initialize(progress: Google::Protobuf::Map.new(:string, :message, Cart::Progress)); end
+                  def initialize(progress: T.unsafe(nil)); end
 
                   sig { void }
                   def clear_progress; end


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
There is no point in trying to construct elaborate default values for the initializer fields, since in the RBI file, the default value is meaningless. What matters is the type of the field and if the field is optional or not. Thus, we can easily simplify the code and generate default values as `T.unsafe(nil)`.

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
Change default values to `T.unsafe(nil)`.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->
Updated existing tests.
