### PR TITLE
Optimize `URLHelpers.gather_constants`

### DIFF
--- a/lib/tapioca/dsl/compilers/url_helpers.rb
+++ b/lib/tapioca/dsl/compilers/url_helpers.rb
@@ -106,19 +106,28 @@ module Tapioca
             routes_reloader = Rails.application.routes_reloader
             routes_reloader.execute_unless_loaded if routes_reloader&.respond_to?(:execute_unless_loaded)
 
-            Object.const_set(:GeneratedUrlHelpersModule, Rails.application.routes.named_routes.url_helpers_module)
-            Object.const_set(:GeneratedPathHelpersModule, Rails.application.routes.named_routes.path_helpers_module)
+            url_helpers_module = Rails.application.routes.named_routes.url_helpers_module
+            path_helpers_module = Rails.application.routes.named_routes.path_helpers_module
+
+            Object.const_set(:GeneratedUrlHelpersModule, url_helpers_module)
+            Object.const_set(:GeneratedPathHelpersModule, path_helpers_module)
 
             constants = all_modules.select do |mod|
               next unless name_of(mod)
 
-              includes_helper?(mod, GeneratedUrlHelpersModule) ||
-                includes_helper?(mod, GeneratedPathHelpersModule) ||
-                includes_helper?(mod.singleton_class, GeneratedUrlHelpersModule) ||
-                includes_helper?(mod.singleton_class, GeneratedPathHelpersModule)
+              # Fast-path to quickly disqualify most classes
+              next false unless mod < url_helpers_module || # rubocop:disable Style/InvertibleUnlessCondition
+                mod < path_helpers_module ||
+                mod.singleton_class < url_helpers_module ||
+                mod.singleton_class < path_helpers_module
+
+              includes_helper?(mod, url_helpers_module) ||
+                includes_helper?(mod, path_helpers_module) ||
+                includes_helper?(mod.singleton_class, url_helpers_module) ||
+                includes_helper?(mod.singleton_class, path_helpers_module)
             end
 
-            constants.concat(NON_DISCOVERABLE_INCLUDERS)
+            constants.concat(NON_DISCOVERABLE_INCLUDERS).push(GeneratedUrlHelpersModule, GeneratedPathHelpersModule)
           end
 
           sig { returns(T::Array[Module]) }
@@ -134,17 +143,21 @@ module Tapioca
             end.freeze
           end
 
+          # Returns `true` if `mod` "directly" includes `helper`.
+          # For classes, this method will return false if the `helper` is included only by a superclass
           sig { params(mod: Module, helper: Module).returns(T::Boolean) }
           private def includes_helper?(mod, helper)
-            superclass_ancestors = []
+            ancestors = ancestors_of(mod)
 
-            if Class === mod
-              superclass = superclass_of(mod)
-              superclass_ancestors = ancestors_of(superclass) if superclass
+            own_ancestors = if Class === mod && (superclass = superclass_of(mod))
+              # These ancestors are unique to `mod`, and exclude those in common with `superclass`.
+              ancestors.take(ancestors.count - ancestors_of(superclass).size)
+            else
+              ancestors
             end
 
-            ancestors = Set.new.compare_by_identity.merge(ancestors_of(mod)).subtract(superclass_ancestors)
-            ancestors.any? { |ancestor| helper == ancestor }
+            # Can't use a simple `include?(helper)` because of edge cases like `XPath`, whose `#==` operator misbehaves.
+            own_ancestors.any? { |a| helper == a }
           end
         end
 

--- a/lib/tapioca/dsl/compilers/url_helpers.rb
+++ b/lib/tapioca/dsl/compilers/url_helpers.rb
@@ -115,11 +115,11 @@ module Tapioca
             constants = all_modules.select do |mod|
               next unless name_of(mod)
 
-              # Fast-path to quickly disqualify most classes
-              next false unless mod < url_helpers_module || # rubocop:disable Style/InvertibleUnlessCondition
-                mod < path_helpers_module ||
-                mod.singleton_class < url_helpers_module ||
-                mod.singleton_class < path_helpers_module
+              # Fast-path to quickly disqualify most cases
+              next false unless url_helpers_module > mod || # rubocop:disable Style/InvertibleUnlessCondition
+                path_helpers_module > mod ||
+                url_helpers_module > mod.singleton_class ||
+                path_helpers_module > mod.singleton_class
 
               includes_helper?(mod, url_helpers_module) ||
                 includes_helper?(mod, path_helpers_module) ||
@@ -156,8 +156,7 @@ module Tapioca
               ancestors
             end
 
