### PR TITLE
Handle ActiveRecord attributes inheriting from `EncryptedAttributeType` with custom `sigs`

### DIFF
--- a/lib/tapioca/dsl/helpers/active_record_column_type_helper.rb
+++ b/lib/tapioca/dsl/helpers/active_record_column_type_helper.rb
@@ -69,6 +69,14 @@ module Tapioca
             "::Money"
           when ActiveRecord::Type::Integer
             "::Integer"
+          when ActiveRecord::Encryption::EncryptedAttributeType
+            # Reflect to see if `ActiveModel::Type::Value` is being used first.
+            getter_type = Tapioca::Dsl::Helpers::ActiveModelTypeHelper.type_for(column_type)
+            return getter_type unless getter_type == "T.untyped"
+
+            # Otherwise fallback to String as `ActiveRecord::Encryption::EncryptedAttributeType` inherits from
+            # `ActiveRecord::Type::Text` which inherits from `ActiveModel::Type::String`.
+            "::String"
           when ActiveRecord::Type::String
             "::String"
           when ActiveRecord::Type::Date


### PR DESCRIPTION
### Motivation

We have a custom type inheriting from `ActiveRecord::Encryption::EncryptedAttributeType` with a `deserialize` method that has a `sig` specifying the return type. 

Previously the column type would hit the `ActiveRecord::Type::String` branch of `type_for_activerecord_value` and return `::String` because `ActiveRecord::Encryption::EncryptedAttributeType` inherits from `ActiveRecord::Type::String`.

### Implementation

I added a case statement for `ActiveRecord::Encryption::EncryptedAttributeType` to `type_for_activerecord_value`.

### Tests

I have.
