### PR TITLE
Ignore missing constants for `--skip-constant` option

### DIFF
--- a/lib/tapioca/commands/abstract_dsl.rb
+++ b/lib/tapioca/commands/abstract_dsl.rb
@@ -127,7 +127,7 @@ module Tapioca
           error_handler: ->(error) {
             say_error(error, :bold, :red)
           },
-          skipped_constants: constantize(@skip_constant),
+          skipped_constants: constantize(@skip_constant, ignore_missing: true),
           number_of_workers: @number_of_workers,
         )
       end


### PR DESCRIPTION
This feature is useful for cases where certain constants aren't available in all environments. We shouldn't error if that's the case

### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->

