### PR TITLE
Support Composite Primary keys in ActiveRecordColumns compiler 

### DIFF
--- a/lib/tapioca/dsl/compilers/active_record_columns.rb
+++ b/lib/tapioca/dsl/compilers/active_record_columns.rb
@@ -110,8 +110,8 @@ module Tapioca
 
           root.create_path(constant) do |model|
             model.create_module(AttributeMethodsModuleName) do |mod|
-              constant.attribute_names.each do |column_name|
-                add_methods_for_attribute(mod, column_name)
+              (constant.attribute_names + ["id"]).uniq.each do |attribute_name|
+                add_methods_for_attribute(mod, attribute_name)
               end
 
               constant.attribute_aliases.each do |attribute_name, column_name|
@@ -127,7 +127,7 @@ module Tapioca
                 old_method_names = patterns.map { |m| m.method_name(column_name) }
                 methods_to_add = new_method_names - old_method_names
 
-                add_methods_for_attribute(mod, column_name, attribute_name, methods_to_add)
+                add_methods_for_attribute(mod, attribute_name, column_name, methods_to_add)
               end
             end
 
@@ -166,13 +166,15 @@ module Tapioca
         sig do
           params(
             klass: RBI::Scope,
-            column_name: String,
             attribute_name: String,
+            column_name: String,
             methods_to_add: T.nilable(T::Array[String]),
           ).void
         end
-        def add_methods_for_attribute(klass, column_name, attribute_name = column_name, methods_to_add = nil)
-          getter_type, setter_type = Helpers::ActiveRecordColumnTypeHelper.new(constant).type_for(column_name)
+        def add_methods_for_attribute(klass, attribute_name, column_name = attribute_name, methods_to_add = nil)
+          getter_type, setter_type = Helpers::ActiveRecordColumnTypeHelper
+            .new(constant)
+            .type_for(attribute_name, column_name)
 
           # Added by ActiveRecord::AttributeMethods::Read
           #

--- a/lib/tapioca/helpers/test/template.rb
+++ b/lib/tapioca/helpers/test/template.rb
@@ -24,12 +24,12 @@ module Tapioca
           ::Gem::Requirement.new(selector).satisfied_by?(ActiveSupport.gem_version)
         end
 
-        sig { params(src: String).returns(String) }
-        def template(src)
+        sig { params(src: String, trim_mode: String).returns(String) }
+        def template(src, trim_mode: ">")
           erb = if ERB_SUPPORTS_KVARGS
-            ::ERB.new(src, trim_mode: ">")
+            ::ERB.new(src, trim_mode: trim_mode)
           else
-            ::ERB.new(src, nil, ">")
+            ::ERB.new(src, nil, trim_mode)
           end
 
           erb.result(binding)

--- a/spec/tapioca/dsl/compilers/active_record_columns_spec.rb
+++ b/spec/tapioca/dsl/compilers/active_record_columns_spec.rb
@@ -1119,6 +1119,30 @@ module Tapioca
 
                 assert_includes(rbi_for(:Post), expected)
               end
+
+              it "generates id accessors when primary key isn't id" do
+                add_ruby_file("schema.rb", <<~RUBY)
+                  ActiveRecord::Migration.suppress_messages do
+                    ActiveRecord::Schema.define do
+                      create_table :posts, primary_key: :number do |t|
+                      end
+                    end
+                  end
+                RUBY
+
+                add_ruby_file("post.rb", <<~RUBY)
+                  class Post < ActiveRecord::Base
+                    self.primary_key = :number
+                  end
+                RUBY
+
+                expected = indented(<<~RBI, 4)
+                  sig { returns(T.nilable(::Integer)) }
+                  def id; end
+                RBI
+
+                assert_includes(rbi_for(:Post), expected)
+              end
             end
 
             describe "when StrongTypeGeneration is defined" do

--- a/spec/tapioca/dsl/compilers/active_record_columns_spec.rb
+++ b/spec/tapioca/dsl/compilers/active_record_columns_spec.rb
@@ -7,6 +7,8 @@ module Tapioca
   module Dsl
     module Compilers
       class ActiveRecordColumnsSpec < ::DslSpec
+        extend Tapioca::Helpers::Test::Template
+
         describe "Tapioca::Dsl::Compilers::ActiveRecordColumns" do
           describe "initialize" do
             it "gathers no constants if there are no ActiveRecord subclasses" do
@@ -65,7 +67,7 @@ module Tapioca
                   end
                 RUBY
 
-                expected = <<~RBI
+                expected = template(<<~RBI, trim_mode: "-")
                   # typed: strong
 
                   class Post
