### PR TITLE
Generate correct return types in IdentityCache compiler

### DIFF
--- a/lib/tapioca/dsl/compilers/identity_cache.rb
+++ b/lib/tapioca/dsl/compilers/identity_cache.rb
@@ -231,7 +231,7 @@ module Tapioca
             "fetch_#{suffix}",
             class_method: true,
             parameters: parameters,
-            return_type: type,
+            return_type: field.unique ? type : COLLECTION_TYPE.call(type),
           )
 
           klass.create_method(

--- a/spec/tapioca/dsl/compilers/identity_cache_spec.rb
+++ b/spec/tapioca/dsl/compilers/identity_cache_spec.rb
@@ -90,10 +90,10 @@ module Tapioca
                     sig { params(title: T.untyped, includes: T.untyped).returns(T::Array[::Post]) }
                     def fetch_by_title(title, includes: nil); end
 
-                    sig { params(blog_id: T.untyped).returns(T.nilable(::Integer)) }
+                    sig { params(blog_id: T.untyped).returns(T::Array[::T.nilable(::Integer)]) }
                     def fetch_id_by_blog_id(blog_id); end
 
-                    sig { params(title: T.untyped).returns(T.nilable(::Integer)) }
+                    sig { params(title: T.untyped).returns(T::Array[::T.nilable(::Integer)]) }
                     def fetch_id_by_title(title); end
 
                     sig { params(index_values: T::Enumerable[T.untyped], includes: T.untyped).returns(T::Array[::Post]) }
@@ -148,7 +148,7 @@ module Tapioca
                     sig { params(title: T.untyped, includes: T.untyped).returns(::Post) }
                     def fetch_by_title!(title, includes: nil); end
 
-                    sig { params(blog_id: T.untyped).returns(T.nilable(::Integer)) }
+                    sig { params(blog_id: T.untyped).returns(T::Array[::T.nilable(::Integer)]) }
                     def fetch_id_by_blog_id(blog_id); end
 
                     sig { params(title: T.untyped).returns(T.nilable(::Integer)) }
@@ -199,7 +199,7 @@ module Tapioca
                     sig { params(blog_id: T.untyped, title: T.untyped, includes: T.untyped).returns(T::Array[::Post]) }
                     def fetch_by_blog_id_and_title(blog_id, title, includes: nil); end
 
-                    sig { params(blog_id: T.untyped, title: T.untyped).returns(T.nilable(::Integer)) }
+                    sig { params(blog_id: T.untyped, title: T.untyped).returns(T::Array[::T.nilable(::Integer)]) }
                     def fetch_id_by_blog_id_and_title(blog_id, title); end
 
                     sig { params(index_values: T::Enumerable[T.untyped], includes: T.untyped).returns(T::Array[::Post]) }
@@ -248,7 +248,7 @@ module Tapioca
                     sig { params(title: T.untyped, review_date: T.untyped, includes: T.untyped).returns(::Post) }
                     def fetch_by_title_and_review_date!(title, review_date, includes: nil); end
 
-                    sig { params(title: T.untyped).returns(T.nilable(::Integer)) }
+                    sig { params(title: T.untyped).returns(T::Array[::T.nilable(::Integer)]) }
                     def fetch_id_by_title(title); end
 
                     sig { params(title: T.untyped, review_date: T.untyped).returns(T.nilable(::Integer)) }


### PR DESCRIPTION
There is a difference in behavior between the return types of the existing IdentityCache compiler and how IdentityCache compiler actually works.

In the aliased fetch methods,[ IdentityCache will return an array unless the field has the `unique` property](https://github.com/Shopify/identity_cache/blob/main/lib/identity_cache/cached/attribute.rb#L63), even if it is not a multi-type. Previously, our IdentityCache compiler was always setting the return type as a single object for those methods.