### PR TITLE
 Support for custom GraphQL input preparation (Phase one)

### DIFF
--- a/lib/tapioca/dsl/helpers/graphql_type_helper.rb
+++ b/lib/tapioca/dsl/helpers/graphql_type_helper.rb
@@ -19,6 +19,7 @@ module Tapioca
           else
             argument.type
           end
+
           unwrapped_type = type.unwrap
 
           parsed_type = case unwrapped_type
@@ -78,6 +79,13 @@ module Tapioca
 
         sig { params(constant: Module).returns(String) }
         def type_for_constant(constant)
+          if constant.instance_methods.include?(:prepare)
+            prepare_method = constant.instance_method(:prepare)
+            if (prepare_signature = Runtime::Reflection.signature_of(prepare_method))
+              return prepare_signature.return_type&.to_s if prepare_signature.return_type
+            end
+          end
+
           Runtime::Reflection.qualified_name_of(constant) || "T.untyped"
         end
 

--- a/spec/tapioca/dsl/compilers/graphql_mutation_spec.rb
+++ b/spec/tapioca/dsl/compilers/graphql_mutation_spec.rb
@@ -176,6 +176,7 @@ module Tapioca
               add_ruby_file("create_comment.rb", <<~RUBY)
                 class DateRangeInput < GraphQL::Schema::InputObject
                   extend T::Sig
+
                   description "Range of dates"
                   argument :min, GraphQL::Types::ISO8601Date, "Minimum value of the range"
                   argument :max, GraphQL::Types::ISO8601Date, "Maximum value of the range"
@@ -186,14 +187,32 @@ module Tapioca
                   end
                 end
 
+                class VoidInput < GraphQL::Schema::InputObject
+                  extend T::Sig
+
+                  argument :void, String, "Not a real input"
+
+                  sig { void }
+                  def prepare; end
+                end
+
+                class UntypedInput < GraphQL::Schema::InputObject
+                  argument :string, String, "Not a real input"
+
+                  def prepare
+                    string.to_i
+                  end
+                end
 
                 class CreateComment < GraphQL::Schema::Mutation
                   extend T::Sig
 
 
                   argument :date_range, DateRangeInput, required: true
+                  argument :void_input, VoidInput, required: true
+                  argument :untyped_input, UntypedInput, required: true
 
-                  def resolve(date_range:)
+                  def resolve(date_range:, void_input:, untyped_input:)
                     # ...
                   end
                 end
@@ -203,8 +222,8 @@ module Tapioca
                 # typed: strong
 
                 class CreateComment
-                  sig { params(date_range: T::Range[::Date]).returns(T.untyped) }
-                  def resolve(date_range:); end
+                  sig { params(date_range: T::Range[::Date], void_input: ::VoidInput, untyped_input: ::UntypedInput).returns(T.untyped) }
+                  def resolve(date_range:, void_input:, untyped_input:); end
                 end
               RBI
 


### PR DESCRIPTION
### Motivation

@eapache-opslevel kinda nerd sniped me on this one, I thought "how hard could it be?"

This just tackles the situation where there's a `prepare` method with a signature, there is a default `prepare` method: https://github.com/rmosolgo/graphql-ruby/blob/565b62f13d3cdd7d2cd880e82d189ab64278b1e8/lib/graphql/schema/input_object.rb#L47-L56

I am unsure if there's a way to define a signature if you use the `prepare: -> (input, context) {}` lambda style `prepare` definition though.

### Implementation
By default `prepare` will return the current object, so I kept that behaviour in this MR, if you define a `prepare` method, without a signature, we assumed you're returning the current object.

If you add a signature to the overriden prepare method, we'll use the return type

I'm not a big fan of my weird nesting in `type_for_constant`, I'm happy for feedback to improve that code.

### Tests

_Yes! Yes I did!_
