### PR TITLE
Allow the `default_command` displayed on failure to be overridden at the command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ Options:
                                                                                                      # Default: development
                [--halt-upon-load-error], [--no-halt-upon-load-error], [--skip-halt-upon-load-error]  # Halt upon a load error while loading the Rails application
                                                                                                      # Default: true
+               [--default-command-override=DEFAULT_COMMAND_OVERRIDE]                                 # Override the default command printed on failure
   -c,          [--config=<config file path>]                                                         # Path to the Tapioca configuration file
                                                                                                      # Default: sorbet/tapioca/config.yml
   -V,          [--verbose], [--no-verbose], [--skip-verbose]                                         # Verbose output for debugging purposes
@@ -367,17 +368,18 @@ Usage:
   tapioca annotations
 
 Options:
-               [--sources=one two three]                      # URIs of the sources to pull gem RBI annotations from
-                                                              # Default: "https://raw.githubusercontent.com/Shopify/rbi-central/main"
-               [--netrc], [--no-netrc], [--skip-netrc]        # Use .netrc to authenticate to private sources
-                                                              # Default: true
-               [--netrc-file=NETRC_FILE]                      # Path to .netrc file
-               [--auth=AUTH]                                  # HTTP authorization header for private sources
-  --typed, -t, [--typed-overrides=gem:level [gem:level ...]]  # Override for typed sigils for pulled annotations
-  -c,          [--config=<config file path>]                  # Path to the Tapioca configuration file
-                                                              # Default: sorbet/tapioca/config.yml
-  -V,          [--verbose], [--no-verbose], [--skip-verbose]  # Verbose output for debugging purposes
-                                                              # Default: false
+               [--sources=one two three]                              # URIs of the sources to pull gem RBI annotations from
+                                                                      # Default: "https://raw.githubusercontent.com/Shopify/rbi-central/main"
+               [--netrc], [--no-netrc], [--skip-netrc]                # Use .netrc to authenticate to private sources
+                                                                      # Default: true
+               [--netrc-file=NETRC_FILE]                              # Path to .netrc file
+               [--auth=AUTH]                                          # HTTP authorization header for private sources
+  --typed, -t, [--typed-overrides=gem:level [gem:level ...]]          # Override for typed sigils for pulled annotations
+               [--default-command-override=DEFAULT_COMMAND_OVERRIDE]  # Override the default command printed on failure
+  -c,          [--config=<config file path>]                          # Path to the Tapioca configuration file
+                                                                      # Default: sorbet/tapioca/config.yml
+  -V,          [--verbose], [--no-verbose], [--skip-verbose]          # Verbose output for debugging purposes
+                                                                      # Default: false
 
 Pull gem RBI annotations from remote sources
 ```
@@ -503,6 +505,7 @@ Options:
                                                                                                    # Default: true
              [--skip-constant=constant [constant ...]]                                             # Do not generate RBI definitions for the given application constant(s)
              [--compiler-options=key:value]                                                        # Options to pass to the DSL compilers
+             [--default-command-override=DEFAULT_COMMAND_OVERRIDE]                                 # Override the default command printed on failure
   -c,        [--config=<config file path>]                                                         # Path to the Tapioca configuration file
                                                                                                    # Default: sorbet/tapioca/config.yml
   -V,        [--verbose], [--no-verbose], [--skip-verbose]                                         # Verbose output for debugging purposes
@@ -939,9 +942,11 @@ The full configuration file, with each option and its default value, would look 
 ---
 require:
   postrequire: sorbet/tapioca/require.rb
+  default_command_override: ''
 todo:
   todo_file: sorbet/rbi/todo.rbi
   file_header: true
+  default_command_override: ''
 dsl:
   outdir: sorbet/rbi/dsl
   file_header: true
@@ -957,6 +962,7 @@ dsl:
   halt_upon_load_error: true
   skip_constant: []
   compiler_options: {}
+  default_command_override: ''
 gem:
   outdir: sorbet/rbi/gems
   file_header: true
@@ -977,6 +983,7 @@ gem:
   rbi_max_line_length: 120
   environment: development
   halt_upon_load_error: true
+  default_command_override: ''
 check_shims:
   gem_rbi_dir: sorbet/rbi/gems
   dsl_rbi_dir: sorbet/rbi/dsl
@@ -991,6 +998,7 @@ annotations:
   netrc: true
   netrc_file: ''
   typed_overrides: {}
+  default_command_override: ''
 ```
 <!-- END_CONFIG_TEMPLATE -->
 

