### PR TITLE
Prevent `abort` call within gem from breaking `tapioca gem` command

### DIFF
--- a/lib/tapioca/commands/abstract_gem.rb
+++ b/lib/tapioca/commands/abstract_gem.rb
@@ -118,7 +118,9 @@ module Tapioca
           reason: "types exported from the `#{gem.name}` gem",
         ) if @file_header
 
-        rbi.root = Tapioca::Gem::Pipeline.new(gem, include_doc: @include_doc, include_loc: @include_loc).compile
+        rbi.root = Runtime::Trackers::Autoload.with_disabled_exits do
+          Tapioca::Gem::Pipeline.new(gem, include_doc: @include_doc, include_loc: @include_loc).compile
+        end
 
         merge_with_exported_rbi(gem, rbi) if @include_exported_rbis
 


### PR DESCRIPTION
### Motivation

I was encountering a `Parallel::DeadWorker` exception when running `tapioca gem` on a new project:

```
bundler: failed to load command: tapioca (/Users/andyw8/.gem/ruby/3.1.1/bin/tapioca)
/Users/andyw8/.gem/ruby/3.1.1/gems/parallel-1.24.0/lib/parallel.rb:83:in `rescue in work': Parallel::DeadWorker (Parallel::DeadWorker)
	from /Users/andyw8/.gem/ruby/3.1.1/gems/parallel-1.24.0/lib/parallel.rb:80:in `work'
	from /Users/andyw8/.gem/ruby/3.1.1/gems/parallel-1.24.0/lib/parallel.rb:522:in `block (4 levels) in work_in_processes'
	from /Users/andyw8/.gem/ruby/3.1.1/gems/parallel-1.24.0/lib/parallel.rb:637:in `with_instrumentation'
	from /Users/andyw8/.gem/ruby/3.1.1/gems/parallel-1.24.0/lib/parallel.rb:521:in `block (3 levels) in work_in_processes'
	from /Users/andyw8/.gem/ruby/3.1.1/gems/parallel-1.24.0/lib/parallel.rb:509:in `loop'
	from /Users/andyw8/.gem/ruby/3.1.1/gems/parallel-1.24.0/lib/parallel.rb:509:in `block (2 levels) in work_in_processes'
	from /Users/andyw8/.gem/ruby/3.1.1/gems/parallel-1.24.0/lib/parallel.rb:219:in `block (4 levels) in in_threads'
<internal:marshal>:34:in `load': end of file reached (EOFError)
	from /Users/andyw8/.gem/ruby/3.1.1/gems/parallel-1.24.0/lib/parallel.rb:81:in `work'
	from /Users/andyw8/.gem/ruby/3.1.1/gems/parallel-1.24.0/lib/parallel.rb:522:in `block (4 levels) in work_in_processes'
	from /Users/andyw8/.gem/ruby/3.1.1/gems/parallel-1.24.0/lib/parallel.rb:637:in `with_instrumentation'
	from /Users/andyw8/.gem/ruby/3.1.1/gems/parallel-1.24.0/lib/parallel.rb:521:in `block (3 levels) in work_in_processes'
	from /Users/andyw8/.gem/ruby/3.1.1/gems/parallel-1.24.0/lib/parallel.rb:509:in `loop'
	from /Users/andyw8/.gem/ruby/3.1.1/gems/parallel-1.24.0/lib/parallel.rb:509:in `block (2 levels) in work_in_processes'
	from /Users/andyw8/.gem/ruby/3.1.1/gems/parallel-1.24.0/lib/parallel.rb:219:in `block (4 levels) in in_threads'
```
With @Morriar's help we determined that the generation for the `rdoc` gem was failing:

`bundle exec tapioca gem rdoc`

(`rdoc` is a dependency of both `irb` and `debug` so this may impact a lot of people).

It outputs ```webrick is not found. You may need to `gem install webrick` to install webrick.``` and no RBI file is generated.

This is due to the `abort` here: https://github.com/ruby/rdoc/blob/d0074a23cc835b09d72ddd2f98d10eee4d23e1ab/lib/rdoc/servlet.rb#L10

(the `Servlet` class is autoloaded [here](https://github.com/ruby/rdoc/blob/d0074a23cc835b09d72ddd2f98d10eee4d23e1ab/lib/rdoc.rb#L165)).

### Implementation

We re-used the `with_disabled_exits` mechanism Tapioca already had. But we're unsure if where we added it is at the right level.

### Tests

None yet... may be tricky.
