### PR TITLE
Add support for GraphQL Argument prepare methods when defined as a method on the constant

### DIFF
--- a/lib/tapioca/dsl/compilers/graphql_input_object.rb
+++ b/lib/tapioca/dsl/compilers/graphql_input_object.rb
@@ -55,7 +55,7 @@ module Tapioca
           root.create_path(constant) do |input_object|
             arguments.each do |argument|
               name = argument.keyword.to_s
-              input_object.create_method(name, return_type: Helpers::GraphqlTypeHelper.type_for(argument))
+              input_object.create_method(name, return_type: Helpers::GraphqlTypeHelper.type_for(argument, constant))
             end
           end
         end

--- a/lib/tapioca/dsl/compilers/graphql_mutation.rb
+++ b/lib/tapioca/dsl/compilers/graphql_mutation.rb
@@ -59,7 +59,7 @@ module Tapioca
           params = compile_method_parameters_to_rbi(method_def).map do |param|
             name = param.param.name
             argument = arguments_by_name.fetch(name, nil)
-            create_typed_param(param.param, argument_type(argument))
+            create_typed_param(param.param, argument_type(argument, constant))
           end
 
           root.create_path(constant) do |mutation|
@@ -67,11 +67,16 @@ module Tapioca
           end
         end
 
-        sig { params(argument: T.nilable(GraphQL::Schema::Argument)).returns(String) }
-        def argument_type(argument)
+        sig do
+          params(
+            argument: T.nilable(GraphQL::Schema::Argument),
+            constant: T.class_of(GraphQL::Schema::Mutation),
+          ).returns(String)
+        end
+        def argument_type(argument, constant)
           return "T.untyped" unless argument
 
-          Helpers::GraphqlTypeHelper.type_for(argument)
+          Helpers::GraphqlTypeHelper.type_for(argument, constant)
         end
 
         class << self

--- a/lib/tapioca/dsl/helpers/graphql_type_helper.rb
+++ b/lib/tapioca/dsl/helpers/graphql_type_helper.rb
@@ -66,9 +66,14 @@ module Tapioca
           end
 
           if argument.prepare.is_a?(Symbol) || argument.prepare.is_a?(String)
-            prepare_signature = Runtime::Reflection.signature_of(constant.method(argument.prepare))
+            if constant.respond_to?(argument.prepare)
+              prepare_method = constant.method(argument.prepare)
+              prepare_signature = Runtime::Reflection.signature_of(prepare_method)
 
-            parsed_type = prepare_signature.return_type&.to_s if valid_return_type?(prepare_signature&.return_type)
+              if valid_return_type?(prepare_signature&.return_type)
+                parsed_type = prepare_signature.return_type&.to_s
+              end
+            end
           end
 
           if type.list?
@@ -88,6 +93,7 @@ module Tapioca
         def type_for_constant(constant)
           if constant.instance_methods.include?(:prepare)
             prepare_method = constant.instance_method(:prepare)
+
             prepare_signature = Runtime::Reflection.signature_of(prepare_method)
 
             return prepare_signature.return_type&.to_s if valid_return_type?(prepare_signature&.return_type)

--- a/spec/tapioca/dsl/compilers/graphql_mutation_spec.rb
+++ b/spec/tapioca/dsl/compilers/graphql_mutation_spec.rb
@@ -173,6 +173,8 @@ module Tapioca
             end
 
             it "generates correct RBI arguments with a prepare method" do
+              # Prepare Methods that return void are technically invalid,
+              # but we don't raise anything and default to the input type
               add_ruby_file("create_comment.rb", <<~RUBY)
                 class CreateComment < GraphQL::Schema::Mutation
                   extend T::Sig


### PR DESCRIPTION
### Motivation
Second part of https://github.com/Shopify/tapioca/issues/1717

This adds support for prepare method when defined as a method on the constant.

[It uses the same check as GraphQL-Ruby](https://github.com/rmosolgo/graphql-ruby/blob/109c26c5fa9118a9c69ed4c4823048c1ce1aea6d/lib/graphql/schema/argument.rb#L217-L226)

And I use the same fallback behaviour as I did in #1720, where it falls back to the base type if the signature is missing or void (technically this is a bad signature I guess? But I'm not sure what we should really be doing here)

### Implementation

I added `constant` as a param in `Tapioca::Dsl::Helpers::GraphqlTypeHelper#type_for` since that holds the actual method on it, and as such I had to update `GraphqlInputObject` to use it too.


### Tests

Yes!
