### PR TITLE
Refactor `Command` classes to make `run` method the public API

### DIFF
--- a/lib/tapioca/cli.rb
+++ b/lib/tapioca/cli.rb
@@ -44,7 +44,7 @@ module Tapioca
         tapioca_config: options[:config],
         default_postrequire: options[:postrequire],
       )
-      command.execute
+      command.run
     end
 
     desc "require", "generate the list of files to be required by tapioca"
@@ -54,9 +54,7 @@ module Tapioca
         requires_path: options[:postrequire],
         sorbet_config_path: SORBET_CONFIG_FILE,
       )
-      Tapioca.silence_warnings do
-        command.execute
-      end
+      command.run
     end
 
     desc "todo", "generate the list of unresolved constants"
@@ -73,9 +71,7 @@ module Tapioca
         todo_file: options[:todo_file],
         file_header: options[:file_header],
       )
-      Tapioca.silence_warnings do
-        command.execute
-      end
+      command.run
     end
 
     desc "dsl [constant...]", "generate RBIs for dynamic methods"
@@ -164,9 +160,7 @@ module Tapioca
         Commands::DslGenerate.new(**command_args)
       end
 
-      Tapioca.silence_warnings do
-        command.execute
-      end
+      command.run
     end
 
     desc "gem [gem...]", "generate RBIs from gems"
@@ -248,47 +242,45 @@ module Tapioca
       desc: "Halt upon a load error while loading the Rails application",
       default: true
     def gem(*gems)
-      Tapioca.silence_warnings do
-        set_environment(options)
+      set_environment(options)
 
-        all = options[:all]
-        verify = options[:verify]
+      all = options[:all]
+      verify = options[:verify]
 
-        raise MalformattedArgumentError, "Options '--all' and '--verify' are mutually exclusive" if all && verify
+      raise MalformattedArgumentError, "Options '--all' and '--verify' are mutually exclusive" if all && verify
 
-        unless gems.empty?
-          raise MalformattedArgumentError, "Option '--all' must be provided without any other arguments" if all
-          raise MalformattedArgumentError, "Option '--verify' must be provided without any other arguments" if verify
-        end
-
-        command_args = {
-          gem_names: all ? [] : gems,
-          exclude: options[:exclude],
-          prerequire: options[:prerequire],
-          postrequire: options[:postrequire],
-          typed_overrides: options[:typed_overrides],
-          outpath: Pathname.new(options[:outdir]),
-          file_header: options[:file_header],
-          include_doc: options[:doc],
-          include_loc: options[:loc],
-          include_exported_rbis: options[:exported_gem_rbis],
-          number_of_workers: options[:workers],
-          auto_strictness: options[:auto_strictness],
-          dsl_dir: options[:dsl_dir],
-          rbi_formatter: rbi_formatter(options),
-          halt_upon_load_error: options[:halt_upon_load_error],
-        }
-
-        command = if verify
-          Commands::GemVerify.new(**command_args)
-        elsif !gems.empty? || all
-          Commands::GemGenerate.new(**command_args)
-        else
-          Commands::GemSync.new(**command_args)
-        end
-
-        command.execute
+      unless gems.empty?
+        raise MalformattedArgumentError, "Option '--all' must be provided without any other arguments" if all
+        raise MalformattedArgumentError, "Option '--verify' must be provided without any other arguments" if verify
       end
+
+      command_args = {
+        gem_names: all ? [] : gems,
+        exclude: options[:exclude],
+        prerequire: options[:prerequire],
+        postrequire: options[:postrequire],
+        typed_overrides: options[:typed_overrides],
+        outpath: Pathname.new(options[:outdir]),
+        file_header: options[:file_header],
+        include_doc: options[:doc],
+        include_loc: options[:loc],
+        include_exported_rbis: options[:exported_gem_rbis],
+        number_of_workers: options[:workers],
+        auto_strictness: options[:auto_strictness],
+        dsl_dir: options[:dsl_dir],
+        rbi_formatter: rbi_formatter(options),
+        halt_upon_load_error: options[:halt_upon_load_error],
+      }
+
+      command = if verify
+        Commands::GemVerify.new(**command_args)
+      elsif !gems.empty? || all
+        Commands::GemGenerate.new(**command_args)
+      else
+        Commands::GemSync.new(**command_args)
+      end
+
+      command.run
     end
     map "gems" => :gem
 
@@ -311,9 +303,7 @@ module Tapioca
         number_of_workers: options[:workers],
       )
 
-      Tapioca.silence_warnings do
-        command.execute
-      end
+      command.run
     end
 
     desc "annotations", "Pull gem RBI annotations from remote sources"
@@ -342,9 +332,7 @@ module Tapioca
         typed_overrides: options[:typed_overrides],
       )
 
-      Tapioca.silence_warnings do
-        command.execute
-      end
+      command.run
     end
 
     map ["--version", "-v"] => :__print_version

--- a/lib/tapioca/commands/annotations.rb
+++ b/lib/tapioca/commands/annotations.rb
@@ -32,6 +32,8 @@ module Tapioca
         @typed_overrides = typed_overrides
       end
 
+      private
+
       sig { override.void }
       def execute
         @indexes = fetch_indexes
@@ -39,8 +41,6 @@ module Tapioca
         remove_expired_annotations(project_gems)
         fetch_annotations(project_gems)
       end
