### PR TITLE
Docs: Tapioca should also be in `test` group in Gemfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Tapioca makes it easy to work with [Sorbet](https://sorbet.org) in your codebase
 Add this line to your application's `Gemfile`:
 
 ```rb
-group :development do
+group :development, :test do
   gem 'tapioca', require: false
 end
 ```


### PR DESCRIPTION
It's common to use `check-shims` in CI, so I believe Tapioca should also be in the `test` group.
