### PR TITLE
Refactor DSL compiler options to be a flat namespaced hash and document them

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Tapioca makes it easy to work with [Sorbet](https://sorbet.org) in your codebase
     * [Changing the typed strictness of annotations files](#changing-the-typed-strictness-of-annotations-files)
   * [Generating RBI files for Rails and other DSLs](#generating-rbi-files-for-rails-and-other-dsls)
     * [Keeping RBI files for DSLs up-to-date](#keeping-rbi-files-for-dsls-up-to-date)
+    * [Using DSL compiler options](#using-dsl-compiler-options)
     * [Writing custom DSL compilers](#writing-custom-dsl-compilers)
     * [Writing custom DSL extensions](#writing-custom-dsl-extensions)
   * [RBI files for missing constants and methods](#rbi-files-for-missing-constants-and-methods)
@@ -544,6 +545,25 @@ if Rails.env.development?
       system("bundle exec tapioca dsl", exception: true)
     end
   end
+```
+
+#### Using DSL compiler options
+
+Some DSL compilers are able to change their behaviour based on the options passed to them. For example, the
+`ActiveRecordColumns` compiler can be configured to change how it generates types for method related to Active Record
+column attributes. To pass options during DSL RBI generation, use the `--compiler-options` flag:
+```shell
+$ bin/tapioca dsl --compiler-options=ActiveRecordColumnTypes:untyped
+```
+which will make the `ActiveRecordColumns` compiler generate untyped signatures for column attribute methods.
+
+Compiler options can be passed through the configuration file, as like any other option, and we expect most users to
+configure them this way. For example, to configure the `ActiveRecordColumns` compiler to generate untyped signatures,
+you need to add the following to your `sorbet/tapioca/config.yml` file:
+```yaml
+dsl:
+  compiler_options:
+    ActiveRecordColumnTypes: untyped
 ```
 
 #### Writing custom DSL compilers

--- a/README.md
+++ b/README.md
@@ -501,6 +501,7 @@ Options:
              [--halt-upon-load-error], [--no-halt-upon-load-error], [--skip-halt-upon-load-error]  # Halt upon a load error while loading the Rails application
                                                                                                    # Default: true
              [--skip-constant=constant [constant ...]]                                             # Do not generate RBI definitions for the given application constant(s)
+             [--compiler-options=key:value]                                                        # Options to pass to the DSL compilers
   -c,        [--config=<config file path>]                                                         # Path to the Tapioca configuration file
                                                                                                    # Default: sorbet/tapioca/config.yml
   -V,        [--verbose], [--no-verbose], [--skip-verbose]                                         # Verbose output for debugging purposes

--- a/lib/tapioca/cli.rb
+++ b/lib/tapioca/cli.rb
@@ -143,16 +143,12 @@ module Tapioca
     option :compiler_options,
       type: :hash,
       desc: "Options to pass to the DSL compilers",
-      hide: true,
       default: {}
     def dsl(*constant_or_paths)
       set_environment(options)
 
       # Assume anything starting with a capital letter or colon is a class, otherwise a path
       constants, paths = constant_or_paths.partition { |c| c =~ /\A[A-Z:]/ }
-
-      # Make sure compiler options are received as a hash
-      compiler_options = process_compiler_options
 
       command_args = {
         requested_constants: constants,
@@ -169,7 +165,7 @@ module Tapioca
         rbi_formatter: rbi_formatter(options),
         app_root: options[:app_root],
         halt_upon_load_error: options[:halt_upon_load_error],
-        compiler_options: compiler_options,
+        compiler_options: options[:compiler_options],
       }
 
       command = if options[:verify]
@@ -380,26 +376,6 @@ module Tapioca
     end
 
     private
-
-    def process_compiler_options
-      compiler_options = options[:compiler_options]
-
-      # Parse all compiler option hash values as YAML if they are Strings
-      compiler_options.transform_values! do |value|
-        value = YAML.safe_load(value) if String === value
-        value
-      rescue YAML::Exception
-        raise MalformattedArgumentError,
-          "Option '--compiler-options' should have well-formatted YAML strings, but received: '#{value}'"
-      end
-
-      unless compiler_options.values.all? { |v| Hash === v }
-        raise MalformattedArgumentError,
-          "Option '--compiler-options' should be a hash of hashes, but received: '#{compiler_options}'"
-      end
-
-      compiler_options
-    end
 
     def print_init_next_steps
       say(<<~OUTPUT)

--- a/lib/tapioca/dsl/compilers/active_record_columns.rb
+++ b/lib/tapioca/dsl/compilers/active_record_columns.rb
@@ -147,16 +147,18 @@ module Tapioca
 
         private
 
-        sig { returns(Helpers::ActiveRecordColumnTypeHelper::ColumnTypeOption) }
+        ColumnTypeOption = Helpers::ActiveRecordColumnTypeHelper::ColumnTypeOption
+
+        sig { returns(ColumnTypeOption) }
         def column_type_option
           @column_type_option ||= T.let(
-            Helpers::ActiveRecordColumnTypeHelper::ColumnTypeOption.from_serialized(
-              options.fetch(
-                "types",
-                Helpers::ActiveRecordColumnTypeHelper::ColumnTypeOption::Persisted.serialize,
-              ),
-            ),
-            T.nilable(Helpers::ActiveRecordColumnTypeHelper::ColumnTypeOption),
+            ColumnTypeOption.from_options(options) do |value, default_column_type_option|
+              add_error(<<~MSG.strip)
+                Unknown value for compiler option `ActiveRecordColumnTypes` given: `#{value}`.
+                Proceeding with the default value: `#{default_column_type_option.serialize}`.
+              MSG
+            end,
+            T.nilable(ColumnTypeOption),
           )
         end
 

--- a/lib/tapioca/dsl/compilers/active_record_columns.rb
+++ b/lib/tapioca/dsl/compilers/active_record_columns.rb
@@ -15,6 +15,21 @@ module Tapioca
       # created for columns and virtual attributes that are defined in the Active Record
       # model.
       #
+      # This compiler accepts a `ActiveRecordColumnTypes` option that can be used to specify
+      # how the types of the column related methods should be generated. The option can be one of the following:
+      #  - `persisted` (_default_): The methods will be generated with the type that matches the actual database
+      #  column type as the return type. This means that if the column is a string, the method return type
+      #  will be `String`, but if the column is also nullable, then the return type will be `T.nilable(String)`. This
+      #  mode basically treats each model as if it was a valid and persisted model. Note that this makes typing
+      #  Active Record models easier, but does not match the behaviour of non-persisted or invalid models, which can
+      #  have all kinds of non-sensical values in their column attributes.
+      #  - `nilable`: All column methods will be generated with `T.nilable` return types. This is strictly the most
+      #  correct way to type the methods, but it can make working with the models more cumbersome, as you will have to
+      #  handle the `nil` cases explicitly using `T.must` or the safe navigation operator `&.`, even for valid
+      #  persisted models.
+      #  - `untyped`: The methods will be generated with `T.untyped` return types. This mode is practical if you are not
+      #  ready to start typing your models strictly yet, but still want to generate RBI files for them.
+      #
       # For example, with the following model class:
       # ~~~rb
       # class Post < ActiveRecord::Base
@@ -33,7 +48,7 @@ module Tapioca
       # end
       # ~~~
       #
-      # this compiler will produce the following methods in the RBI file
+      # this compiler will, by default, produce the following methods in the RBI file
       # `post.rbi`:
       #
       # ~~~rbi
@@ -93,6 +108,17 @@ module Tapioca
       #     ## Also the methods added by https://api.rubyonrails.org/classes/ActiveRecord/AttributeMethods/BeforeTypeCast.html
       #   end
       # end
+      # ~~~
+      #
+      # However, if `ActiveRecordColumnTypes` is set to `nilable`, the `title` method will be generated as:
+      # ~~~rbi
+      #     sig { returns(T.nilable(::String)) }
+      #     def title; end
+      # ~~~
+      # and if the option is set to `untyped`, the `title` method will be generated as:
+      # ~~~rbi
+      #     sig { returns(T.untyped) }
+      #     def title; end
       # ~~~
       class ActiveRecordColumns < Compiler
         extend T::Sig

--- a/lib/tapioca/dsl/helpers/active_record_column_type_helper.rb
+++ b/lib/tapioca/dsl/helpers/active_record_column_type_helper.rb
@@ -12,10 +12,36 @@ module Tapioca
 
         class ColumnTypeOption < T::Enum
           extend T::Sig
+
           enums do
             Untyped = new("untyped")
             Nilable = new("nilable")
             Persisted = new("persisted")
+          end
+
+          class << self
+            extend T::Sig
+
+            sig do
+              params(
+                options: T::Hash[String, T.untyped],
+                block: T.proc.params(value: String, default_column_type_option: ColumnTypeOption).void,
+              ).returns(ColumnTypeOption)
+            end
+            def from_options(options, &block)
+              column_type_option = Persisted
+              value = options["ActiveRecordColumnTypes"]
+
+              if value
+                if has_serialized?(value)
+                  column_type_option = from_serialized(value)
+                else
+                  block.call(value, column_type_option)
+                end
+              end
+
+              column_type_option
+            end
           end
 
           sig { returns(T::Boolean) }

--- a/lib/tapioca/dsl/pipeline.rb
+++ b/lib/tapioca/dsl/pipeline.rb
@@ -33,7 +33,7 @@ module Tapioca
           error_handler: T.proc.params(error: String).void,
           skipped_constants: T::Array[Module],
           number_of_workers: T.nilable(Integer),
-          compiler_options: T::Hash[String, T::Hash[String, T.untyped]],
+          compiler_options: T::Hash[String, T.untyped],
         ).void
       end
       def initialize(
@@ -200,12 +200,7 @@ module Tapioca
         active_compilers.each do |compiler_class|
           next unless compiler_class.handles?(constant)
 
-          compiler_key = T.must(compiler_class.name).dup
-          Tapioca::Dsl::Compilers::NAMESPACES.each do |namespace|
-            compiler_key.delete_prefix!(namespace)
-          end
-          options = @compiler_options.fetch(compiler_key, {})
-          compiler = compiler_class.new(self, file.root, constant, options)
+          compiler = compiler_class.new(self, file.root, constant, @compiler_options)
           compiler.decorate
         rescue
           $stderr.puts("Error: `#{compiler_class.name}` failed to generate RBI for `#{constant}`")

--- a/lib/tapioca/helpers/config_helper.rb
+++ b/lib/tapioca/helpers/config_helper.rb
@@ -133,7 +133,7 @@ module Tapioca
           error_msg = "invalid value for option `#{config_option_key}` for key `#{config_key}` - expected " \
             "`Hash[String, String]` but found `#{config_option_value}`"
           values_to_validate = config_option_value.keys
-          values_to_validate += config_option_value.values unless config_option_key == "compiler_options"
+          values_to_validate += config_option_value.values
           all_strings = values_to_validate.all? { |v| v.is_a?(String) }
           next build_error(error_msg) unless all_strings
         end

--- a/manual/compiler_activerecordcolumns.md
+++ b/manual/compiler_activerecordcolumns.md
@@ -6,6 +6,21 @@ This compiler is only responsible for defining the attribute methods that would 
 created for columns and virtual attributes that are defined in the Active Record
 model.
 
+This compiler accepts a `ActiveRecordColumnTypes` option that can be used to specify
+how the types of the column related methods should be generated. The option can be one of the following:
+ - `persisted` (_default_): The methods will be generated with the type that matches the actual database
+ column type as the return type. This means that if the column is a string, the method return type
+ will be `String`, but if the column is also nullable, then the return type will be `T.nilable(String)`. This
+ mode basically treats each model as if it was a valid and persisted model. Note that this makes typing
+ Active Record models easier, but does not match the behaviour of non-persisted or invalid models, which can
+ have all kinds of non-sensical values in their column attributes.
+ - `nilable`: All column methods will be generated with `T.nilable` return types. This is strictly the most
+ correct way to type the methods, but it can make working with the models more cumbersome, as you will have to
+ handle the `nil` cases explicitly using `T.must` or the safe navigation operator `&.`, even for valid
+ persisted models.
+ - `untyped`: The methods will be generated with `T.untyped` return types. This mode is practical if you are not
+ ready to start typing your models strictly yet, but still want to generate RBI files for them.
+
 For example, with the following model class:
 ~~~rb
 class Post < ActiveRecord::Base
@@ -24,7 +39,7 @@ create_table :posts do |t|
 end
 ~~~
 
-this compiler will produce the following methods in the RBI file
+this compiler will, by default, produce the following methods in the RBI file
 `post.rbi`:
 
 ~~~rbi
@@ -84,4 +99,15 @@ class Post
     ## Also the methods added by https://api.rubyonrails.org/classes/ActiveRecord/AttributeMethods/BeforeTypeCast.html
   end
 end
+~~~
+
+However, if `ActiveRecordColumnTypes` is set to `nilable`, the `title` method will be generated as:
+~~~rbi
+    sig { returns(T.nilable(::String)) }
+    def title; end
+~~~
+and if the option is set to `untyped`, the `title` method will be generated as:
+~~~rbi
+    sig { returns(T.untyped) }
+    def title; end
 ~~~

--- a/spec/tapioca/cli/dsl_spec.rb
+++ b/spec/tapioca/cli/dsl_spec.rb
@@ -2920,7 +2920,7 @@ module Tapioca
           RB
 
           result = @project.tapioca(
-            "dsl Post --only=ActiveRecordColumns --compiler-options='ActiveRecordColumns:{types: untyped}'",
+            "dsl Post --only=ActiveRecordColumns --compiler-options='ActiveRecordColumnTypes:untyped'",
           )
 
           assert_stdout_equals(<<~OUT, result)


### PR DESCRIPTION
I've been thinking about this for a while, and I think namespacing compiler options was a little heavy handed. I've been thinking about cases where a single option might need to be consumed by multiple Active Record compilers, so I think it makes more sense to have a flat hash of options that can be consumed by any compiler.

This makes the code simpler and makes it easier to pass these options on the command line interface, as well.

I've also used this opportunity to improve the documentation, as promised