--- a/lib/tapioca/cli.rb
+++ b/lib/tapioca/cli.rb
@@ -36,6 +36,7 @@ module Tapioca
       Commands::Todo.new(
         todo_file: DEFAULT_TODO_FILE,
         file_header: true,
+        default_command_override: nil,
       ).run
 
       print_init_next_steps
@@ -43,21 +44,25 @@ module Tapioca
 
     desc "configure", "Initialize folder structure and type checking configuration"
     option :postrequire, type: :string, default: DEFAULT_POSTREQUIRE_FILE
+    option :default_command_override, type: :string, desc: "Override the default command printed on failure"
     def configure
       command = Commands::Configure.new(
         sorbet_config: SORBET_CONFIG_FILE,
         tapioca_config: options[:config],
         default_postrequire: options[:postrequire],
+        default_command_override: options[:default_command_override],
       )
       command.run
     end
 
     desc "require", "Generate the list of files to be required by tapioca"
     option :postrequire, type: :string, default: DEFAULT_POSTREQUIRE_FILE
+    option :default_command_override, type: :string, desc: "Override the default command printed on failure"
     def require
       command = Commands::Require.new(
         requires_path: options[:postrequire],
         sorbet_config_path: SORBET_CONFIG_FILE,
+        default_command_override: options[:default_command_override],
       )
       command.run
     end
@@ -71,10 +76,12 @@ module Tapioca
       type: :boolean,
       desc: FILE_HEADER_OPTION_DESC,
       default: true
+    option :default_command_override, type: :string, desc: "Override the default command printed on failure"
     def todo
       command = Commands::Todo.new(
         todo_file: options[:todo_file],
         file_header: options[:file_header],
+        default_command_override: options[:default_command_override],
       )
       command.run_with_deprecation
     end
@@ -144,6 +151,7 @@ module Tapioca
       type: :hash,
       desc: "Options to pass to the DSL compilers",
       default: {}
+    option :default_command_override, type: :string, desc: "Override the default command printed on failure"
     def dsl(*constant_or_paths)
       set_environment(options)
 
@@ -166,6 +174,7 @@ module Tapioca
         app_root: options[:app_root],
         halt_upon_load_error: options[:halt_upon_load_error],
         compiler_options: options[:compiler_options],
+        default_command_override: options[:default_command_override],
       }
 
       command = if options[:verify]
@@ -261,6 +270,7 @@ module Tapioca
       type: :boolean,
       desc: "Halt upon a load error while loading the Rails application",
       default: true
+    option :default_command_override, type: :string, desc: "Override the default command printed on failure"
     def gem(*gems)
       set_environment(options)
 
@@ -295,6 +305,7 @@ module Tapioca
         dsl_dir: options[:dsl_dir],
         rbi_formatter: rbi_formatter(options),
         halt_upon_load_error: options[:halt_upon_load_error],
+        default_command_override: options[:default_command_override],
       }
 
       command = if verify
@@ -326,6 +337,7 @@ module Tapioca
         todo_rbi_file: options[:todo_rbi_file],
         payload: options[:payload],
         number_of_workers: options[:workers],
+        default_command_override: nil,
       )
 
       command.run
@@ -345,6 +357,7 @@ module Tapioca
       banner: "gem:level [gem:level ...]",
       desc: "Override for typed sigils for pulled annotations",
       default: {}
+    option :default_command_override, type: :string, desc: "Override the default command printed on failure"
     def annotations
       if !options[:netrc] && options[:netrc_file]
         raise Thor::Error, set_color("Options `--no-netrc` and `--netrc-file` can't be used together", :bold, :red)
