### PR TITLE
Fix broken parentheses

### DIFF
--- a/lib/tapioca/dsl/compilers/active_record_relations.rb
+++ b/lib/tapioca/dsl/compilers/active_record_relations.rb
@@ -677,7 +677,7 @@ module Tapioca
                 common_relation_methods_module.create_sig(
                   parameters: {
                     args: "NilClass",
-                    block: "T.proc.params(object: #{constant_name}).void)",
+                    block: "T.proc.params(object: #{constant_name}).void",
                   },
                   return_type: as_nilable_type(constant_name),
                 ),

--- a/spec/tapioca/dsl/compilers/active_record_relations_spec.rb
+++ b/spec/tapioca/dsl/compilers/active_record_relations_spec.rb
@@ -108,7 +108,7 @@ module Tapioca
 
                     sig { params(args: T.any(String, Symbol, ::ActiveSupport::Multibyte::Chars, T::Boolean, BigDecimal, Numeric, ::ActiveRecord::Type::Binary::Data, ::ActiveRecord::Type::Time::Value, Date, Time, ::ActiveSupport::Duration, T::Class[T.anything])).returns(::Post) }
                     sig { params(args: T::Array[T.any(String, Symbol, ::ActiveSupport::Multibyte::Chars, T::Boolean, BigDecimal, Numeric, ::ActiveRecord::Type::Binary::Data, ::ActiveRecord::Type::Time::Value, Date, Time, ::ActiveSupport::Duration, T::Class[T.anything])]).returns(T::Enumerable[::Post]) }
-                    sig { params(args: NilClass, block: T.proc.params(object: ::Post).void)).returns(T.nilable(::Post)) }
+                    sig { params(args: NilClass, block: T.proc.params(object: ::Post).void).returns(T.nilable(::Post)) }
                     def find(args = nil, &block); end
 
                     sig { params(args: T.untyped).returns(T.nilable(::Post)) }
@@ -804,7 +804,7 @@ module Tapioca
                 <% else %>
                     sig { params(args: T::Array[T.any(String, Symbol, ::ActiveSupport::Multibyte::Chars, T::Boolean, BigDecimal, Numeric, ::ActiveRecord::Type::Binary::Data, ::ActiveRecord::Type::Time::Value, Date, Time, ::ActiveSupport::Duration, T::Class[T.anything])]).returns(T::Enumerable[::Post]) }
                 <% end %>
-                    sig { params(args: NilClass, block: T.proc.params(object: ::Post).void)).returns(T.nilable(::Post)) }
+                    sig { params(args: NilClass, block: T.proc.params(object: ::Post).void).returns(T.nilable(::Post)) }
                     def find(args = nil, &block); end
 
                     sig { params(args: T.untyped).returns(T.nilable(::Post)) }


### PR DESCRIPTION
### Motivation
On the latest main branch, the parentheses in the `find` signature are broken.

https://github.com/Shopify/tapioca/blob/37e48be85a86e38173740e50f520074d3f3bbcaf/spec/tapioca/dsl/compilers/active_record_relations_spec.rb#L111

### Implementation
Unnecessary `)` has been removed.

### Tests
Tests have also been fixed.

