### PR TITLE
Fix rack gem version in failing test

### DIFF
--- a/spec/tapioca/cli/gem_spec.rb
+++ b/spec/tapioca/cli/gem_spec.rb
@@ -789,7 +789,7 @@ module Tapioca
           assert_project_file_exist("sorbet/rbi/gems/foo@0.0.1.rbi")
           assert_project_file_exist("sorbet/rbi/gems/bar@0.3.0.rbi")
           assert_project_file_exist("sorbet/rbi/gems/actionpack@7.0.6.rbi")
-          assert_project_file_exist("sorbet/rbi/gems/rack@2.2.8.rbi")
+          assert_project_file_exist("sorbet/rbi/gems/rack@2.2.8.1.rbi")
           refute_project_file_exist("sorbet/rbi/gems/baz@0.0.2.rbi")
 
           assert_empty_stderr(result)


### PR DESCRIPTION
### Motivation
CI is currently failing because rack has had a patch release that changes the version on one of the tests.

### Implementation
I updated the gem version in the test.
