### PR TITLE
Complete the `.ruby-version` standardization

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,6 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.3"
           bundler-cache: true
           rubygems: 'latest'
           bundler: 'latest'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,7 +8,6 @@ require:
  - rubocop-rspec
 
 AllCops:
-  TargetRubyVersion: 3.0
   NewCops: disable
   SuggestExtensions: false
   Exclude:


### PR DESCRIPTION

## What are you trying to accomplish?
This repo is well maintained and already follows the standards we set in place. https://github.com/Shopify/tapioca/commit/b164c0bfb759753c9d0c4da8ef8278308e1a1497 added the `.ruby-version` file, a `required_ruby_version` is already set in the `.gemspec`, a `Gemfile.lock` is already built, etc. This PR cleans up the last remaining mentions of Ruby version outside of the `.ruby-version` file (last two bullet points of the list below).

## What should reviewers focus on?
> [!IMPORTANT] 
> Please verify the following before merging:

Verify that the changes in the PR meets the following requirements or adjust manually to make it compliant:
  - [X] `.ruby-version` file is present with the correct Ruby version defined
  - [X] A `required_ruby_version` in your gemspec is set
  - [X] There is no Ruby version present in the  `dev.yml` Ruby task (before: `- ruby: x.x.x`, after: `- ruby`)
  - [X] There is no Ruby version/requirement referenced in the `Gemfile` (no lines with `ruby  <some-version>`)
  - [X] A `Gemfile.lock` is built with the defined Ruby version
  - [X] The version of Rubocop installed is 1.61.0 or greater
  - [X] **There is no `TargetRubyVersion` defined  in `rubocop.yml` (reads from  `required_ruby_version` on Rubocop 1.61.0)**
  - [X] **There is no Ruby argument  present in  `ruby/setup-ruby` Github Actions that do **not**  run on a Ruby matrix (no lines with `ruby-version: “x.x”`)**

Please merge this PR if it looks good, this PR will be merged if there isn't any activity after 4 weeks.

