### PR TITLE
Update Active Record find sig to allow a block

### DIFF
--- a/lib/tapioca/dsl/compilers/active_record_relations.rb
+++ b/lib/tapioca/dsl/compilers/active_record_relations.rb
@@ -667,11 +667,11 @@ module Tapioca
               end
               sigs = [
                 common_relation_methods_module.create_sig(
-                  parameters: [create_param("args", type: id_types)],
+                  parameters: { args: id_types },
                   return_type: constant_name,
                 ),
                 common_relation_methods_module.create_sig(
-                  parameters: [create_param("args", type: array_type)],
+                  parameters: { args: array_type },
                   return_type: "T::Enumerable[#{constant_name}]",
                 ),
               ]
@@ -714,11 +714,11 @@ module Tapioca
             when :first, :last, :take
               sigs = [
                 common_relation_methods_module.create_sig(
-                  parameters: [create_opt_param("limit", type: "NilClass", default: "nil")],
+                  parameters: { limit: "NilClass" },
                   return_type: as_nilable_type(constant_name),
                 ),
                 common_relation_methods_module.create_sig(
-                  parameters: [create_param("limit", type: "Integer")],
+                  parameters: { limit: "Integer" },
                   return_type: "T::Array[#{constant_name}]",
                 ),
               ]
@@ -819,26 +819,20 @@ module Tapioca
             case method_name
             when :find_each
               order = ActiveRecord::Batches.instance_method(:find_each).parameters.include?([:key, :order])
+              parameters = {
+                start: "T.untyped",
+                finish: "T.untyped",
+                batch_size: "Integer",
+                error_on_ignore: "T.untyped",
+                order: ("Symbol" if order),
+              }.compact
               sigs = [
                 common_relation_methods_module.create_sig(
-                  parameters: [
-                    create_kw_opt_param("start", type: "T.untyped", default: "nil"),
-                    create_kw_opt_param("finish", type: "T.untyped", default: "nil"),
-                    create_kw_opt_param("batch_size", type: "Integer", default: "1000"),
-                    create_kw_opt_param("error_on_ignore", type: "T.untyped", default: "nil"),
-                    *(create_kw_opt_param("order", type: "Symbol", default: ":asc") if order),
-                    create_block_param("block", type: "T.proc.params(object: #{constant_name}).void"),
-                  ],
+                  parameters: parameters.merge(block: "T.proc.params(object: #{constant_name}).void"),
                   return_type: "void",
                 ),
                 common_relation_methods_module.create_sig(
-                  parameters: [
-                    create_kw_opt_param("start", type: "T.untyped", default: "nil"),
-                    create_kw_opt_param("finish", type: "T.untyped", default: "nil"),
-                    create_kw_opt_param("batch_size", type: "Integer", default: "1000"),
-                    create_kw_opt_param("error_on_ignore", type: "T.untyped", default: "nil"),
-                    *(create_kw_opt_param("order", type: "Symbol", default: ":asc") if order),
-                  ],
+                  parameters: parameters,
                   return_type: "T::Enumerator[#{constant_name}]",
                 ),
               ]
@@ -856,26 +850,20 @@ module Tapioca
               )
             when :find_in_batches
               order = ActiveRecord::Batches.instance_method(:find_in_batches).parameters.include?([:key, :order])