@@ -111,6 +113,53 @@ module Tapioca
                       sig { returns(T.nilable(::Integer)) }
                       def id_previously_was; end
 
+                    <%- if rails_version(">= 7.1.alpha") -%>
+                      sig { returns(T.nilable(::Integer)) }
+                      def id_value; end
+
+                      sig { params(value: ::Integer).returns(::Integer) }
+                      def id_value=(value); end
+
+                      sig { returns(T::Boolean) }
+                      def id_value?; end
+
+                      sig { returns(T.nilable(::Integer)) }
+                      def id_value_before_last_save; end
+
+                      sig { returns(T.untyped) }
+                      def id_value_before_type_cast; end
+
+                      sig { returns(T::Boolean) }
+                      def id_value_came_from_user?; end
+
+                      sig { returns(T.nilable([T.nilable(::Integer), T.nilable(::Integer)])) }
+                      def id_value_change; end
+
+                      sig { returns(T.nilable([T.nilable(::Integer), T.nilable(::Integer)])) }
+                      def id_value_change_to_be_saved; end
+
+                      sig { params(from: ::Integer, to: ::Integer).returns(T::Boolean) }
+                      def id_value_changed?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+
+                      sig { returns(T.nilable(::Integer)) }
+                      def id_value_in_database; end
+
+                      sig { returns(T.nilable([T.nilable(::Integer), T.nilable(::Integer)])) }
+                      def id_value_previous_change; end
+
+                      sig { params(from: ::Integer, to: ::Integer).returns(T::Boolean) }
+                      def id_value_previously_changed?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+
+                      sig { returns(T.nilable(::Integer)) }
+                      def id_value_previously_was; end
+
+                      sig { returns(T.nilable(::Integer)) }
+                      def id_value_was; end
+
+                      sig { void }
+                      def id_value_will_change!; end
+
+                    <%- end -%>
                       sig { returns(T.nilable(::Integer)) }
                       def id_was; end
 
@@ -120,14 +169,33 @@ module Tapioca
                       sig { void }
                       def restore_id!; end
 
+                    <%- if rails_version(">= 7.1.alpha") -%>
+                      sig { void }
+                      def restore_id_value!; end
+
+                    <%- end -%>
                       sig { returns(T.nilable([T.nilable(::Integer), T.nilable(::Integer)])) }
                       def saved_change_to_id; end
 
                       sig { returns(T::Boolean) }
                       def saved_change_to_id?; end
 
+                    <%- if rails_version(">= 7.1.alpha") -%>
+                      sig { returns(T.nilable([T.nilable(::Integer), T.nilable(::Integer)])) }
+                      def saved_change_to_id_value; end
+
+                      sig { returns(T::Boolean) }
+                      def saved_change_to_id_value?; end
+
                       sig { returns(T::Boolean) }
                       def will_save_change_to_id?; end
+
+                      sig { returns(T::Boolean) }
+                      def will_save_change_to_id_value?; end
+                    <%- else -%>
+                      sig { returns(T::Boolean) }
+                      def will_save_change_to_id?; end
+                    <%- end -%>
                     end
                   end
                 RBI
@@ -1077,7 +1145,7 @@ module Tapioca
                   end
                 RUBY
 
-                expected = <<~RBI
+                expected = template(<<~RBI, trim_mode: "-")
                   # typed: strong
 
                   class Post
@@ -1123,6 +1191,53 @@ module Tapioca
                       sig { returns(T.nilable(::Integer)) }
                       def id_previously_was; end
 
+                    <%- if rails_version(">= 7.1.alpha") -%>
+                      sig { returns(T.nilable(::Integer)) }
+                      def id_value; end
+
+                      sig { params(value: ::Integer).returns(::Integer) }
+                      def id_value=(value); end
+
+                      sig { returns(T::Boolean) }
+                      def id_value?; end
+
+                      sig { returns(T.nilable(::Integer)) }
+                      def id_value_before_last_save; end
+
+                      sig { returns(T.untyped) }
+                      def id_value_before_type_cast; end
+
+                      sig { returns(T::Boolean) }
+                      def id_value_came_from_user?; end
+
+                      sig { returns(T.nilable([T.nilable(::Integer), T.nilable(::Integer)])) }
+                      def id_value_change; end
+
+                      sig { returns(T.nilable([T.nilable(::Integer), T.nilable(::Integer)])) }
+                      def id_value_change_to_be_saved; end
+
+                      sig { params(from: ::Integer, to: ::Integer).returns(T::Boolean) }
+                      def id_value_changed?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+
+                      sig { returns(T.nilable(::Integer)) }
+                      def id_value_in_database; end
+
+                      sig { returns(T.nilable([T.nilable(::Integer), T.nilable(::Integer)])) }
+                      def id_value_previous_change; end
+
+                      sig { params(from: ::Integer, to: ::Integer).returns(T::Boolean) }
+                      def id_value_previously_changed?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+
+                      sig { returns(T.nilable(::Integer)) }
+                      def id_value_previously_was; end
+
+                      sig { returns(T.nilable(::Integer)) }
+                      def id_value_was; end
+
+                      sig { void }
+                      def id_value_will_change!; end
+
+                    <%- end -%>
                       sig { returns(T.nilable(::Integer)) }
                       def id_was; end
 
