### PR TITLE
Fix AASM compiler's global callback method signatures

### DIFF
--- a/lib/tapioca/dsl/compilers/aasm.rb
+++ b/lib/tapioca/dsl/compilers/aasm.rb
@@ -147,7 +147,7 @@ module Tapioca
                 machine.create_method(
                   method,
                   parameters: [
-                    create_opt_param("symbol", type: "T.nilable(Symbol)", default: "nil"),
+                    create_rest_param("callbacks", type: "T.untyped"),
                     create_block_param("block", type: "T.nilable(T.proc.bind(#{constant_name}).void)"),
                   ],
                 )

--- a/lib/tapioca/dsl/compilers/aasm.rb
+++ b/lib/tapioca/dsl/compilers/aasm.rb
@@ -147,7 +147,7 @@ module Tapioca
                 machine.create_method(
                   method,
                   parameters: [
-                    create_rest_param("callbacks", type: "T.untyped"),
+                    create_rest_param("callbacks", type: "T.any(String, Symbol, T::Class[T.anything], Proc)"),
                     create_block_param("block", type: "T.nilable(T.proc.bind(#{constant_name}).void)"),
                   ],
                 )

--- a/spec/tapioca/dsl/compilers/aasm_spec.rb
+++ b/spec/tapioca/dsl/compilers/aasm_spec.rb
@@ -100,25 +100,25 @@ module Tapioca
                   end
 
                   class PrivateAASMMachine < AASM::Base
