### PR TITLE
Update `ActiveSupportCurrentAttributes` compiler to include block param on getters

### DIFF
--- a/lib/tapioca/dsl/compilers/active_support_current_attributes.rb
+++ b/lib/tapioca/dsl/compilers/active_support_current_attributes.rb
@@ -125,7 +125,12 @@ module Tapioca
               return_type: "T.untyped",
             )
           else
-            klass.create_method(method, class_method: class_method, return_type: "T.untyped")
+            klass.create_method(
+              method,
+              parameters: [create_block_param("block", type: "T.nilable(T.proc.void)")],
+              class_method: class_method,
+              return_type: "T.untyped",
+            )
           end
         end
       end

--- a/spec/tapioca/dsl/compilers/active_support_current_attributes_spec.rb
+++ b/spec/tapioca/dsl/compilers/active_support_current_attributes_spec.rb
@@ -60,28 +60,28 @@ module Tapioca
                   include GeneratedAttributeMethods
 
                   class << self
-                    sig { returns(T.untyped) }
-                    def account; end
+                    sig { params(block: T.nilable(T.proc.void)).returns(T.untyped) }
+                    def account(&block); end
 
                     sig { params(value: T.untyped).returns(T.untyped) }
                     def account=(value); end
 
-                    sig { returns(T.untyped) }
-                    def user; end
+                    sig { params(block: T.nilable(T.proc.void)).returns(T.untyped) }
+                    def user(&block); end
 
                     sig { params(value: T.untyped).returns(T.untyped) }
                     def user=(value); end
                   end
 
                   module GeneratedAttributeMethods
-                    sig { returns(T.untyped) }
-                    def account; end
+                    sig { params(block: T.nilable(T.proc.void)).returns(T.untyped) }
+                    def account(&block); end
 
                     sig { params(value: T.untyped).returns(T.untyped) }
                     def account=(value); end
 
-                    sig { returns(T.untyped) }
-                    def user; end
+                    sig { params(block: T.nilable(T.proc.void)).returns(T.untyped) }
+                    def user(&block); end
 
                     sig { params(value: T.untyped).returns(T.untyped) }
                     def user=(value); end
@@ -117,8 +117,8 @@ module Tapioca
                   include GeneratedAttributeMethods
 
                   class << self
-                    sig { returns(T.untyped) }
-                    def account; end
+                    sig { params(block: T.nilable(T.proc.void)).returns(T.untyped) }
+                    def account(&block); end
 
                     sig { params(value: T.untyped).returns(T.untyped) }
                     def account=(value); end
@@ -131,8 +131,8 @@ module Tapioca
                   end
 
                   module GeneratedAttributeMethods
-                    sig { returns(T.untyped) }
-                    def account; end
+                    sig { params(block: T.nilable(T.proc.void)).returns(T.untyped) }
+                    def account(&block); end
 
                     sig { params(value: T.untyped).returns(T.untyped) }
                     def account=(value); end


### PR DESCRIPTION
### Motivation
I'm working on regenerating RBIs on core, and there is a change where classes that inherit from `CurrentAttributes` are having `block` params added to their attribute getter methods. See this example from the `socket-socker` gem RBI:

<img width="712" alt="Screenshot 2024-01-24 at 3 24 55 PM" src="https://github.com/Shopify/tapioca/assets/9601737/0d18431b-c3f0-4280-a5b4-4383cb0f2aa9">

This is causing an issue because these same classes have the methods re-defined in DSL RBI files, generated by the `ActiveSupportCurrentAttributes` compiler, without these block parameters. This causes a type checking error, which is preventing me from fully updating RBIs.

### Implementation
I updated the `ActiveSupportCurrentAttributes` DSL compiler to add this block param to getter methods.

### Tests
I modified the existing compiler tests.

### Questions
I'm not sure I understand why the gem RBIs are changing to have a block param added. Is that expected behavior? There's nothing that jumps out to me in the [current attributes source code](https://github.com/rails/rails/blob/main/activesupport/lib/active_support/current_attributes.rb), but I'll keep looking. 

