### PR TITLE
Add support for `--include-dependencies` flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ Options:
   --post, -a,  [--postrequire=file]                                   # A file to be required after Bundler.require is called
                                                                       # Default: sorbet/tapioca/require.rb
   -x,          [--exclude=gem [gem ...]]                              # Exclude the given gem(s) from RBI generation
+               [--include-dependencies], [--no-include-dependencies]  # Generate RBI files for dependencies of the given gem(s)
   --typed, -t, [--typed-overrides=gem:level [gem:level ...]]          # Override for typed sigils for generated gem RBIs
                                                                       # Default: {"activesupport"=>"false"}
                [--verify], [--no-verify]                              # Verify RBIs are up-to-date
@@ -199,7 +200,7 @@ generate RBIs from gems
 ```
 <!-- END_HELP_COMMAND_GEM -->
 
-By default, running `tapioca gem` will only generate the RBI files for gems that have been added to or removed from the project's `Gemfile` this means that Tapioca will not regenerate the RBI files for untouched gems. However, when changing Tapioca configuration or bumping its version, it may be useful to force the regeneration of the RBI files previously generated. This can be done with the `--all` option:
+By default, running `tapioca gem` will only generate the RBI files for gems that have been added to or removed from the project's `Gemfile` this means that Tapioca will not regenerate the RBI files for untouched gems. If you want to force the regeneration you can supply gem names to the `tapioca gem` command. When supplying gem names if you want to generate RBI files for their dependencies as well, you can use the `--include-dependencies` option. When changing Tapioca configuration or bumping its version, it may be useful to force the regeneration of all the RBI files previously generated. This can be done with the `--all` option:
 
 ```shell
 bin/tapioca gems --all
@@ -904,6 +905,7 @@ gem:
   prerequire: ''
   postrequire: sorbet/tapioca/require.rb
   exclude: []
+  include_dependencies: false
   typed_overrides:
     activesupport: 'false'
   verify: false

--- a/lib/tapioca/cli.rb
+++ b/lib/tapioca/cli.rb
@@ -198,6 +198,10 @@ module Tapioca
       banner: "gem [gem ...]",
       desc: "Exclude the given gem(s) from RBI generation",
       default: []
+    option :include_dependencies,
+      type: :boolean,
+      desc: "Generate RBI files for dependencies of the given gem(s)",
+      default: false
     option :typed_overrides,
       aliases: ["--typed", "-t"],
       type: :hash,
@@ -251,10 +255,14 @@ module Tapioca
 
       all = options[:all]
       verify = options[:verify]
+      include_dependencies = options[:include_dependencies]
 
       raise MalformattedArgumentError, "Options '--all' and '--verify' are mutually exclusive" if all && verify
 
-      unless gems.empty?
+      if gems.empty?
+        raise MalformattedArgumentError,
+          "Option '--include-dependencies' must be provided with gems" if include_dependencies
+      else
         raise MalformattedArgumentError, "Option '--all' must be provided without any other arguments" if all
         raise MalformattedArgumentError, "Option '--verify' must be provided without any other arguments" if verify
       end
@@ -262,6 +270,7 @@ module Tapioca
       command_args = {
         gem_names: all ? [] : gems,
         exclude: options[:exclude],
+        include_dependencies: options[:include_dependencies],
         prerequire: options[:prerequire],
         postrequire: options[:postrequire],
         typed_overrides: options[:typed_overrides],

--- a/lib/tapioca/gemfile.rb
+++ b/lib/tapioca/gemfile.rb
@@ -156,6 +156,11 @@ module Tapioca
         @spec.name
       end
 
+      sig { returns(T::Array[::Gem::Dependency]) }
+      def dependencies
+        @spec.dependencies
+      end
+
       sig { returns(String) }
       def rbi_file_name
         "#{name}@#{version}.rbi"


### PR DESCRIPTION
### Motivation

In my project we have huge Gemfile with a lot of gems. We tried to type some of the files, but we do not need all of the gems to be generated. We tried to use `tapioca gems [name_of_the_gem]` but it was generating only this gem (without dependencies). We tried `exclude` but list was huge.

I think we should have `--include-dependencies` flag that generate RBIs for dependencies as well

### Implementation
I added new flag for CLI that will pick gems and dependencies from the list.

### Tests
I added integration tests

