### PR TITLE
Include the 'has_FIELD?' methods in RBIs generated from protobuf

### DIFF
--- a/lib/tapioca/dsl/compilers/protobuf.rb
+++ b/lib/tapioca/dsl/compilers/protobuf.rb
@@ -302,6 +302,13 @@ module Tapioca
             return_type: "void",
           )
 
+          if desc.has_presence?
+            klass.create_method(
+              "has_#{field.name}?",
+              return_type: "Object",
+            )
+          end
+
           field
         end
 

--- a/spec/tapioca/dsl/compilers/protobuf_spec.rb
+++ b/spec/tapioca/dsl/compilers/protobuf_spec.rb
@@ -73,6 +73,12 @@ module Tapioca
                   sig { params(value: Integer).void }
                   def customer_id=(value); end
 
+                  sig { returns(Object) }
+                  def has_customer_id?; end
+
+                  sig { returns(Object) }
+                  def has_shop_id?; end
+
                   sig { returns(Integer) }
                   def shop_id; end
 
@@ -111,6 +117,9 @@ module Tapioca
 
                   sig { params(value: String).void }
                   def events=(value); end
+
+                  sig { returns(Object) }
+                  def has_events?; end
                 end
               RBI
 
@@ -145,6 +154,9 @@ module Tapioca
 
                   sig { void }
                   def clear_cart_item_index; end
+
+                  sig { returns(Object) }
+                  def has_cart_item_index?; end
                 end
               RBI
 
@@ -178,6 +190,9 @@ module Tapioca
 
                   sig { void }
                   def clear_value_type; end
+
+                  sig { returns(Object) }
+                  def has_value_type?; end
 
                   sig { returns(T.any(Symbol, Integer)) }
                   def value_type; end
@@ -247,6 +262,36 @@ module Tapioca
 
                   sig { params(value: Google::Protobuf::RepeatedField[Google::Protobuf::UInt64Value]).void }
                   def indices=(value); end
+                end
+              RBI
+
+              assert_equal(expected, rbi_for(:Cart))
+            end
+
+            it "generates methods in RBI files for classes with Protobuf with non-optional integer field type" do
+              add_proto_file("cart", <<~PROTO)
+                syntax = "proto3";
+
+                message Cart {
+                  int32 shop_id = 1;
+                }
+              PROTO
+
+              expected = <<~RBI
+                # typed: strong
+
+                class Cart
+                  sig { params(shop_id: T.nilable(Integer)).void }
+                  def initialize(shop_id: nil); end
+
+                  sig { void }
+                  def clear_shop_id; end
+
+                  sig { returns(Integer) }
+                  def shop_id; end
+
+                  sig { params(value: Integer).void }
+                  def shop_id=(value); end
                 end
               RBI
 
@@ -400,6 +445,12 @@ module Tapioca
 
                   sig { void }
                   def clear_ShopName; end
+
+                  sig { returns(Object) }
+                  def has_ShopID?; end
+
+                  sig { returns(Object) }
+                  def has_ShopName?; end
                 end
               RBI
 


### PR DESCRIPTION
### Motivation

Optional fields may not be present in the serialized payload. The regular accessors will still return the default value for that field type (e.g. 0 or ""). Sometimes you want to know the difference between "default value" and "present in payload", and the `has_FIELD?` methods are there for that:

https://protobuf.dev/reference/ruby/ruby-generated/#checking-presence

The return type is pretty weird - it's `false` for when the field isn't present, and 0 for when it is.

```
irb(main):015> u = ShopApp::Protobuf::ServiceApi::V1::User.new
=> <ShopApp::Protobuf::ServiceApi::V1::User: id: 0, uuid: "", email_verified: false>
irb(main):016> u.email
=> ""
irb(main):017> u.has_email?
=> false
irb(main):018> u.email = "buffy@example.com"
=> "buffy@example.com"
irb(main):019> u.has_email?
=> 0
irb(main):020> u.email
=> "buffy@example.com"
irb(main):021> u.clear_email
=> nil
irb(main):022> u.has_email?
=> false
```

### Implementation
Define the `has_FIELD?` method for all fields that are optional.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->

There are tests.

