### PR TITLE
Extract multiple commands from `Gem` command

### DIFF
--- a/lib/tapioca/cli.rb
+++ b/lib/tapioca/cli.rb
@@ -251,7 +251,14 @@ module Tapioca
         all = options[:all]
         verify = options[:verify]
 
-        command = Commands::Gem.new(
+        raise MalformattedArgumentError, "Options '--all' and '--verify' are mutually exclusive" if all && verify
+
+        unless gems.empty?
+          raise MalformattedArgumentError, "Option '--all' must be provided without any other arguments" if all
+          raise MalformattedArgumentError, "Option '--verify' must be provided without any other arguments" if verify
+        end
+
+        command_args = {
           gem_names: all ? [] : gems,
           exclude: options[:exclude],
           prerequire: options[:prerequire],
@@ -267,20 +274,17 @@ module Tapioca
           dsl_dir: options[:dsl_dir],
           rbi_formatter: rbi_formatter(options),
           halt_upon_load_error: options[:halt_upon_load_error],
-        )
+        }
 
-        raise MalformattedArgumentError, "Options '--all' and '--verify' are mutually exclusive" if all && verify
-
-        unless gems.empty?
-          raise MalformattedArgumentError, "Option '--all' must be provided without any other arguments" if all
-          raise MalformattedArgumentError, "Option '--verify' must be provided without any other arguments" if verify
-        end
-
-        if gems.empty? && !all
-          command.sync(should_verify: verify, exclude: options[:exclude])
+        command = if verify
+          Commands::GemVerify.new(**command_args)
+        elsif !gems.empty? || all
+          Commands::GemGenerate.new(**command_args)
         else
-          command.execute
+          Commands::GemSync.new(**command_args)
         end
+
+        command.execute
       end
     end
     map "gems" => :gem

--- a/lib/tapioca/commands.rb
+++ b/lib/tapioca/commands.rb
@@ -9,7 +9,10 @@ module Tapioca
     autoload :CheckShims, "tapioca/commands/check_shims"
     autoload :Dsl, "tapioca/commands/dsl"
     autoload :Configure, "tapioca/commands/configure"
-    autoload :Gem, "tapioca/commands/gem"
+    autoload :AbstractGem, "tapioca/commands/abstract_gem"
+    autoload :GemGenerate, "tapioca/commands/gem_generate"
+    autoload :GemSync, "tapioca/commands/gem_sync"
+    autoload :GemVerify, "tapioca/commands/gem_verify"
     autoload :Require, "tapioca/commands/require"
     autoload :Todo, "tapioca/commands/todo"
   end

--- a/lib/tapioca/commands/gem_generate.rb
+++ b/lib/tapioca/commands/gem_generate.rb
@@ -1,0 +1,47 @@
+# typed: strict
+# frozen_string_literal: true
+
+module Tapioca
+  module Commands
+    class GemGenerate < AbstractGem
+      sig { override.void }
+      def execute
+        Loaders::Gem.load_application(
+          bundle: @bundle,
+          prerequire: @prerequire,
+          postrequire: @postrequire,
+          default_command: default_command(:require),
+          halt_upon_load_error: @halt_upon_load_error,
+        )
+
+        gem_queue = gems_to_generate(@gem_names).reject { |gem| @exclude.include?(gem.name) }
+        anything_done = [
+          perform_removals,
+          gem_queue.any?,
+        ].any?
+
+        Executor.new(gem_queue, number_of_workers: @number_of_workers).run_in_parallel do |gem|
+          shell.indent do
+            compile_gem_rbi(gem)
+            puts
+          end
+        end
+
+        if anything_done
+          validate_rbi_files(
+            command: default_command(:gem, @gem_names.join(" ")),
+            gem_dir: @outpath.to_s,
+            dsl_dir: @dsl_dir,
+            auto_strictness: @auto_strictness,
+            gems: @bundle.dependencies,
+          )
+
+          say("All operations performed in working directory.", [:green, :bold])
+          say("Please review changes and commit them.", [:green, :bold])
+        else
+          say("No operations performed, all RBIs are up-to-date.", [:green, :bold])
+        end
+      end
+    end
+  end
+end

--- a/lib/tapioca/commands/gem_sync.rb
+++ b/lib/tapioca/commands/gem_sync.rb
@@ -1,0 +1,33 @@
+# typed: strict
+# frozen_string_literal: true
+
+module Tapioca
+  module Commands
+    class GemSync < AbstractGem
+      sig { override.void }
+      def execute
+        anything_done = [
+          perform_removals,
+          perform_additions,
+        ].any?
+
+        if anything_done
+          validate_rbi_files(
+            command: default_command(:gem),
+            gem_dir: @outpath.to_s,
+            dsl_dir: @dsl_dir,
+            auto_strictness: @auto_strictness,
+            gems: @bundle.dependencies,
+          )
+
+          say("All operations performed in working directory.", [:green, :bold])
+          say("Please review changes and commit them.", [:green, :bold])
+        else
+          say("No operations performed, all RBIs are up-to-date.", [:green, :bold])
+        end
+
+        puts
+      end
+    end
+  end
+end

--- a/lib/tapioca/commands/gem_verify.rb
+++ b/lib/tapioca/commands/gem_verify.rb
@@ -1,0 +1,36 @@
+# typed: strict
+# frozen_string_literal: true
+
+module Tapioca
+  module Commands
+    class GemVerify < AbstractGem
+      sig { override.void }
+      def execute
+        say("Checking for out-of-date RBIs...")
+        say("")
+        perform_sync_verification
+      end
+
+      private
+
+      sig { void }
+      def perform_sync_verification
+        diff = {}
+
+        removed_rbis.each do |gem_name|
+          next if @exclude.include?(gem_name)
+
+          filename = existing_rbi(gem_name)
+          diff[filename] = :removed
+        end
+
+        added_rbis.each do |gem_name|
+          filename = expected_rbi(gem_name)
+          diff[filename] = gem_rbi_exists?(gem_name) ? :changed : :added
+        end
+
+        report_diff_and_exit_if_out_of_date(diff, :gem)
+      end
+    end
+  end
+end


### PR DESCRIPTION


### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
We'd been using the `Gem` command to perform three distinct tasks:
1. synchronize RBI files for gems
2. generate RBI files for specified or all gems
3. verify that the gem RBI files are up-to-date

All of this functionality bunched together in a single command was making it hard to change behaviour or to add uniform behaviour to all `Command` classes, since not all of them would call the `execute` method in the end.

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->

This PR extracts an abstact gem command super class and splits the previous `Gem` command into separate commands that each handle one of these three tasks.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->
There should be no behaviour change.
