### PR TITLE
Capitalize descriptions shown in CLI help

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,16 +71,16 @@ Run `bundle install` and make sure Tapioca is properly installed:
 $ tapioca help
 
 Commands:
-  tapioca --version, -v      # show version
+  tapioca --version, -v      # Show version
   tapioca annotations        # Pull gem RBI annotations from remote sources
-  tapioca check-shims        # check duplicated definitions in shim RBIs
-  tapioca configure          # initialize folder structure and type checking configuration
-  tapioca dsl [constant...]  # generate RBIs for dynamic methods
-  tapioca gem [gem...]       # generate RBIs from gems
+  tapioca check-shims        # Check duplicated definitions in shim RBIs
+  tapioca configure          # Initialize folder structure and type checking configuration
+  tapioca dsl [constant...]  # Generate RBIs for dynamic methods
+  tapioca gem [gem...]       # Generate RBIs from gems
   tapioca help [COMMAND]     # Describe available commands or one specific command
-  tapioca init               # get project ready for type checking
-  tapioca require            # generate the list of files to be required by tapioca
-  tapioca todo               # generate the list of unresolved constants
+  tapioca init               # Get project ready for type checking
+  tapioca require            # Generate the list of files to be required by tapioca
+  tapioca todo               # Generate the list of unresolved constants
 
 Options:
   -c, [--config=<config file path>]  # Path to the Tapioca configuration file
@@ -120,7 +120,7 @@ Options:
                                      # Default: sorbet/tapioca/config.yml
   -V, [--verbose], [--no-verbose]    # Verbose output for debugging purposes
 
-get project ready for type checking
+Get project ready for type checking
 ```
 <!-- END_HELP_COMMAND_INIT -->
 
@@ -196,7 +196,7 @@ Options:
                                                                       # Default: sorbet/tapioca/config.yml
   -V,          [--verbose], [--no-verbose]                            # Verbose output for debugging purposes
 
-generate RBIs from gems
+Generate RBIs from gems
 ```
 <!-- END_HELP_COMMAND_GEM -->
 
@@ -483,7 +483,7 @@ Options:
                                                                     # Default: sorbet/tapioca/config.yml
   -V,        [--verbose], [--no-verbose]                            # Verbose output for debugging purposes
 
-generate RBIs for dynamic methods
+Generate RBIs for dynamic methods
 ```
 <!-- END_HELP_COMMAND_DSL -->
 
@@ -846,7 +846,7 @@ Options:
                                                    # Default: sorbet/tapioca/config.yml
   -V, [--verbose], [--no-verbose]                  # Verbose output for debugging purposes
 
-check duplicated definitions in shim RBIs
+Check duplicated definitions in shim RBIs
 ```
 <!-- END_HELP_COMMAND_CHECK_SHIMS -->
 

--- a/lib/tapioca/cli.rb
+++ b/lib/tapioca/cli.rb
@@ -23,7 +23,7 @@ module Tapioca
       desc: "Verbose output for debugging purposes",
       default: false
 
-    desc "init", "get project ready for type checking"
+    desc "init", "Get project ready for type checking"
     def init
       # We need to make sure that trackers stay enabled until the `gem` command is invoked
       Runtime::Trackers.with_trackers_enabled do
@@ -41,7 +41,7 @@ module Tapioca
       print_init_next_steps
     end
 
