### PR TITLE
Remove `net-smtp` dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,11 +43,6 @@ group :development, :test do
   gem "bcrypt", require: false
   gem "xpath", require: false
   gem "kredis", require: false
-
-  # net-smtp was removed from default gems in Ruby 3.1, but is used by the `mail` gem.
-  # So we need to add it as a dependency until `mail` is fixed:
-  # https://github.com/rails/rails/blob/0919aa97260ab8240150278d3b07a1547489e3fd/Gemfile#L178-L191
-  gem "net-smtp", "0.4.0.1", require: false
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -432,7 +432,6 @@ DEPENDENCIES
   minitest
   minitest-hooks
   minitest-reporters
-  net-smtp (= 0.4.0.1)
   nokogiri
   pry
   pry-byebug


### PR DESCRIPTION
Was resolved in v2.8.1 of `mail`:
https://github.com/mikel/mail/commit/d9d8dcc6bae1774a033ad488cea6217db3a3ebf3