@@ -355,6 +368,7 @@ module Tapioca
         auth: options[:auth],
         netrc_file: netrc_file(options),
         typed_overrides: options[:typed_overrides],
+        default_command_override: options[:default_command_override],
       )
 
       command.run

--- a/lib/tapioca/commands/abstract_dsl.rb
+++ b/lib/tapioca/commands/abstract_dsl.rb
@@ -18,6 +18,7 @@ module Tapioca
           exclude: T::Array[String],
           file_header: T::Boolean,
           tapioca_path: String,
+          default_command_override: T.nilable(String),
           skip_constant: T::Array[String],
           quiet: T::Boolean,
           verbose: T::Boolean,
@@ -38,6 +39,7 @@ module Tapioca
         exclude:,
         file_header:,
         tapioca_path:,
+        default_command_override: nil,
         skip_constant: [],
         quiet: false,
         verbose: false,
@@ -67,7 +69,7 @@ module Tapioca
         @skip_constant = skip_constant
         @compiler_options = compiler_options
 
-        super()
+        super(default_command_override: default_command_override)
       end
 
       private

--- a/lib/tapioca/commands/abstract_gem.rb
+++ b/lib/tapioca/commands/abstract_gem.rb
@@ -22,6 +22,7 @@ module Tapioca
           include_doc: T::Boolean,
           include_loc: T::Boolean,
           include_exported_rbis: T::Boolean,
+          default_command_override: T.nilable(String),
           number_of_workers: T.nilable(Integer),
           auto_strictness: T::Boolean,
           dsl_dir: String,
@@ -41,6 +42,7 @@ module Tapioca
         include_doc:,
         include_loc:,
         include_exported_rbis:,
+        default_command_override: nil,
         number_of_workers: nil,
         auto_strictness: true,
         dsl_dir: DEFAULT_DSL_DIR,
@@ -60,7 +62,7 @@ module Tapioca
         @dsl_dir = dsl_dir
         @rbi_formatter = rbi_formatter
 
-        super()
+        super(default_command_override: default_command_override)
 
         @bundle = T.let(Gemfile.new(exclude), Gemfile)
         @existing_rbis = T.let(nil, T.nilable(T::Hash[String, String]))

--- a/lib/tapioca/commands/annotations.rb
+++ b/lib/tapioca/commands/annotations.rb
@@ -9,6 +9,7 @@ module Tapioca
       sig do
         params(
           central_repo_root_uris: T::Array[String],
+          default_command_override: T.nilable(String),
           auth: T.nilable(String),
           netrc_file: T.nilable(String),
           central_repo_index_path: String,
@@ -17,12 +18,13 @@ module Tapioca
       end
       def initialize(
         central_repo_root_uris:,
+        default_command_override: nil,
         auth: nil,
         netrc_file: nil,
         central_repo_index_path: CENTRAL_REPO_INDEX_PATH,
         typed_overrides: {}
       )
-        super()
+        super(default_command_override: default_command_override)
         @outpath = T.let(Pathname.new(DEFAULT_ANNOTATIONS_DIR), Pathname)
         @central_repo_root_uris = central_repo_root_uris
         @auth = auth

--- a/lib/tapioca/commands/check_shims.rb
+++ b/lib/tapioca/commands/check_shims.rb
@@ -17,6 +17,7 @@ module Tapioca
           todo_rbi_file: String,
           payload: T::Boolean,
           number_of_workers: T.nilable(Integer),
+          default_command_override: T.nilable(String),
         ).void
       end
       def initialize(
@@ -26,9 +27,10 @@ module Tapioca
         shim_rbi_dir:,
         todo_rbi_file:,
         payload:,
-        number_of_workers:
+        number_of_workers:,
+        default_command_override: nil
       )
-        super()
+        super(default_command_override: default_command_override)
         @gem_rbi_dir = gem_rbi_dir
         @dsl_rbi_dir = dsl_rbi_dir
         @annotations_rbi_dir = annotations_rbi_dir