-    desc "configure", "initialize folder structure and type checking configuration"
+    desc "configure", "Initialize folder structure and type checking configuration"
     option :postrequire, type: :string, default: DEFAULT_POSTREQUIRE_FILE
     def configure
       command = Commands::Configure.new(
@@ -52,7 +52,7 @@ module Tapioca
       command.run
     end
 
-    desc "require", "generate the list of files to be required by tapioca"
+    desc "require", "Generate the list of files to be required by tapioca"
     option :postrequire, type: :string, default: DEFAULT_POSTREQUIRE_FILE
     def require
       command = Commands::Require.new(
@@ -62,7 +62,7 @@ module Tapioca
       command.run
     end
 
-    desc "todo", "generate the list of unresolved constants"
+    desc "todo", "Generate the list of unresolved constants"
     option :todo_file,
       type: :string,
       desc: "Path to the generated todo RBI file",
@@ -79,7 +79,7 @@ module Tapioca
       command.run_with_deprecation
     end
 
-    desc "dsl [constant...]", "generate RBIs for dynamic methods"
+    desc "dsl [constant...]", "Generate RBIs for dynamic methods"
     option :outdir,
       aliases: ["--out", "-o"],
       banner: "directory",
@@ -168,7 +168,7 @@ module Tapioca
       command.run
     end
 
-    desc "gem [gem...]", "generate RBIs from gems"
+    desc "gem [gem...]", "Generate RBIs from gems"
     option :outdir,
       aliases: ["--out", "-o"],
       banner: "directory",
@@ -298,7 +298,7 @@ module Tapioca
     end
     map "gems" => :gem
 
-    desc "check-shims", "check duplicated definitions in shim RBIs"
+    desc "check-shims", "Check duplicated definitions in shim RBIs"
     option :gem_rbi_dir, type: :string, desc: "Path to gem RBIs", default: DEFAULT_GEM_DIR
     option :dsl_rbi_dir, type: :string, desc: "Path to DSL RBIs", default: DEFAULT_DSL_DIR
     option :shim_rbi_dir, type: :string, desc: "Path to shim RBIs", default: DEFAULT_SHIM_DIR
@@ -351,7 +351,7 @@ module Tapioca
 
     map ["--version", "-v"] => :__print_version
 
-    desc "--version, -v", "show version"
+    desc "--version, -v", "Show version"
     def __print_version
       puts "Tapioca v#{Tapioca::VERSION}"
     end

--- a/spec/tapioca/cli/help_spec.rb
+++ b/spec/tapioca/cli/help_spec.rb
@@ -1,0 +1,38 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Tapioca
+  class HelpSpec < SpecWithProject
+    describe("cli::help") do
+      before(:all) do
+        project.bundle_install
+      end
+
+      it "must display the help when passing --help" do
+        result = @project.tapioca("--help")
+        stdout_lines = result.out.strip.split("\n")
+        assert_equal("Commands:", stdout_lines.first)
+        assert_empty_stderr(result)
+        assert_success_status(result)
+      end
+
+      it "must display the help when passing -h" do
+        result = @project.tapioca("-h")
+        stdout_lines = result.out.strip.split("\n")
+        assert_equal("Commands:", stdout_lines.first)
+        assert_empty_stderr(result)
+        assert_success_status(result)
+      end
+
+      it "must begin every command description of help text with a capital letter" do
+        result = @project.tapioca("--help")
+        stdout_lines = result.out.strip.split("\n")
+        assert_equal(stdout_lines.reject { / # [a-z]/.match?(_1) }.size, stdout_lines.size)
+        assert_empty_stderr(result)
+        assert_success_status(result)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Motivation
I noticed that the casing of descriptions' initial letters are not unified, so I tried to capitalize them.

```shellsession
$ bundle exec tapioca --version
Tapioca v0.11.8

$ bundle exec tapioca -h
Commands:
  tapioca --version, -v      # show version
  tapioca annotations        # Pull gem RBI annotations from remote sources
  tapioca check-shims        # check duplicated definitions in shim RBIs
  tapioca configure          # initialize folder structure and type checking configuration
  tapioca dsl [constant...]  # generate RBIs for dynamic methods
  tapioca gem [gem...]       # generate RBIs from gems
  tapioca help [COMMAND]     # Describe available commands or one specific command
  tapioca init               # get project ready for type checking
  tapioca require            # generate the list of files to be required by tapioca
  tapioca todo               # generate the list of unresolved constants

Options:
  -c, [--config=<config file path>]  # Path to the Tapioca configuration file
                                     # Default: sorbet/tapioca/config.yml
  -V, [--verbose], [--no-verbose]    # Verbose output for debugging purposes
```

### Implementation

I replaced with following oneliner:

```sh
cat lib/tapioca/cli.rb | ruby -ple '$_=~/^ *desc / ? $_.gsub(/[a-zA-Z][^"]+"$/){_1.capitalize} : $_'
```

Here is output after substitution:

```shellsession
$ bundle exec tapioca -h
Commands:
  tapioca --version, -v      # Show version
  tapioca annotations        # Pull gem RBI annotations from remote sources
  tapioca check-shims        # Check duplicated definitions in shim RBIs
  tapioca configure          # Initialize folder structure and type checking configuration
  tapioca dsl [constant...]  # Generate RBIs for dynamic methods
  tapioca gem [gem...]       # Generate RBIs from gems
  tapioca help [COMMAND]     # Describe available commands or one specific command
  tapioca init               # Get project ready for type checking
  tapioca require            # Generate the list of files to be required by tapioca
  tapioca todo               # Generate the list of unresolved constants

Options:
  -c, [--config=<config file path>]  # Path to the Tapioca configuration file
                                     # Default: sorbet/tapioca/config.yml
  -V, [--verbose], [--no-verbose]    # Verbose output for debugging purposes

```

### Tests

Check if:
- `tapioca -h` and `tapioca --help` is worked correctly
- all descriptions of `tapioca --help` start with upper letter