-            # Can't use a simple `include?(helper)` because of edge cases like `XPath`, whose `#==` operator misbehaves.
-            own_ancestors.any? { |a| helper == a }
+            own_ancestors.include?(helper)
           end
         end
 


### PR DESCRIPTION
### Motivation

Profiling `tapioca DSL SomeConst` identified this method as a hot spot, taking roughly 1 out of the 6 total second spent by Tapioca (not including application load time).

The changes in this PR speed up running `tapioca dsl` against Shopify core by **1 entire second!**

## Benchmark results (writeup WIP)

| run   | gather_constants | User time | Syscall time | Total |
|-------|------------------|-----------|--------------|-------|
| Master          | 2s 350ms | 37s 383ms | 6s 760ms | 33s 10ms  |
| [Original improvements](https://github.com/Shopify/tapioca/commit/2344fdf731b73ad01fd6be71317e57e46518790e)        | 1s 333ms | 36s 383ms | 6s 970ms | 32s 216ms |
| [Ufuk suggestion](https://github.com/Shopify/tapioca/pull/1935/commits/70d7fb5491fe655715da1e7f52dbd8ac1085418e) | 1s 473ms | 36s 593ms | 6s 750ms | 32s 313ms |
| [Final improvement](https://github.com/Shopify/tapioca/pull/1935/commits/ef5e6c9674fb77f59cd2f8a4f1003f83a442d73e) | **1s 330ms** | 35s 533ms | 6s 420ms | **31s 27ms** |
| [Set (dumb)](https://github.com/Shopify/tapioca/compare/70d7fb5491fe655715da1e7f52dbd8ac1085418e..684c6d7a98a612f268f814d8f079f0c6756a216b)      | 1s 530ms | 36s 710ms | 6s 657ms | 32s 308ms |
| [Set (smart)](https://github.com/Shopify/tapioca/compare/70d7fb5491fe655715da1e7f52dbd8ac1085418e..c31a9ef73c59a8965ec0679440b10ee7c3e90379)     | 1s 523ms | 37s 260ms | 6s 770ms | 32s 901ms |

<details><summary>Benchmark run details</summary>

### Master

| run   | gather_constants | User time | Syscall time | Total |
|-------|------------------|-----------|--------------|-------|
| run 1 | 2s 350ms | 37s 420ms | 6s 710ms | 32s 889ms |
| run 2 | 2s 410ms | 37s 210ms | 6s 830ms | 32s 992ms |
| run 3 | 2s 290ms | 37s 520ms | 6s 740ms | 33s 149ms |
|  avg  | 2s 350ms | 37s 383ms | 6s 760ms | 33s 10ms  |

### My original approach

Doesn't handle `prepend`ed modules correctly.

https://github.com/Shopify/tapioca/commit/2344fdf731b73ad01fd6be71317e57e46518790e

| run   | gather_constants | User time | Syscall time | Total |
|-------|------------------|-----------|--------------|-------|
| run 1 | 1s 470ms | 36s 470ms | 7s 70ms  | 32s 523ms |
| run 2 | 1s 500ms | 36s 320ms | 6s 870ms | 32s 118ms |
| run 3 | 1s 30ms  | 36s 360ms | 6s 970ms | 32s 6ms   |
|  avg  | 1s 333ms | 36s 383ms | 6s 970ms | 32s 216ms |

### Ufuk's improvement

Fixes logic for `prepend`ed modules.

https://github.com/Shopify/tapioca/pull/1935/commits/70d7fb5491fe655715da1e7f52dbd8ac1085418e

| run   | gather_constants | User time | Syscall time | Total |
|-------|------------------|-----------|--------------|-------|
| run 1 | 1s 380ms | 36s 650ms | 6s 770ms | 32s 577ms |
| run 2 | 1s 520ms | 36s 560ms | 6s 750ms | 32s 156ms |
| run 3 | 1s 520ms | 36s 570ms | 6s 730ms | 32s 205ms |
|  avg  | 1s 473ms | 36s 593ms | 6s 750ms | 32s 313ms |

### Final improvement

See the commit message of https://github.com/Shopify/tapioca/pull/1935/commits/ef5e6c9674fb77f59cd2f8a4f1003f83a442d73e

| run   | gather_constants | User time | Syscall time | Total |
|-------|------------------|-----------|--------------|-------|
| run 1 | 1s 430ms | 35s 510ms | 6s 430ms | 31s 74ms |
| run 2 | 1s 460ms | 35s 520ms | 6s 340ms | 30s 805ms|
| run 3 | 1s 100ms | 35s 570ms | 6s 490ms | 31s 201ms|
|  avg  | 1s 330ms | 35s 533ms | 6s 420ms | 31s 27ms |

### Using a `Set` (poorly)

Uses a `Set` to accelerate the `.include?` checks. However, since this `Set` isn't reused, the overhead of created it is larger than the benefit of the faster lookup.

https://github.com/Shopify/tapioca/compare/70d7fb5491fe655715da1e7f52dbd8ac1085418e..684c6d7a98a612f268f814d8f079f0c6756a216b

| run   | gather_constants | User time | Syscall time | Total |
|-------|------------------|-----------|--------------|-------|
| run 1 | 1s 570ms | 36s 930ms | 6s 760ms | 32s 716ms |
| run 2 | 1s 520ms | 36s 580ms | 6s 650ms | 32s 6ms   |
| run 3 | 1s 500ms | 36s 620ms | 6s 560ms | 32s 202ms |
|  avg  | 1s 530ms | 36s 710ms | 6s 657ms | 32s 308ms |

### Using a set (properly)

Ammortize the `Set` construction over two consecutive `.include?` checks

https://github.com/Shopify/tapioca/compare/70d7fb5491fe655715da1e7f52dbd8ac1085418e..c31a9ef73c59a8965ec0679440b10ee7c3e90379

| run   | gather_constants | User time | Syscall time | Total |
|-------|------------------|-----------|--------------|-------|
| run 1 | 1s 570ms | 37s 600ms | 6s 810ms | 33s 341ms |
| run 2 | 1s 550ms | 37s 230ms | 6s 780ms | 32s 985ms |
| run 3 | 1s 450ms | 36s 950ms | 6s 720ms | 32s 378ms |
|  avg  | 1s 523ms | 37s 260ms | 6s 770ms | 32s 901ms |

</details>


<details><summary>other toy micro-benchmarks</summary>

```ruby
#!/usr/bin/ruby

#require "awesome_print"
#require "active_support/all"
require "benchmark/ips"

module HelloWorld
  def hello_world!
    puts "Hello, word!"
  end
end

class GrandParent; end

class Parent < GrandParent; end

class Child < Parent
  include HelloWorld
end

module Unrelated; end

def ancestors_of(mod) = mod.ancestors
def superclass_of(cls) = cls.superclass

def includes_helper?(mod, helper)
  superclass_ancestors = []
  
  if Class === mod
    superclass = superclass_of(mod)
    superclass_ancestors = ancestors_of(superclass) if superclass
  end
  
  ancestors = Set.new.compare_by_identity.merge(ancestors_of(mod)).subtract(superclass_ancestors)
  ancestors.any? { |ancestor| helper == ancestor }
end

def includes_helper_2?(mod, helper)
  if Class === mod
    superclass = superclass_of(mod)
    ancestors_of(mod).take_while { |a| !superclass.equal?(a) }.include?(helper)
  else
    ancestors_of(mod).include?(helper)
  end
end

def includes_helper_3?(mod, helper)
  return ancestors_of(mod).include?(helper) unless Class === mod

  superclass = superclass_of(mod)

  ancestors_of(mod).each do |a|
    return true if helper.equal?(a)
    return false if superclass.equal?(a)
  end

  false
end

def direct_ancestors_of(mod)
  if Class === mod
    superclass = superclass_of(mod)
    ancestors_of(mod).take_while { |a| !superclass.equal?(a) }
  else
    ancestors_of(mod)
  end
end

Benchmark.ips do |x|
  x.config(warmup: 1, time: 5)
  
  x.report("original") do |times|
    i = 0
    while (i += 1) < times
      includes_helper?(Child, HelloWorld)
      includes_helper?(Child, Unrelated)
    end
  end
  
  x.report("variant 2") do |times|
    i = 0
    while (i += 1) < times
      includes_helper_2?(Child, HelloWorld)
      includes_helper_2?(Child, Unrelated)
    end
  end
  
  x.report("variant 3") do |times|
    i = 0
    while (i += 1) < times
      includes_helper_3?(Child, HelloWorld)
      includes_helper_3?(Child, Unrelated)
    end
  end
  
  x.report("direct_ancestors_of") do |times|
    i = 0
    while (i += 1) < times
      direct_ancestors = direct_ancestors_of(Child)
      direct_ancestors.include?(HelloWorld)
      direct_ancestors.include?(Unrelated)
    end
  end
  
  x.compare!
end
```

</details>