### PR TITLE
Make it possible to extend list of id types for ActiveRecord relations

### DIFF
--- a/lib/tapioca/dsl/compilers/active_record_relations.rb
+++ b/lib/tapioca/dsl/compilers/active_record_relations.rb
@@ -155,6 +155,25 @@ module Tapioca
 
         ConstantType = type_member { { fixed: T.class_of(::ActiveRecord::Base) } }
 
+        # From ActiveRecord::ConnectionAdapter::Quoting#quote, minus nil
+        ID_TYPES = T.let(
+          [
+            "String",
+            "Symbol",
+            "::ActiveSupport::Multibyte::Chars",
+            "T::Boolean",
+            "BigDecimal",
+            "Numeric",
+            "::ActiveRecord::Type::Binary::Data",
+            "::ActiveRecord::Type::Time::Value",
+            "Date",
+            "Time",
+            "::ActiveSupport::Duration",
+            "T::Class[T.anything]",
+          ].to_set.freeze,
+          T::Set[String],
+        )
+
         sig { override.void }
         def decorate
           create_classes_and_includes
@@ -663,27 +682,14 @@ module Tapioca
                 return_type: "T::Boolean",
               )
             when :find
-              # From ActiveRecord::ConnectionAdapter::Quoting#quote, minus nil
-              id_types = [
-                "String",
-                "Symbol",
-                "::ActiveSupport::Multibyte::Chars",
-                "T::Boolean",
-                "BigDecimal",
-                "Numeric",
-                "::ActiveRecord::Type::Binary::Data",
-                "::ActiveRecord::Type::Time::Value",
-                "Date",
-                "Time",
-                "::ActiveSupport::Duration",
-                "T::Class[T.anything]",
-              ].to_set
+              id_types = ID_TYPES
 
               if constant.table_exists?
                 primary_key_type = constant.type_for_attribute(constant.primary_key)
                 type = Tapioca::Dsl::Helpers::ActiveModelTypeHelper.type_for(primary_key_type)
                 type = RBIHelper.as_non_nilable_type(type)
-                id_types << type if type != "T.untyped"
+
+                id_types = ID_TYPES.union([type]) if type != "T.untyped"
               end
 
               id_types = "T.any(#{id_types.to_a.join(", ")})"


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
Fixes the root problem specified in #1965 

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
By moving the list of id types to a constant, we are now making it possible to extend the list of id types for ActiveRecord relations in gem or application level "compilers".

All that a "compiler" needs to do is to read the list of id types from the `Tapioca::DSL::Compilers::ActiveRecordRelations::ID_TYPES` constant, add the new id type to the list and then assign the result back to `Tapioca::DSL::Compilers::ActiveRecordRelations::ID_TYPES`.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->
Added a DSL CLI test to show how "compilers" can change the behaviour of the AR relations compiler.
