### PR TITLE
Stronger checks for existence of `config` gem

### DIFF
--- a/lib/tapioca/dsl/compilers/config.rb
+++ b/lib/tapioca/dsl/compilers/config.rb
@@ -1,7 +1,7 @@
 # typed: strict
 # frozen_string_literal: true
 
-return unless defined?(Config)
+return unless defined?(Config) && defined?(Config::VERSION) && defined?(Config.const_name)
 
 module Tapioca
   module Dsl


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
Solve a problem experienced with a Shopify project.

Just checking for the existence of a `Config` constant does not necessarily guarantee that the `config` gem is loaded, since an application could define their own top-level `Config` constant.

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
It is better to check for the existence of `Config::VERSION` and `Config.const_name` as well, to be reasonably sure that the constant is coming from the gem.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->
All existing tests pass
