### PR TITLE
Drop Ruby 2.7 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.7", "3.0", "3.1", "3.2"]
+        ruby: ["3.0", "3.1", "3.2"]
         gemfile:
           - Gemfile
           - gemfiles/Gemfile-rails-6-1

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,7 +8,7 @@ require:
  - rubocop-rspec
 
 AllCops:
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: 3.0
   NewCops: disable
   SuggestExtensions: false
   Exclude:

--- a/tapioca.gemspec
+++ b/tapioca.gemspec
@@ -32,5 +32,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency("thor", ">= 1.2.0")
   spec.add_dependency("yard-sorbet")
 
-  spec.required_ruby_version = ">= 2.7"
+  spec.required_ruby_version = ">= 3.0"
 end


### PR DESCRIPTION
Ruby 2.7 has been EOL since 31 Mar 2023.