### PR TITLE
Start downloading the latest protoc binary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install protobuf
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           gh release download --repo google/protobuf --pattern '*-linux-x86_64*' --output protoc.zip
           unzip protoc.zip bin/protoc -d $HOME/.local

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install protobuf
         run: |
-          gh release -R google/protobuf download -p '*-linux-x86_64*' -O protoc.zip
+          gh release download --repo google/protobuf --pattern '*-linux-x86_64*' --output protoc.zip
           unzip protoc.zip bin/protoc -d $HOME/.local
           export PATH="$PATH:$HOME/.local/bin"
       - name: Remove Gemfile.lock

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,8 +52,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install protobuf
         run: |
-          curl -OL https://github.com/google/protobuf/releases/download/v25.3/protoc-25.3-linux-x86_64.zip
-          unzip protoc-25.3-linux-x86_64.zip -d $HOME/.local
+          gh release -R google/protobuf download -p '*-linux-x86_64*' -O protoc.zip
+          unzip protoc.zip bin/protoc -d $HOME/.local
           export PATH="$PATH:$HOME/.local/bin"
       - name: Remove Gemfile.lock
         # Remove Gemfile.lock for Ruby head builds and non-Rails current builds


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
Instead of hard-coding a certain protoc binary URL into our CI code, we can use the `gh` tool to download the latest Linux x64 binary of `protoc` and unzip it to the correct location. This should make this step less brittle.

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
Start using the `gh release download` command to download the latest archive and only extract the `protoc` binary from it.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->
No tests

