### PR TITLE
Add `ActiveSupportTimeExt` compiler

### DIFF
--- a/lib/tapioca/dsl/compilers/active_support_time_ext.rb
+++ b/lib/tapioca/dsl/compilers/active_support_time_ext.rb
@@ -1,0 +1,68 @@
+# typed: strict
+# frozen_string_literal: true
+
+return unless defined?(Time.current) && defined?(ActiveSupport::TimeWithZone)
+
+module Tapioca
+  module Dsl
+    module Compilers
+      # `Tapioca::Dsl::Compilers::ActiveSupportTimeExt` generates an RBI file for the `Time#current` method
+      # defined by [Active Support's Time extensions](https://api.rubyonrails.org/classes/Time.html).
+      #
+      # If `Time.zone` or `config.time_zone` are set, then the `Time.current` method will be defined as returning
+      # an instance of `ActiveSupport::TimeWithZone`, otherwise it will return an instance of `Time`.
+      #
+      # For an application that is configured with:
+      # ```ruby
+      # config.time_zone = "UTC"
+      # ```
+      # this compiler will produce the following RBI file:
+      # ```rbi
+      # class Time
+      #   class << self
+      #     sig { returns(::ActiveSupport::TimeWithZone) }
+      #     def current; end
+      #   end
+      # end
+      # ```
+      # whereas if `Time.zone` and `config.time_zone` are not set, it will produce:
+      # ```rbi
+      # class Time
+      #   class << self
+      #     sig { returns(::Time) }
+      #     def current; end
+      #   end
+      # end
+      # ```
+      class ActiveSupportTimeExt < Compiler
+        extend T::Sig
+
+        ConstantType = type_member { { fixed: T.class_of(::Time) } }
+
+        sig { override.void }
+        def decorate
+          return unless constant.respond_to?(:zone)
+
+          root.create_path(constant) do |mod|
+            return_type = if ::Time.zone
+              "::ActiveSupport::TimeWithZone"
+            else
+              "::Time"
+            end
+
+            mod.create_method("current", return_type: return_type, class_method: true)
+          end
+        end
+
+        class << self
+          extend T::Sig
+
+          sig { override.returns(T::Enumerable[Module]) }
+          def gather_constants
+            [::Time]
+          end
+        end
+      end
+    end
+  end
+end

--- a/manual/compiler_activesupporttimeext.md
+++ b/manual/compiler_activesupporttimeext.md
@@ -1,0 +1,30 @@
+## ActiveSupportTimeExt
+
+`Tapioca::Dsl::Compilers::ActiveSupportTimeExt` generates an RBI file for the `Time#current` method
+defined by [Active Support's Time extensions](https://api.rubyonrails.org/classes/Time.html).
+
+If `Time.zone` or `config.time_zone` are set, then the `Time.current` method will be defined as returning
+an instance of `ActiveSupport::TimeWithZone`, otherwise it will return an instance of `Time`.
+
+For an application that is configured with:
+```ruby
+config.time_zone = "UTC"
+```
+this compiler will produce the following RBI file:
+```rbi
+class Time
+  class << self
+    sig { returns(::ActiveSupport::TimeWithZone) }
+    def current; end
+  end
+end
+```
+whereas if `Time.zone` and `config.time_zone` are not set, it will produce:
+```rbi
+class Time
+  class << self
+    sig { returns(::Time) }
+    def current; end
+  end
+end
+```

--- a/manual/compilers.md
+++ b/manual/compilers.md
@@ -25,6 +25,7 @@ In the following section you will find all available DSL compilers:
 * [ActiveStorage](compiler_activestorage.md)
 * [ActiveSupportConcern](compiler_activesupportconcern.md)
 * [ActiveSupportCurrentAttributes](compiler_activesupportcurrentattributes.md)
+* [ActiveSupportTimeExt](compiler_activesupporttimeext.md)
 * [Config](compiler_config.md)
 * [FrozenRecord](compiler_frozenrecord.md)
 * [GraphqlInputObject](compiler_graphqlinputobject.md)

--- a/spec/tapioca/dsl/compilers/active_support_time_ext_spec.rb
+++ b/spec/tapioca/dsl/compilers/active_support_time_ext_spec.rb
@@ -1,0 +1,61 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Tapioca
+  module Dsl
+    module Compilers
+      class ActiveSupportTimeExtSpec < ::DslSpec
+        sig { void }
+        def before_setup
+          require "active_support/core_ext/time"
+        end
+
+        describe "Tapioca::Dsl::Compilers::ActiveSupportTimeExt" do
+          describe "gather_constants" do
+            it "gathers only `Time` as a constant" do
+              assert_equal(["Time"], gathered_constants)
+            end
+          end
+
+          describe "decorate" do
+            it "generates a Time.current that returns Time if Time.zone isn't defined" do
+              expected = <<~RBI
+                # typed: strong
+
+                class Time
+                  class << self
+                    sig { returns(::Time) }
+                    def current; end
+                  end
+                end
+              RBI
+
+              assert_equal(expected, rbi_for(:Time))
+            end
+
+            it "generates a Time.current that returns ActiveSupport::TimeWithZone if Time.zone is defined" do
+              add_ruby_file("time_zone.rb", <<~RUBY)
+                Time.zone = "UTC"
+              RUBY
+
+              expected = <<~RBI
+                # typed: strong
+
+                class Time
+                  class << self
+                    sig { returns(::ActiveSupport::TimeWithZone) }
+                    def current; end
+                  end
+                end
+              RBI
+
+              assert_equal(expected, rbi_for(:Time))
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This compiler generates an RBI file for Active Support's Time extensions. Currently this is limited to the return type of the `Time.current` method which changes its return type depending on if `Time.zone` is set or not.

### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
https://github.com/Shopify/rbi-central/pull/262#issuecomment-2230885870

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
Add a new compiler that only handles `Time` constant and is only loaded if `Time.current` method is defined.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->
Added tests for the new compiler.
