### PR TITLE
Make unprocessable compilers a warning instead of an error

### DIFF
--- a/lib/tapioca/commands/abstract_dsl.rb
+++ b/lib/tapioca/commands/abstract_dsl.rb
@@ -175,10 +175,11 @@ module Tapioca
 
         unless unprocessable_compilers.empty?
           message = unprocessable_compilers.map do |name, _|
-            set_color("Error: Cannot find compiler '#{name}'", :red)
+            set_color("Warning: Cannot find compiler '#{name}'", :yellow)
           end.join("\n")
 
-          raise Thor::Error, message
+          say(message)
+          say("")
         end
 
         T.cast(compiler_map.values, T::Array[T.class_of(Tapioca::Dsl::Compiler)])

--- a/spec/tapioca/cli/dsl_spec.rb
+++ b/spec/tapioca/cli/dsl_spec.rb
@@ -1163,8 +1163,17 @@ module Tapioca
           assert_success_status(result)
         end
 
-        it "errors if there are no matching compilers" do
-          result = @project.tapioca("dsl --only NonexistentCompiler")
+        it "warns if there are no matching compilers but continues processing" do
+          @project.write!("lib/post.rb", <<~RB)
+            require "smart_properties"
+
+            class Post
+              include SmartProperties
+              property :title, accepts: String
+            end
+          RB
+
+          result = @project.tapioca("dsl --only SmartProperties NonexistentCompiler")
 
           assert_equal(<<~OUT, result.out)
             Loading DSL extension classes... Done
@@ -1172,13 +1181,21 @@ module Tapioca
             Loading DSL compiler classes... Done
             Compiling DSL RBI files...
 
+            Warning: Cannot find compiler 'NonexistentCompiler'
+
+                  create  sorbet/rbi/dsl/post.rbi
+
+            Done
+
+            Checking generated RBI files...  Done
+              No errors found
+
+            All operations performed in working directory.
+            Please review changes and commit them.
           OUT
 
-          assert_equal(<<~ERROR, result.err)
-            Error: Cannot find compiler 'NonexistentCompiler'
-          ERROR
-
-          refute_success_status(result)
+          assert_empty_stderr(result)
+          assert_success_status(result)
         end
 
         it "must respect `exclude` option" do
@@ -1252,7 +1269,16 @@ module Tapioca
           assert_success_status(result)
         end
 
-        it "errors if there are no matching `exclude` compilers" do
+        it "warns if there are no matching `exclude` compilers but continues processing" do
+          @project.write!("lib/post.rb", <<~RB)
+            require "smart_properties"
+
+            class Post
+              include SmartProperties
+              property :title, accepts: String
+            end
+          RB
+
           result = @project.tapioca("dsl --exclude NonexistentCompiler")
 
           assert_equal(<<~OUT, result.out)
@@ -1261,13 +1287,21 @@ module Tapioca
             Loading DSL compiler classes... Done
             Compiling DSL RBI files...
 
+            Warning: Cannot find compiler 'NonexistentCompiler'
+
+                  create  sorbet/rbi/dsl/post.rbi
+
+            Done
+
+            Checking generated RBI files...  Done
+              No errors found
+
+            All operations performed in working directory.
+            Please review changes and commit them.
           OUT
 
-          assert_equal(<<~ERROR, result.err)
-            Error: Cannot find compiler 'NonexistentCompiler'
-          ERROR
-
-          refute_success_status(result)
+          assert_empty_stderr(result)
+          assert_success_status(result)
         end
 
         it "must warn about reloaded constants and process only the newest one" do


### PR DESCRIPTION

### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
Fix #1786

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
Since we change if the compilers are loaded depending on if various constants are defined, running the same `tapioca dsl` command in different contexts could end up loading a different set of compilers. However, this creates a problem if users are passing in `--only` or `--exclude` for compilers with a predetermined set of compiler names, since the set of compiler names could change between runs.

It is better to show a warning that the requested compilers are not available, and continue with the rest of the DSL generation process, rather than erroring out.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->
Updates existing tests

