### PR TITLE
Make DSL compiler test helper work without needing an extra require

### DIFF
--- a/lib/tapioca/helpers/test/dsl_compiler.rb
+++ b/lib/tapioca/helpers/test/dsl_compiler.rb
@@ -1,6 +1,7 @@
 # typed: strict
 # frozen_string_literal: true
 
+require "tapioca/dsl"
 require "tapioca/helpers/test/content"
 require "tapioca/helpers/test/isolation"
 require "tapioca/helpers/test/template"


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
Currently Tapioca exports a DSL compiler test helper that is used by other app or gems to test their DSL compilers. However, the helper requires a lot of Tapioca DSL classes to be defined before it can be used. This is a problem because it means that the helper can't be used in isolation, without the rest of Tapioca. A common workaround for this is to start requiring "tapioca/internal" in the test file that uses the helper, but that ends up causing Sorbet runtime related behaviour changes due to the Sorbet runtime patches that that require pulls in.

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
In order to fix this, all we need to do is to require "tapioca/dsl" which brings in only the DSL classes that the helper needs. This way, the helper can be used in isolation without needing to require "tapioca/internal" and without causing any Sorbet runtime related behaviour changes.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->
No new tests