### PR TITLE
Generate *_changed? and *_previously_changed? sigs for belongs_to relations

### DIFF
--- a/lib/tapioca/dsl/compilers/active_record_associations.rb
+++ b/lib/tapioca/dsl/compilers/active_record_associations.rb
@@ -206,6 +206,16 @@ module Tapioca
             "reset_#{association_name}",
             return_type: "void",
           )
+          if reflection.is_a?(ActiveRecord::Reflection::BelongsToReflection)
+            klass.create_method(
+              "#{association_name}_changed?",
+              return_type: "T::Boolean",
+            )
+            klass.create_method(
+              "#{association_name}_previously_changed?",
+              return_type: "T::Boolean",
+            )
+          end
           unless reflection.polymorphic?
             klass.create_method(
               "build_#{association_name}",

--- a/spec/tapioca/dsl/compilers/active_record_associations_spec.rb
+++ b/spec/tapioca/dsl/compilers/active_record_associations_spec.rb
@@ -124,6 +124,12 @@ module Tapioca
                         sig { params(attributes: T.untyped).returns(T.untyped) }
                         def author_attributes=(attributes); end
 
+                        sig { returns(T::Boolean) }
+                        def author_changed?; end
+
+                        sig { returns(T::Boolean) }
+                        def author_previously_changed?; end
+
                         sig { params(args: T.untyped, blk: T.untyped).returns(::User) }
                         def build_author(*args, &blk); end
 
@@ -138,6 +144,12 @@ module Tapioca
 
                         sig { params(attributes: T.untyped).returns(T.untyped) }
                         def category_attributes=(attributes); end
+
+                        sig { returns(T::Boolean) }
+                        def category_changed?; end
+
+                        sig { returns(T::Boolean) }
+                        def category_previously_changed?; end
 
                         sig { params(args: T.untyped, blk: T.untyped).returns(::User) }
                         def create_author(*args, &blk); end
@@ -198,6 +210,12 @@ module Tapioca
 
                         sig { params(attributes: T.untyped).returns(T.untyped) }
                         def category_attributes=(attributes); end
+
+                        sig { returns(T::Boolean) }
+                        def category_changed?; end
+
+                        sig { returns(T::Boolean) }
+                        def category_previously_changed?; end
 
                         sig { returns(T.untyped) }
                         def reload_category; end
@@ -558,6 +576,12 @@ module Tapioca
                         sig { params(value: T.nilable(::Blog::Author)).void }
                         def author=(value); end
 
+                        sig { returns(T::Boolean) }
+                        def author_changed?; end
+
+                        sig { returns(T::Boolean) }
+                        def author_previously_changed?; end
+
                         sig { params(args: T.untyped, blk: T.untyped).returns(::Blog::Author) }
                         def build_author(*args, &blk); end
 
@@ -639,6 +663,12 @@ module Tapioca
 
                         sig { params(value: T.nilable(::Blog::Core::Post)).void }
                         def post=(value); end
+
+                        sig { returns(T::Boolean) }
+                        def post_changed?; end
+
+                        sig { returns(T::Boolean) }
+                        def post_previously_changed?; end
 
                         sig { returns(T.nilable(::Blog::Core::Post)) }
                         def reload_post; end
@@ -771,6 +801,12 @@ module Tapioca
 
                         sig { params(value: T.nilable(::Shop)).void }
                         def shop=(value); end
+
+                        sig { returns(T::Boolean) }
+                        def shop_changed?; end
+
+                        sig { returns(T::Boolean) }
+                        def shop_previously_changed?; end
                       end
                     end
                   RBI
@@ -847,6 +883,12 @@ module Tapioca
                         sig { params(attributes: T.untyped).returns(T.untyped) }
                         def author_attributes=(attributes); end
 
+                        sig { returns(T::Boolean) }
+                        def author_changed?; end
+
+                        sig { returns(T::Boolean) }
+                        def author_previously_changed?; end
+
                         sig { params(args: T.untyped, blk: T.untyped).returns(::User) }
                         def build_author(*args, &blk); end
 
@@ -861,6 +903,12 @@ module Tapioca
 
                         sig { params(attributes: T.untyped).returns(T.untyped) }
                         def category_attributes=(attributes); end
+
+                        sig { returns(T::Boolean) }
+                        def category_changed?; end
+
+                        sig { returns(T::Boolean) }
+                        def category_previously_changed?; end
 
                         sig { params(args: T.untyped, blk: T.untyped).returns(::User) }
                         def create_author(*args, &blk); end
@@ -921,6 +969,12 @@ module Tapioca
 
                         sig { params(attributes: T.untyped).returns(T.untyped) }
                         def category_attributes=(attributes); end
+
+                        sig { returns(T::Boolean) }
+                        def category_changed?; end
+
+                        sig { returns(T::Boolean) }
+                        def category_previously_changed?; end
 
                         sig { returns(T.untyped) }
                         def reload_category; end
@@ -1281,6 +1335,12 @@ module Tapioca
                         sig { params(value: T.nilable(::Blog::Author)).void }
                         def author=(value); end
 
+                        sig { returns(T::Boolean) }
+                        def author_changed?; end
+
+                        sig { returns(T::Boolean) }
+                        def author_previously_changed?; end
+
                         sig { params(args: T.untyped, blk: T.untyped).returns(::Blog::Author) }
                         def build_author(*args, &blk); end
 
@@ -1362,6 +1422,12 @@ module Tapioca
 
                         sig { params(value: T.nilable(::Blog::Core::Post)).void }
                         def post=(value); end
+
+                        sig { returns(T::Boolean) }
+                        def post_changed?; end
+
+                        sig { returns(T::Boolean) }
+                        def post_previously_changed?; end
 
                         sig { returns(T.nilable(::Blog::Core::Post)) }
                         def reload_post; end
@@ -1494,6 +1560,12 @@ module Tapioca
 
                         sig { params(value: T.nilable(::Shop)).void }
                         def shop=(value); end
+
+                        sig { returns(T::Boolean) }
+                        def shop_changed?; end
+
+                        sig { returns(T::Boolean) }
+                        def shop_previously_changed?; end
                       end
                     end
                   RBI


### PR DESCRIPTION
### Motivation

Models with a `belongs_to` relation now have a `_changed?` and `_previously_changed?` method since https://github.com/rails/rails/pull/42751. This shipped in Rails 7, see https://github.com/rails/rails/blob/b84fa1083ca7e6422356fdf80cb33751d0a23eff/activerecord/CHANGELOG.md#rails-700alpha1-september-15-2021.

I noticed in my project Sorbet was giving me an error about my model not having a `foo_changed?` method when I had a `belongs_to :foo`, even though a `respond_to?(:foo_changed?)` returned true.

### Implementation

I referenced existing `_changed?` method generation for regular columns on a model:

https://github.com/Shopify/tapioca/blob/df5079fd5063b61a3f110e330329c2eacd039ecb/lib/tapioca/dsl/compilers/active_record_columns.rb#L296-L305

While @erinnachen pointed out https://github.com/Shopify/tapioca/blob/main/lib/tapioca/dsl/compilers/active_record_associations.rb looked to be the compiler for methods coming from `belongs_to` relations, so I added the new method generation there.

I verified in the Rails implementation in https://github.com/rails/rails/pull/42751/files#diff-084ec489ba3b9f2e388734a99876f0d94776111278acfe4901235dca570040c5 that the new methods take no parameters.

### Tests

I updated existing tests to expect the new method signatures to be present.

