### PR TITLE
Use `T.any(Integer, Float, BigDecimal)` as the return type for ActiveRecord calculation methods

### DIFF
--- a/lib/tapioca/dsl/compilers/active_record_relations.rb
+++ b/lib/tapioca/dsl/compilers/active_record_relations.rb
@@ -364,7 +364,8 @@ module Tapioca
                 parameters: [
                   create_param("column_name", type: "T.any(String, Symbol)"),
                 ],
-                return_type: "T::Hash[T.untyped, #{method_name == :average ? "Numeric" : "T.untyped"}]",
+                return_type: "T::Hash[T.untyped, " \
+                  "#{method_name == :average ? "T.any(Integer, Float, BigDecimal)" : "T.untyped"}]",
               )
             when :calculate
               klass.create_method(
@@ -373,7 +374,7 @@ module Tapioca
                   create_param("operation", type: "Symbol"),
                   create_param("column_name", type: "T.any(String, Symbol)"),
                 ],
-                return_type: "T::Hash[T.untyped, Numeric]",
+                return_type: "T::Hash[T.untyped, T.any(Integer, Float, BigDecimal)]",
               )
             when :count
               klass.create_method(
@@ -390,7 +391,7 @@ module Tapioca
                   create_opt_param("column_name", type: "T.nilable(T.any(String, Symbol))", default: "nil"),
                   create_block_param("block", type: "T.nilable(T.proc.params(record: T.untyped).returns(T.untyped))"),
                 ],
-                return_type: "T::Hash[T.untyped, Numeric]",
+                return_type: "T::Hash[T.untyped, T.any(Integer, Float, BigDecimal)]",
               )
             end
           end
@@ -781,7 +782,7 @@ module Tapioca
                 parameters: [
                   create_param("column_name", type: "T.any(String, Symbol)"),
                 ],
-                return_type: method_name == :average ? "Numeric" : "T.untyped",
+                return_type: method_name == :average ? "T.any(Integer, Float, BigDecimal)" : "T.untyped",
               )
             when :calculate
               create_common_method(
@@ -790,7 +791,7 @@ module Tapioca
                   create_param("operation", type: "Symbol"),
                   create_param("column_name", type: "T.any(String, Symbol)"),
                 ],
