### PR TITLE
Small ActiveRecord column related changes

### DIFF
--- a/lib/tapioca/dsl/compilers/active_model_attributes.rb
+++ b/lib/tapioca/dsl/compilers/active_model_attributes.rb
@@ -70,7 +70,7 @@ module Tapioca
 
         sig { returns(T::Array[[::String, ::String]]) }
         def attribute_methods_for_constant
-          patterns = if constant.respond_to?(:attribute_method_patterns)
+          patterns = if Helpers::ActiveRecordColumnTypeHelper::HasAttributeMethodPatternsMethod
             # https://github.com/rails/rails/pull/44367
             T.unsafe(constant).attribute_method_patterns
           else

--- a/lib/tapioca/dsl/compilers/active_record_columns.rb
+++ b/lib/tapioca/dsl/compilers/active_record_columns.rb
@@ -108,6 +108,11 @@ module Tapioca
         def decorate
           return unless constant.table_exists?
 
+          # We need to call this to ensure that some attribute aliases are defined, e.g.
+          # `id_value` as an alias for `id`.
+          # I think this is a regression on Rails 7.1, but we are where we are.
+          constant.define_attribute_methods
+
           root.create_path(constant) do |model|
             model.create_module(AttributeMethodsModuleName) do |mod|
               (constant.attribute_names + ["id"]).uniq.each do |attribute_name|

--- a/lib/tapioca/dsl/compilers/active_record_columns.rb
+++ b/lib/tapioca/dsl/compilers/active_record_columns.rb
@@ -122,7 +122,7 @@ module Tapioca
               constant.attribute_aliases.each do |attribute_name, column_name|
                 attribute_name = attribute_name.to_s
                 column_name = column_name.to_s
-                patterns = if constant.respond_to?(:attribute_method_patterns)
+                patterns = if Helpers::ActiveRecordColumnTypeHelper::HasAttributeMethodPatternsMethod
                   # https://github.com/rails/rails/pull/44367
                   T.unsafe(constant).attribute_method_patterns
                 else

--- a/lib/tapioca/dsl/helpers/active_record_column_type_helper.rb
+++ b/lib/tapioca/dsl/helpers/active_record_column_type_helper.rb
@@ -8,6 +8,13 @@ module Tapioca
         extend T::Sig
         include RBIHelper
 
+        HasAttributeMethodPatternsMethod = T.let(
+          Class.new do
+            include ActiveModel::AttributeMethods
+          end.method_defined?(:attribute_method_patterns),
+          T::Boolean,
+        )
+
         sig { params(constant: T.class_of(ActiveRecord::Base)).void }
         def initialize(constant)
           @constant = constant


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
The main motivation for this PR is to make sure the new Rails 7.1 behaviour of the `id_value` attribute alias being defined too late is accounted for.

After [this change](https://github.com/Shopify/shopify/pull/471447/files#diff-df235247748c2d0fa248f44258702609d6fdd1d5b3afecfb88e394f3623e1458L163-L167) was merged in Rails, the `id_value` attribute alias is only defined while methods are being defined on the model. However, that creates a problem since an eager load of the application causes a different behaviour (since eager load loads the schema and defined the methods on models) than a non-eager load of the application. Thus, depending on how a model is loaded, it could list `id_value` as an alias to `id` in `attribute_aliases`, or not.

The only workaround is to trigger method definitions on each model, which unfortunately costs us some performance, but makes the behaviour predictable.

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
Call `define_method_attributes` on each model before attempting to discover attribute names and aliases.

I've also moved the check for the existence of `attribute_method_patterns` method to a constant, so that we don't have to keep doing the same check over and over again for each model.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->
No additional tests.