### PR TITLE
Fix proc type generation for `T::Struct` props

### DIFF
--- a/lib/tapioca/gem/listeners/sorbet_props.rb
+++ b/lib/tapioca/gem/listeners/sorbet_props.rb
@@ -6,6 +6,7 @@ module Tapioca
     module Listeners
       class SorbetProps < Base
         extend T::Sig
+        include RBIHelper
 
         private
 
@@ -17,7 +18,7 @@ module Tapioca
           return unless T::Props::ClassMethods === constant
 
           constant.props.map do |name, prop|
-            type = prop.fetch(:type_object, "T.untyped").to_s.gsub(".returns(<VOID>)", ".void")
+            type = sanitize_signature_types(prop.fetch(:type_object, "T.untyped").to_s)
 
             default = prop.key?(:default) || prop.key?(:factory) ? "T.unsafe(nil)" : nil
             node << if prop.fetch(:immutable, false)

--- a/spec/tapioca/gem/pipeline_spec.rb
+++ b/spec/tapioca/gem/pipeline_spec.rb
@@ -3062,6 +3062,8 @@ class Tapioca::Gem::PipelineSpec < Minitest::HooksSpec
           const :baz, T::Hash[String, T.untyped]
           prop :quux, T.untyped, default: [1, 2, 3]
           const :quuz, Integer, factory: -> { 1 }
+          prop :fuzz, T.proc.returns(String), default: -> { "" }
+          prop :buzz, T.proc.void, factory: -> { 42 }
         end
       RUBY
 
@@ -3236,6 +3238,8 @@ class Tapioca::Gem::PipelineSpec < Minitest::HooksSpec
           const :baz, T::Hash[::String, T.untyped]
           prop :quux, T.untyped, default: T.unsafe(nil)
           const :quuz, ::Integer, default: T.unsafe(nil)
+          prop :fuzz, T.proc.returns(::String), default: T.unsafe(nil)
+          prop :buzz, T.proc.void, default: T.unsafe(nil)
 
           class << self
             def inherited(s); end


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
Fix #1725 

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
Use existing `RBIHelper#sanitize_signature_types` method to generate the type.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->
Added extra test cases that fail without this patch and pass with it.
