### PR TITLE
Handle arguments with loads in Graphql mutations

### DIFF
--- a/lib/tapioca/dsl/compilers/graphql_mutation.rb
+++ b/lib/tapioca/dsl/compilers/graphql_mutation.rb
@@ -72,7 +72,16 @@ module Tapioca
           return "T.untyped" unless argument
 
           argument_type = if argument.loads
-            if GraphQL::Schema::NonNull === argument.type
+            non_null = GraphQL::Schema::NonNull === argument.type
+            if argument.type.list?
+              if non_null
+                GraphQL::Schema::NonNull.new(
+                  GraphQL::Schema::List.new(GraphQL::Schema::NonNull.new(argument.loads)),
+                )
+              else
+                GraphQL::Schema::List.new(argument.loads)
+              end
+            elsif non_null
               GraphQL::Schema::NonNull.new(argument.loads)
             else
               GraphQL::Schema::Wrapper.new(argument.loads)

--- a/lib/tapioca/dsl/compilers/graphql_mutation.rb
+++ b/lib/tapioca/dsl/compilers/graphql_mutation.rb
@@ -42,7 +42,7 @@ module Tapioca
       class GraphqlMutation < Compiler
         extend T::Sig
 
-        ConstantType = type_member { { fixed: T.class_of(GraphQL::Schema::InputObject) } }
+        ConstantType = type_member { { fixed: T.class_of(GraphQL::Schema::Mutation) } }
 
         sig { override.void }
         def decorate
@@ -59,7 +59,11 @@ module Tapioca
           params = compile_method_parameters_to_rbi(method_def).map do |param|
             name = param.param.name
             argument = arguments_by_name.fetch(name, nil)
-            create_typed_param(param.param, argument ? Helpers::GraphqlTypeHelper.type_for(argument.type) : "T.untyped")
+            type = argument.loads ? GraphQL::Schema::Wrapper.new(argument.loads) : argument.type if argument
+            create_typed_param(
+              param.param,
+              argument ? Helpers::GraphqlTypeHelper.type_for(type) : "T.untyped",
+            )
           end
 
           root.create_path(constant) do |mutation|

--- a/spec/tapioca/dsl/compilers/graphql_mutation_spec.rb
+++ b/spec/tapioca/dsl/compilers/graphql_mutation_spec.rb
@@ -132,9 +132,11 @@ module Tapioca
                   argument :input_object, CreateCommentInput, required: true
                   argument :custom_scalar, CustomScalar, required: true
                   argument :loaded_argument_id, ID, required: true, loads: LoadedType
-                  argument :loaded_argument_optional_id, ID, required: false, loads: LoadedType
+                  argument :optional_loaded_argument_id, ID, required: false, loads: LoadedType
+                  argument :loaded_argument_ids, [ID], required: true, loads: LoadedType
+                  argument :optional_loaded_argument_ids, [ID], required: false, loads: LoadedType
 
-                  def resolve(boolean:, float:, id:, int:, date:, datetime:, json:, string:, enum_a:, enum_b:, input_object:, custom_scalar:, loaded_argument:, loaded_argument_optional: nil)
+                  def resolve(boolean:, float:, id:, int:, date:, datetime:, json:, string:, enum_a:, enum_b:, input_object:, custom_scalar:, loaded_argument:, loaded_arguments:, optional_loaded_argument: nil, optional_loaded_arguments: nil)
                     # ...
                   end
                 end
@@ -144,8 +146,8 @@ module Tapioca
                 # typed: strong
 
                 class CreateComment
-                  sig { params(boolean: T::Boolean, float: ::Float, id: ::String, int: ::Integer, date: ::Date, datetime: ::Time, json: T::Hash[::String, T.untyped], string: ::String, enum_a: ::String, enum_b: T.any(::String, ::Symbol), input_object: ::CreateCommentInput, custom_scalar: T.untyped, loaded_argument: T.untyped, loaded_argument_optional: T.untyped).returns(T.untyped) }
-                  def resolve(boolean:, float:, id:, int:, date:, datetime:, json:, string:, enum_a:, enum_b:, input_object:, custom_scalar:, loaded_argument:, loaded_argument_optional: T.unsafe(nil)); end
+                  sig { params(boolean: T::Boolean, float: ::Float, id: ::String, int: ::Integer, date: ::Date, datetime: ::Time, json: T::Hash[::String, T.untyped], string: ::String, enum_a: ::String, enum_b: T.any(::String, ::Symbol), input_object: ::CreateCommentInput, custom_scalar: T.untyped, loaded_argument: T.untyped, loaded_arguments: T::Array[T.untyped], optional_loaded_argument: T.untyped, optional_loaded_arguments: T.nilable(T::Array[T.untyped])).returns(T.untyped) }
+                  def resolve(boolean:, float:, id:, int:, date:, datetime:, json:, string:, enum_a:, enum_b:, input_object:, custom_scalar:, loaded_argument:, loaded_arguments:, optional_loaded_argument: T.unsafe(nil), optional_loaded_arguments: T.unsafe(nil)); end
                 end
               RBI
 

