### PR TITLE
Remove duplicate block parameter in ActiveJob#perform_later

### DIFF
--- a/lib/tapioca/dsl/compilers/active_job.rb
+++ b/lib/tapioca/dsl/compilers/active_job.rb
@@ -83,6 +83,7 @@ module Tapioca
         end
         def perform_later_parameters(parameters, constant_name)
           if ::Gem::Requirement.new(">= 7.0").satisfied_by?(::ActiveJob.gem_version)
+            parameters.reject! { |typed_param| RBI::BlockParam === typed_param.param }
             parameters + [create_block_param(
               "block",
               type: "T.nilable(T.proc.params(job: #{constant_name}).void)",


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->

If an `ActiveJob#perform` contains a `&block` argument, tapioca will generate a duplicate block argument.

### Before
```
class TestJob
  class << self
    sig do
      params(
        args: T.untyped,
        _arg1: T.untyped,
        block: T.untyped,
        block: T.nilable(T.proc.params(job: TestJob).void)
      ).returns(T.any(TestJob, FalseClass))
    end
    def perform_later(*args, **_arg1, &block, &block); end

    sig { params(args: T.untyped, _arg1: T.untyped).returns(T.untyped) }
    def perform_now(*args, **_arg1); end
  end
end
```

### After
```
class TestJob
  class << self
    sig do
      params(
        args: T.untyped,
        _arg1: T.untyped,
        block: T.nilable(T.proc.params(job: TestJob).void)
      ).returns(T.any(TestJob, FalseClass))
    end
    def perform_later(*args, **_arg1, &block); end

    sig { params(args: T.untyped, _arg1: T.untyped).returns(T.untyped) }
    def perform_now(*args, **_arg1); end
  end
end
```

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->

In `perform_later_parameters`, it'll remove any existing block argument before adding one in. Not sure if there's a better way to approach it.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->
Added a test case where the Job parameter has a block parameter.


