### PR TITLE
Relax version constraint on Spoom

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,7 +14,7 @@ PATH
       parallel (>= 1.21.0)
       rbi (>= 0.1.4, < 0.2)
       sorbet-static-and-runtime (>= 0.5.11087)
-      spoom (~> 1.2.0, >= 1.2.0)
+      spoom (>= 1.2.0)
       thor (>= 1.2.0)
       yard-sorbet
 

--- a/tapioca.gemspec
+++ b/tapioca.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency("parallel", ">= 1.21.0")
   spec.add_dependency("rbi", ">= 0.1.4", "< 0.2")
   spec.add_dependency("sorbet-static-and-runtime", ">= 0.5.11087")
-  spec.add_dependency("spoom", "~> 1.2.0", ">= 1.2.0")
+  spec.add_dependency("spoom", ">= 1.2.0")
   spec.add_dependency("thor", ">= 1.2.0")
   spec.add_dependency("yard-sorbet")
 


### PR DESCRIPTION
### Motivation

Because Spoom depends on Tapioca, having a `~> 1.2.0` constraint back to Spoom blocks us from bumping it to 1.3.0.

I think the `>= 1.2.0` constraint is enough?
