### PR TITLE
Use `create_method_from_def` to simplify `CurrentAttributes` compiler

### DIFF
--- a/lib/tapioca/dsl/compilers/active_support_current_attributes.rb
+++ b/lib/tapioca/dsl/compilers/active_support_current_attributes.rb
@@ -116,17 +116,13 @@ module Tapioca
 
         sig { params(klass: RBI::Scope, method: String, class_method: T::Boolean).void }
         def generate_method(klass, method, class_method:)
-          if method.end_with?("=")
-            parameter = create_param("value", type: "T.untyped")
-            klass.create_method(
-              method,
-              class_method: class_method,
-              parameters: [parameter],
-              return_type: "T.untyped",
-            )
+          method_def = if class_method
+            constant.method(method)
           else
-            klass.create_method(method, class_method: class_method, return_type: "T.untyped")
+            constant.instance_method(method)
           end
+
+          create_method_from_def(klass, method_def, class_method: class_method)
         end
       end
     end


### PR DESCRIPTION
This makes Tapioca less sensitive to changes in gem code.

In Core, classes that inherit from `CurrentAttributes` were having `block` params added to their attribute getter methods due to [this](https://github.com/rails/rails/commit/2cd4abcc876bdbe3adc2cbbfeee9712fc2bc0601) change. This was later [fixed](https://github.com/rails/rails/pull/50872) in Rails, but it exposed this fragility.

Thanks for @paracycle for the suggested refactoring.