### PR TITLE
Support Postgres `cidr` column type

### DIFF
--- a/lib/tapioca/dsl/helpers/active_record_column_type_helper.rb
+++ b/lib/tapioca/dsl/helpers/active_record_column_type_helper.rb
@@ -101,6 +101,9 @@ module Tapioca
           when defined?(ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Uuid) &&
             ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Uuid
             "::String"
+          when defined?(ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Cidr) &&
+            ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Cidr
+            "::IPAddr"
           when defined?(ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Hstore) &&
             ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Hstore
             "T::Hash[::String, ::String]"

--- a/sorbet/rbi/shims/activerecord_postgresql.rbi
+++ b/sorbet/rbi/shims/activerecord_postgresql.rbi
@@ -4,3 +4,4 @@
 module ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Uuid; end
 module ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Array; end
 module ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Hstore; end
+module ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Cidr; end


### PR DESCRIPTION
### Motivation

#1837 This adds types for `cidr` columns

### Implementation

I added a `when` to `type_for_activerecord_value`, following the pattern used for `Uuid`.

### Tests

I didn't because I don't believe there's an established way in the test suite to test against Postgres directly. I verified this worked in our app that has a `Cidr` column.
