### PR TITLE
Do not notify Slack on synchronize

### DIFF
--- a/.github/workflows/team_ruby_dx.yml
+++ b/.github/workflows/team_ruby_dx.yml
@@ -2,7 +2,7 @@ name: Team RubyDX notification
 
 on:
   pull_request_target:
-    types: [opened, reopened, synchronize]
+    types: [opened, reopened]
 
 permissions: {}
 


### PR DESCRIPTION
### Motivation

Reduce the noisiness of the Slack integration.

### Implementation

Removed `synchronize` events.
