### PR TITLE
Check if prepare argument is a symbol or string

### DIFF
--- a/lib/tapioca/dsl/helpers/graphql_type_helper.rb
+++ b/lib/tapioca/dsl/helpers/graphql_type_helper.rb
@@ -26,9 +26,9 @@ module Tapioca
           end
 
           prepare = argument.prepare
-          prepare_method = if prepare
+          prepare_method = if prepare.is_a?(Symbol) || prepare.is_a?(String)
             if constant.respond_to?(prepare)
-              constant.method(prepare)
+              constant.method(prepare.to_sym)
             end
           end
 

--- a/spec/tapioca/dsl/compilers/graphql_mutation_spec.rb
+++ b/spec/tapioca/dsl/compilers/graphql_mutation_spec.rb
@@ -199,8 +199,9 @@ module Tapioca
                   argument :min, GraphQL::Types::ISO8601Date, "Minimum value of the range", prepare: :prepare_dates
                   argument :max, GraphQL::Types::ISO8601Date, "Maximum value of the range", prepare: :prepare_dates_void
                   argument :other, GraphQL::Types::ISO8601Date, "Some value of the range ", prepare: :prepare_dates_untyped
+                  argument :proc, GraphQL::Types::ISO8601Date, "Some value of the range ", prepare: ->(value, _ctx) { value }
 
-                  def resolve(min:, max:, other:)
+                  def resolve(min:, max:, other:, proc:)
                     # ...
                   end
                 end
@@ -210,8 +211,8 @@ module Tapioca
                 # typed: strong
 
                 class CreateComment
-                  sig { params(min: T::Range[::Date], max: ::Date, other: ::Date).returns(T.untyped) }
-                  def resolve(min:, max:, other:); end
+                  sig { params(min: T::Range[::Date], max: ::Date, other: ::Date, proc: ::Date).returns(T.untyped) }
+                  def resolve(min:, max:, other:, proc:); end
                 end
               RBI
 

--- a/spec/tapioca/dsl/helpers/graphql_type_helper_spec.rb
+++ b/spec/tapioca/dsl/helpers/graphql_type_helper_spec.rb
@@ -2,15 +2,14 @@
 # frozen_string_literal: true
 
 require "spec_helper"
+require "graphql"
+require "tapioca/dsl/helpers/graphql_type_helper"
 
 module Tapioca
   module Dsl
     module Helpers
       class GraphqlTypeHelperSpec < Minitest::Spec
         extend T::Sig
-
-        require "graphql"
-        require_relative "../../../../lib/tapioca/dsl/helpers/graphql_type_helper.rb"
 
         it "generates the expected sorbet type expression when using type GraphQL::Types::Boolean" do
           type = GraphQL::Types::Boolean


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
Leftover from the refactor https://github.com/Shopify/tapioca/pull/1714/files#diff-8b787801eb4d5ed2047d8b5d37043650443fae0500ae270f8d7ededeb311f27cL68. It causes TypeError's when the argument isn't a symbol or a string.

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
Bring back the previous check, call `to_sym` to please Sorbet.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->
Added