### PR TITLE
Handle deferred route drawing in URL helpers DSL compiler

### DIFF
--- a/lib/tapioca/dsl/compilers/url_helpers.rb
+++ b/lib/tapioca/dsl/compilers/url_helpers.rb
@@ -102,6 +102,9 @@ module Tapioca
           def gather_constants
             return [] unless defined?(Rails.application) && Rails.application
 
+            routes_reloader = Rails.application.routes_reloader
+            routes_reloader.execute_unless_loaded if routes_reloader&.respond_to?(:execute_unless_loaded)
+
             Object.const_set(:GeneratedUrlHelpersModule, Rails.application.routes.named_routes.url_helpers_module)
             Object.const_set(:GeneratedPathHelpersModule, Rails.application.routes.named_routes.path_helpers_module)
 


### PR DESCRIPTION
### Motivation

The URL helpers DSL compiler appears broken after https://github.com/rails/rails/commit/e97db3b3957781c781a61fb01265feb2b57688bb introduced deferred route drawing. 

This leads to all helper methods being stripped from `GeneratedUrlHelpersModule` and `GeneratedPathHelpersModule`.

### Implementation

Ensure routes are loaded before generating `GeneratedUrlHelpersModule` and `GeneratedPathHelpersModule`.

### Tests

Open to any ideas on how to test this behavior—it seems like the existing tests pass despite the change in Rails itself.