### PR TITLE
Add support for custom GraphQL scalar coercion

### DIFF
--- a/lib/tapioca/dsl/helpers/graphql_type_helper.rb
+++ b/lib/tapioca/dsl/helpers/graphql_type_helper.rb
@@ -28,7 +28,7 @@ module Tapioca
             type_for_constant(Float)
           when GraphQL::Types::ID.singleton_class, GraphQL::Types::String.singleton_class
             type_for_constant(String)
-          when GraphQL::Types::Int.singleton_class
+          when GraphQL::Types::Int.singleton_class, GraphQL::Types::BigInt.singleton_class
             type_for_constant(Integer)
           when GraphQL::Types::ISO8601Date.singleton_class
             type_for_constant(Date)

--- a/lib/tapioca/dsl/helpers/graphql_type_helper.rb
+++ b/lib/tapioca/dsl/helpers/graphql_type_helper.rb
@@ -45,6 +45,10 @@ module Tapioca
             else
               "T.any(#{value_types.join(", ")})"
             end
+          when GraphQL::Schema::Scalar.singleton_class
+            method = Runtime::Reflection.method_of(unwrapped_type, :coerce_input)
+            signature = Runtime::Reflection.signature_of(method)
+            signature&.return_type&.to_s || "T.untyped"
           when GraphQL::Schema::InputObject.singleton_class
             type_for_constant(unwrapped_type)
           when GraphQL::Schema::NonNull.singleton_class

--- a/lib/tapioca/dsl/helpers/graphql_type_helper.rb
+++ b/lib/tapioca/dsl/helpers/graphql_type_helper.rb
@@ -48,7 +48,13 @@ module Tapioca
           when GraphQL::Schema::Scalar.singleton_class
             method = Runtime::Reflection.method_of(unwrapped_type, :coerce_input)
             signature = Runtime::Reflection.signature_of(method)
-            signature&.return_type&.to_s || "T.untyped"
+            return_type = signature&.return_type
+
+            if return_type && !(T::Private::Types::Void === return_type || T::Private::Types::NotTyped === return_type)
+              return_type.to_s
+            else
+              "T.untyped"
+            end
           when GraphQL::Schema::InputObject.singleton_class
             type_for_constant(unwrapped_type)
           when GraphQL::Schema::NonNull.singleton_class

--- a/spec/tapioca/dsl/compilers/graphql_mutation_spec.rb
+++ b/spec/tapioca/dsl/compilers/graphql_mutation_spec.rb
@@ -163,7 +163,7 @@ module Tapioca
                 # typed: strong
 
                 class CreateComment
-                  sig { params(boolean: T::Boolean, float: ::Float, id: ::String, int: ::Integer, date: ::Date, datetime: ::Time, json: T::Hash[::String, T.untyped], string: ::String, enum_a: ::String, enum_b: T.any(::String, ::Symbol), input_object: ::CreateCommentInput, custom_scalar: ::CustomScalar).returns(T.untyped) }
+                  sig { params(boolean: T::Boolean, float: ::Float, id: ::String, int: ::Integer, date: ::Date, datetime: ::Time, json: T::Hash[::String, T.untyped], string: ::String, enum_a: ::String, enum_b: T.any(::String, ::Symbol), input_object: ::CreateCommentInput, custom_scalar: T.untyped).returns(T.untyped) }
                   def resolve(boolean:, float:, id:, int:, date:, datetime:, json:, string:, enum_a:, enum_b:, input_object:, custom_scalar:); end
                 end
               RBI
@@ -196,6 +196,44 @@ module Tapioca
                 class CreateComment
                   sig { params(loaded_argument: ::LoadedType, loaded_arguments: T::Array[::LoadedType], custom_name: ::LoadedType, optional_loaded_argument: T.nilable(::LoadedType), optional_loaded_arguments: T.nilable(T::Array[::LoadedType])).returns(T.untyped) }
                   def resolve(loaded_argument:, loaded_arguments:, custom_name:, optional_loaded_argument: T.unsafe(nil), optional_loaded_arguments: T.unsafe(nil)); end
+                end
+              RBI
+
+              assert_equal(expected, rbi_for(:CreateComment))
+            end
+
+            it "generates correct RBI for custom scalars with return types" do
+              add_ruby_file("create_comment.rb", <<~RUBY)
+                class CustomScalar; end
+
+                class CustomScalarType < GraphQL::Schema::Scalar
+                  class << self
+                    extend T::Sig
+
+                    sig { params(value: T.untyped, context: GraphQL::Query::Context).returns(CustomScalar) }
+                    def coerce_input(value, context)
+                      CustomScalar.new
+                    end
+                  end
+                end
+
+                class CreateComment < GraphQL::Schema::Mutation
+                  argument :custom_scalar, CustomScalarType, required: true
+                  argument :custom_scalar_array, [CustomScalarType], required: true
+                  argument :optional_custom_scalar, CustomScalarType, required: false
+
+                  def resolve(custom_scalar:, custom_scalar_array:, optional_custom_scalar: nil)
+                    # ...
+                  end
+                end
+              RUBY
+
+              expected = <<~RBI
+                # typed: strong
+
+                class CreateComment
+                  sig { params(custom_scalar: ::CustomScalar, custom_scalar_array: T::Array[::CustomScalar], optional_custom_scalar: T.nilable(::CustomScalar)).returns(T.untyped) }
+                  def resolve(custom_scalar:, custom_scalar_array:, optional_custom_scalar: T.unsafe(nil)); end
                 end
               RBI
 

