### PR TITLE
Restore `type_for(type)` function

### DIFF
--- a/lib/tapioca/dsl/compilers/graphql_input_object.rb
+++ b/lib/tapioca/dsl/compilers/graphql_input_object.rb
@@ -55,7 +55,10 @@ module Tapioca
           root.create_path(constant) do |input_object|
             arguments.each do |argument|
               name = argument.keyword.to_s
-              input_object.create_method(name, return_type: Helpers::GraphqlTypeHelper.type_for(argument, constant))
+              input_object.create_method(
+                name,
+                return_type: Helpers::GraphqlTypeHelper.type_for_argument(argument, constant),
+              )
             end
           end
         end

--- a/lib/tapioca/dsl/compilers/graphql_mutation.rb
+++ b/lib/tapioca/dsl/compilers/graphql_mutation.rb
@@ -76,7 +76,7 @@ module Tapioca
         def argument_type(argument, constant)
           return "T.untyped" unless argument
 
-          Helpers::GraphqlTypeHelper.type_for(argument, constant)
+          Helpers::GraphqlTypeHelper.type_for_argument(argument, constant)
         end
 
         class << self

--- a/lib/tapioca/dsl/helpers/graphql_type_helper.rb
+++ b/lib/tapioca/dsl/helpers/graphql_type_helper.rb
@@ -26,7 +26,7 @@ module Tapioca
           end
 
           prepare = argument.prepare
-          prepare_method = if prepare.is_a?(Symbol) || prepare.is_a?(String)
+          prepare_method = if prepare
             if constant.respond_to?(prepare)
               constant.method(prepare)
             end

