### PR TITLE
Infer types for active record fixtures

### DIFF
--- a/lib/tapioca/dsl/compilers/active_record_fixtures.rb
+++ b/lib/tapioca/dsl/compilers/active_record_fixtures.rb
@@ -24,8 +24,9 @@ module Tapioca
       # # test_case.rbi
       # # typed: true
       # class ActiveSupport::TestCase
-      #   sig { params(fixture_names: T.any(String, Symbol)).returns(T.untyped) }
-      #   def posts(*fixture_names); end
+      #   sig { params(fixture_name: T.any(String, Symbol), other_fixtures: NilClass)).returns(T.untyped) }
+      #   sig { params(fixture_name: T.any(String, Symbol), other_fixtures: T.any(String, Symbol))).returns(T::Array[T.untyped]) }
+      #   def posts(fixture_name, *other_fixtures); end
       # end
       # ~~~
       class ActiveRecordFixtures < Compiler
@@ -104,10 +105,28 @@ module Tapioca
 
         sig { params(mod: RBI::Scope, name: String).void }
         def create_fixture_method(mod, name)
-          mod.create_method(
+          mod.create_method_with_sigs(
             name,
-            parameters: [create_rest_param("fixture_names", type: "T.any(String, Symbol)")],
-            return_type: "T.untyped",
+            sigs: [
+              mod.create_sig(
+                parameters: {
+                  fixture_name: "T.any(String, Symbol)",
+                  other_fixtures: "NilClass",
+                },
+                return_type: "T.untyped",
+              ),
+              mod.create_sig(
+                parameters: {
+                  fixture_name: "T.any(String, Symbol)",
+                  other_fixtures: "T.any(String, Symbol)",
+                },
+                return_type: "T::Array[T.untyped]",
+              ),
+            ],
+            parameters: [
+              RBI::ReqParam.new("fixture_name"),
+              RBI::RestParam.new("other_fixtures"),
+            ],
           )
         end
       end

--- a/manual/compiler_activerecordfixtures.md
+++ b/manual/compiler_activerecordfixtures.md
@@ -18,7 +18,9 @@ The generated RBI by this compiler will produce the following
 # test_case.rbi
 # typed: true
 class ActiveSupport::TestCase
-  sig { params(fixture_names: T.any(String, Symbol)).returns(T.untyped) }
-  def posts(*fixture_names); end
+  sig { params(fixture_name: T.any(String, Symbol), other_fixtures: NilClass).returns(Post) }
+  sig { params(fixture_name: T.any(String, Symbol), other_fixtures: T.any(String, Symbol))
+          .returns(T::Array[Post]) }
+  def posts(fixture_name, *other_fixtures); end
 end
 ~~~

--- a/sorbet/rbi/shims/active_record_fixture_set.rbi
+++ b/sorbet/rbi/shims/active_record_fixture_set.rbi
@@ -1,0 +1,16 @@
+# typed: strict
+
+# ActiveRecord::TestFixtures can't be loaded outside of a Rails application
+
+class ActiveRecord::FixtureSet
+  sig { params(name: String).returns(String) }
+  def self.default_fixture_model_name(name); end
+end
+
+class ActiveRecord::FixtureSet::File
+  sig { returns(T.nilable(String)) }
+  def modle_class; end
+
+  sig params(filename: String, blk: T.proc.params(arg0: ActiveRecord::FixtureSet::File).void)
+  def self.open(filename, &block); end
+end

--- a/spec/tapioca/dsl/compilers/active_record_fixtures_spec.rb
+++ b/spec/tapioca/dsl/compilers/active_record_fixtures_spec.rb
@@ -68,8 +68,9 @@ module Tapioca
                 # typed: strong
 
                 class ActiveSupport::TestCase
-                  sig { params(fixture_names: T.any(String, Symbol)).returns(T.untyped) }
-                  def posts(*fixture_names); end
+                  sig { params(fixture_name: T.any(String, Symbol), other_fixtures: NilClass).returns(T.untyped) }
+                  sig { params(fixture_name: T.any(String, Symbol), other_fixtures: T.any(String, Symbol)).returns(T::Array[T.untyped]) }
+                  def posts(fixture_name, *other_fixtures); end
                 end
               RBI
 
@@ -97,11 +98,13 @@ module Tapioca
                 # typed: strong
 
                 class ActiveSupport::TestCase
-                  sig { params(fixture_names: T.any(String, Symbol)).returns(T.untyped) }
-                  def posts(*fixture_names); end
+                  sig { params(fixture_name: T.any(String, Symbol), other_fixtures: NilClass).returns(T.untyped) }
+                  sig { params(fixture_name: T.any(String, Symbol), other_fixtures: T.any(String, Symbol)).returns(T::Array[T.untyped]) }
+                  def posts(fixture_name, *other_fixtures); end
 
-                  sig { params(fixture_names: T.any(String, Symbol)).returns(T.untyped) }
-                  def users(*fixture_names); end
+                  sig { params(fixture_name: T.any(String, Symbol), other_fixtures: NilClass).returns(T.untyped) }
+                  sig { params(fixture_name: T.any(String, Symbol), other_fixtures: T.any(String, Symbol)).returns(T::Array[T.untyped]) }
+                  def users(fixture_name, *other_fixtures); end
                 end
               RBI
 

--- a/spec/tapioca/dsl/compilers/active_record_fixtures_spec.rb
+++ b/spec/tapioca/dsl/compilers/active_record_fixtures_spec.rb
@@ -78,7 +78,7 @@ module Tapioca
             end
 
             it "generates methods for fixtures from multiple sources" do
-              add_content_file("test/fixtures/posts.yml", <<~YAML)
+              add_content_file("test/fixtures/blog/posts.yml", <<~YAML)
                 super_post:
                   title: An incredible Ruby post
                   author: Johnny Developer
@@ -100,7 +100,7 @@ module Tapioca
                 class ActiveSupport::TestCase
                   sig { params(fixture_name: T.any(String, Symbol), other_fixtures: NilClass).returns(T.untyped) }
                   sig { params(fixture_name: T.any(String, Symbol), other_fixtures: T.any(String, Symbol)).returns(T::Array[T.untyped]) }
-                  def posts(fixture_name, *other_fixtures); end
+                  def blog_posts(fixture_name, *other_fixtures); end
 
                   sig { params(fixture_name: T.any(String, Symbol), other_fixtures: NilClass).returns(T.untyped) }
                   sig { params(fixture_name: T.any(String, Symbol), other_fixtures: T.any(String, Symbol)).returns(T::Array[T.untyped]) }

--- a/spec/tapioca/dsl/compilers/active_record_fixtures_spec.rb
+++ b/spec/tapioca/dsl/compilers/active_record_fixtures_spec.rb
@@ -124,6 +124,35 @@ module Tapioca
               assert_equal(expected, rbi_for("ActiveSupport::TestCase"))
             end
 
+            it "generates methods for fixtures with explicit class name" do
+              add_content_file("test/fixtures/posts_with_other_names.yml", <<~YAML)
+                _fixture:
+                  model_class: Post
+                super_post:
+                  title: An incredible Ruby post
+                  author: Johnny Developer
+                  created_at: 2021-09-08 11:00:00
+                  updated_at: 2021-09-08 11:00:00
+              YAML
+
+              add_ruby_file("test_models.rb", <<~RUBY)
+                class Post < ActiveRecord::Base
+                end
+              RUBY
+
+              expected = <<~RBI
+                # typed: strong
+
+                class ActiveSupport::TestCase
+                  sig { params(fixture_name: T.any(String, Symbol), other_fixtures: NilClass).returns(Post) }
+                  sig { params(fixture_name: T.any(String, Symbol), other_fixtures: T.any(String, Symbol)).returns(T::Array[Post]) }
+                  def posts_with_other_names(fixture_name, *other_fixtures); end
+                end
+              RBI
+
+              assert_equal(expected, rbi_for("ActiveSupport::TestCase"))
+            end
+
             it "generates methods for fixtures with a fallback to T.untyped if no matching model exists" do
               add_content_file("test/fixtures/posts.yml", <<~YAML)
                 super_post:

--- a/spec/tapioca/dsl/compilers/active_record_fixtures_spec.rb
+++ b/spec/tapioca/dsl/compilers/active_record_fixtures_spec.rb
@@ -124,6 +124,28 @@ module Tapioca
               assert_equal(expected, rbi_for("ActiveSupport::TestCase"))
             end
 
+            it "generates methods for fixtures with a fallback to T.untyped if no matching model exists" do
+              add_content_file("test/fixtures/posts.yml", <<~YAML)
+                super_post:
+                  title: An incredible Ruby post
+                  author: Johnny Developer
+                  created_at: 2021-09-08 11:00:00
+                  updated_at: 2021-09-08 11:00:00
+              YAML
+
+              expected = <<~RBI
+                # typed: strong
+
+                class ActiveSupport::TestCase
+                  sig { params(fixture_name: T.any(String, Symbol), other_fixtures: NilClass).returns(T.untyped) }
+                  sig { params(fixture_name: T.any(String, Symbol), other_fixtures: T.any(String, Symbol)).returns(T::Array[T.untyped]) }
+                  def posts(fixture_name, *other_fixtures); end
+                end
+              RBI
+
+              assert_equal(expected, rbi_for("ActiveSupport::TestCase"))
+            end
+
             it "generates no methods for file fixtures" do
               add_content_file("test/fixtures/files/posts.yml", <<~YAML)
                 super_post:

--- a/spec/tapioca/dsl/compilers/active_record_fixtures_spec.rb
+++ b/spec/tapioca/dsl/compilers/active_record_fixtures_spec.rb
@@ -64,12 +64,17 @@ module Tapioca
                   updated_at: 2021-09-08 11:00:00
               YAML
 
+              add_ruby_file("test_models.rb", <<~RUBY)
+                class Post < ActiveRecord::Base
+                end
+              RUBY
+
               expected = <<~RBI
                 # typed: strong
 
                 class ActiveSupport::TestCase
-                  sig { params(fixture_name: T.any(String, Symbol), other_fixtures: NilClass).returns(T.untyped) }
-                  sig { params(fixture_name: T.any(String, Symbol), other_fixtures: T.any(String, Symbol)).returns(T::Array[T.untyped]) }
+                  sig { params(fixture_name: T.any(String, Symbol), other_fixtures: NilClass).returns(Post) }
+                  sig { params(fixture_name: T.any(String, Symbol), other_fixtures: T.any(String, Symbol)).returns(T::Array[Post]) }
                   def posts(fixture_name, *other_fixtures); end
                 end
               RBI
@@ -78,6 +83,14 @@ module Tapioca
             end
 
             it "generates methods for fixtures from multiple sources" do
+              add_ruby_file("test_models.rb", <<~RUBY)
+                module Blog
+                  class Post < ActiveRecord::Base
+                  end
+                end
+                class User < ActiveRecord::Base
+                end
+              RUBY
               add_content_file("test/fixtures/blog/posts.yml", <<~YAML)
                 super_post:
                   title: An incredible Ruby post
@@ -98,12 +111,12 @@ module Tapioca
                 # typed: strong
 
                 class ActiveSupport::TestCase
-                  sig { params(fixture_name: T.any(String, Symbol), other_fixtures: NilClass).returns(T.untyped) }
-                  sig { params(fixture_name: T.any(String, Symbol), other_fixtures: T.any(String, Symbol)).returns(T::Array[T.untyped]) }
+                  sig { params(fixture_name: T.any(String, Symbol), other_fixtures: NilClass).returns(Blog::Post) }
+                  sig { params(fixture_name: T.any(String, Symbol), other_fixtures: T.any(String, Symbol)).returns(T::Array[Blog::Post]) }
                   def blog_posts(fixture_name, *other_fixtures); end
 
-                  sig { params(fixture_name: T.any(String, Symbol), other_fixtures: NilClass).returns(T.untyped) }
-                  sig { params(fixture_name: T.any(String, Symbol), other_fixtures: T.any(String, Symbol)).returns(T::Array[T.untyped]) }
+                  sig { params(fixture_name: T.any(String, Symbol), other_fixtures: NilClass).returns(User) }
+                  sig { params(fixture_name: T.any(String, Symbol), other_fixtures: T.any(String, Symbol)).returns(T::Array[User]) }
                   def users(fixture_name, *other_fixtures); end
                 end
               RBI


### PR DESCRIPTION
### Motivation
It has been bugging me some time that fixtures are T.untyped.
After a conversation today with @vinistock we realized that method overloading might work - and lo and behold - it does work.

The generated signatures return `Model` for `models(:one)` and `T::Array[Model]` for `models(:one, :two)` by overloading it with nil as the rest arg type, hat tip to @vinistock for the idea.

### Implementation
The signature of the fixture methods changed from `users(*fixture_names)` to `users(fixture_name, *other_fixutres)` in order to allow overloading based on the type of the rest args (e.g. `nil` or `T.any(String, Symbol`).

The mapping for fixture method (e.g. `users`) to model name (e.g. `User`) happens by creating a lookup table (once) for a mapping from underscore name to name. All descendants of `ActiveRecord::Base` go into the lookup table.
This is required since there are potential conflicts with the fixture method name between `FooBar` and `Foo::Bar` which both map to `foo_bars`.
By building this lookup table once we can map this reasonably efficiently and correctly.

Should no matching model be found it falls back to T.untyped.
Do we have some way of collecting metrics if/how often this happens?

I added an ad-hoc implementation for turning the `Blog::Post` into `blog_posts` - I would assume there is something like that already but I did not find it - any pointers would be more than welcome!

### Tests
I modified the class documentation and tests to account for the changed signature and added the correct return types.
I also modified one test case to have a namespaces model `Post` -> `Blog::Post` to ensure that namespaced models are handled correctly and I also added a test that ensures the fallback to `T.untyped` happens as expected.

I also ran this on a personal project of mine (rails app with ~10k lines of ruby) and it worked as expected and `srb tc` still passed (meaning I used the fixtures as expected but also, at least for my case, it generated reasonable rbis)