### PR TITLE
Introduce `skip_constants` flag to `dsl`

### DIFF
--- a/README.md
+++ b/README.md
@@ -500,6 +500,7 @@ Options:
                                                                                                    # Default: .
              [--halt-upon-load-error], [--no-halt-upon-load-error], [--skip-halt-upon-load-error]  # Halt upon a load error while loading the Rails application
                                                                                                    # Default: true
+             [--skip-constant=constant [constant ...]]                                             # Do not generate RBI definitions for the given application constant(s)
   -c,        [--config=<config file path>]                                                         # Path to the Tapioca configuration file
                                                                                                    # Default: sorbet/tapioca/config.yml
   -V,        [--verbose], [--no-verbose], [--skip-verbose]                                         # Verbose output for debugging purposes
@@ -933,6 +934,7 @@ dsl:
   list_compilers: false
   app_root: "."
   halt_upon_load_error: true
+  skip_constant: []
 gem:
   outdir: sorbet/rbi/gems
   file_header: true

--- a/lib/tapioca/cli.rb
+++ b/lib/tapioca/cli.rb
@@ -135,6 +135,11 @@ module Tapioca
       type: :boolean,
       desc: "Halt upon a load error while loading the Rails application",
       default: true
+    option :skip_constant,
+      type: :array,
+      banner: "constant [constant ...]",
+      desc: "Do not generate RBI definitions for the given application constant(s)",
+      default: []
     def dsl(*constant_or_paths)
       set_environment(options)
 
@@ -149,6 +154,7 @@ module Tapioca
         exclude: options[:exclude],
         file_header: options[:file_header],
         tapioca_path: TAPIOCA_DIR,
+        skip_constant: options[:skip_constant],
         quiet: options[:quiet],
         verbose: options[:verbose],
         number_of_workers: options[:workers],

--- a/lib/tapioca/commands/abstract_dsl.rb
+++ b/lib/tapioca/commands/abstract_dsl.rb
@@ -18,6 +18,7 @@ module Tapioca
           exclude: T::Array[String],
           file_header: T::Boolean,
           tapioca_path: String,
+          skip_constant: T::Array[String],
           quiet: T::Boolean,
           verbose: T::Boolean,
           number_of_workers: T.nilable(Integer),
@@ -36,6 +37,7 @@ module Tapioca
         exclude:,
         file_header:,
         tapioca_path:,
+        skip_constant: [],
         quiet: false,
         verbose: false,
         number_of_workers: nil,
@@ -60,6 +62,7 @@ module Tapioca
         @rbi_formatter = rbi_formatter
         @app_root = app_root
         @halt_upon_load_error = halt_upon_load_error
+        @skip_constant = skip_constant
 
         super()
       end
@@ -124,6 +127,7 @@ module Tapioca
           error_handler: ->(error) {
             say_error(error, :bold, :red)
           },
+          skipped_constants: constantize(@skip_constant),
           number_of_workers: @number_of_workers,
         )
       end

--- a/spec/tapioca/cli/dsl_spec.rb
+++ b/spec/tapioca/cli/dsl_spec.rb
@@ -1371,6 +1371,136 @@ module Tapioca
           RBI
         end
 
+        it "must respect `skip_constant` option" do
+          @project.write!("lib/post.rb", <<~RB)
+            class Post; end
+          RB
+
+          @project.write!("lib/job.rb", <<~RB)
+            class Job; end
+          RB
+
+          @project.write!("lib/user.rb", <<~RB)
+            class User; end
+          RB
+
+          @project.write!("lib/compilers/foo/compiler.rb", <<~RB)
+            require "job"
+            require "post"
+            require "user"
+
+            module Foo
+              class Compiler < Tapioca::Dsl::Compiler
+                extend T::Sig
+
+                ConstantType = type_member { { fixed: Module } }
+
+                sig { override.void }
+                def decorate
+                  root.create_path(constant) do |job|
+                    job.create_module("FooModule")
+                  end
+                end
+
+                sig { override.returns(T::Enumerable[Module]) }
+                def self.gather_constants
+                  [Job, Post, User]
+                end
+              end
+            end
+          RB
+
+          result = @project.tapioca("dsl --skip-constant Job User")
+
+          assert_stdout_equals(<<~OUT, result)
+            Loading DSL extension classes... Done
+            Loading Rails application... Done
+            Loading DSL compiler classes... Done
+            Compiling DSL RBI files...
+
+                  create  sorbet/rbi/dsl/post.rbi
+
+            Done
+
+            Checking generated RBI files...  Done
+              No errors found
+
+            All operations performed in working directory.
+            Please review changes and commit them.
+          OUT
+
+          assert_empty_stderr(result)
+
+          refute_project_file_exist("sorbet/rbi/dsl/job.rbi")
+          refute_project_file_exist("sorbet/rbi/dsl/user.rbi")
+          assert_project_file_exist("sorbet/rbi/dsl/post.rbi")
+
+          assert_success_status(result)
+        end
+
+        it "warns when requested constants include skipped constants" do
+          @project.write!("lib/post.rb", <<~RB)
+            class Post; end
+          RB
+
+          @project.write!("lib/job.rb", <<~RB)
+            class Job; end
+          RB
+
+          @project.write!("lib/compilers/foo/compiler.rb", <<~RB)
+            require "job"
+            require "post"
+
+            module Foo
+              class Compiler < Tapioca::Dsl::Compiler
+                extend T::Sig
+
+                ConstantType = type_member { { fixed: Module } }
+
+                sig { override.void }
+                def decorate
+                  root.create_path(constant) do |job|
+                    job.create_module("FooModule")
+                  end
+                end
+
+                sig { override.returns(T::Enumerable[Module]) }
+                def self.gather_constants
+                  [Post, Job]
+                end
+              end
+            end
+          RB
+
+          result = @project.tapioca("dsl Job Post --skip-constant Job")
+
+          assert_stdout_equals(<<~OUT, result)
+            Loading DSL extension classes... Done
+            Loading Rails application... Done
+            Loading DSL compiler classes... Done
+            Compiling DSL RBI files...
+
+                  create  sorbet/rbi/dsl/post.rbi
+
+            Done
+
+            Checking generated RBI files...  Done
+              No errors found
+
+            All operations performed in working directory.
+            Please review changes and commit them.
+          OUT
+
+          assert_stderr_equals(<<~ERR, result)
+            WARNING: Requested constants are being skipped due to configuration:[Job]. Check the supplied arguments and your `sorbet/tapioca/config.yml` file.
+          ERR
+
+          refute_project_file_exist("sorbet/rbi/dsl/job.rbi")
+          assert_project_file_exist("sorbet/rbi/dsl/post.rbi")
+
+          assert_success_status(result)
+        end
+
         describe "pending migrations" do
           before do
             @project.write!("db/migrate/202001010000_create_articles.rb", <<~RB)


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
There might be need for an escape hatch that will prevent tapioca from generation DSL RBIs for specific constants.

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
Remove specified constants from the list of processable constants coming from DSL compilers

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->
Included

