### PR TITLE
generate overloaded sigs for active record sum

### DIFF
--- a/lib/tapioca/dsl/compilers/active_record_relations.rb
+++ b/lib/tapioca/dsl/compilers/active_record_relations.rb
@@ -822,13 +822,34 @@ module Tapioca
                 return_type: "T.untyped",
               )
             when :sum
-              create_common_method(
-                "sum",
+              sigs = [
+                common_relation_methods_module.create_sig(
+                  parameters: [create_opt_param(
+                    "initial_value_or_column",
+                    type: "T.nilable(T.any(String, Symbol))",
+                    default: "0",
+                  )],
+                  return_type: "Numeric",
+                ),
+                common_relation_methods_module.create_sig(
+                  type_parameters: ["U"],
+                  parameters: [
+                    create_param("initial_value_or_column", type: "T.nilable(T.type_parameter(:U))"),
+                    create_block_param(
+                      "block",
+                      type: "T.proc.params(object: #{constant_name}).returns(T.type_parameter(:U))",
+                    ),
+                  ],
+                  return_type: "T.type_parameter(:U)",
+                ),
+              ]
+              common_relation_methods_module.create_method_with_sigs(
+                method_name.to_s,
+                sigs: sigs,
                 parameters: [
-                  create_opt_param("column_name", type: "T.nilable(T.any(String, Symbol))", default: "nil"),
-                  create_block_param("block", type: "T.nilable(T.proc.params(record: T.untyped).returns(T.untyped))"),
+                  RBI::OptParam.new("initial_value_or_column", "0"),
+                  RBI::BlockParam.new("block"),
                 ],
-                return_type: "Numeric",
               )
             end
           end

--- a/lib/tapioca/dsl/compilers/active_record_relations.rb
+++ b/lib/tapioca/dsl/compilers/active_record_relations.rb
@@ -824,22 +824,16 @@ module Tapioca
             when :sum
               sigs = [
                 common_relation_methods_module.create_sig(
-                  parameters: [create_opt_param(
-                    "initial_value_or_column",
-                    type: "T.nilable(T.any(String, Symbol))",
-                    default: "0",
-                  )],
+                  parameters: { initial_value_or_column: "T.untyped" },
                   return_type: "Numeric",
                 ),
                 common_relation_methods_module.create_sig(
                   type_parameters: ["U"],
-                  parameters: [
-                    create_param("initial_value_or_column", type: "T.nilable(T.type_parameter(:U))"),
-                    create_block_param(
-                      "block",
-                      type: "T.proc.params(object: #{constant_name}).returns(T.type_parameter(:U))",
-                    ),
-                  ],
+                  parameters:
+                  {
+                    initial_value_or_column: "T.nilable(T.type_parameter(:U))",
+                    block: "T.proc.params(object: #{constant_name}).returns(T.type_parameter(:U))",
+                  },
                   return_type: "T.type_parameter(:U)",
                 ),
               ]
@@ -847,7 +841,7 @@ module Tapioca
                 method_name.to_s,
                 sigs: sigs,
                 parameters: [
-                  RBI::OptParam.new("initial_value_or_column", "0"),
+                  RBI::OptParam.new("initial_value_or_column", "nil"),
                   RBI::BlockParam.new("block"),
                 ],
               )

--- a/lib/tapioca/rbi_ext/model.rb
+++ b/lib/tapioca/rbi_ext/model.rb
@@ -128,14 +128,15 @@ module RBI
     sig do
       params(
         parameters: T::Hash[T.any(String, Symbol), String],
+        type_parameters: T::Array[String],
         return_type: String,
       ).returns(RBI::Sig)
     end
-    def create_sig(parameters:, return_type: "T.untyped")
+    def create_sig(parameters:, type_parameters: [], return_type: "T.untyped")
       params = parameters.map do |name, type|
         RBI::SigParam.new(name.to_s, type)
       end
-      RBI::Sig.new(params: params, return_type: return_type)
+      RBI::Sig.new(type_params: type_parameters, params: params, return_type: return_type)
     end
 
     private

--- a/sorbet/rbi/gems/rbi@0.1.10.rbi
+++ b/sorbet/rbi/gems/rbi@0.1.10.rbi
@@ -2858,9 +2858,15 @@ class RBI::Tree < ::RBI::NodeWithComments
   sig { params(constant: ::Module, block: T.nilable(T.proc.params(scope: ::RBI::Scope).void)).returns(::RBI::Scope) }
   def create_path(constant, &block); end
 
-  # source://tapioca/0.13.1/lib/tapioca/rbi_ext/model.rb#134
-  sig { params(parameters: T::Hash[T.any(::String, ::Symbol), ::String], return_type: ::String).returns(::RBI::Sig) }
-  def create_sig(parameters:, return_type: T.unsafe(nil)); end
+  # source://tapioca/0.13.1/lib/tapioca/rbi_ext/model.rb#135
+  sig do
+    params(
+      parameters: T::Hash[T.any(::String, ::Symbol), ::String],
+      type_parameters: T::Array[::String],
+      return_type: ::String
+    ).returns(::RBI::Sig)
+  end
+  def create_sig(parameters:, type_parameters: T.unsafe(nil), return_type: T.unsafe(nil)); end
 
   # source://tapioca/0.13.1/lib/tapioca/rbi_ext/model.rb#74
   sig do
