### PR TITLE
Remove identity comparison feature check in favour of a conditional

### DIFF
--- a/lib/tapioca/gem/listeners/sorbet_signatures.rb
+++ b/lib/tapioca/gem/listeners/sorbet_signatures.rb
@@ -67,12 +67,9 @@ module Tapioca
         sig { params(signature: T.untyped).returns(T::Boolean) }
         def signature_final?(signature)
           modules_with_final = T::Private::Methods.instance_variable_get(:@modules_with_final)
-          final_methods = if sorbet_supports?(:identity_comparison)
-            modules_with_final[signature.owner]
-          else
-            modules_with_final[signature.owner.object_id]
-          end
-
+          # In https://github.com/sorbet/sorbet/pull/7531, Sorbet changed internal hashes to be compared by identity,
+          # starting on version 0.5.11155
+          final_methods = modules_with_final[signature.owner] || modules_with_final[signature.owner.object_id]
           return false unless final_methods
 
           final_methods.include?(signature.method_name)

--- a/lib/tapioca/helpers/sorbet_helper.rb
+++ b/lib/tapioca/helpers/sorbet_helper.rb
@@ -26,7 +26,6 @@ module Tapioca
         # feature_name: ::Gem::Requirement.new(">= ___"), # https://github.com/sorbet/sorbet/pull/___
         non_generic_weak_map: ::Gem::Requirement.new(">= 0.5.10587"), # https://github.com/sorbet/sorbet/pull/6610
         generic_class: ::Gem::Requirement.new(">= 0.5.10820"), # https://github.com/sorbet/sorbet/pull/6781
-        identity_comparison: ::Gem::Requirement.new(">= 0.5.11155"), # https://github.com/sorbet/sorbet/pull/7531
       }.freeze,
       T::Hash[Symbol, ::Gem::Requirement],
     )


### PR DESCRIPTION
### Motivation

Context: https://github.com/Shopify/tapioca/pull/1732/files#r1428547394

Instead of maintaining a feature check, we can just use a conditional and reduce complexity.

### Implementation

Got rid of the feature check and switch to a conditional. Also, left a comment with the PR and version it gets introduced since we may want to remove part of the conditional in the future if we make our Sorbet requirement more strict.

### Tests

Existing tests should continue to pass.