### PR TITLE
Update GraphQL mutation compiler to consider arguments with `replace_null_with_default`

### DIFF
--- a/lib/tapioca/dsl/compilers/graphql_input_object.rb
+++ b/lib/tapioca/dsl/compilers/graphql_input_object.rb
@@ -55,7 +55,7 @@ module Tapioca
           root.create_path(constant) do |input_object|
             arguments.each do |argument|
               name = argument.keyword.to_s
-              input_object.create_method(name, return_type: Helpers::GraphqlTypeHelper.type_for(argument.type))
+              input_object.create_method(name, return_type: Helpers::GraphqlTypeHelper.type_for(argument))
             end
           end
         end

--- a/lib/tapioca/dsl/compilers/graphql_mutation.rb
+++ b/lib/tapioca/dsl/compilers/graphql_mutation.rb
@@ -71,15 +71,7 @@ module Tapioca
         def argument_type(argument)
           return "T.untyped" unless argument
 
-          argument_type = if argument.loads
-            loads_type = ::GraphQL::Schema::Wrapper.new(argument.loads)
-            loads_type = loads_type.to_list_type if argument.type.list?
-            loads_type = loads_type.to_non_null_type if argument.type.non_null?
-            loads_type
-          else
-            argument.type
-          end
-          Helpers::GraphqlTypeHelper.type_for(argument_type)
+          Helpers::GraphqlTypeHelper.type_for(argument)
         end
 
         class << self

--- a/spec/tapioca/dsl/compilers/graphql_mutation_spec.rb
+++ b/spec/tapioca/dsl/compilers/graphql_mutation_spec.rb
@@ -98,6 +98,31 @@ module Tapioca
               assert_equal(expected, rbi_for(:CreateComment))
             end
 
+            it "generates correct RBI for default values with replacement" do
+              add_ruby_file("create_comment.rb", <<~RUBY)
+                class CreateComment < GraphQL::Schema::Mutation
+                  argument :body, String, required: false, default_value: "comment", replace_null_with_default: true
+                  argument :author, String, required: false, default_value: nil, replace_null_with_default: true
+                  argument :post_id, ID, required: true
+
+                  def resolve(body:, author:, post_id:)
+                    # ...
+                  end
+                end
+              RUBY
+
+              expected = <<~RBI
+                # typed: strong
+
+                class CreateComment
+                  sig { params(body: ::String, author: T.nilable(::String), post_id: ::String).returns(T.untyped) }
+                  def resolve(body:, author:, post_id:); end
+                end
+              RBI
+
+              assert_equal(expected, rbi_for(:CreateComment))
+            end
+
             it "generates correct RBI for all graphql types" do
               add_ruby_file("create_comment.rb", <<~RUBY)
                 class EnumA < GraphQL::Schema::Enum


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
With `graphql-ruby` arguments, you can set `required: false, default_value: 'foo', replace_null_with_default: true` to fill a `null` sent by a client with the default value ([docs](https://graphql-ruby.org/fields/arguments.html#default-values)). The current graphql mutation compiler doesn't take this into account, and assumes that all `required: false` arguments are nilable, when in reality a non-nil `default_value` plus `replace_null_with_default` means the resolver will always receive a non-nil value.

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
I updated `GraphqlTypeHelper.type_for` to take in a `GraphQL::Schema::Argument`, rather than just the argument type, and check for the other `Argument` params when deciding if the type is nilable.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->
Added a test with both a nil and a non-nil `default_value` to the existing graphql mutation compiler tests.

