### PR TITLE
Filter gem RBIs by version during `annotations` command

### DIFF
--- a/lib/tapioca/commands/annotations.rb
+++ b/lib/tapioca/commands/annotations.rb
@@ -46,22 +46,22 @@ module Tapioca
         GitAttributes.create_vendored_attribute_file(@outpath)
       end
 
-      sig { returns(T::Array[String]) }
+      sig { returns(T::Array[GemInfo]) }
       def list_gemfile_gems
         say("Listing gems from Gemfile.lock... ", [:blue, :bold])
         gemfile = Bundler.read_file("Gemfile.lock")
         parser = Bundler::LockfileParser.new(gemfile)
-        gem_names = parser.specs.map(&:name)
+        gem_info = parser.specs.map { |spec| GemInfo.from_spec(spec) }
         say("Done", :green)
-        gem_names
+        gem_info
       end
 
-      sig { params(project_gems: T::Array[String]).void }
+      sig { params(project_gems: T::Array[GemInfo]).void }
       def remove_expired_annotations(project_gems)
         say("Removing annotations for gems that have been removed... ", [:blue, :bold])
 
         annotations = Pathname.glob(@outpath.join("*.rbi")).map { |f| f.basename(".*").to_s }
-        expired = annotations - project_gems
+        expired = annotations - project_gems.map(&:name)
 
         if expired.empty?
           say(" Nothing to do")
@@ -109,14 +109,14 @@ module Tapioca
         index
       end
 
-      sig { params(gem_names: T::Array[String]).returns(T::Array[String]) }
-      def fetch_annotations(gem_names)
+      sig { params(project_gems: T::Array[GemInfo]).returns(T::Array[String]) }
+      def fetch_annotations(project_gems)
         say("Fetching gem annotations from central repository... ", [:blue, :bold])
-        fetchable_gems = T.let(Hash.new { |h, k| h[k] = [] }, T::Hash[String, T::Array[String]])
+        fetchable_gems = T.let(Hash.new { |h, k| h[k] = [] }, T::Hash[GemInfo, T::Array[String]])
 
-        gem_names.each_with_object(fetchable_gems) do |gem_name, hash|
+        project_gems.each_with_object(fetchable_gems) do |gem_info, hash|
           @indexes.each do |uri, index|
-            T.must(hash[gem_name]) << uri if index.has_gem?(gem_name)
+            T.must(hash[gem_info]) << uri if index.has_gem?(gem_info.name)
           end
         end
 
@@ -127,13 +127,15 @@ module Tapioca
         end
 
         say("\n")
-        fetched_gems = fetchable_gems.select { |gem_name, repo_uris| fetch_annotation(repo_uris, gem_name) }
+        fetched_gems = fetchable_gems.select { |gem_info, repo_uris| fetch_annotation(repo_uris, gem_info) }
         say("\nDone", :green)
-        fetched_gems.keys.sort
+        fetched_gems.keys.map(&:name).sort
       end
 
-      sig { params(repo_uris: T::Array[String], gem_name: String).void }
-      def fetch_annotation(repo_uris, gem_name)
+      sig { params(repo_uris: T::Array[String], gem_info: GemInfo).void }
+      def fetch_annotation(repo_uris, gem_info)
+        gem_name = gem_info.name
+
         contents = repo_uris.map do |repo_uri|
           fetch_file(repo_uri, "#{CENTRAL_REPO_ANNOTATIONS_DIR}/#{gem_name}.rbi")
         end

--- a/lib/tapioca/gem_info.rb
+++ b/lib/tapioca/gem_info.rb
@@ -1,0 +1,18 @@
+# typed: strict
+# frozen_string_literal: true
+
+module Tapioca
+  class GemInfo < T::Struct
+    const :name, String
+    const :version, ::Gem::Version
+
+    class << self
+      extend(T::Sig)
+
+      sig { params(spec: Bundler::LazySpecification).returns(GemInfo) }
+      def from_spec(spec)
+        new(name: spec.name, version: spec.version)
+      end
+    end
+  end
+end

--- a/lib/tapioca/internal.rb
+++ b/lib/tapioca/internal.rb
@@ -45,6 +45,7 @@ require "tapioca/helpers/env_helper"
 
 require "tapioca/repo_index"
 require "tapioca/gemfile"
+require "tapioca/gem_info"
 require "tapioca/executor"
 
 require "tapioca/static/symbol_table_parser"

--- a/spec/tapioca/cli/annotations_spec.rb
+++ b/spec/tapioca/cli/annotations_spec.rb
@@ -12,6 +12,7 @@ module Tapioca
 
       after do
         @project.remove!("sorbet/rbi/annotations")
+        @project.write!("Gemfile", @project.tapioca_gemfile)
       end
 
       it "does nothing if the repo is empty" do
@@ -352,6 +353,45 @@ module Tapioca
           # Please run `bin/tapioca annotations` to update it.
 
           class AnnotationForSpoom; end
+        RBI
+
+        assert_success_status(result)
+
+        repo.destroy!
+      end
+
+      it "filters RBI file based on gem version" do
+        foo = mock_gem("foo", "0.3.4") do
+          write!("lib/foo.rb", <<~BAR)
+            class Foo; end
+          BAR
+        end
+
+        @project.require_mock_gem(foo)
+        @project.bundle_install!
+
+        repo = create_repo({
+          foo: <<~RBI,
+            # typed: false
+
+            # @version > 0.3.5
+            class AnnotationForFoo; end
+            class Foo; end
+          RBI
+        })
+
+        result = @project.tapioca("annotations --sources #{repo.absolute_path}")
+
+        assert_stdout_includes(result, "create  sorbet/rbi/annotations/foo.rbi")
+
+        assert_project_annotation_equal("sorbet/rbi/annotations/foo.rbi", <<~RBI)
+          # typed: false
+
+          # DO NOT EDIT MANUALLY
+          # This file was pulled from a central RBI files repository.
+          # Please run `bin/tapioca annotations` to update it.
+
+          class Foo; end
         RBI
 
         assert_success_status(result)

--- a/spec/tapioca/commands/annotations_spec.rb
+++ b/spec/tapioca/commands/annotations_spec.rb
@@ -58,7 +58,11 @@ module Tapioca
 
           gems = T.unsafe(command).stub(:say, ->(*_args) {}) do
             T.unsafe(command).stub(:create_file, ->(*_args) {}) do
-              command.send(:fetch_annotations, ["foo", "bar"])
+              annotations = [
+                GemInfo.new(name: "foo", version: ::Gem::Version.new("1.0.0")),
+                GemInfo.new(name: "bar", version: ::Gem::Version.new("2.0.0")),
+              ]
+              command.send(:fetch_annotations, annotations)
             end
           end
 


### PR DESCRIPTION
### Motivation

This PR aims to solve the problem of versioning RBIs. Up until now, there is no default way to write RBI for different versions of the same gem. This can lead to confusing issues for Sorbet users where RBIs don't match the version of a gem they're using, and they have to spend time figuring out whether their gem is out of date, whether the RBI is wrong, or if it's even both! Having a way to specify RBI for multiple versions of the same gem would allow people to adopt and use Sorbet without having to go through this hassle.

### Implementation
The actual RBI filtering behavior is implemented in [the RBI repo](https://github.com/Shopify/rbi/pull/180). This uses the `FilterVersions` rewriter during the annotations command to remove parts of the annotation RBI that aren't relevant to a certain gem version.

### Tests
I have added a test for this functionality.