### PR TITLE
Suggest bin/tapioca dsl -e test for CI failures

### DIFF
--- a/lib/tapioca/cli.rb
+++ b/lib/tapioca/cli.rb
@@ -155,6 +155,7 @@ module Tapioca
         rbi_formatter: rbi_formatter(options),
         app_root: options[:app_root],
         halt_upon_load_error: options[:halt_upon_load_error],
+        environment: options[:environment],
       }
 
       command = if options[:verify]

--- a/lib/tapioca/commands/abstract_dsl.rb
+++ b/lib/tapioca/commands/abstract_dsl.rb
@@ -26,6 +26,7 @@ module Tapioca
           rbi_formatter: RBIFormatter,
           app_root: String,
           halt_upon_load_error: T::Boolean,
+          environment: String,
         ).void
       end
       def initialize(
@@ -43,7 +44,8 @@ module Tapioca
         gem_dir: DEFAULT_GEM_DIR,
         rbi_formatter: DEFAULT_RBI_FORMATTER,
         app_root: ".",
-        halt_upon_load_error: true
+        halt_upon_load_error: true,
+        environment: DEFAULT_ENVIRONMENT
       )
         @requested_constants = requested_constants
         @requested_paths = requested_paths
@@ -60,6 +62,7 @@ module Tapioca
         @rbi_formatter = rbi_formatter
         @app_root = app_root
         @halt_upon_load_error = halt_upon_load_error
+        @environment = environment
 
         super()
       end
@@ -298,9 +301,15 @@ module Tapioca
             build_error_for_files(cause, diff_for_cause.map(&:first))
           end.join("\n")
 
+          suggested_command = if @environment != DEFAULT_ENVIRONMENT
+            default_command(command, "-e", @environment)
+          else
+            default_command(command)
+          end
+
           raise Thor::Error, <<~ERROR
-            #{set_color("RBI files are out-of-date. In your development environment, please run:", :green)}
-              #{set_color("`#{default_command(command)}`", :green, :bold)}
+            #{set_color("RBI files are out-of-date. To update the RBI files, please run:", :green)}
+              #{set_color("`#{suggested_command}`", :green, :bold)}
             #{set_color("Once it is complete, be sure to commit and push any changes", :green)}
             If you don't observe any changes after running the command locally, ensure your database is in a good
             state e.g. run `bin/rails db:reset`

--- a/spec/helpers/mock_project.rb
+++ b/spec/helpers/mock_project.rb
@@ -123,12 +123,13 @@ module Tapioca
     sig do
       params(
         command: String,
+        args: T::Array[String],
         enforce_typechecking: T::Boolean,
         exclude: T::Array[String],
       ).returns(ExecResult)
     end
-    def tapioca(command, enforce_typechecking: true, exclude: tapioca_dependencies)
-      exec_command = ["tapioca", command]
+    def tapioca(command, args: [], enforce_typechecking: true, exclude: tapioca_dependencies)
+      exec_command = ["tapioca", command, *args]
       if command.start_with?(/gem/)
         exec_command << "--workers=1" unless command.match?("--workers")
         exec_command << "--no-doc" unless command.match?("--doc")

--- a/spec/tapioca/cli/dsl_spec.rb
+++ b/spec/tapioca/cli/dsl_spec.rb
@@ -1649,7 +1649,7 @@ module Tapioca
           OUT
 
           assert_equal(<<~ERROR, result.err)
-            RBI files are out-of-date. In your development environment, please run:
+            RBI files are out-of-date. To update the RBI files, please run:
               `bin/tapioca dsl`
             Once it is complete, be sure to commit and push any changes
             If you don't observe any changes after running the command locally, ensure your database is in a good
@@ -1688,7 +1688,7 @@ module Tapioca
           OUT
 
           assert_equal(<<~ERROR, result.err)
-            RBI files are out-of-date. In your development environment, please run:
+            RBI files are out-of-date. To update the RBI files, please run:
               `bin/tapioca dsl`
             Once it is complete, be sure to commit and push any changes
             If you don't observe any changes after running the command locally, ensure your database is in a good
@@ -1738,8 +1738,56 @@ module Tapioca
           OUT
 
           assert_equal(<<~ERROR, result.err)
-            RBI files are out-of-date. In your development environment, please run:
+            RBI files are out-of-date. To update the RBI files, please run:
               `bin/tapioca dsl`
+            Once it is complete, be sure to commit and push any changes
+            If you don't observe any changes after running the command locally, ensure your database is in a good
+            state e.g. run `bin/rails db:reset`
+
+            Reason:
+              File(s) changed:
+              - sorbet/rbi/dsl/post.rbi
+          ERROR
+
+          refute_success_status(result)
+        end
+
+        it "suggest commands for regenerating RBIs using the same environment argument" do
+          @project.write("lib/post.rb", <<~RB)
+            require "smart_properties"
+
+            class Post
+              include SmartProperties
+              property :title, accepts: String
+            end
+          RB
+
+          @project.tapioca("dsl")
+
+          @project.write("lib/post.rb", <<~RB)
+            require "smart_properties"
+
+            class Post
+              include SmartProperties
+              property :title, accepts: String
+              property :desc, accepts: String
+            end
+          RB
+
+          result = @project.tapioca("dsl", args: ["--verify", "-e", "test"])
+
+          assert_equal(<<~OUT, result.out)
+            Loading DSL extension classes... Done
+            Loading Rails application... Done
+            Loading DSL compiler classes... Done
+            Checking for out-of-date RBIs...
+
+
+          OUT
+
+          assert_equal(<<~ERROR, result.err)
+            RBI files are out-of-date. To update the RBI files, please run:
+              `bin/tapioca dsl -e test`
             Once it is complete, be sure to commit and push any changes
             If you don't observe any changes after running the command locally, ensure your database is in a good
             state e.g. run `bin/rails db:reset`


### PR DESCRIPTION
### Motivation

Different Rails environments can yield different RBIs when running `bin/tapioca dsl`, due to custom routes loaded only in specific environments (e.g.: development). See this [common example](https://github.com/Shopify/tapioca/issues/657#issuecomment-1003532239) that happens in Rails due to routes injected by the framework only in the development environment.

Related to #657 and #979 

### Implementation

- Passed the environment arg down the chain of calls from `cli` to `abstract_dsl`
- With this additional context, `abstract_dsl#report_diff_and_exit_if_out_of_date` can print a suggestion to regenerate the RBIs with the same runtime context that failed the verification:
```bash
bin/tapioca dsl --verify         # fails => then `bin/tapioca dsl` is suggested to update the RBIs
bin/tapioca dsl --verify -e test # fails => then `bin/tapioca dsl -e test` is suggested instead
```

### Tests

- Adapted existing tests assertions to expect the new message.
- Added a new test case to assert the new environment logic
