### PR TITLE
Trigger matrix status check for push and PR events

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
         continue-on-error: ${{ !!matrix.experimental }}
 
   buildall:
-    if: ${{ always() && github.event.pull_request }}
+    if: ${{ always() }}
     runs-on: ubuntu-latest
     name: Build (matrix)
     needs: [linters, tests]


### PR DESCRIPTION
### Motivation
Github uses commit status to set the status for the branch so we need this to run on pushes.

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->