@@ -2928,11 +2934,11 @@ class RBI::Tree < ::RBI::NodeWithComments
 
   private
 
-  # source://tapioca/0.13.1/lib/tapioca/rbi_ext/model.rb#149
+  # source://tapioca/0.13.1/lib/tapioca/rbi_ext/model.rb#150
   sig { params(node: ::RBI::Node).returns(::RBI::Node) }
   def create_node(node); end
 
-  # source://tapioca/0.13.1/lib/tapioca/rbi_ext/model.rb#144
+  # source://tapioca/0.13.1/lib/tapioca/rbi_ext/model.rb#145
   sig { returns(T::Hash[::String, ::RBI::Node]) }
   def nodes_cache; end
 end

--- a/spec/tapioca/dsl/compilers/active_record_relations_spec.rb
+++ b/spec/tapioca/dsl/compilers/active_record_relations_spec.rb
@@ -231,8 +231,9 @@ module Tapioca
                     def sole; end
 
                 <% end %>
-                    sig { params(column_name: T.nilable(T.any(String, Symbol)), block: T.nilable(T.proc.params(record: T.untyped).returns(T.untyped))).returns(Numeric) }
-                    def sum(column_name = nil, &block); end
+                    sig { params(initial_value_or_column: T.nilable(T.any(String, Symbol))).returns(Numeric) }
+                    sig { type_parameters(:U).params(initial_value_or_column: T.nilable(T.type_parameter(:U)), block: T.proc.params(object: ::Post).returns(T.type_parameter(:U)).returns(T.type_parameter(:U)) }
+                    def sum(initial_value_or_column = 0, &block); end
 
                     sig { params(limit: NilClass).returns(T.nilable(::Post)) }
                     sig { params(limit: Integer).returns(T::Array[::Post]) }

--- a/spec/tapioca/dsl/compilers/active_record_relations_spec.rb
+++ b/spec/tapioca/dsl/compilers/active_record_relations_spec.rb
@@ -231,9 +231,9 @@ module Tapioca
                     def sole; end
 
                 <% end %>
-                    sig { params(initial_value_or_column: T.nilable(T.any(String, Symbol))).returns(Numeric) }
+                    sig { params(initial_value_or_column: T.untyped).returns(Numeric) }
                     sig { type_parameters(:U).params(initial_value_or_column: T.nilable(T.type_parameter(:U)), block: T.proc.params(object: ::Post).returns(T.type_parameter(:U))).returns(T.type_parameter(:U)) }
-                    def sum(initial_value_or_column = 0, &block); end
+                    def sum(initial_value_or_column = nil, &block); end
 
                     sig { params(limit: NilClass).returns(T.nilable(::Post)) }
                     sig { params(limit: Integer).returns(T::Array[::Post]) }
@@ -928,8 +928,9 @@ module Tapioca
                     def sole; end
 
                 <% end %>
-                    sig { params(column_name: T.nilable(T.any(String, Symbol)), block: T.nilable(T.proc.params(record: T.untyped).returns(T.untyped))).returns(Numeric) }
-                    def sum(column_name = nil, &block); end
+                    sig { params(initial_value_or_column: T.untyped).returns(Numeric) }
+                    sig { type_parameters(:U).params(initial_value_or_column: T.nilable(T.type_parameter(:U)), block: T.proc.params(object: ::Post).returns(T.type_parameter(:U))).returns(T.type_parameter(:U)) }
+                    def sum(initial_value_or_column = nil, &block); end
 
                     sig { params(limit: NilClass).returns(T.nilable(::Post)) }
                     sig { params(limit: Integer).returns(T::Array[::Post]) }

--- a/spec/tapioca/dsl/compilers/active_record_relations_spec.rb
+++ b/spec/tapioca/dsl/compilers/active_record_relations_spec.rb
@@ -232,7 +232,7 @@ module Tapioca
 
                 <% end %>
                     sig { params(initial_value_or_column: T.nilable(T.any(String, Symbol))).returns(Numeric) }
-                    sig { type_parameters(:U).params(initial_value_or_column: T.nilable(T.type_parameter(:U)), block: T.proc.params(object: ::Post).returns(T.type_parameter(:U)).returns(T.type_parameter(:U)) }
+                    sig { type_parameters(:U).params(initial_value_or_column: T.nilable(T.type_parameter(:U)), block: T.proc.params(object: ::Post).returns(T.type_parameter(:U))).returns(T.type_parameter(:U)) }
                     def sum(initial_value_or_column = 0, &block); end
 
                     sig { params(limit: NilClass).returns(T.nilable(::Post)) }


### PR DESCRIPTION
### Motivation
Closes https://github.com/Shopify/tapioca/issues/1822. See discussion there for full context. 

TL;DR: The current sigs are incorrect when given a block.

### Tests
I believe I updated the spec here correctly. 