### PR TITLE
Start generating `.gitattributes` file for generated and vendored RBI files

### DIFF
--- a/lib/tapioca/commands/dsl_generate.rb
+++ b/lib/tapioca/commands/dsl_generate.rb
@@ -32,6 +32,8 @@ module Tapioca
 
         say("All operations performed in working directory.", [:green, :bold])
         say("Please review changes and commit them.", [:green, :bold])
+      ensure
+        GitAttributes.create_generated_attribute_file(@outpath)
       end
     end
   end

--- a/lib/tapioca/commands/gem_generate.rb
+++ b/lib/tapioca/commands/gem_generate.rb
@@ -43,6 +43,8 @@ module Tapioca
         else
           say("No operations performed, all RBIs are up-to-date.", [:green, :bold])
         end
+      ensure
+        GitAttributes.create_generated_attribute_file(@outpath)
       end
     end
   end

--- a/lib/tapioca/commands/gem_sync.rb
+++ b/lib/tapioca/commands/gem_sync.rb
@@ -29,6 +29,8 @@ module Tapioca
         end
 
         puts
+      ensure
+        GitAttributes.create_generated_attribute_file(@outpath)
       end
     end
   end

--- a/lib/tapioca/helpers/git_attributes.rb
+++ b/lib/tapioca/helpers/git_attributes.rb
@@ -1,0 +1,34 @@
+# typed: strict
+# frozen_string_literal: true
+
+class GitAttributes
+  class << self
+    extend T::Sig
+
+    sig { params(path: Pathname).void }
+    def create_generated_attribute_file(path)
+      create_gitattributes_file(path, <<~CONTENT)
+        **/*.rbi linguist-generated=true
+      CONTENT
+    end
+
+    sig { params(path: Pathname).void }
+    def create_vendored_attribute_file(path)
+      create_gitattributes_file(path, <<~CONTENT)
+        **/*.rbi linguist-vendored=true
+      CONTENT
+    end
+
+    private
+
+    sig { params(path: Pathname, content: String).void }
+    def create_gitattributes_file(path, content)
+      # We don't want to start creating folders, just to write
+      # the `.gitattributes` file. So, if the folder doesn't
+      # exist, we just return.
+      return unless path.exist?
+
+      File.write(path.join(".gitattributes"), content)
+    end
+  end
+end

--- a/lib/tapioca/internal.rb
+++ b/lib/tapioca/internal.rb
@@ -28,6 +28,7 @@ require "yard-sorbet"
 require "tapioca/runtime/dynamic_mixin_compiler"
 require "tapioca/helpers/gem_helper"
 
+require "tapioca/helpers/git_attributes"
 require "tapioca/helpers/sorbet_helper"
 require "tapioca/helpers/rbi_helper"
 require "tapioca/sorbet_ext/backcompat_patches"

--- a/spec/tapioca/cli/annotations_spec.rb
+++ b/spec/tapioca/cli/annotations_spec.rb
@@ -27,6 +27,7 @@ module Tapioca
         OUT
 
         assert_success_status(result)
+        refute(File.directory?(@project.absolute_path("sorbet/rbi/annotations")))
 
         repo.destroy
       end
@@ -94,6 +95,9 @@ module Tapioca
           class AnnotationForSpoom; end
         RBI
 
+        assert_project_file_equal("sorbet/rbi/annotations/.gitattributes", <<~CONTENT)
+          **/*.rbi linguist-vendored=true
+        CONTENT
         refute_project_file_exist("sorbet/rbi/annotations/foo.rbi")
         assert_success_status(result)
 

--- a/spec/tapioca/cli/gem_spec.rb
+++ b/spec/tapioca/cli/gem_spec.rb
@@ -213,6 +213,52 @@ module Tapioca
           project.remove("config/application.rb")
         end
 
+        it "must generate a .gitattributes file in the output folder" do
+          foo = mock_gem("foo", "0.0.1") do
+            write("lib/foo.rb", FOO_RB)
+          end
+
+          @project.require_mock_gem(foo)
+          @project.bundle_install
+          result = @project.tapioca("gem foo --outdir output")
+
+          assert_stdout_includes(result, <<~OUT)
+            Compiled foo
+          OUT
+
+          assert_empty_stderr(result)
+          assert_success_status(result)
+
+          assert_project_file_equal("output/.gitattributes", <<~CONTENT)
+            **/*.rbi linguist-generated=true
+          CONTENT
+        ensure
+          @project.remove("output")
+        end
+
+        it "must not generate a .gitattributes file if the output folder is not created" do
+          foo = mock_gem("foo", "0.0.1") do
+            write("lib/foo.rb", FOO_RB)
+          end
+
+          @project.require_mock_gem(foo)
+          @project.bundle_install
+
+          # Generate for `foo` but exclude it as well, so that we don't create the output folder
+          result = @project.tapioca("gem foo --outdir output --exclude foo")
+
+          assert_stdout_includes(result, <<~OUT)
+            Nothing to do.
+          OUT
+
+          assert_empty_stderr(result)
+          assert_success_status(result)
+
+          refute_project_file_exist("output/.gitattributes")
+        ensure
+          @project.remove("output")
+        end
+
         it "must generate a single gem RBI" do
           foo = mock_gem("foo", "0.0.1") do
             write("lib/foo.rb", FOO_RB)
@@ -1596,6 +1642,20 @@ module Tapioca
 
         after(:all) do
           @project.remove("../gems")
+        end
+
+        it "must generate a .gitattributes file in the output folder" do
+          result = @project.tapioca("gem --outdir output")
+
+          assert_stdout_includes(result, "create  output/foo@0.0.1.rbi")
+          assert_empty_stderr(result)
+          assert_success_status(result)
+
+          assert_project_file_equal("output/.gitattributes", <<~CONTENT)
+            **/*.rbi linguist-generated=true
+          CONTENT
+        ensure
+          @project.remove("output")
         end
 
         it "must perform no operations if everything is up-to-date" do


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
Fixes https://github.com/Shopify/ruby-dev-exp-issues/issues/651

The `linguist` gem added support for detecting generated and vendored RBI files in https://github.com/github-linguist/linguist/pull/6143, but it parses the RBI file header comments to understand that, which is quite brittle.

Tapioca can do a better job of this, since it already knows that `dsl` and `gem` commands will create "generated" RBI files in the output directory and the `annotations` command will create "vendored" RBI files. So, Tapioca should be generating the appropriate `.gitattributes` files in the relevant output directories to signal that the RBI files contained are generated/vendored.

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
1. Added a `GitAttributes` helper module that knows how to create `.gitattributes` files that state the `**/*.rbi` files in the folder are either generated or vendored RBI files.
2. Uses the helper module in `DslGenerate`, `GemGenerate`, `GemSync` and `Annotations` commands to create appropriate `.gitattributes` files in the output folder.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->
Added extra test cases for checking generated `.gitattributes` files.

