### PR TITLE
Constrain sqlite3 gem dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,7 +35,7 @@ group :development, :test do
   gem "sprockets"
   gem "state_machines"
   gem "activerecord-typedstore"
-  gem "sqlite3"
+  gem "sqlite3", "~>1.4"
   gem "identity_cache"
   gem "cityhash",
     git: "https://github.com/csfrancis/cityhash.git",

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -406,7 +406,7 @@ DEPENDENCIES
   sidekiq
   smart_properties
   sprockets
-  sqlite3
+  sqlite3 (~> 1.4)
   state_machines
   tapioca!
   webmock

--- a/spec/tapioca/cli/dsl_spec.rb
+++ b/spec/tapioca/cli/dsl_spec.rb
@@ -1618,7 +1618,7 @@ module Tapioca
 
         it "generates RBIs for lower versions of activerecord-typedstore" do
           @project.require_real_gem("activerecord-typedstore", "1.4.0")
-          @project.require_real_gem("sqlite3")
+          @project.require_real_gem("sqlite3", "1.7.3")
           @project.bundle_install!
           @project.write!("lib/post.rb", <<~RB)
             require "active_record"


### PR DESCRIPTION
@TobiasBales was seeing [failures](https://github.com/Shopify/tapioca/actions/runs/8735153192/job/23967349760) relating to the sqlite3 v2.0.0 release. I think we need to constrain it, [as we did for ruby-lsp-rails](https://github.com/Shopify/ruby-lsp-rails/pull/344).