@@ -1132,14 +1247,33 @@ module Tapioca
                       sig { void }
                       def restore_id!; end
 
+                    <%- if rails_version(">= 7.1.alpha") -%>
+                      sig { void }
+                      def restore_id_value!; end
+
+                    <%- end -%>
                       sig { returns(T.nilable([T.nilable(::Integer), T.nilable(::Integer)])) }
                       def saved_change_to_id; end
 
                       sig { returns(T::Boolean) }
                       def saved_change_to_id?; end
 
+                    <%- if rails_version(">= 7.1.alpha") -%>
+                      sig { returns(T.nilable([T.nilable(::Integer), T.nilable(::Integer)])) }
+                      def saved_change_to_id_value; end
+
+                      sig { returns(T::Boolean) }
+                      def saved_change_to_id_value?; end
+
                       sig { returns(T::Boolean) }
                       def will_save_change_to_id?; end
+
+                      sig { returns(T::Boolean) }
+                      def will_save_change_to_id_value?; end
+                    <%- else -%>
+                      sig { returns(T::Boolean) }
+                      def will_save_change_to_id?; end
+                    <%- end -%>
                     end
                   end
                 RBI
@@ -1163,7 +1297,7 @@ module Tapioca
                   end
                 RUBY
 
-                expected = <<~RBI
+                expected = template(<<~RBI, trim_mode: "-")
                   # typed: strong
 
                   class Post
@@ -1209,6 +1343,53 @@ module Tapioca
                       sig { returns(T.untyped) }
                       def id_previously_was; end
 
+                    <%- if rails_version(">= 7.1.alpha") -%>
+                      sig { returns(T.untyped) }
+                      def id_value; end
+
+                      sig { params(value: T.untyped).returns(T.untyped) }
+                      def id_value=(value); end
+
+                      sig { returns(T::Boolean) }
+                      def id_value?; end
+
+                      sig { returns(T.untyped) }
+                      def id_value_before_last_save; end
+
+                      sig { returns(T.untyped) }
+                      def id_value_before_type_cast; end
+
+                      sig { returns(T::Boolean) }
+                      def id_value_came_from_user?; end
+
+                      sig { returns(T.nilable([T.untyped, T.untyped])) }
+                      def id_value_change; end
+
+                      sig { returns(T.nilable([T.untyped, T.untyped])) }
+                      def id_value_change_to_be_saved; end
+
+                      sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
+                      def id_value_changed?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+
+                      sig { returns(T.untyped) }
+                      def id_value_in_database; end
+
+                      sig { returns(T.nilable([T.untyped, T.untyped])) }
+                      def id_value_previous_change; end
+
+                      sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
+                      def id_value_previously_changed?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+
+                      sig { returns(T.untyped) }
+                      def id_value_previously_was; end
+
+                      sig { returns(T.untyped) }
+                      def id_value_was; end
+
+                      sig { void }
+                      def id_value_will_change!; end
+
+                    <%- end -%>
                       sig { returns(T.untyped) }
                       def id_was; end
 
@@ -1218,14 +1399,33 @@ module Tapioca
                       sig { void }
                       def restore_id!; end
 
+                    <%- if rails_version(">= 7.1.alpha") -%>
+                      sig { void }
+                      def restore_id_value!; end
+
+                    <%- end -%>
                       sig { returns(T.nilable([T.untyped, T.untyped])) }
                       def saved_change_to_id; end
 
                       sig { returns(T::Boolean) }
                       def saved_change_to_id?; end
 
+                    <%- if rails_version(">= 7.1.alpha") -%>
+                      sig { returns(T.nilable([T.untyped, T.untyped])) }
+                      def saved_change_to_id_value; end
+
+                      sig { returns(T::Boolean) }
+                      def saved_change_to_id_value?; end
+
                       sig { returns(T::Boolean) }
                       def will_save_change_to_id?; end
