### PR TITLE
Update the workaround for `debug` gem

### DIFF
--- a/lib/tapioca/helpers/env_helper.rb
+++ b/lib/tapioca/helpers/env_helper.rb
@@ -11,7 +11,7 @@ module Tapioca
     sig { params(options: T::Hash[Symbol, T.untyped]).void }
     def set_environment(options) # rubocop:disable Naming/AccessorMethodName
       ENV["RAILS_ENV"] = ENV["RACK_ENV"] = options[:environment]
-      ENV["RUBY_DEBUG_ENABLE"] = "0"
+      ENV["RUBY_DEBUG_LAZY"] = "1"
     end
   end
 end


### PR DESCRIPTION
### Motivation

The current approach of disabling `debug` loading makes it impossible to debug Tapioca itself with the gem.

### Implementation

But by lazily activate the debugger, we can avoid the side-effect as well as allowing breakpoints to lazily load the debugger.

It's the same as doing `require "debug/prelude"`, which only defines the breakpoint methods.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->

