### PR TITLE
Fix deprecation warning (fixture_path -> fixture_paths)

### DIFF
--- a/lib/tapioca/dsl/compilers/active_record_fixtures.rb
+++ b/lib/tapioca/dsl/compilers/active_record_fixtures.rb
@@ -76,7 +76,12 @@ module Tapioca
             Class.new do
               T.unsafe(self).include(ActiveRecord::TestFixtures)
 
-              T.unsafe(self).fixture_path = Rails.root.join("test", "fixtures")
+              if respond_to?(:fixture_paths=)
+                T.unsafe(self).fixture_paths = [Rails.root.join("test", "fixtures")]
+              else
+                T.unsafe(self).fixture_path = Rails.root.join("test", "fixtures")
+              end
+
               # https://github.com/rails/rails/blob/7c70791470fc517deb7c640bead9f1b47efb5539/activerecord/lib/active_record/test_fixtures.rb#L46
               singleton_class.define_method(:file_fixture_path) do
                 Rails.root.join("test", "fixtures", "files")


### PR DESCRIPTION
Resolves:

```
ActiveSupport::DeprecationException: DEPRECATION WARNING: TestFixtures.fixture_path= is deprecated and will be removed in Rails 7.2. Use .fixture_paths= instead. (called from use_ui at /Users/alexevanczuk/.rbenv/versions/3.2.0/lib/ruby/site_ruby/3.2.0/rubygems/user_interaction.rb:47) (Parallel::UndumpableException)

```

Still need to add some tests!
