### PR TITLE
Handle standard errors in association generation

### DIFF
--- a/lib/tapioca/dsl/compilers/active_record_associations.rb
+++ b/lib/tapioca/dsl/compilers/active_record_associations.rb
@@ -173,6 +173,10 @@ module Tapioca
             add_error(<<~MSG.strip)
               Cannot generate association `#{declaration(reflection)}` on `#{constant}` since the constant `#{error.class_name}` does not exist.
             MSG
+          rescue StandardError => error
+            add_error(<<~MSG.strip)
+              Cannot generate association `#{association_name}` on `#{constant}` because of `#{error}`.".
+            MSG
           end
         end
 


### PR DESCRIPTION
### Motivation

This commit addresses an issue where standard errors raised during the association generation process were not properly handled, leading to failures in generating RBI files. Now, these errors are captured and logged appropriately, improving the robustness of the association generation process. A new test case has been added to verify this functionality.

### Implementation

Handle unexpected errors during building reflections. It should just ignore this reflection and move on.

### Tests

I added specs

