### PR TITLE
Bump `sorbet-static-and-runtime` requirement to v0.5.11087

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 PATH
   remote: .
   specs:
-    tapioca (0.12.0)
+    tapioca (0.13.0)
       bundler (>= 2.2.25)
       netrc (>= 0.11.0)
       parallel (>= 1.21.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,7 +13,7 @@ PATH
       netrc (>= 0.11.0)
       parallel (>= 1.21.0)
       rbi (>= 0.1.4, < 0.2)
-      sorbet-static-and-runtime (>= 0.5.10820)
+      sorbet-static-and-runtime (>= 0.5.11087)
       spoom (~> 1.2.0, >= 1.2.0)
       thor (>= 1.2.0)
       yard-sorbet

--- a/lib/tapioca/version.rb
+++ b/lib/tapioca/version.rb
@@ -2,5 +2,5 @@
 # frozen_string_literal: true
 
 module Tapioca
-  VERSION = "0.12.0"
+  VERSION = "0.13.0"
 end

--- a/tapioca.gemspec
+++ b/tapioca.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency("netrc", ">= 0.11.0")
   spec.add_dependency("parallel", ">= 1.21.0")
   spec.add_dependency("rbi", ">= 0.1.4", "< 0.2")
-  spec.add_dependency("sorbet-static-and-runtime", ">= 0.5.10820")
+  spec.add_dependency("sorbet-static-and-runtime", ">= 0.5.11087")
   spec.add_dependency("spoom", "~> 1.2.0", ">= 1.2.0")
   spec.add_dependency("thor", ">= 1.2.0")
   spec.add_dependency("yard-sorbet")


### PR DESCRIPTION
### Motivation

Sorbet support for multiple RBI signatures on a same method was added at this version. We need this feature for new work such as https://github.com/Shopify/tapioca/pull/1799 and https://github.com/Shopify/tapioca/tree/uk-rbs-converter.

The v0.5.11087 is ~5 months old, it should be okay.