+              parameters = {
+                start: "T.untyped",
+                finish: "T.untyped",
+                batch_size: "Integer",
+                error_on_ignore: "T.untyped",
+                order: ("Symbol" if order),
+              }.compact
               sigs = [
                 common_relation_methods_module.create_sig(
-                  parameters: [
-                    create_kw_opt_param("start", type: "T.untyped", default: "nil"),
-                    create_kw_opt_param("finish", type: "T.untyped", default: "nil"),
-                    create_kw_opt_param("batch_size", type: "Integer", default: "1000"),
-                    create_kw_opt_param("error_on_ignore", type: "T.untyped", default: "nil"),
-                    *(create_kw_opt_param("order", type: "Symbol", default: ":asc") if order),
-                    create_block_param("block", type: "T.proc.params(object: T::Array[#{constant_name}]).void"),
-                  ],
+                  parameters: parameters.merge(block: "T.proc.params(object: T::Array[#{constant_name}]).void"),
                   return_type: "void",
                 ),
                 common_relation_methods_module.create_sig(
-                  parameters: [
-                    create_kw_opt_param("start", type: "T.untyped", default: "nil"),
-                    create_kw_opt_param("finish", type: "T.untyped", default: "nil"),
-                    create_kw_opt_param("batch_size", type: "Integer", default: "1000"),
-                    create_kw_opt_param("error_on_ignore", type: "T.untyped", default: "nil"),
-                    *(create_kw_opt_param("order", type: "Symbol", default: ":asc") if order),
-                  ],
+                  parameters: parameters,
                   return_type: "T::Enumerator[T::Enumerator[#{constant_name}]]",
                 ),
               ]
@@ -894,30 +882,22 @@ module Tapioca
             when :in_batches
               order = ActiveRecord::Batches.instance_method(:in_batches).parameters.include?([:key, :order])
               use_ranges = ActiveRecord::Batches.instance_method(:in_batches).parameters.include?([:key, :use_ranges])
+              parameters = {
+                of: "Integer",
+                start: "T.untyped",
+                finish: "T.untyped",
+                load: "T.untyped",
+                error_on_ignore: "T.untyped",
+                order: ("Symbol" if order),
+                use_ranges: ("T.untyped" if use_ranges),
+              }.compact
               sigs = [
                 common_relation_methods_module.create_sig(
-                  parameters: [
-                    create_kw_opt_param("of", type: "Integer", default: "1000"),
-                    create_kw_opt_param("start", type: "T.untyped", default: "nil"),
-                    create_kw_opt_param("finish", type: "T.untyped", default: "nil"),
-                    create_kw_opt_param("load", type: "T.untyped", default: "false"),
-                    create_kw_opt_param("error_on_ignore", type: "T.untyped", default: "nil"),
-                    *(create_kw_opt_param("order", type: "Symbol", default: ":asc") if order),
-                    *(create_kw_opt_param("use_ranges", type: "T.untyped", default: "nil") if use_ranges),
-                    create_block_param("block", type: "T.proc.params(object: #{RelationClassName}).void"),
-                  ],
+                  parameters: parameters.merge(block: "T.proc.params(object: #{RelationClassName}).void"),
                   return_type: "void",
                 ),
                 common_relation_methods_module.create_sig(
-                  parameters: [
-                    create_kw_opt_param("of", type: "Integer", default: "1000"),
-                    create_kw_opt_param("start", type: "T.untyped", default: "nil"),
-                    create_kw_opt_param("finish", type: "T.untyped", default: "nil"),
-                    create_kw_opt_param("load", type: "T.untyped", default: "false"),
-                    create_kw_opt_param("error_on_ignore", type: "T.untyped", default: "nil"),
-                    *(create_kw_opt_param("order", type: "Symbol", default: ":asc") if order),
-                    *(create_kw_opt_param("use_ranges", type: "T.untyped", default: "nil") if use_ranges),
-                  ],
+                  parameters: parameters,
                   return_type: "::ActiveRecord::Batches::BatchEnumerator",
                 ),
               ]

--- a/lib/tapioca/dsl/compilers/active_record_relations.rb
+++ b/lib/tapioca/dsl/compilers/active_record_relations.rb
@@ -674,11 +674,18 @@ module Tapioca
                   parameters: { args: array_type },
                   return_type: "T::Enumerable[#{constant_name}]",
                 ),
