### PR TITLE
Exclude testing of Ruby 3.0 against Rails main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,9 @@ jobs:
             experimental: true
           - ruby: "head"
             experimental: true
+        exclude:
+          - gemfile: gemfiles/Gemfile-rails-main
+            ruby: "3.0"
     name: Ruby ${{ matrix.ruby }} - ${{ matrix.gemfile }}
     env:
       BUNDLE_GEMFILE: ${{ matrix.gemfile }}


### PR DESCRIPTION
The minimum is now 3.1.0:
https://github.com/rails/rails/commit/6ba2fdb2fe85751b573aadd05608471daf1a44ff