### PR TITLE
Remove `ActiveSupport::Deprecation` silencing from loader

### DIFF
--- a/lib/tapioca/loaders/loader.rb
+++ b/lib/tapioca/loaders/loader.rb
@@ -49,8 +49,6 @@ module Tapioca
       def load_rails_application(environment_load: false, eager_load: false, app_root: ".", halt_upon_load_error: true)
         return unless File.exist?("#{app_root}/config/application.rb")
 
-        silence_deprecations
-
         if environment_load
           require "./#{app_root}/config/environment"
         else
@@ -184,14 +182,6 @@ module Tapioca
         require path
       rescue LoadError
         nil
-      end
-
-      sig { void }
-      def silence_deprecations
-        # Stop any ActiveSupport Deprecations from being reported
-        if defined?(ActiveSupport::Deprecation)
-          ActiveSupport::Deprecation.silenced = true
-        end
       end
 
       sig { void }


### PR DESCRIPTION
### Motivation

See #1890

### Implementation

~~Just check if the deprecated method is actually defined or not.~~ Remove deprecation silencing.

There's probably a longer term solution using `Rails.application.deprecators.silence { ... }` but it seems like the current solution assumes we can globally silence all `ActiveSupport::Deprecation` warnings _before_ the Rails application is loaded.

### Tests

N/A (I could be missing something, but I don't see any existing tests for this behavior)