-                    sig { params(callbacks: T.untyped, block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
+                    sig { params(callbacks: T.any(String, Symbol, T::Class[T.anything], Proc), block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
                     def after_all_events(*callbacks, &block); end
 
-                    sig { params(callbacks: T.untyped, block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
+                    sig { params(callbacks: T.any(String, Symbol, T::Class[T.anything], Proc), block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
                     def after_all_transactions(*callbacks, &block); end
 
-                    sig { params(callbacks: T.untyped, block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
+                    sig { params(callbacks: T.any(String, Symbol, T::Class[T.anything], Proc), block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
                     def after_all_transitions(*callbacks, &block); end
 
-                    sig { params(callbacks: T.untyped, block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
+                    sig { params(callbacks: T.any(String, Symbol, T::Class[T.anything], Proc), block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
                     def before_all_events(*callbacks, &block); end
 
-                    sig { params(callbacks: T.untyped, block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
+                    sig { params(callbacks: T.any(String, Symbol, T::Class[T.anything], Proc), block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
                     def before_all_transactions(*callbacks, &block); end
 
-                    sig { params(callbacks: T.untyped, block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
+                    sig { params(callbacks: T.any(String, Symbol, T::Class[T.anything], Proc), block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
                     def ensure_on_all_events(*callbacks, &block); end
 
-                    sig { params(callbacks: T.untyped, block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
+                    sig { params(callbacks: T.any(String, Symbol, T::Class[T.anything], Proc), block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
                     def error_on_all_events(*callbacks, &block); end
 
                     sig { params(name: T.untyped, options: T.untyped, block: T.proc.bind(PrivateAASMEvent).void).returns(T.untyped) }
@@ -224,25 +224,25 @@ module Tapioca
                   end
 
                   class PrivateAASMMachine < AASM::Base
-                    sig { params(callbacks: T.untyped, block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
+                    sig { params(callbacks: T.any(String, Symbol, T::Class[T.anything], Proc), block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
                     def after_all_events(*callbacks, &block); end
 
-                    sig { params(callbacks: T.untyped, block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
+                    sig { params(callbacks: T.any(String, Symbol, T::Class[T.anything], Proc), block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
                     def after_all_transactions(*callbacks, &block); end
 
-                    sig { params(callbacks: T.untyped, block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
+                    sig { params(callbacks: T.any(String, Symbol, T::Class[T.anything], Proc), block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
                     def after_all_transitions(*callbacks, &block); end
 
-                    sig { params(callbacks: T.untyped, block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
+                    sig { params(callbacks: T.any(String, Symbol, T::Class[T.anything], Proc), block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
                     def before_all_events(*callbacks, &block); end
 
-                    sig { params(callbacks: T.untyped, block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
+                    sig { params(callbacks: T.any(String, Symbol, T::Class[T.anything], Proc), block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
                     def before_all_transactions(*callbacks, &block); end
 
-                    sig { params(callbacks: T.untyped, block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
+                    sig { params(callbacks: T.any(String, Symbol, T::Class[T.anything], Proc), block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
                     def ensure_on_all_events(*callbacks, &block); end
 
-                    sig { params(callbacks: T.untyped, block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
+                    sig { params(callbacks: T.any(String, Symbol, T::Class[T.anything], Proc), block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
                     def error_on_all_events(*callbacks, &block); end
 
                     sig { params(name: T.untyped, options: T.untyped, block: T.proc.bind(PrivateAASMEvent).void).returns(T.untyped) }
@@ -351,25 +351,25 @@ module Tapioca
                   end
 
                   class PrivateAASMMachine < AASM::Base
-                    sig { params(callbacks: T.untyped, block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
+                    sig { params(callbacks: T.any(String, Symbol, T::Class[T.anything], Proc), block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
                     def after_all_events(*callbacks, &block); end
 
-                    sig { params(callbacks: T.untyped, block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
+                    sig { params(callbacks: T.any(String, Symbol, T::Class[T.anything], Proc), block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
                     def after_all_transactions(*callbacks, &block); end
 
-                    sig { params(callbacks: T.untyped, block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
+                    sig { params(callbacks: T.any(String, Symbol, T::Class[T.anything], Proc), block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
                     def after_all_transitions(*callbacks, &block); end
 
-                    sig { params(callbacks: T.untyped, block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
+                    sig { params(callbacks: T.any(String, Symbol, T::Class[T.anything], Proc), block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
                     def before_all_events(*callbacks, &block); end
 
-                    sig { params(callbacks: T.untyped, block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
+                    sig { params(callbacks: T.any(String, Symbol, T::Class[T.anything], Proc), block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
                     def before_all_transactions(*callbacks, &block); end
 
-                    sig { params(callbacks: T.untyped, block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
+                    sig { params(callbacks: T.any(String, Symbol, T::Class[T.anything], Proc), block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
                     def ensure_on_all_events(*callbacks, &block); end
 
-                    sig { params(callbacks: T.untyped, block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
+                    sig { params(callbacks: T.any(String, Symbol, T::Class[T.anything], Proc), block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
                     def error_on_all_events(*callbacks, &block); end
 
                     sig { params(name: T.untyped, options: T.untyped, block: T.proc.bind(PrivateAASMEvent).void).returns(T.untyped) }

--- a/spec/tapioca/dsl/compilers/aasm_spec.rb
+++ b/spec/tapioca/dsl/compilers/aasm_spec.rb
@@ -100,26 +100,26 @@ module Tapioca
                   end
 
                   class PrivateAASMMachine < AASM::Base
-                    sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
-                    def after_all_events(symbol = nil, &block); end
+                    sig { params(callbacks: T.untyped, block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
+                    def after_all_events(*callbacks, &block); end
 
-                    sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
-                    def after_all_transactions(symbol = nil, &block); end
+                    sig { params(callbacks: T.untyped, block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
+                    def after_all_transactions(*callbacks, &block); end
 
-                    sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
-                    def after_all_transitions(symbol = nil, &block); end
+                    sig { params(callbacks: T.untyped, block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
+                    def after_all_transitions(*callbacks, &block); end
 
-                    sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
-                    def before_all_events(symbol = nil, &block); end
+                    sig { params(callbacks: T.untyped, block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
+                    def before_all_events(*callbacks, &block); end
 
-                    sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
-                    def before_all_transactions(symbol = nil, &block); end
+                    sig { params(callbacks: T.untyped, block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
+                    def before_all_transactions(*callbacks, &block); end
 
-                    sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
-                    def ensure_on_all_events(symbol = nil, &block); end
+                    sig { params(callbacks: T.untyped, block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
+                    def ensure_on_all_events(*callbacks, &block); end
 
-                    sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
-                    def error_on_all_events(symbol = nil, &block); end
+                    sig { params(callbacks: T.untyped, block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
+                    def error_on_all_events(*callbacks, &block); end
 
                     sig { params(name: T.untyped, options: T.untyped, block: T.proc.bind(PrivateAASMEvent).void).returns(T.untyped) }
                     def event(name, options = nil, &block); end
@@ -224,26 +224,26 @@ module Tapioca
                   end
 
                   class PrivateAASMMachine < AASM::Base
-                    sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
-                    def after_all_events(symbol = nil, &block); end
+                    sig { params(callbacks: T.untyped, block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
+                    def after_all_events(*callbacks, &block); end
 
-                    sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
-                    def after_all_transactions(symbol = nil, &block); end
+                    sig { params(callbacks: T.untyped, block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
+                    def after_all_transactions(*callbacks, &block); end
 
-                    sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
-                    def after_all_transitions(symbol = nil, &block); end
+                    sig { params(callbacks: T.untyped, block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
+                    def after_all_transitions(*callbacks, &block); end
 
-                    sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
-                    def before_all_events(symbol = nil, &block); end
+                    sig { params(callbacks: T.untyped, block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
+                    def before_all_events(*callbacks, &block); end
 
-                    sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
-                    def before_all_transactions(symbol = nil, &block); end
+                    sig { params(callbacks: T.untyped, block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
+                    def before_all_transactions(*callbacks, &block); end
 
-                    sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
-                    def ensure_on_all_events(symbol = nil, &block); end
+                    sig { params(callbacks: T.untyped, block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
+                    def ensure_on_all_events(*callbacks, &block); end
 
-                    sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
-                    def error_on_all_events(symbol = nil, &block); end
+                    sig { params(callbacks: T.untyped, block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
+                    def error_on_all_events(*callbacks, &block); end
 
                     sig { params(name: T.untyped, options: T.untyped, block: T.proc.bind(PrivateAASMEvent).void).returns(T.untyped) }
                     def event(name, options = nil, &block); end
@@ -351,26 +351,26 @@ module Tapioca
                   end
 
                   class PrivateAASMMachine < AASM::Base
-                    sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
-                    def after_all_events(symbol = nil, &block); end
+                    sig { params(callbacks: T.untyped, block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
+                    def after_all_events(*callbacks, &block); end
 
-                    sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
-                    def after_all_transactions(symbol = nil, &block); end
+                    sig { params(callbacks: T.untyped, block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
+                    def after_all_transactions(*callbacks, &block); end
 
-                    sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
-                    def after_all_transitions(symbol = nil, &block); end
+                    sig { params(callbacks: T.untyped, block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
+                    def after_all_transitions(*callbacks, &block); end
 
-                    sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
-                    def before_all_events(symbol = nil, &block); end
+                    sig { params(callbacks: T.untyped, block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
+                    def before_all_events(*callbacks, &block); end
 
-                    sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
-                    def before_all_transactions(symbol = nil, &block); end
+                    sig { params(callbacks: T.untyped, block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
+                    def before_all_transactions(*callbacks, &block); end
 
-                    sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
-                    def ensure_on_all_events(symbol = nil, &block); end
+                    sig { params(callbacks: T.untyped, block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
+                    def ensure_on_all_events(*callbacks, &block); end
 
-                    sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
-                    def error_on_all_events(symbol = nil, &block); end
+                    sig { params(callbacks: T.untyped, block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
+                    def error_on_all_events(*callbacks, &block); end
 
                     sig { params(name: T.untyped, options: T.untyped, block: T.proc.bind(PrivateAASMEvent).void).returns(T.untyped) }
                     def event(name, options = nil, &block); end


### PR DESCRIPTION
### Motivation

AASM global callbacks takes splat argument as first argument instead of a nilable symbol: https://github.com/aasm/aasm/blob/0e03746a2b86558ee1bf7bd7db873938cbb3b29b/lib/aasm/base.rb#L145-L171

### Implementation

Change AASM compiler to use correct params definition.

### Tests

Added accordingly. 

