### PR TITLE
Remove Ruby 3.0 from CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,16 +35,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.0", "3.1", "3.2", "3.3", "head"]
+        ruby: ["3.1", "3.2", "3.3", "head"]
         rails: ["7.0", "current", "main"]
         include:
           - rails: "main"
             experimental: true
           - ruby: "head"
             experimental: true
-        exclude:
-          - ruby: "3.0"
-            rails: "main"
     name: Ruby ${{ matrix.ruby }} - Rails ${{ matrix.rails }}
     env:
       RAILS_VERSION: ${{ matrix.rails }}

--- a/tapioca.gemspec
+++ b/tapioca.gemspec
@@ -32,5 +32,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency("thor", ">= 1.2.0")
   spec.add_dependency("yard-sorbet")
 
-  spec.required_ruby_version = ">= 3.0"
+  spec.required_ruby_version = ">= 3.1"
 end


### PR DESCRIPTION
Ruby 3.0 is EOL since 2024-04-23.

See https://www.ruby-lang.org/en/downloads/branches/.