### PR TITLE
In ActiveRecordColumns persisted mode, remove T.nilable from reflected sigs

### DIFF
--- a/lib/tapioca/dsl/helpers/active_record_column_type_helper.rb
+++ b/lib/tapioca/dsl/helpers/active_record_column_type_helper.rb
@@ -114,7 +114,10 @@ module Tapioca
             end
 
           if @column_type_option.persisted? && !column&.null
-            [getter_type, setter_type]
+            # It's possible that when ActiveModel::Type::Value is used, the signature being reflected on in
+            # ActiveModelTypeHelper.type_for(type_value) may say the type can be nilable. However, if the type is
+            # persisted and the column is not nullable, we can assume it's not nilable.
+            [as_non_nilable_type(getter_type), as_non_nilable_type(setter_type)]
           else
             getter_type = as_nilable_type(getter_type) unless not_nilable_serialized_column?(column_type)
             [getter_type, as_nilable_type(setter_type)]

--- a/spec/tapioca/dsl/compilers/active_record_columns_spec.rb
+++ b/spec/tapioca/dsl/compilers/active_record_columns_spec.rb
@@ -984,6 +984,53 @@ module Tapioca
                 assert_includes(rbi_for(:Post), expected)
               end
 
+              it "strips T.nilable from reflected signatures method for non-nilable columns in persisted mode" do
+                add_ruby_file("schema.rb", <<~RUBY)
+                  ActiveRecord::Migration.suppress_messages do
+                    ActiveRecord::Schema.define do
+                      create_table :posts do |t|
+                        t.decimal :cost, null: false
+                      end
+                    end
+                  end
+                RUBY
+
+                add_ruby_file("custom_type.rb", <<~RUBY)
+                  class CustomType
+                    attr_accessor :value
+
+                    def initialize(number = 0.0)
+                      @value = number
+                    end
+
+                    class Type < ActiveRecord::Type::Value
+                      extend(T::Sig)
+
+                      sig { params(value: T.nilable(Numeric)).returns(T.nilable(::CustomType))}
+                      def deserialize(value)
+                        CustomType.new(value) if value
+                      end
+                    end
+                  end
+                RUBY
+
+                add_ruby_file("post.rb", <<~RUBY)
+                  class Post < ActiveRecord::Base
+                    attribute :cost, CustomType::Type.new
+                  end
+                RUBY
+
+                expected = indented(<<~RBI, 4)
+                  sig { returns(::CustomType) }
+                  def cost; end
+
+                  sig { params(value: ::CustomType).returns(::CustomType) }
+                  def cost=(value); end
+                RBI
+
+                assert_includes(rbi_for(:Post), expected)
+              end
+
               it "generates id accessors when primary key isn't id" do
                 add_ruby_file("schema.rb", <<~RUBY)
                   ActiveRecord::Migration.suppress_messages do


### PR DESCRIPTION
### Motivation

We use types inheriting from `ActiveModel::Type::Value` where the `deserialize` sig says it returns `T.nilable([custom type])`. However when using the new dsl `persisted` mode, we can assume the type won't be nilable.

### Implementation

Apply `as_non_nilable_type` to `getter_type` and `setter_type` only in persisted mode and when the column is not nullable.

### Tests

I've added tests.