-
-      private
 
       sig { returns(T::Array[String]) }
       def list_gemfile_gems

--- a/lib/tapioca/commands/check_shims.rb
+++ b/lib/tapioca/commands/check_shims.rb
@@ -38,6 +38,8 @@ module Tapioca
         @number_of_workers = number_of_workers
       end
 
+      private
+
       sig { override.void }
       def execute
         index = RBI::Index.new

--- a/lib/tapioca/commands/command.rb
+++ b/lib/tapioca/commands/command.rb
@@ -21,10 +21,17 @@ module Tapioca
         @file_writer = T.let(FileWriter.new, Thor::Actions)
       end
 
-      sig { abstract.void }
-      def execute; end
+      sig { void }
+      def run
+        Tapioca.silence_warnings do
+          execute
+        end
+      end
 
       private
+
+      sig { abstract.void }
+      def execute; end
 
       sig { params(command: Symbol, args: String).returns(String) }
       def default_command(command, *args)

--- a/lib/tapioca/commands/command.rb
+++ b/lib/tapioca/commands/command.rb
@@ -21,7 +21,7 @@ module Tapioca
         @file_writer = T.let(FileWriter.new, Thor::Actions)
       end
 
-      sig { void }
+      sig(:final) { void }
       def run
         Tapioca.silence_warnings do
           execute

--- a/lib/tapioca/commands/configure.rb
+++ b/lib/tapioca/commands/configure.rb
@@ -26,6 +26,8 @@ module Tapioca
         @spec = T.let(nil, T.nilable(Bundler::StubSpecification))
       end
 
+      private
+
       sig { override.void }
       def execute
         create_sorbet_config
@@ -33,8 +35,6 @@ module Tapioca
         create_post_require
         create_binstub
       end
-
-      private
 
       sig { void }
       def create_sorbet_config

--- a/lib/tapioca/commands/dsl_compiler_list.rb
+++ b/lib/tapioca/commands/dsl_compiler_list.rb
@@ -4,6 +4,8 @@
 module Tapioca
   module Commands
     class DslCompilerList < AbstractDsl
+      private
+
       sig { override.void }
       def execute
         Loaders::Dsl.load_application(

--- a/lib/tapioca/commands/dsl_generate.rb
+++ b/lib/tapioca/commands/dsl_generate.rb
@@ -4,6 +4,8 @@
 module Tapioca
   module Commands
     class DslGenerate < AbstractDsl
+      private
+
       sig { override.void }
       def execute
         Loaders::Dsl.load_application(

--- a/lib/tapioca/commands/dsl_verify.rb
+++ b/lib/tapioca/commands/dsl_verify.rb
@@ -4,6 +4,8 @@
 module Tapioca
   module Commands
     class DslVerify < AbstractDsl
+      private
+
       sig { override.void }
       def execute
         Loaders::Dsl.load_application(

--- a/lib/tapioca/commands/gem_generate.rb
+++ b/lib/tapioca/commands/gem_generate.rb
@@ -4,6 +4,8 @@
 module Tapioca
   module Commands
     class GemGenerate < AbstractGem
+      private
+
       sig { override.void }
       def execute
         Loaders::Gem.load_application(

--- a/lib/tapioca/commands/gem_sync.rb
+++ b/lib/tapioca/commands/gem_sync.rb
@@ -4,6 +4,8 @@
 module Tapioca
   module Commands
     class GemSync < AbstractGem
+      private
+
       sig { override.void }
       def execute
         anything_done = [

--- a/lib/tapioca/commands/gem_verify.rb
+++ b/lib/tapioca/commands/gem_verify.rb
@@ -4,14 +4,14 @@
 module Tapioca
   module Commands
     class GemVerify < AbstractGem
+      private
+
       sig { override.void }
       def execute
         say("Checking for out-of-date RBIs...")
         say("")
         perform_sync_verification
       end
-
-      private
 
       sig { void }
       def perform_sync_verification

--- a/lib/tapioca/commands/require.rb
+++ b/lib/tapioca/commands/require.rb
@@ -17,6 +17,8 @@ module Tapioca
         super()
       end
 
+      private
+
       sig { override.void }
       def execute
         compiler = Static::RequiresCompiler.new(@sorbet_config_path)

--- a/lib/tapioca/commands/todo.rb
+++ b/lib/tapioca/commands/todo.rb
@@ -19,6 +19,8 @@ module Tapioca
         super()
       end
 
+      private
+
       sig { override.void }
       def execute
         say("Finding all unresolved constants, this may take a few seconds... ")
@@ -42,8 +44,6 @@ module Tapioca
         say("\nAll unresolved constants have been written to #{name}.", [:green, :bold])
         say("Please review changes and commit them.", [:green, :bold])
       end
-
-      private
 
       sig { params(constants: T::Array[String], command: String).returns(RBI::File) }
       def rbi(constants, command:)


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
Finally getting around to https://github.com/Shopify/tapioca/pull/1218#pullrequestreview-1134759632 comment by @Morriar.

By making the abstract `execute` method be a private method, we can ensure that all commands are invoked via the `run` method, which allows us to wrap them in `Tapioca.silence_warnings` today and potentially do more in the future.

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
Add `Command#run` method that calls `Command#execute` and make `Command#execute` a private method. Encapsulate all `Tapioca.silence_warnings` calls.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->
There should be no behaviour change.