+
+                      sig { returns(T::Boolean) }
+                      def will_save_change_to_id_value?; end
+                    <%- else -%>
+                      sig { returns(T::Boolean) }
+                      def will_save_change_to_id?; end
+                    <%- end -%>
                     end
                   end
                 RBI
@@ -1263,6 +1463,211 @@ module Tapioca
                 RBI
 
                 assert_includes(rbi_for(:Post), expected)
+              end
+
+              if rails_version(">= 7.1.alpha")
+                it "generates composite id type if models has composite primary keys" do
+                  T.bind(self, ActiveRecordColumnsSpec)
+                  add_ruby_file("schema.rb", <<~RUBY)
+                    ActiveRecord::Migration.suppress_messages do
+                      ActiveRecord::Schema.define do
+                        create_table(:posts, primary_key: [:id, :blog_id]) do |t|
+                          t.integer :id
+                          t.integer :blog_id
+                        end
+                      end
+                    end
+                  RUBY
+
+                  add_ruby_file("post.rb", <<~RUBY)
+                    class Post < ActiveRecord::Base
+                      extend StrongTypeGeneration
+                    end
+                  RUBY
+
+                  expected = <<~RBI
+                    # typed: strong
+
+                    class Post
+                      include GeneratedAttributeMethods
+
+                      module GeneratedAttributeMethods
+                        sig { returns(T.nilable(::Integer)) }
+                        def blog_id; end
+
+                        sig { params(value: T.nilable(::Integer)).returns(T.nilable(::Integer)) }
+                        def blog_id=(value); end
+
+                        sig { returns(T::Boolean) }
+                        def blog_id?; end
+
+                        sig { returns(T.nilable(::Integer)) }
+                        def blog_id_before_last_save; end
+
+                        sig { returns(T.untyped) }
+                        def blog_id_before_type_cast; end
+
+                        sig { returns(T::Boolean) }
+                        def blog_id_came_from_user?; end
+
+                        sig { returns(T.nilable([T.nilable(::Integer), T.nilable(::Integer)])) }
+                        def blog_id_change; end
+
+                        sig { returns(T.nilable([T.nilable(::Integer), T.nilable(::Integer)])) }
+                        def blog_id_change_to_be_saved; end
+
+                        sig { params(from: T.nilable(::Integer), to: T.nilable(::Integer)).returns(T::Boolean) }
+                        def blog_id_changed?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+
+                        sig { returns(T.nilable(::Integer)) }
+                        def blog_id_in_database; end
+
+                        sig { returns(T.nilable([T.nilable(::Integer), T.nilable(::Integer)])) }
+                        def blog_id_previous_change; end
+
+                        sig { params(from: T.nilable(::Integer), to: T.nilable(::Integer)).returns(T::Boolean) }
+                        def blog_id_previously_changed?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+
+                        sig { returns(T.nilable(::Integer)) }
+                        def blog_id_previously_was; end
+
+                        sig { returns(T.nilable(::Integer)) }
+                        def blog_id_was; end
+
+                        sig { void }
+                        def blog_id_will_change!; end
+
+                        sig { returns([T.nilable(::Integer), T.nilable(::Integer)]) }
+                        def id; end
+
+                        sig { params(value: [T.nilable(::Integer), T.nilable(::Integer)]).returns([T.nilable(::Integer), T.nilable(::Integer)]) }
+                        def id=(value); end
+
+                        sig { returns(T::Boolean) }
+                        def id?; end
+
+                        sig { returns(T.nilable([T.nilable(::Integer), T.nilable(::Integer)])) }
+                        def id_before_last_save; end
+
+                        sig { returns(T.untyped) }
+                        def id_before_type_cast; end
+
+                        sig { returns(T::Boolean) }
+                        def id_came_from_user?; end
+
+                        sig { returns(T.nilable([[T.nilable(::Integer), T.nilable(::Integer)], [T.nilable(::Integer), T.nilable(::Integer)]])) }
+                        def id_change; end
+
+                        sig { returns(T.nilable([[T.nilable(::Integer), T.nilable(::Integer)], [T.nilable(::Integer), T.nilable(::Integer)]])) }
+                        def id_change_to_be_saved; end
+
+                        sig { params(from: [T.nilable(::Integer), T.nilable(::Integer)], to: [T.nilable(::Integer), T.nilable(::Integer)]).returns(T::Boolean) }
+                        def id_changed?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+
+                        sig { returns(T.nilable([T.nilable(::Integer), T.nilable(::Integer)])) }
+                        def id_in_database; end
+
+                        sig { returns(T.nilable([[T.nilable(::Integer), T.nilable(::Integer)], [T.nilable(::Integer), T.nilable(::Integer)]])) }
+                        def id_previous_change; end
+
+                        sig { params(from: [T.nilable(::Integer), T.nilable(::Integer)], to: [T.nilable(::Integer), T.nilable(::Integer)]).returns(T::Boolean) }
+                        def id_previously_changed?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+
+                        sig { returns(T.nilable([T.nilable(::Integer), T.nilable(::Integer)])) }
+                        def id_previously_was; end
+
+                        sig { returns(T.nilable(::Integer)) }
+                        def id_value; end
+
+                        sig { params(value: T.nilable(::Integer)).returns(T.nilable(::Integer)) }
+                        def id_value=(value); end
+
+                        sig { returns(T::Boolean) }
+                        def id_value?; end
+
+                        sig { returns(T.nilable(::Integer)) }
+                        def id_value_before_last_save; end
+
+                        sig { returns(T.untyped) }
+                        def id_value_before_type_cast; end
+
+                        sig { returns(T::Boolean) }
+                        def id_value_came_from_user?; end
+
+                        sig { returns(T.nilable([T.nilable(::Integer), T.nilable(::Integer)])) }
+                        def id_value_change; end
+
+                        sig { returns(T.nilable([T.nilable(::Integer), T.nilable(::Integer)])) }
+                        def id_value_change_to_be_saved; end
+
+                        sig { params(from: T.nilable(::Integer), to: T.nilable(::Integer)).returns(T::Boolean) }
+                        def id_value_changed?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+
+                        sig { returns(T.nilable(::Integer)) }
+                        def id_value_in_database; end
+
+                        sig { returns(T.nilable([T.nilable(::Integer), T.nilable(::Integer)])) }
+                        def id_value_previous_change; end
+
+                        sig { params(from: T.nilable(::Integer), to: T.nilable(::Integer)).returns(T::Boolean) }
+                        def id_value_previously_changed?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+
+                        sig { returns(T.nilable(::Integer)) }
+                        def id_value_previously_was; end
+
+                        sig { returns(T.nilable(::Integer)) }
+                        def id_value_was; end
+
+                        sig { void }
+                        def id_value_will_change!; end
+
+                        sig { returns(T.nilable([T.nilable(::Integer), T.nilable(::Integer)])) }
+                        def id_was; end
+
+                        sig { void }
+                        def id_will_change!; end
+
+                        sig { void }
+                        def restore_blog_id!; end
+
+                        sig { void }
+                        def restore_id!; end
+
+                        sig { void }
+                        def restore_id_value!; end
+
+                        sig { returns(T.nilable([T.nilable(::Integer), T.nilable(::Integer)])) }
+                        def saved_change_to_blog_id; end
+
+                        sig { returns(T::Boolean) }
+                        def saved_change_to_blog_id?; end
+
+                        sig { returns(T.nilable([[T.nilable(::Integer), T.nilable(::Integer)], [T.nilable(::Integer), T.nilable(::Integer)]])) }
+                        def saved_change_to_id; end
+
+                        sig { returns(T::Boolean) }
+                        def saved_change_to_id?; end
+
+                        sig { returns(T.nilable([T.nilable(::Integer), T.nilable(::Integer)])) }
+                        def saved_change_to_id_value; end
+
+                        sig { returns(T::Boolean) }
+                        def saved_change_to_id_value?; end
+
+                        sig { returns(T::Boolean) }
+                        def will_save_change_to_blog_id?; end
+
+                        sig { returns(T::Boolean) }
+                        def will_save_change_to_id?; end
+
+                        sig { returns(T::Boolean) }
+                        def will_save_change_to_id_value?; end
+                      end
+                    end
+                  RBI
+
+                  assert_equal(rbi_for(:Post), expected)
+                end
               end
 
               it "generates attributes with weak types if model does not extend StrongTypeGeneration" do


### PR DESCRIPTION
### Motivation
Support Active Record composite primary keys in `ActiveRecordColumns` compiler.

### Implementation
I imagine using Rails edge may not be ideal, and if it isn't, we can look at merging this closer to when CPK is released. Due to how the compiler works, I would also consider renaming it to `ActiveRecordAttributes` instead.

### Tests
The implementation inadvertently fixed a bug where the generated attribute methods don't include `id` when using a non-id primary key. Active Record always has an `id` method defined via https://github.com/rails/rails/blob/bc2892ab4557136a959e95c329c2dcc0133c7585/activerecord/lib/active_record/attribute_methods/primary_key.rb.