-                return_type: "Numeric",
+                return_type: "T.any(Integer, Float, BigDecimal)",
               )
             when :count
               sigs = [
@@ -825,7 +826,7 @@ module Tapioca
               sigs = [
                 common_relation_methods_module.create_sig(
                   parameters: { initial_value_or_column: "T.untyped" },
-                  return_type: "Numeric",
+                  return_type: "T.any(Integer, Float, BigDecimal)",
                 ),
                 common_relation_methods_module.create_sig(
                   type_parameters: ["U"],

--- a/spec/tapioca/dsl/compilers/active_record_relations_spec.rb
+++ b/spec/tapioca/dsl/compilers/active_record_relations_spec.rb
@@ -69,13 +69,13 @@ module Tapioca
                     sig { params(block: T.nilable(T.proc.params(record: ::Post).returns(T.untyped))).returns(T::Boolean) }
                     def any?(&block); end
 
-                    sig { params(column_name: T.any(String, Symbol)).returns(Numeric) }
+                    sig { params(column_name: T.any(String, Symbol)).returns(T.any(Integer, Float, BigDecimal)) }
                     def average(column_name); end
 
                     sig { params(attributes: T.untyped, block: T.nilable(T.proc.params(object: ::Post).void)).returns(::Post) }
                     def build(attributes = nil, &block); end
 
-                    sig { params(operation: Symbol, column_name: T.any(String, Symbol)).returns(Numeric) }
+                    sig { params(operation: Symbol, column_name: T.any(String, Symbol)).returns(T.any(Integer, Float, BigDecimal)) }
                     def calculate(operation, column_name); end
 
                     sig { params(column_name: T.nilable(T.any(String, Symbol))).returns(Integer) }
@@ -231,7 +231,7 @@ module Tapioca
                     def sole; end
 
                 <% end %>
-                    sig { params(initial_value_or_column: T.untyped).returns(Numeric) }
+                    sig { params(initial_value_or_column: T.untyped).returns(T.any(Integer, Float, BigDecimal)) }
                     sig { type_parameters(:U).params(initial_value_or_column: T.nilable(T.type_parameter(:U)), block: T.proc.params(object: ::Post).returns(T.type_parameter(:U))).returns(T.type_parameter(:U)) }
                     def sum(initial_value_or_column = nil, &block); end
 
@@ -595,10 +595,10 @@ module Tapioca
                   class PrivateAssociationRelationGroupChain < PrivateAssociationRelation
                     Elem = type_member { { fixed: ::Post } }
 
-                    sig { params(column_name: T.any(String, Symbol)).returns(T::Hash[T.untyped, Numeric]) }
+                    sig { params(column_name: T.any(String, Symbol)).returns(T::Hash[T.untyped, T.any(Integer, Float, BigDecimal)]) }
                     def average(column_name); end
 
-                    sig { params(operation: Symbol, column_name: T.any(String, Symbol)).returns(T::Hash[T.untyped, Numeric]) }
+                    sig { params(operation: Symbol, column_name: T.any(String, Symbol)).returns(T::Hash[T.untyped, T.any(Integer, Float, BigDecimal)]) }
                     def calculate(operation, column_name); end
 
                     sig { params(column_name: T.untyped).returns(T::Hash[T.untyped, Integer]) }
@@ -613,7 +613,7 @@ module Tapioca
                     sig { params(column_name: T.any(String, Symbol)).returns(T::Hash[T.untyped, T.untyped]) }
                     def minimum(column_name); end
 
-                    sig { params(column_name: T.nilable(T.any(String, Symbol)), block: T.nilable(T.proc.params(record: T.untyped).returns(T.untyped))).returns(T::Hash[T.untyped, Numeric]) }
+                    sig { params(column_name: T.nilable(T.any(String, Symbol)), block: T.nilable(T.proc.params(record: T.untyped).returns(T.untyped))).returns(T::Hash[T.untyped, T.any(Integer, Float, BigDecimal)]) }
                     def sum(column_name = nil, &block); end
                   end
 
@@ -697,10 +697,10 @@ module Tapioca
                   class PrivateRelationGroupChain < PrivateRelation
                     Elem = type_member { { fixed: ::Post } }
 
-                    sig { params(column_name: T.any(String, Symbol)).returns(T::Hash[T.untyped, Numeric]) }
+                    sig { params(column_name: T.any(String, Symbol)).returns(T::Hash[T.untyped, T.any(Integer, Float, BigDecimal)]) }
                     def average(column_name); end
 
-                    sig { params(operation: Symbol, column_name: T.any(String, Symbol)).returns(T::Hash[T.untyped, Numeric]) }
+                    sig { params(operation: Symbol, column_name: T.any(String, Symbol)).returns(T::Hash[T.untyped, T.any(Integer, Float, BigDecimal)]) }
                     def calculate(operation, column_name); end
 
                     sig { params(column_name: T.untyped).returns(T::Hash[T.untyped, Integer]) }
@@ -715,7 +715,7 @@ module Tapioca
                     sig { params(column_name: T.any(String, Symbol)).returns(T::Hash[T.untyped, T.untyped]) }
                     def minimum(column_name); end
 
-                    sig { params(column_name: T.nilable(T.any(String, Symbol)), block: T.nilable(T.proc.params(record: T.untyped).returns(T.untyped))).returns(T::Hash[T.untyped, Numeric]) }
+                    sig { params(column_name: T.nilable(T.any(String, Symbol)), block: T.nilable(T.proc.params(record: T.untyped).returns(T.untyped))).returns(T::Hash[T.untyped, T.any(Integer, Float, BigDecimal)]) }
                     def sum(column_name = nil, &block); end
                   end
 
@@ -762,13 +762,13 @@ module Tapioca
                     sig { params(block: T.nilable(T.proc.params(record: ::Post).returns(T.untyped))).returns(T::Boolean) }
                     def any?(&block); end
 
-                    sig { params(column_name: T.any(String, Symbol)).returns(Numeric) }
+                    sig { params(column_name: T.any(String, Symbol)).returns(T.any(Integer, Float, BigDecimal)) }
                     def average(column_name); end
 
                     sig { params(attributes: T.untyped, block: T.nilable(T.proc.params(object: ::Post).void)).returns(::Post) }
                     def build(attributes = nil, &block); end
 
-                    sig { params(operation: Symbol, column_name: T.any(String, Symbol)).returns(Numeric) }
+                    sig { params(operation: Symbol, column_name: T.any(String, Symbol)).returns(T.any(Integer, Float, BigDecimal)) }
                     def calculate(operation, column_name); end
 
                     sig { params(column_name: T.nilable(T.any(String, Symbol))).returns(Integer) }
@@ -928,7 +928,7 @@ module Tapioca
                     def sole; end
 
                 <% end %>
-                    sig { params(initial_value_or_column: T.untyped).returns(Numeric) }
+                    sig { params(initial_value_or_column: T.untyped).returns(T.any(Integer, Float, BigDecimal)) }
                     sig { type_parameters(:U).params(initial_value_or_column: T.nilable(T.type_parameter(:U)), block: T.proc.params(object: ::Post).returns(T.type_parameter(:U))).returns(T.type_parameter(:U)) }
                     def sum(initial_value_or_column = nil, &block); end
 
@@ -1292,10 +1292,10 @@ module Tapioca
                   class PrivateAssociationRelationGroupChain < PrivateAssociationRelation
                     Elem = type_member { { fixed: ::Post } }
 
-                    sig { params(column_name: T.any(String, Symbol)).returns(T::Hash[T.untyped, Numeric]) }
+                    sig { params(column_name: T.any(String, Symbol)).returns(T::Hash[T.untyped, T.any(Integer, Float, BigDecimal)]) }
                     def average(column_name); end
 
-                    sig { params(operation: Symbol, column_name: T.any(String, Symbol)).returns(T::Hash[T.untyped, Numeric]) }
+                    sig { params(operation: Symbol, column_name: T.any(String, Symbol)).returns(T::Hash[T.untyped, T.any(Integer, Float, BigDecimal)]) }
                     def calculate(operation, column_name); end
 
                     sig { params(column_name: T.untyped).returns(T::Hash[T.untyped, Integer]) }
@@ -1310,7 +1310,7 @@ module Tapioca
                     sig { params(column_name: T.any(String, Symbol)).returns(T::Hash[T.untyped, T.untyped]) }
                     def minimum(column_name); end
 
-                    sig { params(column_name: T.nilable(T.any(String, Symbol)), block: T.nilable(T.proc.params(record: T.untyped).returns(T.untyped))).returns(T::Hash[T.untyped, Numeric]) }
+                    sig { params(column_name: T.nilable(T.any(String, Symbol)), block: T.nilable(T.proc.params(record: T.untyped).returns(T.untyped))).returns(T::Hash[T.untyped, T.any(Integer, Float, BigDecimal)]) }
                     def sum(column_name = nil, &block); end
                   end
 
@@ -1394,10 +1394,10 @@ module Tapioca
                   class PrivateRelationGroupChain < PrivateRelation
                     Elem = type_member { { fixed: ::Post } }
 
-                    sig { params(column_name: T.any(String, Symbol)).returns(T::Hash[T.untyped, Numeric]) }
+                    sig { params(column_name: T.any(String, Symbol)).returns(T::Hash[T.untyped, T.any(Integer, Float, BigDecimal)]) }
                     def average(column_name); end
 
-                    sig { params(operation: Symbol, column_name: T.any(String, Symbol)).returns(T::Hash[T.untyped, Numeric]) }
+                    sig { params(operation: Symbol, column_name: T.any(String, Symbol)).returns(T::Hash[T.untyped, T.any(Integer, Float, BigDecimal)]) }
                     def calculate(operation, column_name); end
 
                     sig { params(column_name: T.untyped).returns(T::Hash[T.untyped, Integer]) }
@@ -1412,7 +1412,7 @@ module Tapioca
                     sig { params(column_name: T.any(String, Symbol)).returns(T::Hash[T.untyped, T.untyped]) }
                     def minimum(column_name); end
 
-                    sig { params(column_name: T.nilable(T.any(String, Symbol)), block: T.nilable(T.proc.params(record: T.untyped).returns(T.untyped))).returns(T::Hash[T.untyped, Numeric]) }
+                    sig { params(column_name: T.nilable(T.any(String, Symbol)), block: T.nilable(T.proc.params(record: T.untyped).returns(T.untyped))).returns(T::Hash[T.untyped, T.any(Integer, Float, BigDecimal)]) }
                     def sum(column_name = nil, &block); end
                   end
 


### PR DESCRIPTION
Use `T.any(Integer, Float, BigDecimal)` as the return type for ActiveRecord calculation methods.

Closes #1850.

### Motivation

See discussion in #1850.

### Implementation
Updated `ActiveRecordRelations` compiler to use `T.any(Integer, Float, BigDecimal)` instead of `Numeric` as the return type for `sum` methods.

Some notes/thoughts:
- Should other calculation methods be updated accordingly? E.g. `average`, `minimum`, `maximum`, `calculate`
    - Yes ➡️  Done!
- `BigDecimal` is only available after `require "bigdecimal"` (and, in a future Ruby version, bigdecimal will switch from a default gem to a bundled gem). That's probably fine since bigdecimal is a dependency of activesupport, so presumably any Rails / ActiveRecord user already has the gem in their app.

### Tests
Updated existing tests in `spec/tapioca/dsl/compilers/active_record_relations_spec.rb`
