### PR TITLE
fix: add default keyword argument to kredis extension attributes

### DIFF
--- a/lib/tapioca/dsl/extensions/kredis.rb
+++ b/lib/tapioca/dsl/extensions/kredis.rb
@@ -19,32 +19,32 @@ module Tapioca
             super
           end
 
-          def kredis_string(name, key: nil, config: :shared, after_change: nil, expires_in: nil)
+          def kredis_string(name, key: nil, default: nil, config: :shared, after_change: nil, expires_in: nil)
             collect_kredis_type(name, "Kredis::Types::Scalar")
             super
           end
 
-          def kredis_integer(name, key: nil, config: :shared, after_change: nil, expires_in: nil)
+          def kredis_integer(name, key: nil, default: nil, config: :shared, after_change: nil, expires_in: nil)
             collect_kredis_type(name, "Kredis::Types::Scalar")
             super
           end
 
-          def kredis_decimal(name, key: nil, config: :shared, after_change: nil, expires_in: nil)
+          def kredis_decimal(name, key: nil, default: nil, config: :shared, after_change: nil, expires_in: nil)
             collect_kredis_type(name, "Kredis::Types::Scalar")
             super
           end
 
-          def kredis_datetime(name, key: nil, config: :shared, after_change: nil, expires_in: nil)
+          def kredis_datetime(name, key: nil, default: nil, config: :shared, after_change: nil, expires_in: nil)
             collect_kredis_type(name, "Kredis::Types::Scalar")
             super
           end
 
-          def kredis_flag(name, key: nil, config: :shared, after_change: nil, expires_in: nil)
+          def kredis_flag(name, key: nil, default: nil, config: :shared, after_change: nil, expires_in: nil)
             collect_kredis_type(name, "Kredis::Types::Flag")
             super
           end
 
-          def kredis_float(name, key: nil, config: :shared, after_change: nil, expires_in: nil)
+          def kredis_float(name, key: nil, default: nil, config: :shared, after_change: nil, expires_in: nil)
             collect_kredis_type(name, "Kredis::Types::Scalar")
             super
           end
@@ -54,22 +54,23 @@ module Tapioca
             super
           end
 
-          def kredis_json(name, key: nil, config: :shared, after_change: nil, expires_in: nil)
+          def kredis_json(name, key: nil, default: nil, config: :shared, after_change: nil, expires_in: nil)
             collect_kredis_type(name, "Kredis::Types::Scalar")
             super
           end
 
-          def kredis_list(name, key: nil, typed: :string, config: :shared, after_change: nil)
+          def kredis_list(name, key: nil, default: nil, typed: :string, config: :shared, after_change: nil)
             collect_kredis_type(name, "Kredis::Types::List")
             super
           end
 
-          def kredis_unique_list(name, limit: nil, key: nil, typed: :string, config: :shared, after_change: nil)
+          def kredis_unique_list(name, limit: nil, key: nil, default: nil, typed: :string, config: :shared,
+            after_change: nil)
             collect_kredis_type(name, "Kredis::Types::UniqueList")
             super
           end
 
-          def kredis_set(name, key: nil, typed: :string, config: :shared, after_change: nil)
+          def kredis_set(name, key: nil, default: nil, typed: :string, config: :shared, after_change: nil)
             collect_kredis_type(name, "Kredis::Types::Set")
             super
           end
@@ -84,17 +85,17 @@ module Tapioca
             super
           end
 
-          def kredis_counter(name, key: nil, config: :shared, after_change: nil, expires_in: nil)
+          def kredis_counter(name, key: nil, default: nil, config: :shared, after_change: nil, expires_in: nil)
             collect_kredis_type(name, "Kredis::Types::Counter")
             super
           end
 
-          def kredis_hash(name, key: nil, typed: :string, config: :shared, after_change: nil)
+          def kredis_hash(name, key: nil, default: nil, typed: :string, config: :shared, after_change: nil)
             collect_kredis_type(name, "Kredis::Types::Hash")
             super
           end
 
-          def kredis_boolean(name, key: nil, config: :shared, after_change: nil, expires_in: nil)
+          def kredis_boolean(name, key: nil, default: nil, config: :shared, after_change: nil, expires_in: nil)
             collect_kredis_type(name, "Kredis::Types::Scalar")
             super
           end


### PR DESCRIPTION
### Motivation
The arguments for many attributes in `Tapioca::Dsl::Compilers::Extensions::Kredis` are missing the `default:` keyword argument defined in the kredis gem [here](https://github.com/rails/kredis/blob/main/lib/kredis/attributes.rb). This is causing the following error whenever you generate the DSLs for an application that uses the `default:` argument on a kredis attribute.

```
lib/tapioca/dsl/extensions/kredis.rb:27:in `kredis_integer`: unknown keyword: :default (ArgumentError)
```

### Implementation
Added the `default:` keyword argument to all of the following kredis attribute methods:
- `kredis_string`
- `kredis_integer`
- `kredis_decimal`
- `kredis_datetime`
- `kredis_flag`
- `kredis_float`
- `kredis_json`
- `kredis_list`
- `kredis_unique_list`
- `kredis_set`
- `kredis_counter`
- `kredis_hash`
- `kredis_boolean`

### Tests
I did not add new tests for this change as there don't appear to be existing tests for any of the other optional arguments here and this argument would not meaningfully change the DSL output (just allows it to not error when the `default:` argument is provided). Willing to add tests for this if needed -- leaning on the side of following the existing pattern here.

