### PR TITLE
Extract common functionality from DSL commands to base class

### DIFF
--- a/lib/tapioca/commands/dsl_compiler_list.rb
+++ b/lib/tapioca/commands/dsl_compiler_list.rb
@@ -8,14 +8,7 @@ module Tapioca
 
       sig { override.void }
       def execute
-        Loaders::Dsl.load_application(
-          tapioca_path: @tapioca_path,
-          eager_load: @requested_constants.empty? && @requested_paths.empty?,
-          app_root: @app_root,
-          halt_upon_load_error: @halt_upon_load_error,
-        )
-
-        pipeline = create_pipeline
+        load_application
 
         say("")
         say("Loaded DSL compiler classes:")

--- a/lib/tapioca/commands/dsl_generate.rb
+++ b/lib/tapioca/commands/dsl_generate.rb
@@ -8,39 +8,12 @@ module Tapioca
 
       sig { override.void }
       def execute
-        Loaders::Dsl.load_application(
-          tapioca_path: @tapioca_path,
-          eager_load: @requested_constants.empty? && @requested_paths.empty?,
-          app_root: @app_root,
-          halt_upon_load_error: @halt_upon_load_error,
-        )
+        load_application
 
         say("Compiling DSL RBI files...")
         say("")
 
-        all_requested_constants = @requested_constants + constants_from_requested_paths
-
-        rbi_files_to_purge = existing_rbi_filenames(all_requested_constants)
-
-        pipeline = create_pipeline
-
-        processed_files = pipeline.run do |constant, contents|
-          constant_name = T.must(Tapioca::Runtime::Reflection.name_of(constant))
-
-          if @verbose && !@quiet
-            say_status(:processing, constant_name, :yellow)
-          end
-
-          compile_dsl_rbi(
-            constant_name,
-            contents,
-            outpath: @outpath,
-            quiet: @quiet && !@verbose,
-          )
-        end
-
-        processed_files.each { |filename| rbi_files_to_purge.delete(T.must(filename)) }
-
+        rbi_files_to_purge = generate_dsl_rbi_files(@outpath, quiet: @quiet && !@verbose)
         say("")
 
         purge_stale_dsl_rbi_files(rbi_files_to_purge)

--- a/lib/tapioca/commands/dsl_verify.rb
+++ b/lib/tapioca/commands/dsl_verify.rb
@@ -8,40 +8,14 @@ module Tapioca
 
       sig { override.void }
       def execute
-        Loaders::Dsl.load_application(
-          tapioca_path: @tapioca_path,
-          eager_load: @requested_constants.empty? && @requested_paths.empty?,
-          app_root: @app_root,
-          halt_upon_load_error: @halt_upon_load_error,
-        )
+        load_application
 
         say("Checking for out-of-date RBIs...")
         say("")
 
-        all_requested_constants = @requested_constants + constants_from_requested_paths
-
         outpath = Pathname.new(Dir.mktmpdir)
-        rbi_files_to_purge = existing_rbi_filenames(all_requested_constants)
 
-        pipeline = create_pipeline
-
-        processed_files = pipeline.run do |constant, contents|
-          constant_name = T.must(Tapioca::Runtime::Reflection.name_of(constant))
-
-          if @verbose && !@quiet
-            say_status(:processing, constant_name, :yellow)
-          end
-
-          compile_dsl_rbi(
-            constant_name,
-            contents,
-            outpath: outpath,
-            quiet: true,
-          )
-        end
-
-        processed_files.each { |filename| rbi_files_to_purge.delete(T.must(filename)) }
-
+        generate_dsl_rbi_files(outpath, quiet: true)
         say("")
 
         perform_dsl_verification(outpath)


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
In order to make the specific DSL commands more DRY, I want to extract common functionality into the abstract DSL command base class.

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
Simple method extraction and, in certain places, code simplification.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->
No extra tests, the behaviour should be unchanged.
