### PR TITLE
Fix ActiveRecordRelation compiler's handling of composite primary keys

### DIFF
--- a/lib/tapioca/dsl/compilers/active_record_relations.rb
+++ b/lib/tapioca/dsl/compilers/active_record_relations.rb
@@ -687,12 +687,11 @@ module Tapioca
               end
 
               id_types = "T.any(#{id_types.to_a.join(", ")})"
-
-              array_type = if constant.try(:composite_primary_key?)
-                "T::Array[T::Array[#{id_types}]]"
-              else
-                "T::Array[#{id_types}]"
+              if constant.try(:composite_primary_key?)
+                id_types = "T::Array[#{id_types}]"
               end
+
+              array_type = "T::Array[#{id_types}]"
 
               common_relation_methods_module.create_method("find") do |method|
                 method.add_opt_param("args", "nil")

--- a/spec/tapioca/dsl/compilers/active_record_relations_spec.rb
+++ b/spec/tapioca/dsl/compilers/active_record_relations_spec.rb
@@ -838,10 +838,11 @@ module Tapioca
                     sig { returns(::Post) }
                     def fifth!; end
 
-                    sig { params(args: T.any(String, Symbol, ::ActiveSupport::Multibyte::Chars, T::Boolean, BigDecimal, Numeric, ::ActiveRecord::Type::Binary::Data, ::ActiveRecord::Type::Time::Value, Date, Time, ::ActiveSupport::Duration, T::Class[T.anything])).returns(::Post) }
                 <% if rails_version(">= 7.1") %>
+                    sig { params(args: T::Array[T.any(String, Symbol, ::ActiveSupport::Multibyte::Chars, T::Boolean, BigDecimal, Numeric, ::ActiveRecord::Type::Binary::Data, ::ActiveRecord::Type::Time::Value, Date, Time, ::ActiveSupport::Duration, T::Class[T.anything])]).returns(::Post) }
                     sig { params(args: T::Array[T::Array[T.any(String, Symbol, ::ActiveSupport::Multibyte::Chars, T::Boolean, BigDecimal, Numeric, ::ActiveRecord::Type::Binary::Data, ::ActiveRecord::Type::Time::Value, Date, Time, ::ActiveSupport::Duration, T::Class[T.anything])]]).returns(T::Enumerable[::Post]) }
                 <% else %>
+                    sig { params(args: T.any(String, Symbol, ::ActiveSupport::Multibyte::Chars, T::Boolean, BigDecimal, Numeric, ::ActiveRecord::Type::Binary::Data, ::ActiveRecord::Type::Time::Value, Date, Time, ::ActiveSupport::Duration, T::Class[T.anything])).returns(::Post) }
                     sig { params(args: T::Array[T.any(String, Symbol, ::ActiveSupport::Multibyte::Chars, T::Boolean, BigDecimal, Numeric, ::ActiveRecord::Type::Binary::Data, ::ActiveRecord::Type::Time::Value, Date, Time, ::ActiveSupport::Duration, T::Class[T.anything])]).returns(T::Enumerable[::Post]) }
                 <% end %>
                     sig { params(args: NilClass, block: T.proc.params(object: ::Post).void).returns(T.nilable(::Post)) }


### PR DESCRIPTION
### Motivation

During `ActiveRecordRelation` compiler's decorate it generates the wrong method signature of the `#find` method for records with composite keys. The signature for the method appears to have been updated when multiple values are passed (i.e. array of arrays), but the singular value still shows as `T.any(....)` when it should be wrapped in an array.

### Implementation

I've updated the handling so if `#composite_primary_key?` is present and returns a truthy value then the value of ids will be updated to be an array of instead. This then works forward so that the value for an array of composite keys is correct too.

### Tests

Updated tests to reflect changes.