--- a/lib/tapioca/commands/command.rb
+++ b/lib/tapioca/commands/command.rb
@@ -16,8 +16,9 @@ module Tapioca
 
       abstract!
 
-      sig { void }
-      def initialize
+      sig { params(default_command_override: T.nilable(String)).void }
+      def initialize(default_command_override: nil)
+        @default_command_override = default_command_override
         @file_writer = T.let(FileWriter.new, Thor::Actions)
       end
 
@@ -35,7 +36,7 @@ module Tapioca
 
       sig { params(command: Symbol, args: String).returns(String) }
       def default_command(command, *args)
-        [Tapioca::BINARY_FILE, command.to_s, *args].join(" ")
+        @default_command_override || [Tapioca::BINARY_FILE, command.to_s, *args].join(" ")
       end
 
       sig { returns(Thor::Actions) }

--- a/lib/tapioca/commands/command_without_tracker.rb
+++ b/lib/tapioca/commands/command_without_tracker.rb
@@ -8,10 +8,10 @@ module Tapioca
 
       abstract!
 
-      sig { void }
-      def initialize
+      sig { params(default_command_override: T.nilable(String)).void }
+      def initialize(default_command_override: nil)
         Tapioca::Runtime::Trackers.disable_all!
-        super
+        super(default_command_override: default_command_override)
       end
     end
   end

--- a/lib/tapioca/commands/configure.rb
+++ b/lib/tapioca/commands/configure.rb
@@ -9,18 +9,20 @@ module Tapioca
           sorbet_config: String,
           tapioca_config: String,
           default_postrequire: String,
+          default_command_override: T.nilable(String),
         ).void
       end
       def initialize(
         sorbet_config:,
         tapioca_config:,
-        default_postrequire:
+        default_postrequire:,
+        default_command_override: nil
       )
         @sorbet_config = sorbet_config
         @tapioca_config = tapioca_config
         @default_postrequire = default_postrequire
 
-        super()
+        super(default_command_override: default_command_override)
 
         @installer = T.let(nil, T.nilable(Bundler::Installer))
         @spec = T.let(nil, T.nilable(Bundler::StubSpecification))

--- a/lib/tapioca/commands/require.rb
+++ b/lib/tapioca/commands/require.rb
@@ -8,13 +8,14 @@ module Tapioca
         params(
           requires_path: String,
           sorbet_config_path: String,
+          default_command_override: T.nilable(String),
         ).void
       end
-      def initialize(requires_path:, sorbet_config_path:)
+      def initialize(requires_path:, sorbet_config_path:, default_command_override: nil)
         @requires_path = requires_path
         @sorbet_config_path = sorbet_config_path
 
-        super()
+        super(default_command_override: default_command_override)
       end
 
       private

--- a/lib/tapioca/commands/todo.rb
+++ b/lib/tapioca/commands/todo.rb
@@ -21,13 +21,14 @@ module Tapioca
         params(
           todo_file: String,
           file_header: T::Boolean,
+          default_command_override: T.nilable(String),
         ).void
       end
-      def initialize(todo_file:, file_header:)
+      def initialize(todo_file:, file_header:, default_command_override: nil)
         @todo_file = todo_file
         @file_header = file_header
 
-        super()
+        super(default_command_override: default_command_override)
       end
 
       sig { void }


### PR DESCRIPTION
### Motivation

When a command like `rbi --verify` is run, it prints out the `default_command(command)` on failure to give instructions on how to regenerate RBIs and such. It is instructions to the user.

Unfortunately, in cases where the command passed in has complex arguments, it just prints the default command. This is unhelpful. An example from Shopify:
<img width="721" alt="image" src="https://github.com/Shopify/tapioca/assets/84159/53cb417c-be19-46d1-bb78-ed7c45728571">

This should print the command that is on the first line.


### Implementation

Allow a `default_command_override` to be passed in at the command line which overrides what is printed on failure, and what is printed in the headers.

We chose to pass this through basically everywhere for completeness, but this caused a ton of signatures to change. I will comment inline on the actual important changes.

Paired with @Morriar 