### PR TITLE
Add support for `#to_a` in ActiveRecord relations compiler

### DIFF
--- a/lib/tapioca/dsl/compilers/active_record_relations.rb
+++ b/lib/tapioca/dsl/compilers/active_record_relations.rb
@@ -126,6 +126,9 @@ module Tapioca
       #     include GeneratedAssociationRelationMethods
       #
       #     sig { returns(T::Array[::Post]) }
+      #     def to_a; end
+      #
+      #     sig { returns(T::Array[::Post]) }
       #     def to_ary; end
       #
       #     Elem = type_member { { fixed: ::Post } }
@@ -147,6 +150,9 @@ module Tapioca
       #   class PrivateRelation < ::ActiveRecord::Relation
       #     include CommonRelationMethods
       #     include GeneratedRelationMethods
+      #
+      #     sig { returns(T::Array[::Post]) }
+      #     def to_a; end
       #
       #     sig { returns(T::Array[::Post]) }
       #     def to_ary; end
@@ -226,6 +232,7 @@ module Tapioca
           T::Array[Symbol],
         )
         BUILDER_METHODS = T.let([:new, :build, :create, :create!], T::Array[Symbol])
+        TO_ARRAY_METHODS = T.let([:to_ary, :to_a], T::Array[Symbol])
 
         private
 
@@ -296,7 +303,9 @@ module Tapioca
             klass.create_include(RelationMethodsModuleName)
             klass.create_type_variable("Elem", type: "type_member", fixed: constant_name)
 
-            klass.create_method("to_ary", return_type: "T::Array[#{constant_name}]")
+            TO_ARRAY_METHODS.each do |method_name|
+              klass.create_method(method_name.to_s, return_type: "T::Array[#{constant_name}]")
+            end
           end
 
           create_relation_where_chain_class
@@ -312,7 +321,9 @@ module Tapioca
             klass.create_include(AssociationRelationMethodsModuleName)
             klass.create_type_variable("Elem", type: "type_member", fixed: constant_name)
 
-            klass.create_method("to_ary", return_type: "T::Array[#{constant_name}]")
+            TO_ARRAY_METHODS.each do |method_name|
+              klass.create_method(method_name.to_s, return_type: "T::Array[#{constant_name}]")
+            end
           end
 
           create_association_relation_where_chain_class
@@ -372,7 +383,9 @@ module Tapioca
             klass.create_include(AssociationRelationMethodsModuleName)
             klass.create_type_variable("Elem", type: "type_member", fixed: constant_name)
 
-            klass.create_method("to_ary", return_type: "T::Array[#{constant_name}]")
+            TO_ARRAY_METHODS.each do |method_name|
+              klass.create_method(method_name.to_s, return_type: "T::Array[#{constant_name}]")
+            end
             create_collection_proxy_methods(klass)
           end
         end

--- a/manual/compiler_activerecordrelations.md
+++ b/manual/compiler_activerecordrelations.md
@@ -114,6 +114,9 @@ class Post
     include GeneratedAssociationRelationMethods
 
     sig { returns(T::Array[::Post]) }
+    def to_a; end
+
+    sig { returns(T::Array[::Post]) }
     def to_ary; end
 
     Elem = type_member { { fixed: ::Post } }
@@ -135,6 +138,9 @@ class Post
   class PrivateRelation < ::ActiveRecord::Relation
     include CommonRelationMethods
     include GeneratedRelationMethods
+
+    sig { returns(T::Array[::Post]) }
+    def to_a; end
 
     sig { returns(T::Array[::Post]) }
     def to_ary; end

--- a/spec/tapioca/dsl/compilers/active_record_relations_spec.rb
+++ b/spec/tapioca/dsl/compilers/active_record_relations_spec.rb
@@ -561,6 +561,9 @@ module Tapioca
                     Elem = type_member { { fixed: ::Post } }
 
                     sig { returns(T::Array[::Post]) }
+                    def to_a; end
+
+                    sig { returns(T::Array[::Post]) }
                     def to_ary; end
                   end
 
@@ -622,6 +625,9 @@ module Tapioca
                     def target; end
 
                     sig { returns(T::Array[::Post]) }
+                    def to_a; end
+
+                    sig { returns(T::Array[::Post]) }
                     def to_ary; end
                   end
 
@@ -630,6 +636,9 @@ module Tapioca
                     include GeneratedRelationMethods
 
                     Elem = type_member { { fixed: ::Post } }
+
+                    sig { returns(T::Array[::Post]) }
+                    def to_a; end
 
                     sig { returns(T::Array[::Post]) }
                     def to_ary; end


