### PR TITLE
Add support for Rails 7.1 normalization to Active Record columns compiler

### DIFF
--- a/lib/tapioca/dsl/helpers/active_record_column_type_helper.rb
+++ b/lib/tapioca/dsl/helpers/active_record_column_type_helper.rb
@@ -85,6 +85,9 @@ module Tapioca
             "::String"
           when ActiveRecord::Type::Serialized
             serialized_column_type(column_type)
+          when defined?(ActiveRecord::Normalization::NormalizedValueType) &&
+            ActiveRecord::Normalization::NormalizedValueType
+            type_for_activerecord_value(column_type.cast_type)
           when defined?(ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Uuid) &&
             ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Uuid
             "::String"


### PR DESCRIPTION

### Motivation
Rails 7.1 added a new `normalizes` DSL. Here is a blog post explaining the feature: https://www.bigbinary.com/blog/rails-7-1-adds-activerecord-base-normalizes

This PR adds support for `normalizes` to the Active Record columns compiler. Without this change, any column using `normalizes` would be typed as returning `T.untyped`.

### Implementation
Internally, normalized attributes have a column type of [`ActiveRecord::Normalization::NormalizedValueType`](https://github.com/rails/rails/blob/v7.1.2/activerecord/lib/active_record/normalization.rb#L120-L165), which wraps the actual type in its `cast_type` attribute:
```
column_type = Post.attribute_types["title"]
column_type.class # => ActiveRecord::Normalization::NormalizedValueType
column_type.cast_type # => #<ActiveModel::Type::String:0x000000013b594fc0 @false="f", @limit=nil, @precision=nil, @scale=nil, @true="t">
```

The fix was trivial: update the `Tapioca::Dsl::Helpers::ActiveRecordColumnTypeHelper#type_for_activerecord_value` method to add a clause for `ActiveRecord::Normalization::NormalizedValueType`, which simply calls itself with the `cast_type` value.

### Tests
I added a test to ensure the cast type is properly discovered.
