### PR TITLE
Exclude Rails from grouped updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,8 @@ updates:
         update-types:
           - "minor"
           - "patch"
+        exclude-patterns:
+          - "rails"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
As seen in https://github.com/Shopify/tapioca/pull/1688, Rails updates often need additional work, so let's exclude that from the grouped updates.