+                common_relation_methods_module.create_sig(
+                  parameters: {
+                    args: "NilClass",
+                    block: "T.proc.params(object: #{constant_name}).void)",
+                  },
+                  return_type: as_nilable_type(constant_name),
+                ),
               ]
               common_relation_methods_module.create_method_with_sigs(
                 "find",
                 sigs: sigs,
-                parameters: [RBI::ReqParam.new("args")],
+                parameters: [RBI::OptParam.new("args", "nil"), RBI::BlockParam.new("block")],
               )
             when :find_by
               create_common_method(

--- a/lib/tapioca/rbi_ext/model.rb
+++ b/lib/tapioca/rbi_ext/model.rb
@@ -88,7 +88,8 @@ module RBI
     end
     def create_method(name, parameters: [], return_type: "T.untyped", class_method: false, visibility: RBI::Public.new,
       comments: [])
-      sig = create_sig(parameters: parameters, return_type: return_type)
+      sig_params = parameters.to_h { |param| [param.param.name, param.type] }
+      sig = create_sig(parameters: sig_params, return_type: return_type)
       create_method_with_sigs(
         name,
         sigs: [sig],
@@ -126,13 +127,13 @@ module RBI
 
     sig do
       params(
-        parameters: T::Array[RBI::TypedParam],
+        parameters: T::Hash[T.any(String, Symbol), String],
         return_type: String,
       ).returns(RBI::Sig)
     end
-    def create_sig(parameters: [], return_type: "T.untyped")
-      params = parameters.map do |param|
-        RBI::SigParam.new(param.param.name, param.type)
+    def create_sig(parameters:, return_type: "T.untyped")
+      params = parameters.map do |name, type|
+        RBI::SigParam.new(name.to_s, type)
       end
       RBI::Sig.new(params: params, return_type: return_type)
     end

--- a/spec/tapioca/dsl/compilers/active_record_relations_spec.rb
+++ b/spec/tapioca/dsl/compilers/active_record_relations_spec.rb
@@ -107,7 +107,8 @@ module Tapioca
 
                     sig { params(args: T.any(String, Symbol, ::ActiveSupport::Multibyte::Chars, T::Boolean, BigDecimal, Numeric, ::ActiveRecord::Type::Binary::Data, ::ActiveRecord::Type::Time::Value, Date, Time, ::ActiveSupport::Duration, T::Class[T.anything])).returns(::Post) }
                     sig { params(args: T::Array[T.any(String, Symbol, ::ActiveSupport::Multibyte::Chars, T::Boolean, BigDecimal, Numeric, ::ActiveRecord::Type::Binary::Data, ::ActiveRecord::Type::Time::Value, Date, Time, ::ActiveSupport::Duration, T::Class[T.anything])]).returns(T::Enumerable[::Post]) }
-                    def find(args); end
+                    sig { params(args: NilClass, block: T.proc.params(object: ::Post).void)).returns(T.nilable(::Post)) }
+                    def find(args = nil, &block); end
 
                     sig { params(args: T.untyped).returns(T.nilable(::Post)) }
                     def find_by(*args); end
@@ -801,7 +802,8 @@ module Tapioca
                 <% else %>
                     sig { params(args: T::Array[T.any(String, Symbol, ::ActiveSupport::Multibyte::Chars, T::Boolean, BigDecimal, Numeric, ::ActiveRecord::Type::Binary::Data, ::ActiveRecord::Type::Time::Value, Date, Time, ::ActiveSupport::Duration, T::Class[T.anything])]).returns(T::Enumerable[::Post]) }
                 <% end %>
-                    def find(args); end
+                    sig { params(args: NilClass, block: T.proc.params(object: ::Post).void)).returns(T.nilable(::Post)) }
+                    def find(args = nil, &block); end
 
                     sig { params(args: T.untyped).returns(T.nilable(::Post)) }
                     def find_by(*args); end


### PR DESCRIPTION
### Motivation
While upgrading our app since working on https://github.com/Shopify/tapioca/pull/1799 I came across code that looks like `Model.where(condition: true).find { |m| m.computed_attribute == "foo" }` and this doesn't fit the signatures generated. While replacing `find` with `detect` was an easy enough workaround, here's the proper fix.

### Tests
Updated existing tests.

