### PR TITLE
Add Action Text compiler

### DIFF
--- a/lib/tapioca/dsl/compilers/action_text.rb
+++ b/lib/tapioca/dsl/compilers/action_text.rb
@@ -1,0 +1,100 @@
+# typed: strict
+# frozen_string_literal: true
+
+begin
+  require "action_text"
+rescue LoadError
+  return
+end
+
+module Tapioca
+  module Dsl
+    module Compilers
+      # `Tapioca::Dsl::Compilers::ActionText` decorates RBI files for subclasses of
+      # `ActiveRecord::Base` that declare [has_rich_text](https://edgeguides.rubyonrails.org/action_text_overview.html#creating-rich-text-content)
+      #
+      # For example, with the following `ActiveRecord::Base` subclass:
+      #
+      # ~~~rb
+      # class Post < ApplicationRecord
+      #  has_rich_text :body
+      #  has_rich_text :title, encrypted: true
+      # end
+      # ~~~
+      #
+      # this compiler will produce the RBI file `post.rbi` with the following content:
+      #
+      # ~~~rbi
+      # # typed: strong
+      #
+      # class Post
+      #  sig { returns(ActionText::RichText) }
+      #  def body; end
+      #
+      #  sig { params(value: T.nilable(T.any(ActionText::RichText, String))).returns(T.untyped) }
+      #  def body=(value); end
+      #
+      #  sig { returns(T::Boolean) }
+      #  def body?; end
+      #
+      #  sig { returns(ActionText::EncryptedRichText) }
+      #  def title; end
+      #
+      #  sig { params(value: T.nilable(T.any(ActionText::EncryptedRichText, String))).returns(T.untyped) }
+      #  def title=(value); end
+      #
+      #  sig { returns(T::Boolean) }
+      #  def title?; end
+      # end
+      # ~~~
+      class ActionText < Compiler
+        extend T::Sig
+
+        ConstantType = type_member { { fixed: T.class_of(::ActiveRecord::Base) } }
+
+        sig { override.void }
+        def decorate
+          root.create_path(constant) do |scope|
+            self.class.action_text_associations(constant).each do |name|
+              reflection = constant.reflections.fetch(name)
+              type = reflection.options.fetch(:class_name)
+              name = reflection.name.to_s.sub("rich_text_", "")
+              scope.create_method(
+                name,
+                return_type: type,
+              )
+              scope.create_method(
+                "#{name}?",
+                return_type: "T::Boolean",
+              )
+              scope.create_method(
+                "#{name}=",
+                parameters: [create_param("value", type: "T.nilable(T.any(#{type}, String))")],
+                return_type: "T.untyped",
+              )
+            end
+          end
+        end
+
+        class << self
+          extend T::Sig
+
+          sig { params(constant: T.class_of(::ActiveRecord::Base)).returns(T::Array[String]) }
+          def action_text_associations(constant)
+            # Implementation copied from https://github.com/rails/rails/blob/31052d0e518b9da103eea2f79d250242ed1e3705/actiontext/lib/action_text/attribute.rb#L66
+            constant.reflect_on_all_associations(:has_one)
+              .map(&:name).map(&:to_s)
+              .select { |n| n.start_with?("rich_text_") }
+          end
+
+          sig { override.returns(T::Enumerable[Module]) }
+          def gather_constants
+            descendants_of(::ActiveRecord::Base)
+              .reject(&:abstract_class?)
+              .select { |c| action_text_associations(c).any? }
+          end
+        end
+      end
+    end
+  end
+end

