### PR TITLE
Short circuit Rails app loading if Rails constant isn't defined

### DIFF
--- a/lib/tapioca/loaders/loader.rb
+++ b/lib/tapioca/loaders/loader.rb
@@ -47,12 +47,23 @@ module Tapioca
         ).void
       end
       def load_rails_application(environment_load: false, eager_load: false, app_root: ".", halt_upon_load_error: true)
-        return unless File.exist?("#{app_root}/config/application.rb")
+        return unless File.exist?(File.expand_path("config/application.rb", app_root))
 
-        if environment_load
-          require "./#{app_root}/config/environment"
+        load_path = if environment_load
+          "config/environment"
         else
-          require "./#{app_root}/config/application"
+          "config/application"
+        end
+
+        require File.expand_path(load_path, app_root)
+
+        unless defined?(Rails)
+          say(
+            "\nTried to load the app from `#{load_path}` as a Rails application " \
+              "but the `Rails` constant wasn't defined after loading the file.",
+            :yellow,
+          )
+          return
         end
 
         eager_load_rails_app if eager_load


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
There are sometimes Rails-lookalike applications that might have defined a `config/application.rb` file but don't actually have Rails loaded.

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
This change short circuits the Rails app loading if the `Rails` constant isn't defined after loading the `config/environment.rb` file or the `config/application.rb` file.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->
Added a new test that exercises the new code path.
