### PR TITLE
Add dependencies to label check list

### DIFF
--- a/.github/workflows/require_label.yml
+++ b/.github/workflows/require_label.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Check for Pull Request Labels
         shell: bash
         run: |
-          REQUIRED_LABELS=("documentation" "bugfix" "chore" "enhancement" "ignore-for-release" "security" "sorbet")
+          REQUIRED_LABELS=("documentation" "bugfix" "chore" "enhancement" "ignore-for-release" "security" "sorbet" "dependencies")
           LABELS=$(gh pr view --json labels --jq ".labels[] .name" ${{ github.event.pull_request.number }})
 
           errorMessage=""


### PR DESCRIPTION
### Motivation

So that the checks don't break on dependabot PRs like https://github.com/Shopify/tapioca/pull/1798.

