### PR TITLE
Handle nil dependencies in case of inheritance

### DIFF
--- a/lib/tapioca/dsl/compilers/active_support_concern.rb
+++ b/lib/tapioca/dsl/compilers/active_support_concern.rb
@@ -85,7 +85,7 @@ module Tapioca
 
           sig { params(concern: Module).returns(T::Array[Module]) }
           def dependencies_of(concern)
-            concern.instance_variable_get(:@_dependencies)
+            concern.instance_variable_get(:@_dependencies) || []
           end
         end
 

--- a/spec/tapioca/dsl/compilers/active_support_concern_spec.rb
+++ b/spec/tapioca/dsl/compilers/active_support_concern_spec.rb
@@ -93,6 +93,27 @@ module Tapioca
               assert_equal([], gathered_constants_in_namespace(:TestCase))
             end
 
+            it "does not gather constants that inherit from a class that extend ActiveSupport::Concern" do
+              add_ruby_file("test_case.rb", <<~RUBY)
+                module TestCase
+                  module Foo
+                    extend ActiveSupport::Concern
+                  end
+
+                  class Bar
+                    extend ActiveSupport::Concern
+                    include Foo
+                  end
+
+                  class Baz < Bar
+                    include Foo
+                  end
+                end
+              RUBY
+
+              assert_equal(["TestCase::Bar"], gathered_constants_in_namespace(:TestCase))
+            end
+
             it "gathers constants for nested AS::Concern" do
               add_ruby_file("test_case.rb", <<~RUBY)
                 module TestCase


### PR DESCRIPTION
### Motivation

When you inherit from class that extends `ActiveSupport::Concern` it will break DSL compiler `ActiveSupportConcern`.

### Implementation

This commit modifies the `dependencies_of` method in the ActiveSupport::Concern compiler to ensure it returns an empty array when the concern has no dependencies, preventing potential `nil` errors.

A new test ensures that constants inheriting from a class extending ActiveSupport::Concern are not gathered, ensuring only direct dependencies are included.

### Tests

I added specs

