### PR TITLE
Fix ActiveRecordRelations compiler to dedup #all

### DIFF
--- a/lib/tapioca/dsl/compilers/active_record_relations.rb
+++ b/lib/tapioca/dsl/compilers/active_record_relations.rb
@@ -190,7 +190,7 @@ module Tapioca
             # Grab all Spawn methods
             query_methods |= ActiveRecord::SpawnMethods.instance_methods(false)
             # Remove the ones we know are private API
-            query_methods -= [:arel, :build_subquery, :construct_join_dependency, :extensions, :spawn]
+            query_methods -= [:all, :arel, :build_subquery, :construct_join_dependency, :extensions, :spawn]
             # Remove "group" which needs a custom return type for GroupChains
             query_methods -= [:group]
             # Remove "where" which needs a custom return type for WhereChains


### PR DESCRIPTION
### Motivation

Rails head has been updated to include `#all` under `ActiveRecord::QueryMethods` ([source](https://github.com/rails/rails/commit/fd5bd98b34774ec8ccb0fc649d5325b9ac9a875e#diff-79b53b2602bf702bdd8ce677e096be6a6923a54236e17237c16068a510078683R258-R261)).

### Implementation

I had tried to update the `QUERY_METHODS` constant to remove the intersection with `ActiveRecord::AssociationRelation.instance_methods` as that is where all is originally coming from, but this was over zealous causing a bunch of errors.

The option I've gone with is to update the ones removed as "private api" since they overlap with what is [done in Rails](https://github.com/rails/rails/commit/fd5bd98b34774ec8ccb0fc649d5325b9ac9a875e#diff-2d6b8d6b15542ae5c458ef5663a0e5f1a0178ec66455571839256d8b75d4939dR65): 
https://github.com/Shopify/tapioca/blob/d652d570b0d73aca16edb2927163f369c3dddeba/lib/tapioca/dsl/compilers/active_record_relations.rb#L194

### Tests

Tested against rails head.

