### PR TITLE
require `rubygems/user_interaction`

### DIFF
--- a/lib/tapioca.rb
+++ b/lib/tapioca.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "sorbet-runtime"
+require "rubygems/user_interaction"
 
 module Tapioca
   extend T::Sig


### PR DESCRIPTION
### Motivation
I was seeing the same error as #1485. 

### Implementation
Added the import recommended by @tadman.

### Tests
I don't think there's an easy way to test this, but happy to be proven wrong.

