### PR TITLE
Fix HelperMethods definitions

### DIFF
--- a/lib/tapioca/dsl/compilers/action_controller_helpers.rb
+++ b/lib/tapioca/dsl/compilers/action_controller_helpers.rb
@@ -126,7 +126,7 @@ module Tapioca
 
           sig { override.returns(T::Enumerable[Module]) }
           def gather_constants
-            descendants_of(::ActionController::Base).reject(&:abstract?).select(&:name)
+            descendants_of(::ActionController::Base).select(&:name)
           end
         end
 

--- a/lib/tapioca/dsl/compilers/action_controller_helpers.rb
+++ b/lib/tapioca/dsl/compilers/action_controller_helpers.rb
@@ -126,7 +126,9 @@ module Tapioca
 
           sig { override.returns(T::Enumerable[Module]) }
           def gather_constants
-            descendants_of(::ActionController::Base).select(&:name)
+            descendants_of(::ActionController::Base).select(&:name).select do |klass|
+              klass.const_defined?(:HelperMethods, false)
+            end
           end
         end
 


### PR DESCRIPTION
This fixes two problems with the ActionControllerHelpers compiler:

First is that this previously didn't gather abstract controllers. This broke for us because we have an abstract ApplicationController, and subclasses of that (all of our controllers) may then generate `include ApplicationController::HelperMethods` which sorbet then can't find. This PR re-includes abstract controllers, I don't see any reason not to include them, but maybe I've missed something.

Second this avoids generating `HelperMethods` for controllers which are only inheriting. Since Rails 6.1, [when a controller has identical helpers to its superclass Rails **will not** generate a new HelperMethods module](https://github.com/rails/rails/pull/40204/commits/758ad13c580241fa48f35409585ecf74698b4e9d). We should do the same to avoid defining modules which do not actually exist, both because it's incorrect (pretty mildly incorrect, it pretends a constant exists where one doesn't, but the same constant with the same values exists in the superclass) but also it generates a lot of unnecessary files (which I think is the same motivation as #1299).

I'm new to tapioca/sorbet so please let me know if I've missed something 😅.