### PR TITLE
Improve ActiveRecord::QueryMethods#distinct

### DIFF
--- a/lib/tapioca/dsl/compilers/active_record_relations.rb
+++ b/lib/tapioca/dsl/compilers/active_record_relations.rb
@@ -560,6 +560,11 @@ module Tapioca
 
           QUERY_METHODS.each do |method_name|
             case method_name
+            when :distinct
+              create_relation_method(
+                method_name.to_s,
+                parameters: [create_opt_param("value", type: "T::Boolean", default: "true")],
+              )
             when :extract_associated
               parameters = [create_param("association", type: "Symbol")]
               return_type = "T::Array[T.untyped]"

--- a/spec/tapioca/dsl/compilers/active_record_relations_spec.rb
+++ b/spec/tapioca/dsl/compilers/active_record_relations_spec.rb
@@ -268,8 +268,8 @@ module Tapioca
                     sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
                     def create_with(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
-                    def distinct(*args, &blk); end
+                    sig { params(value: T::Boolean).returns(PrivateAssociationRelation) }
+                    def distinct(value = true); end
 
                     sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
                     def eager_load(*args, &blk); end
@@ -439,8 +439,8 @@ module Tapioca
                     sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
                     def create_with(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
-                    def distinct(*args, &blk); end
+                    sig { params(value: T::Boolean).returns(PrivateRelation) }
+                    def distinct(value = true); end
 
                     sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
                     def eager_load(*args, &blk); end
@@ -965,8 +965,8 @@ module Tapioca
                     sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
                     def create_with(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
-                    def distinct(*args, &blk); end
+                    sig { params(value: T::Boolean).returns(PrivateAssociationRelation) }
+                    def distinct(value = true); end
 
                     sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
                     def eager_load(*args, &blk); end
@@ -1136,8 +1136,8 @@ module Tapioca
                     sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
                     def create_with(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
-                    def distinct(*args, &blk); end
+                    sig { params(value: T::Boolean).returns(PrivateRelation) }
+                    def distinct(value = true); end
 
                     sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
                     def eager_load(*args, &blk); end


### PR DESCRIPTION
### Motivation
We tried to use this in a way (passing a column name as argument) that [doesn't work](https://api.rubyonrails.org/v7.1.3.2/classes/ActiveRecord/QueryMethods.html#method-i-distinct), and were caught off guard that Sorbet didn't warn us about it. This fixes that :) 

### Tests
Updated tests.