--- a/spec/tapioca/dsl/helpers/graphql_type_helper_spec.rb
+++ b/spec/tapioca/dsl/helpers/graphql_type_helper_spec.rb
@@ -1,0 +1,197 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Tapioca
+  module Dsl
+    module Helpers
+      class GraphqlTypeHelperSpec < Minitest::Spec
+        extend T::Sig
+
+        require "graphql"
+        require_relative "../../../../lib/tapioca/dsl/helpers/graphql_type_helper.rb"
+
+        it "generates the expected sorbet type expression when using type GraphQL::Types::Boolean" do
+          type = GraphQL::Types::Boolean
+          assert_equal(
+            "T.nilable(T::Boolean)",
+            Tapioca::Dsl::Helpers::GraphqlTypeHelper.type_for(type),
+          )
+          assert_equal(
+            "T.nilable(T::Boolean)",
+            Tapioca::Dsl::Helpers::GraphqlTypeHelper.type_for(GraphQL::Schema::Wrapper.new(type)),
+          )
+          assert_equal(
+            "T.nilable(T::Array[T::Boolean])",
+            Tapioca::Dsl::Helpers::GraphqlTypeHelper.type_for(GraphQL::Schema::List.new(type)),
+          )
+          assert_equal(
+            "T::Boolean",
+            Tapioca::Dsl::Helpers::GraphqlTypeHelper.type_for(GraphQL::Schema::NonNull.new(type)),
+          )
+        end
+
+        it "generates the expected sorbet type expression when using type GraphQL::Types::String" do
+          type = GraphQL::Types::String
+          assert_equal(
+            "T.nilable(::String)",
+            Tapioca::Dsl::Helpers::GraphqlTypeHelper.type_for(type),
+          )
+          assert_equal(
+            "T.nilable(::String)",
+            Tapioca::Dsl::Helpers::GraphqlTypeHelper.type_for(GraphQL::Schema::Wrapper.new(type)),
+          )
+          assert_equal(
+            "T.nilable(T::Array[::String])",
+            Tapioca::Dsl::Helpers::GraphqlTypeHelper.type_for(GraphQL::Schema::List.new(type)),
+          )
+          assert_equal(
+            "::String",
+            Tapioca::Dsl::Helpers::GraphqlTypeHelper.type_for(GraphQL::Schema::NonNull.new(type)),
+          )
+        end
+
+        it "generates the expected sorbet type expression when using type GraphQL::Types::Float" do
+          type = GraphQL::Types::Float
+          assert_equal(
+            "T.nilable(::Float)",
+            Tapioca::Dsl::Helpers::GraphqlTypeHelper.type_for(type),
+          )
+          assert_equal(
+            "T.nilable(::Float)",
+            Tapioca::Dsl::Helpers::GraphqlTypeHelper.type_for(GraphQL::Schema::Wrapper.new(type)),
+          )
+          assert_equal(
+            "T.nilable(T::Array[::Float])",
+            Tapioca::Dsl::Helpers::GraphqlTypeHelper.type_for(GraphQL::Schema::List.new(type)),
+          )
+          assert_equal(
+            "::Float",
+            Tapioca::Dsl::Helpers::GraphqlTypeHelper.type_for(GraphQL::Schema::NonNull.new(type)),
+          )
+        end
+
+        it "generates the expected sorbet type expression when using type GraphQL::Types::ID" do
+          type = GraphQL::Types::ID
+          assert_equal(
+            "T.nilable(::String)",
+            Tapioca::Dsl::Helpers::GraphqlTypeHelper.type_for(type),
+          )
+          assert_equal(
+            "T.nilable(::String)",
+            Tapioca::Dsl::Helpers::GraphqlTypeHelper.type_for(GraphQL::Schema::Wrapper.new(type)),
+          )
+          assert_equal(
+            "T.nilable(T::Array[::String])",
+            Tapioca::Dsl::Helpers::GraphqlTypeHelper.type_for(GraphQL::Schema::List.new(type)),
+          )
+          assert_equal(
+            "::String",
+            Tapioca::Dsl::Helpers::GraphqlTypeHelper.type_for(GraphQL::Schema::NonNull.new(type)),
+          )
+        end
+
+        it "generates the expected sorbet type expression when using type GraphQL::Types::Int" do
+          type = GraphQL::Types::Int
+          assert_equal(
+            "T.nilable(::Integer)",
+            Tapioca::Dsl::Helpers::GraphqlTypeHelper.type_for(type),
+          )
+          assert_equal(
+            "T.nilable(::Integer)",
+            Tapioca::Dsl::Helpers::GraphqlTypeHelper.type_for(GraphQL::Schema::Wrapper.new(type)),
+          )
+          assert_equal(
+            "T.nilable(T::Array[::Integer])",
+            Tapioca::Dsl::Helpers::GraphqlTypeHelper.type_for(GraphQL::Schema::List.new(type)),
+          )
+          assert_equal(
+            "::Integer",
+            Tapioca::Dsl::Helpers::GraphqlTypeHelper.type_for(GraphQL::Schema::NonNull.new(type)),
+          )
+        end
+
+        it "generates the expected sorbet type expression when using type GraphQL::Types::BigInt" do
+          type = GraphQL::Types::BigInt
+          assert_equal(
+            "T.nilable(::Integer)",
+            Tapioca::Dsl::Helpers::GraphqlTypeHelper.type_for(type),
+          )
+          assert_equal(
+            "T.nilable(::Integer)",
+            Tapioca::Dsl::Helpers::GraphqlTypeHelper.type_for(GraphQL::Schema::Wrapper.new(type)),
+          )
+          assert_equal(
+            "T.nilable(T::Array[::Integer])",
+            Tapioca::Dsl::Helpers::GraphqlTypeHelper.type_for(GraphQL::Schema::List.new(type)),
+          )
+          assert_equal(
+            "::Integer",
+            Tapioca::Dsl::Helpers::GraphqlTypeHelper.type_for(GraphQL::Schema::NonNull.new(type)),
+          )
+        end
+
+        it "generates the expected sorbet type expression when using type GraphQL::Types::ISO8601Date" do
+          type = GraphQL::Types::ISO8601Date
+          assert_equal(
+            "T.nilable(::Date)",
+            Tapioca::Dsl::Helpers::GraphqlTypeHelper.type_for(type),
+          )
+          assert_equal(
+            "T.nilable(::Date)",
+            Tapioca::Dsl::Helpers::GraphqlTypeHelper.type_for(GraphQL::Schema::Wrapper.new(type)),
+          )
+          assert_equal(
+            "T.nilable(T::Array[::Date])",
+            Tapioca::Dsl::Helpers::GraphqlTypeHelper.type_for(GraphQL::Schema::List.new(type)),
+          )
+          assert_equal(
+            "::Date",
+            Tapioca::Dsl::Helpers::GraphqlTypeHelper.type_for(GraphQL::Schema::NonNull.new(type)),
+          )
+        end
+
+        it "generates the expected sorbet type expression when using type GraphQL::Types::ISO8601DateTime" do
+          type = GraphQL::Types::ISO8601DateTime
+          assert_equal(
+            "T.nilable(::Time)",
+            Tapioca::Dsl::Helpers::GraphqlTypeHelper.type_for(type),
+          )
+          assert_equal(
+            "T.nilable(::Time)",
+            Tapioca::Dsl::Helpers::GraphqlTypeHelper.type_for(GraphQL::Schema::Wrapper.new(type)),
+          )
+          assert_equal(
+            "T.nilable(T::Array[::Time])",
+            Tapioca::Dsl::Helpers::GraphqlTypeHelper.type_for(GraphQL::Schema::List.new(type)),
+          )
+          assert_equal(
+            "::Time",
+            Tapioca::Dsl::Helpers::GraphqlTypeHelper.type_for(GraphQL::Schema::NonNull.new(type)),
+          )
+        end
+
+        it "generates the expected sorbet type expression when using type GraphQL::Types::JSON" do
+          type = GraphQL::Types::JSON
+          assert_equal(
+            "T.nilable(T::Hash[::String, T.untyped])",
+            Tapioca::Dsl::Helpers::GraphqlTypeHelper.type_for(type),
+          )
+          assert_equal(
+            "T.nilable(T::Hash[::String, T.untyped])",
+            Tapioca::Dsl::Helpers::GraphqlTypeHelper.type_for(GraphQL::Schema::Wrapper.new(type)),
+          )
+          assert_equal(
+            "T.nilable(T::Array[T::Hash[::String, T.untyped]])",
+            Tapioca::Dsl::Helpers::GraphqlTypeHelper.type_for(GraphQL::Schema::List.new(type)),
+          )
+          assert_equal(
+            "T::Hash[::String, T.untyped]",
+            Tapioca::Dsl::Helpers::GraphqlTypeHelper.type_for(GraphQL::Schema::NonNull.new(type)),
+          )
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Motivation

Following https://github.com/Shopify/tapioca/pull/1622 the function `Tapioca::Dsl::Helpers::GraphqlTypeHelper#type_for` required an `GraphQL::Schema::Argument` (instead of a `GraphQL::Schema::Wrapper`) to be passed.

Though this did make perfectly sense, we actually used that method to explicitly compute types in our DSL process without this being necessarily "for a field". For example it could be for union types.

### Implementation

What I did was:

1. Rework the `type_for` method to be backward compatible with the pre https://github.com/Shopify/tapioca/pull/1622 code (e.g. keep accepting a sole `GraphQL::Schema::Wrapper` argument as a parameter)
2. Introduce an explicit `type_for_argument` which would be redirecting appropriately to keep https://github.com/Shopify/tapioca/pull/1622 feature

### Tests

I added tests for some introduced adherence.