--- a/spec/tapioca/dsl/compilers/graphql_mutation_spec.rb
+++ b/spec/tapioca/dsl/compilers/graphql_mutation_spec.rb
@@ -218,12 +218,31 @@ module Tapioca
                   end
                 end
 
+                class BrokenScalarType < GraphQL::Schema::Scalar
+                  class << self
+                    extend T::Sig
+
+                    sig { params(value: T.untyped, context: GraphQL::Query::Context).void }
+                    def coerce_input(value, context)
+                    end
+                  end
+                end
+
+                class NoSigScalarType < GraphQL::Schema::Scalar
+                  class << self
+                    def coerce_input(value, context)
+                    end
+                  end
+                end
+
                 class CreateComment < GraphQL::Schema::Mutation
                   argument :custom_scalar, CustomScalarType, required: true
                   argument :custom_scalar_array, [CustomScalarType], required: true
+                  argument :broken_scalar, BrokenScalarType, required: true
+                  argument :no_sig_scalar, NoSigScalarType, required: true
                   argument :optional_custom_scalar, CustomScalarType, required: false
 
-                  def resolve(custom_scalar:, custom_scalar_array:, optional_custom_scalar: nil)
+                  def resolve(custom_scalar:, custom_scalar_array:, broken_scalar:, no_sig_scalar:, optional_custom_scalar: nil)
                     # ...
                   end
                 end
@@ -233,8 +252,8 @@ module Tapioca
                 # typed: strong
 
                 class CreateComment
-                  sig { params(custom_scalar: ::CustomScalar, custom_scalar_array: T::Array[::CustomScalar], optional_custom_scalar: T.nilable(::CustomScalar)).returns(T.untyped) }
-                  def resolve(custom_scalar:, custom_scalar_array:, optional_custom_scalar: T.unsafe(nil)); end
+                  sig { params(custom_scalar: ::CustomScalar, custom_scalar_array: T::Array[::CustomScalar], broken_scalar: T.untyped, no_sig_scalar: T.untyped, optional_custom_scalar: T.nilable(::CustomScalar)).returns(T.untyped) }
+                  def resolve(custom_scalar:, custom_scalar_array:, broken_scalar:, no_sig_scalar:, optional_custom_scalar: T.unsafe(nil)); end
                 end
               RBI
 

--- a/spec/tapioca/dsl/compilers/graphql_mutation_spec.rb
+++ b/spec/tapioca/dsl/compilers/graphql_mutation_spec.rb
@@ -144,6 +144,7 @@ module Tapioca
                   argument :float, Float, required: true
                   argument :id, ID, required: true
                   argument :int, Int, required: true
+                  argument :big_int, GraphQL::Types::BigInt, required: true
                   argument :date, GraphQL::Types::ISO8601Date, required: true
                   argument :datetime, GraphQL::Types::ISO8601DateTime, required: true
                   argument :json, GraphQL::Types::JSON, required: true
@@ -153,7 +154,7 @@ module Tapioca
                   argument :input_object, CreateCommentInput, required: true
                   argument :custom_scalar, CustomScalar, required: true
 
-                  def resolve(boolean:, float:, id:, int:, date:, datetime:, json:, string:, enum_a:, enum_b:, input_object:, custom_scalar:)
+                  def resolve(boolean:, float:, id:, int:, big_int:, date:, datetime:, json:, string:, enum_a:, enum_b:, input_object:, custom_scalar:)
                     # ...
                   end
                 end
@@ -163,8 +164,8 @@ module Tapioca
                 # typed: strong
 
                 class CreateComment
-                  sig { params(boolean: T::Boolean, float: ::Float, id: ::String, int: ::Integer, date: ::Date, datetime: ::Time, json: T::Hash[::String, T.untyped], string: ::String, enum_a: ::String, enum_b: T.any(::String, ::Symbol), input_object: ::CreateCommentInput, custom_scalar: T.untyped).returns(T.untyped) }
-                  def resolve(boolean:, float:, id:, int:, date:, datetime:, json:, string:, enum_a:, enum_b:, input_object:, custom_scalar:); end
+                  sig { params(boolean: T::Boolean, float: ::Float, id: ::String, int: ::Integer, big_int: ::Integer, date: ::Date, datetime: ::Time, json: T::Hash[::String, T.untyped], string: ::String, enum_a: ::String, enum_b: T.any(::String, ::Symbol), input_object: ::CreateCommentInput, custom_scalar: T.untyped).returns(T.untyped) }
+                  def resolve(boolean:, float:, id:, int:, big_int:, date:, datetime:, json:, string:, enum_a:, enum_b:, input_object:, custom_scalar:); end
                 end
               RBI
 


### PR DESCRIPTION
### Motivation
When trying to update our project to Tapioca v0.11.9, I ran into an issue with our custom scalars: Tapioca currently uses the GraphQL scalar class as the return type even if it defines a `coerce_input` method with a different return type. For example, if I have a scalar `MyScalarType` that inherits from `GraphQL::Schema::Scalar` and has a `coerce_input` that returns `MyScalar`, Tapioca will wrongly use `MyScalarType` in generated signatures for mutations and input objects. This is an attempt at fixing that issue.

I also shoehorned `GraphQL::Types::BigInt` here since I noticed it wasn't working properly either. Happy to separate that into its own PR if needed.

### Implementation
The approach I took is to simply check if a type signature exists on `coerce_input` and use the return type if it does. If not, it falls back to the current behaviour.

### Tests
I've added a test here and also checked against our project to make sure I didn't miss anything.