### PR DESCRIPTION
### Motivation
This PR adds support for [`#to_a`](https://api.rubyonrails.org/classes/ActiveRecord/Relation.html#method-i-to_a) to the ActiveRecord relations compiler.

Sorbet can usually infer that `#to_a` returns the same type as `#to_ary`, but because Active Record explicitly aliases `#to_ary` to `#to_a` ([here](https://github.com/rails/rails/blob/v7.1.1/activerecord/lib/active_record/relation.rb#L261)), Sorbet thinks `#to_a` is a separate method with no signature and thus returns `T.untyped`.

Cf. [sorbet.run bug repro](https://sorbet.run/#%23%20typed%3A%20true%0A%0Aclass%20Module%0A%20include%20%20T%3A%3ASig%0Aend%0A%0Aclass%20ActiveRecord%3A%3AAssociationRelation%0A%20%20include%20Enumerable%0A%0A%20%20def%20each%28%26blk%29%3B%20end%0Aend%0A%0Aclass%20ActiveRecord%3A%3AAssociations%3A%3ACollectionProxy%0A%20%20include%20Enumerable%0A%0A%20%20def%20each%28%26blk%29%3B%20end%0Aend%0A%0Aclass%20ActiveRecord%3A%3ARelation%0A%20%20include%20Enumerable%0A%0A%20%20def%20each%28%26blk%29%3B%20end%0A%0A%20%20def%20to_ary%3B%20end%0A%20%20alias%20to_a%20to_ary%0Aend%0A%0Aclass%20Post%0A%20%20extend%20CommonRelationMethods%0A%20%20extend%20GeneratedRelationMethods%0A%0A%20%20private%0A%0A%20%20sig%20%7B%20returns%28NilClass%29%20%7D%0A%20%20def%20to_ary%3B%20end%0A%0A%20%20module%20CommonRelationMethods%0A%20%20end%0A%0A%20%20module%20GeneratedAssociationRelationMethods%0A%20%20end%0A%0A%20%20module%20GeneratedRelationMethods%0A%20%20end%0A%0A%20%20class%20PrivateAssociationRelation%0A%20%20%20%20include%20CommonRelationMethods%0A%20%20%20%20include%20GeneratedAssociationRelationMethods%0A%20%20%20%20extend%20T%3A%3AGeneric%0A%0A%20%20%20%20Elem%20%3D%20type_member%20%7B%20%7B%20fixed%3A%20%3A%3APost%20%7D%20%7D%0A%0A%20%20%20%20sig%20%7B%20returns%28T%3A%3AArray%5B%3A%3APost%5D%29%20%7D%0A%20%20%20%20def%20to_ary%0A%20%20%20%20%20%20T.unsafe%28nil%29%0A%20%20%20%20end%0A%20%20end%0A%0A%20%20class%20PrivateCollectionProxy%20%3C%20%3A%3AActiveRecord%3A%3AAssociations%3A%3ACollectionProxy%0A%20%20%20%20include%20CommonRelationMethods%0A%20%20%20%20include%20GeneratedAssociationRelationMethods%0A%20%20%20%20extend%20T%3A%3AGeneric%0A%0A%20%20%20%20Elem%20%3D%20type_member%20%7B%20%7B%20fixed%3A%20%3A%3APost%20%7D%20%7D%0A%0A%20%20%20%20sig%20%7B%20returns%28T%3A%3AArray%5B%3A%3APost%5D%29%20%7D%0A%20%20%20%20def%20to_ary%0A%20%20%20%20%20%20T.unsafe%28nil%29%0A%20%20%20%20end%0A%20%20end%0A%0A%20%20class%20PrivateRelation%20%3C%20%3A%3AActiveRecord%3A%3ARelation%0A%20%20%20%20include%20CommonRelationMethods%0A%20%20%20%20include%20GeneratedRelationMethods%0A%20%20%20%20extend%20T%3A%3AGeneric%0A%0A%20%20%20%20Elem%20%3D%20type_member%20%7B%20%7B%20fixed%3A%20%3A%3APost%20%7D%20%7D%0A%0A%20%20%20%20sig%20%7B%20returns%28T%3A%3AArray%5B%3A%3APost%5D%29%20%7D%0A%20%20%20%20def%20to_ary%0A%20%20%20%20%20%20T.unsafe%28nil%29%0A%20%20%20%20end%0A%20%20end%0Aend%0A%0Afoo%20%3D%20T.cast%28nil%2C%20Post%3A%3APrivateRelation%29%0AT.reveal_type%28foo.to_ary%29%0AT.reveal_type%28foo.to_a%29%0A). 

### Implementation
Updated every place where a signature is defined for `#to_ary` to also define the same signature for `#to_a`, with the exception of the signature that returns `NilClass` (cf. [comment below](https://github.com/Shopify/tapioca/pull/1701#issuecomment-1798953446)).

### Tests
Updated the existing test for the compiler with the new signatures.
