### PR TITLE
Improve GraphQL Mutation compiler

### DIFF
--- a/lib/tapioca/dsl/compilers/graphql_mutation.rb
+++ b/lib/tapioca/dsl/compilers/graphql_mutation.rb
@@ -72,20 +72,10 @@ module Tapioca
           return "T.untyped" unless argument
 
           argument_type = if argument.loads
-            non_null = GraphQL::Schema::NonNull === argument.type
-            if argument.type.list?
-              if non_null
-                GraphQL::Schema::NonNull.new(
-                  GraphQL::Schema::List.new(GraphQL::Schema::NonNull.new(argument.loads)),
-                )
-              else
-                GraphQL::Schema::List.new(argument.loads)
-              end
-            elsif non_null
-              GraphQL::Schema::NonNull.new(argument.loads)
-            else
-              GraphQL::Schema::Wrapper.new(argument.loads)
-            end
+            loads_type = ::GraphQL::Schema::Wrapper.new(argument.loads)
+            loads_type = loads_type.to_list_type if argument.type.list?
+            loads_type = loads_type.to_non_null_type if argument.type.non_null?
+            loads_type
           else
             argument.type
           end

--- a/lib/tapioca/dsl/helpers/graphql_type_helper.rb
+++ b/lib/tapioca/dsl/helpers/graphql_type_helper.rb
@@ -39,6 +39,10 @@ module Tapioca
             end
           when GraphQL::Schema::InputObject.singleton_class
             type_for_constant(unwrapped_type)
+          when GraphQL::Schema::NonNull.singleton_class
+            type_for(unwrapped_type.of_type)
+          when Module
+            Runtime::Reflection.qualified_name_of(unwrapped_type) || "T.untyped"
           else
             "T.untyped"
           end

--- a/spec/tapioca/dsl/compilers/graphql_mutation_spec.rb
+++ b/spec/tapioca/dsl/compilers/graphql_mutation_spec.rb
@@ -100,10 +100,6 @@ module Tapioca
 
             it "generates correct RBI for all graphql types" do
               add_ruby_file("create_comment.rb", <<~RUBY)
-                class LoadedType < GraphQL::Schema::Object
-                  field "foo", type: String
-                end
-
                 class EnumA < GraphQL::Schema::Enum
                   value "foo"
                 end
@@ -131,12 +127,8 @@ module Tapioca
                   argument :enum_b, EnumB, required: true
                   argument :input_object, CreateCommentInput, required: true
                   argument :custom_scalar, CustomScalar, required: true
-                  argument :loaded_argument_id, ID, required: true, loads: LoadedType
-                  argument :optional_loaded_argument_id, ID, required: false, loads: LoadedType
-                  argument :loaded_argument_ids, [ID], required: true, loads: LoadedType
-                  argument :optional_loaded_argument_ids, [ID], required: false, loads: LoadedType
 
-                  def resolve(boolean:, float:, id:, int:, date:, datetime:, json:, string:, enum_a:, enum_b:, input_object:, custom_scalar:, loaded_argument:, loaded_arguments:, optional_loaded_argument: nil, optional_loaded_arguments: nil)
+                  def resolve(boolean:, float:, id:, int:, date:, datetime:, json:, string:, enum_a:, enum_b:, input_object:, custom_scalar:)
                     # ...
                   end
                 end
@@ -146,8 +138,38 @@ module Tapioca
                 # typed: strong
 
                 class CreateComment
-                  sig { params(boolean: T::Boolean, float: ::Float, id: ::String, int: ::Integer, date: ::Date, datetime: ::Time, json: T::Hash[::String, T.untyped], string: ::String, enum_a: ::String, enum_b: T.any(::String, ::Symbol), input_object: ::CreateCommentInput, custom_scalar: ::CustomScalar, loaded_argument: ::LoadedType, loaded_arguments: T::Array[::LoadedType], optional_loaded_argument: T.nilable(::LoadedType), optional_loaded_arguments: T.nilable(T::Array[::LoadedType])).returns(T.untyped) }
-                  def resolve(boolean:, float:, id:, int:, date:, datetime:, json:, string:, enum_a:, enum_b:, input_object:, custom_scalar:, loaded_argument:, loaded_arguments:, optional_loaded_argument: T.unsafe(nil), optional_loaded_arguments: T.unsafe(nil)); end
+                  sig { params(boolean: T::Boolean, float: ::Float, id: ::String, int: ::Integer, date: ::Date, datetime: ::Time, json: T::Hash[::String, T.untyped], string: ::String, enum_a: ::String, enum_b: T.any(::String, ::Symbol), input_object: ::CreateCommentInput, custom_scalar: ::CustomScalar).returns(T.untyped) }
+                  def resolve(boolean:, float:, id:, int:, date:, datetime:, json:, string:, enum_a:, enum_b:, input_object:, custom_scalar:); end
+                end
+              RBI
+
+              assert_equal(expected, rbi_for(:CreateComment))
+            end
+
+            it "generates correct RBI for mutation loaders" do
+              add_ruby_file("create_comment.rb", <<~RUBY)
+                class LoadedType < GraphQL::Schema::Object
+                  field "foo", type: String
+                end
+
+                class CreateComment < GraphQL::Schema::Mutation
+                  argument :loaded_argument_id, ID, required: true, loads: LoadedType
+                  argument :optional_loaded_argument_id, ID, required: false, loads: LoadedType
+                  argument :loaded_argument_ids, [ID], required: true, loads: LoadedType
+                  argument :optional_loaded_argument_ids, [ID], required: false, loads: LoadedType
+
+                  def resolve(loaded_argument:, loaded_arguments:, optional_loaded_argument: nil, optional_loaded_arguments: nil)
+                    # ...
+                  end
+                end
+              RUBY
+
+              expected = <<~RBI
+                # typed: strong
+
+                class CreateComment
+                  sig { params(loaded_argument: ::LoadedType, loaded_arguments: T::Array[::LoadedType], optional_loaded_argument: T.nilable(::LoadedType), optional_loaded_arguments: T.nilable(T::Array[::LoadedType])).returns(T.untyped) }
+                  def resolve(loaded_argument:, loaded_arguments:, optional_loaded_argument: T.unsafe(nil), optional_loaded_arguments: T.unsafe(nil)); end
                 end
               RBI
 

