### PR TITLE
Update AASM compiler for instance aasm method

### DIFF
--- a/lib/tapioca/dsl/compilers/aasm.rb
+++ b/lib/tapioca/dsl/compilers/aasm.rb
@@ -121,6 +121,14 @@ module Tapioca
               end
             end
 
+            model.create_method(
+              "aasm",
+              parameters: [
+                create_opt_param("name", type: "T.untyped", default: ":default"),
+              ],
+              return_type: "AASM::InstanceBase",
+            )
+
             # Create the overall state machine method, which will return an
             # instance of the PrivateAASMMachine class.
             model.create_method(

--- a/spec/tapioca/dsl/compilers/aasm_spec.rb
+++ b/spec/tapioca/dsl/compilers/aasm_spec.rb
@@ -67,6 +67,9 @@ module Tapioca
                 # typed: strong
 
                 class StateMachine
+                  sig { params(name: T.untyped).returns(AASM::InstanceBase) }
+                  def aasm(name = :default); end
+
                   sig { returns(T::Boolean) }
                   def cleaning?; end
 
@@ -188,6 +191,9 @@ module Tapioca
                 # typed: strong
 
                 class StateMachine
+                  sig { params(name: T.untyped).returns(AASM::InstanceBase) }
+                  def aasm(name = :default); end
+
                   sig { returns(T::Boolean) }
                   def cleaning?; end
 
@@ -309,6 +315,9 @@ module Tapioca
                 # typed: strong
 
                 class StateMachine
+                  sig { params(name: T.untyped).returns(AASM::InstanceBase) }
+                  def aasm(name = :default); end
+
                   sig { returns(T::Boolean) }
                   def foo_cleaning?; end
 


### PR DESCRIPTION
### Motivation
This is useful for e.g. `model.aasm.may_fire_event?(params[:event].to_sym)`.

### Implementation
See https://github.com/aasm/aasm/blob/2e952ff2088082c9f00c95e3c1261afc826f737c/lib/aasm/aasm.rb#L67-L74

### Tests
✅ 

