### PR TITLE
Fix the types for state-machine states

### DIFF
--- a/lib/tapioca/dsl/compilers/state_machines.rb
+++ b/lib/tapioca/dsl/compilers/state_machines.rb
@@ -231,12 +231,12 @@ module Tapioca
           instance_module.create_method(
             attribute,
             return_type: state_type,
-          )
+          ) if ::StateMachines::HelperModule === machine.owner_class.instance_method(attribute).owner
           instance_module.create_method(
             "#{attribute}=",
             parameters: [create_param("value", type: state_type)],
             return_type: state_type,
-          )
+          ) if ::StateMachines::HelperModule === machine.owner_class.instance_method("#{attribute}=").owner
         end
 
         sig { params(instance_module: RBI::Module, machine: ::StateMachines::Machine).void }

--- a/spec/tapioca/dsl/compilers/state_machines_spec.rb
+++ b/spec/tapioca/dsl/compilers/state_machines_spec.rb
@@ -312,6 +312,44 @@ module Tapioca
 
               assert_includes(rbi_for(:Vehicle), expected)
             end
+
+            it "generates an RBI with no machine state reader if reader defined on class" do
+              add_ruby_file("vehicle.rb", <<~RUBY)
+                class Vehicle
+                  attr_reader :state
+                  state_machine :state
+                end
+              RUBY
+
+              reader = indented(<<~RBI, 4)
+                def state; end
+              RBI
+              refute_includes(rbi_for(:Vehicle), reader)
+
+              writer = indented(<<~RBI, 4)
+                def state=(value); end
+              RBI
+              assert_includes(rbi_for(:Vehicle), writer)
+            end
+
+            it "generates an RBI with no machine state writer if writer defined on class" do
+              add_ruby_file("vehicle.rb", <<~RUBY)
+                class Vehicle
+                  attr_writer :state
+                  state_machine :state
+                end
+              RUBY
+
+              reader = indented(<<~RBI, 4)
+                def state; end
+              RBI
+              assert_includes(rbi_for(:Vehicle), reader)
+
+              writer = indented(<<~RBI, 4)
+                def state=(value); end
+              RBI
+              refute_includes(rbi_for(:Vehicle), writer)
+            end
           end
         end
       end


### PR DESCRIPTION
### Motivation

When using the state machine gem it is encouraged to use either `String` or `Symbol` for state types, but this isn't strictly enforced. 

```ruby
class Vehicle
  ACTIVE = 1
  OFF = 0

  state_machine :alarm_state, initial: ACTIVE do
    before_transition any => ACTIVE do |unit|
      unit.some_cool_method_at = Time.now.utc
    end

    event :enable do
      transition all => ACTIVE
    end

    event :disable do
      transition all => OFF
    end

    state ACTIVE
    state OFF
  end
end
```
If someone were to use a different type like in this example, the type generated for `alarm_state=` would still be `T.any(String, Symbol)` despite actually wanting `Integer`. There are a few other methods that suffer this as well.

This stems from using `State#value` to determine the states to use. This value is set as a `to_s` version of the name unless otherwise specified ([source](https://github.com/state-machines/state_machines/blob/e9f212ab0342494d2741008603be344d21c462ef/lib/state_machines/state.rb#L60)). What this means practically is that if in the example above someone were to write `vehicle.alarm_state = Vehicle::OFF` they would get an error.

It appears as though everything is triple indexed, once by raw value of `name` then by the string and symbol versions too ([source](https://github.com/state-machines/state_machines/blob/e9f212ab0342494d2741008603be344d21c462ef/lib/state_machines/node_collection.rb#L182-L186)). So this is how it still allows it to work despite having `value` set to the stringified version.

### Implementation

I've updated the `#state_type_for` method to use `name` instead of `value` to get the correct type. This is then passed into wherever it is needed to properly validate. 

I'd originally check if the `value` is a string version of `name` and if so returning `name` instead, but this doesn't work for cases where `value` is provided to the state, like so:
```ruby
state_machine do
  state :active, :value => 1
end
```
This would then fail because value would be the `Integer` value of `1` causing `Integer` to be the type for `state=` which won't work for `state = :inactive`.

### Question for reviewers

I've been pondering if the `state` methods for the machine should also include `String` and `Symbol` by default because they _can_ have those. I'm leaning toward the current implementation because if all states are defined with a single type then it shouldn't expect any others. Are there any thoughts on this?

### Tests

Test added for new case.
