### PR TITLE
prevent infinite recursion if a type is seen again

### DIFF
--- a/lib/tapioca/runtime/trackers/autoload.rb
+++ b/lib/tapioca/runtime/trackers/autoload.rb
@@ -18,10 +18,16 @@ module Tapioca
           sig { void }
           def eager_load_all!
             with_disabled_exits do
+              seen_constant_name = {}
               until @constant_names_registered_for_autoload.empty?
                 # Grab the next constant name
                 constant_name = T.must(@constant_names_registered_for_autoload.shift)
+
+                # Skip constants which have already been processed.
+                next if seen_constant_name.key?(constant_name)
+
                 # Trigger autoload by constantizing the registered name
+                seen_constant_name[constant_name] = true
                 Reflection.constantize(constant_name, inherit: true)
               end
             end


### PR DESCRIPTION
### Motivation

The algorithm used to force load all constants is vulnerable to an infinite loop. I hit just such a case when trying to bootstrap sorbet with tapioca in an internal Rails repository at my employer. Running any Tapioca command using this eager load algorithm hung indefinitely after printing that it was loading the Rails application.

I tracked down the issue by vendoring tapioca and adding debug logging statements. The execution continued until `Tapioca::Runtime::Trackers::Autoload.eager_load_all!` at which point the loop continued indefinitely for the same few constant names.

### Implementation

The fix is relatively straightforward: Just maintain a cache of constant names which have already been seen, and skip the processing of a constant name if it was already processed.

### Tests

[WIP] I know which internal code is triggering the issue, but still need to generate a test case from it.