--- a/spec/tapioca/dsl/compilers/graphql_mutation_spec.rb
+++ b/spec/tapioca/dsl/compilers/graphql_mutation_spec.rb
@@ -157,8 +157,9 @@ module Tapioca
                   argument :optional_loaded_argument_id, ID, required: false, loads: LoadedType
                   argument :loaded_argument_ids, [ID], required: true, loads: LoadedType
                   argument :optional_loaded_argument_ids, [ID], required: false, loads: LoadedType
+                  argument :renamed_loaded_argument, ID, required: true, loads: LoadedType, as: :custom_name
 
-                  def resolve(loaded_argument:, loaded_arguments:, optional_loaded_argument: nil, optional_loaded_arguments: nil)
+                  def resolve(loaded_argument:, loaded_arguments:, custom_name:, optional_loaded_argument: nil, optional_loaded_arguments: nil)
                     # ...
                   end
                 end
@@ -168,8 +169,8 @@ module Tapioca
                 # typed: strong
 
                 class CreateComment
-                  sig { params(loaded_argument: ::LoadedType, loaded_arguments: T::Array[::LoadedType], optional_loaded_argument: T.nilable(::LoadedType), optional_loaded_arguments: T.nilable(T::Array[::LoadedType])).returns(T.untyped) }
-                  def resolve(loaded_argument:, loaded_arguments:, optional_loaded_argument: T.unsafe(nil), optional_loaded_arguments: T.unsafe(nil)); end
+                  sig { params(loaded_argument: ::LoadedType, loaded_arguments: T::Array[::LoadedType], custom_name: ::LoadedType, optional_loaded_argument: T.nilable(::LoadedType), optional_loaded_arguments: T.nilable(T::Array[::LoadedType])).returns(T.untyped) }
+                  def resolve(loaded_argument:, loaded_arguments:, custom_name:, optional_loaded_argument: T.unsafe(nil), optional_loaded_arguments: T.unsafe(nil)); end
                 end
               RBI
 

--- a/spec/tapioca/dsl/compilers/graphql_mutation_spec.rb
+++ b/spec/tapioca/dsl/compilers/graphql_mutation_spec.rb
@@ -146,7 +146,7 @@ module Tapioca
                 # typed: strong
 
                 class CreateComment
-                  sig { params(boolean: T::Boolean, float: ::Float, id: ::String, int: ::Integer, date: ::Date, datetime: ::Time, json: T::Hash[::String, T.untyped], string: ::String, enum_a: ::String, enum_b: T.any(::String, ::Symbol), input_object: ::CreateCommentInput, custom_scalar: T.untyped, loaded_argument: T.untyped, loaded_arguments: T::Array[T.untyped], optional_loaded_argument: T.untyped, optional_loaded_arguments: T.nilable(T::Array[T.untyped])).returns(T.untyped) }
+                  sig { params(boolean: T::Boolean, float: ::Float, id: ::String, int: ::Integer, date: ::Date, datetime: ::Time, json: T::Hash[::String, T.untyped], string: ::String, enum_a: ::String, enum_b: T.any(::String, ::Symbol), input_object: ::CreateCommentInput, custom_scalar: ::CustomScalar, loaded_argument: ::LoadedType, loaded_arguments: T::Array[::LoadedType], optional_loaded_argument: T.nilable(::LoadedType), optional_loaded_arguments: T.nilable(T::Array[::LoadedType])).returns(T.untyped) }
                   def resolve(boolean:, float:, id:, int:, date:, datetime:, json:, string:, enum_a:, enum_b:, input_object:, custom_scalar:, loaded_argument:, loaded_arguments:, optional_loaded_argument: T.unsafe(nil), optional_loaded_arguments: T.unsafe(nil)); end
                 end
               RBI


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
We were generating `T.untyped` for some of the cases we could handle, which became apparent with the recent change to the mutation compiler to support argument with loads in #1556.

/cc @such

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
This PR does a few things:
1. It extends the `GraphqlTypeHelper#type_for` method to handle `NonNull` types and types that are just plain module references.
2. It simplifies the argument loads type mapping code.
3. It refactors, updates and slightly extends the existing tests.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->
Updated tests
