### PR TITLE
Fix engine loading for Rails 7.2

### DIFF
--- a/lib/tapioca/loaders/loader.rb
+++ b/lib/tapioca/loaders/loader.rb
@@ -80,6 +80,8 @@ module Tapioca
       def load_rails_engines
         return if engines.empty?
 
+        normalize_eager_load_paths_configuration!
+
         with_rails_application do
           run_initializers
 
@@ -110,7 +112,7 @@ module Tapioca
         autoloader = Zeitwerk::Loader.new
 
         engines.each do |engine|
-          engine.config.eager_load_paths.each do |path|
+          engine.config.all_eager_load_paths.each do |path|
             # Zeitwerk only accepts existing directories in `push_dir`.
             next unless File.directory?(path)
             # We should not add directories that are already managed by a Zeitwerk loader.
@@ -131,7 +133,7 @@ module Tapioca
         # We can't use `Rails::Engine#eager_load!` directly because it will raise as soon as it encounters
         # an error, which is not what we want. We want to try to load as much as we can.
         engines.each do |engine|
-          engine.config.eager_load_paths.each do |load_path|
+          engine.config.all_eager_load_paths.each do |load_path|
             Dir.glob("#{load_path}/**/*.rb").sort.each do |file|
               require_dependency file
             end
@@ -177,6 +179,19 @@ module Tapioca
           .descendants
           .reject(&:abstract_railtie?)
           .reject { |engine| gem_in_app_dir?(project_path, engine.config.root.to_path) }
+      end
+
+      # Rails 7.2 renamed `eager_load_paths` to `all_eager_load_paths`, which maintains the same original functionality.
+      # The `eager_load_paths` method still exists, but doens't return all paths anymore and causes Tapioca to miss some
+      # engine paths. The following commit is the change:
+      # https://github.com/rails/rails/commit/ebfca905db14020589c22e6937382e6f8f687664
+      #
+      # Here we make sure that the new `all_eager_load_paths` is always defined for every Rails version below 7.2, so
+      # that we can use it everywhere
+      def normalize_eager_load_paths_configuration!
+        return if Rails::VERSION::MAJOR >= 7 && Rails::VERSION::MINOR >= 2
+
+        engines.each { |e| e.config.all_eager_load_paths = e.config.eager_load_paths }
       end
 
       sig { params(path: String).void }

--- a/lib/tapioca/static/symbol_loader.rb
+++ b/lib/tapioca/static/symbol_loader.rb
@@ -27,7 +27,7 @@ module Tapioca
 
           return Set.new unless gem_engine
 
-          paths = gem_engine.config.eager_load_paths.flat_map do |load_path|
+          paths = gem_engine.config.all_eager_load_paths.flat_map do |load_path|
             Pathname.glob("#{load_path}/**/*.rb")
           end
 


### PR DESCRIPTION
### Motivation

Commit https://github.com/rails/rails/commit/ebfca905db14020589c22e6937382e6f8f687664 renamed `eager_load_paths` to `all_eager_load_paths`.

For Rails applications pointing to `main`, Tapioca ends up not loading all engine paths

### Implementation

The idea of the implementation is to switch to using the Rails 7.2 name of the configuration and just ensure it always exists even for older versions.

### Tests

I'm not sure how we can write a test for this given that 7.2 has no releases yet. I did test this in Core though.