### PR TITLE
Downgrade bundler in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,8 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
-          rubygems: 'latest'
-          bundler: 'latest'
+          rubygems: 3.5.11
+          bundler: 2.5.11
       - name: Run type check
         run: bin/typecheck
       - name: Lint Ruby files
@@ -61,8 +61,8 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
-          rubygems: 'latest'
-          bundler: 'latest'
+          rubygems: 3.5.11
+          bundler: 2.5.11
       - name: Run tests
         run: bin/test
         continue-on-error: ${{ !!matrix.experimental }}


### PR DESCRIPTION
### Motivation
Resolves strange CI failures on main https://github.com/Shopify/tapioca/actions/runs/9519041069
### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
2.5.11 is the previous version. I updated RubyGems version too thinking maybe they need to be compatible since they are released from the same repo.
### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->

