### PR TITLE
Upgrade development Ruby to 3.3.0

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -3,7 +3,7 @@ name: tapioca
 type: ruby
 
 up:
-  - ruby: '3.2.0'
+  - ruby: '3.3.0'
   - bundler
 
 env:


### PR DESCRIPTION
### Motivation

Let's use the latest Ruby for development. It was already on CI, so all I had to change was dev.yml.