--- a/spec/tapioca/dsl/compilers/graphql_mutation_spec.rb
+++ b/spec/tapioca/dsl/compilers/graphql_mutation_spec.rb
@@ -132,8 +132,9 @@ module Tapioca
                   argument :input_object, CreateCommentInput, required: true
                   argument :custom_scalar, CustomScalar, required: true
                   argument :loaded_argument_id, ID, required: true, loads: LoadedType
+                  argument :loaded_argument_optional_id, ID, required: false, loads: LoadedType
 
-                  def resolve(boolean:, float:, id:, int:, date:, datetime:, json:, string:, enum_a:, enum_b:, input_object:, custom_scalar:, loaded_argument:)
+                  def resolve(boolean:, float:, id:, int:, date:, datetime:, json:, string:, enum_a:, enum_b:, input_object:, custom_scalar:, loaded_argument:, loaded_argument_optional: nil)
                     # ...
                   end
                 end
@@ -143,8 +144,8 @@ module Tapioca
                 # typed: strong
 
                 class CreateComment
-                  sig { params(boolean: T::Boolean, float: ::Float, id: ::String, int: ::Integer, date: ::Date, datetime: ::Time, json: T::Hash[::String, T.untyped], string: ::String, enum_a: ::String, enum_b: T.any(::String, ::Symbol), input_object: ::CreateCommentInput, custom_scalar: T.untyped, loaded_argument: T.untyped).returns(T.untyped) }
-                  def resolve(boolean:, float:, id:, int:, date:, datetime:, json:, string:, enum_a:, enum_b:, input_object:, custom_scalar:, loaded_argument:); end
+                  sig { params(boolean: T::Boolean, float: ::Float, id: ::String, int: ::Integer, date: ::Date, datetime: ::Time, json: T::Hash[::String, T.untyped], string: ::String, enum_a: ::String, enum_b: T.any(::String, ::Symbol), input_object: ::CreateCommentInput, custom_scalar: T.untyped, loaded_argument: T.untyped, loaded_argument_optional: T.untyped).returns(T.untyped) }
+                  def resolve(boolean:, float:, id:, int:, date:, datetime:, json:, string:, enum_a:, enum_b:, input_object:, custom_scalar:, loaded_argument:, loaded_argument_optional: T.unsafe(nil)); end
                 end
               RBI
 

--- a/spec/tapioca/dsl/compilers/graphql_mutation_spec.rb
+++ b/spec/tapioca/dsl/compilers/graphql_mutation_spec.rb
@@ -100,6 +100,10 @@ module Tapioca
 
             it "generates correct RBI for all graphql types" do
               add_ruby_file("create_comment.rb", <<~RUBY)
+                class LoadedType < GraphQL::Schema::Object
+                  field "foo", type: String
+                end
+
                 class EnumA < GraphQL::Schema::Enum
                   value "foo"
                 end
@@ -127,8 +131,9 @@ module Tapioca
                   argument :enum_b, EnumB, required: true
                   argument :input_object, CreateCommentInput, required: true
                   argument :custom_scalar, CustomScalar, required: true
+                  argument :loaded_argument_id, ID, required: true, loads: LoadedType
 
-                  def resolve(boolean:, float:, id:, int:, date:, datetime:, json:, string:, enum_a:, enum_b:, input_object:, custom_scalar:)
+                  def resolve(boolean:, float:, id:, int:, date:, datetime:, json:, string:, enum_a:, enum_b:, input_object:, custom_scalar:, loaded_argument:)
                     # ...
                   end
                 end
@@ -138,8 +143,8 @@ module Tapioca
                 # typed: strong
 
                 class CreateComment
-                  sig { params(boolean: T::Boolean, float: ::Float, id: ::String, int: ::Integer, date: ::Date, datetime: ::Time, json: T::Hash[::String, T.untyped], string: ::String, enum_a: ::String, enum_b: T.any(::String, ::Symbol), input_object: ::CreateCommentInput, custom_scalar: T.untyped).returns(T.untyped) }
-                  def resolve(boolean:, float:, id:, int:, date:, datetime:, json:, string:, enum_a:, enum_b:, input_object:, custom_scalar:); end
+                  sig { params(boolean: T::Boolean, float: ::Float, id: ::String, int: ::Integer, date: ::Date, datetime: ::Time, json: T::Hash[::String, T.untyped], string: ::String, enum_a: ::String, enum_b: T.any(::String, ::Symbol), input_object: ::CreateCommentInput, custom_scalar: T.untyped, loaded_argument: T.untyped).returns(T.untyped) }
+                  def resolve(boolean:, float:, id:, int:, date:, datetime:, json:, string:, enum_a:, enum_b:, input_object:, custom_scalar:, loaded_argument:); end
                 end
               RBI
 


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->

The generated sig is wrong when a Graphql mutation argument specifies a type that is automatically "loaded".

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->

Check whether each argument uses the loads keyword