--- a/manual/compiler_actiontext.md
+++ b/manual/compiler_actiontext.md
@@ -1,0 +1,39 @@
+## ActionText
+
+`Tapioca::Dsl::Compilers::ActionText` decorates RBI files for subclasses of
+`ActiveRecord::Base` that declare [has_rich_text](https://edgeguides.rubyonrails.org/action_text_overview.html#creating-rich-text-content)
+
+For example, with the following `ActiveRecord::Base` subclass:
+
+~~~rb
+class Post < ApplicationRecord
+ has_rich_text :body
+ has_rich_text :title, encrypted: true
+end
+~~~
+
+this compiler will produce the RBI file `post.rbi` with the following content:
+
+~~~rbi
+# typed: strong
+
+class Post
+ sig { returns(ActionText::RichText) }
+ def body; end
+
+ sig { params(value: T.nilable(T.any(ActionText::RichText, String))).returns(T.untyped) }
+ def body=(value); end
+
+ sig { returns(T::Boolean) }
+ def body?; end
+
+ sig { returns(ActionText::EncryptedRichText) }
+ def title; end
+
+ sig { params(value: T.nilable(T.any(ActionText::EncryptedRichText, String))).returns(T.untyped) }
+ def title=(value); end
+
+ sig { returns(T::Boolean) }
+ def title?; end
+end
+~~~

--- a/manual/compilers.md
+++ b/manual/compilers.md
@@ -6,6 +6,7 @@ In the following section you will find all available DSL compilers:
 * [AASM](compiler_aasm.md)
 * [ActionControllerHelpers](compiler_actioncontrollerhelpers.md)
 * [ActionMailer](compiler_actionmailer.md)
+* [ActionText](compiler_actiontext.md)
 * [ActiveJob](compiler_activejob.md)
 * [ActiveModelAttributes](compiler_activemodelattributes.md)
 * [ActiveModelSecurePassword](compiler_activemodelsecurepassword.md)

--- a/spec/tapioca/dsl/compilers/action_text_spec.rb
+++ b/spec/tapioca/dsl/compilers/action_text_spec.rb
@@ -1,0 +1,111 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Tapioca
+  module Dsl
+    module Compilers
+      class ActionTextSpec < ::DslSpec
+        describe "Tapioca::Dsl::Compilers::ActionText" do
+          before do
+            add_ruby_file("require.rb", <<~RUBY)
+              require "active_record"
+              require "action_text"
+              ::ActiveRecord::Base.include(::ActionText::Attribute)
+              ::ActiveRecord::Base.prepend(::ActionText::Encryption) if defined?(::ActionText::Encryption)
+            RUBY
+          end
+
+          describe "initialize" do
+            it "gathers no constants if there are no ActiveRecord classes" do
+              assert_empty(gathered_constants)
+            end
+
+            it "gathers only ActiveRecord constants with rich text" do
+              add_ruby_file("conversation.rb", <<~RUBY)
+                class Post < ActiveRecord::Base
+                  has_rich_text :body
+                end
+
+                class Product < ActiveRecord::Base
+                  self.abstract_class = true
+                  has_rich_text :title
+                end
+
+                class User
+                end
+              RUBY
+
+              assert_equal(["Post"], gathered_constants)
+            end
+          end
+
+          describe "decorate" do
+            it "generates RBI file for ActiveRecord classes with a rich text" do
+              add_ruby_file("post.rb", <<~RUBY)
+                class Post < ActiveRecord::Base
+                  has_rich_text :body
+                  has_rich_text :title
+                end
+              RUBY
+
+              expected = <<~RBI
+                # typed: strong
+
+                class Post
+                  sig { returns(ActionText::RichText) }
+                  def body; end
+
+                  sig { params(value: T.nilable(T.any(ActionText::RichText, String))).returns(T.untyped) }
+                  def body=(value); end
+
+                  sig { returns(T::Boolean) }
+                  def body?; end
+
+                  sig { returns(ActionText::RichText) }
+                  def title; end
+
+                  sig { params(value: T.nilable(T.any(ActionText::RichText, String))).returns(T.untyped) }
+                  def title=(value); end
+
+                  sig { returns(T::Boolean) }
+                  def title?; end
+                end
+              RBI
+
+              assert_equal(expected, rbi_for(:Post))
+            end
+
+            it "generates RBI file for ActiveRecord classes with encrypted rich text" do
+              skip unless defined?(::ActionText::Encryption)
+
+              add_ruby_file("post.rb", <<~RUBY)
+                class Post < ActiveRecord::Base
+                  has_rich_text :body, encrypted: true
+                end
+              RUBY
+
+              expected = <<~RBI
+                # typed: strong
+
+                class Post
+                  sig { returns(ActionText::EncryptedRichText) }
+                  def body; end
+
+                  sig { params(value: T.nilable(T.any(ActionText::EncryptedRichText, String))).returns(T.untyped) }
+                  def body=(value); end
+
+                  sig { returns(T::Boolean) }
+                  def body?; end
+                end
+              RBI
+
+              assert_equal(expected, rbi_for(:Post))
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Motivation

Adds a compiler for Action Text.

### Implementation

I based most of this off the Active Storage compiler. Action Text is not very complex internally so the compiler was not too hard to write.

### Tests

Added tests and confirmed they match our home-made RBIs.
