### PR TITLE
Flip subtype checks (`<` → `>`)

### DIFF
--- a/lib/tapioca/dsl/compilers/active_model_validations_confirmation.rb
+++ b/lib/tapioca/dsl/compilers/active_model_validations_confirmation.rb
@@ -58,7 +58,7 @@ module Tapioca
           def gather_constants
             # Collect all the classes that include ActiveModel::Validations
             all_classes.select do |c|
-              c < ActiveModel::Validations
+              ActiveModel::Validations > c
             end
           end
         end

--- a/lib/tapioca/dsl/compilers/active_model_validations_confirmation.rb
+++ b/lib/tapioca/dsl/compilers/active_model_validations_confirmation.rb
@@ -57,9 +57,7 @@ module Tapioca
           sig { override.returns(T::Enumerable[Module]) }
           def gather_constants
             # Collect all the classes that include ActiveModel::Validations
-            all_classes.select do |c|
-              ActiveModel::Validations > c
-            end
+            all_classes.select { |c| ActiveModel::Validations > c }
           end
         end
 

--- a/lib/tapioca/dsl/compilers/active_support_concern.rb
+++ b/lib/tapioca/dsl/compilers/active_support_concern.rb
@@ -73,7 +73,7 @@ module Tapioca
                 # not singleton classes
                 !mod.singleton_class? &&
                 # extend ActiveSupport::Concern, and
-                mod.singleton_class < ActiveSupport::Concern &&
+                ActiveSupport::Concern > mod.singleton_class &&
                 # have dependencies (i.e. include another concern)
                 !dependencies_of(mod).empty?
             end

--- a/lib/tapioca/dsl/compilers/active_support_concern.rb
+++ b/lib/tapioca/dsl/compilers/active_support_concern.rb
@@ -66,18 +66,17 @@ module Tapioca
 
           sig { override.returns(T::Enumerable[Module]) }
           def gather_constants
-            # Find all Modules that are:
             all_modules.select do |mod|
-              # named (i.e. not anonymous)
-              name_of(mod) &&
-                # not singleton classes
+              name_of(mod) && # i.e. not anonymous
                 !mod.singleton_class? &&
-                # extend ActiveSupport::Concern, and
                 ActiveSupport::Concern > mod.singleton_class &&
-                # have dependencies (i.e. include another concern)
-                !dependencies_of(mod).empty?
+                has_dependencies?(mod)
             end
           end
+
+          # Returns true when `mod` includes other concerns
+          sig { params(mod: Module).returns(T::Boolean) }
+          def has_dependencies?(mod) = dependencies_of(mod).any?
 
           sig { params(concern: Module).returns(T::Array[Module]) }
           def dependencies_of(concern)

--- a/lib/tapioca/dsl/compilers/graphql_input_object.rb
+++ b/lib/tapioca/dsl/compilers/graphql_input_object.rb
@@ -80,7 +80,7 @@ module Tapioca
 
           sig { override.returns(T::Enumerable[Module]) }
           def gather_constants
-            all_classes.select { |c| c < GraphQL::Schema::InputObject }
+            all_classes.select { |c| GraphQL::Schema::InputObject > c }
           end
         end
       end

--- a/lib/tapioca/dsl/compilers/graphql_mutation.rb
+++ b/lib/tapioca/dsl/compilers/graphql_mutation.rb
@@ -80,7 +80,7 @@ module Tapioca
 
           sig { override.returns(T::Enumerable[Module]) }
           def gather_constants
-            all_classes.select { |c| c < GraphQL::Schema::Mutation && c != GraphQL::Schema::RelayClassicMutation }
+            all_classes.select { |c| GraphQL::Schema::Mutation > c && GraphQL::Schema::RelayClassicMutation != c }
           end
         end
       end

--- a/lib/tapioca/dsl/compilers/identity_cache.rb
+++ b/lib/tapioca/dsl/compilers/identity_cache.rb
@@ -100,7 +100,7 @@ module Tapioca
           sig { override.returns(T::Enumerable[Module]) }
           def gather_constants
             descendants_of(::ActiveRecord::Base).select do |klass|
-              klass < ::IdentityCache::WithoutPrimaryIndex
+              ::IdentityCache::WithoutPrimaryIndex > klass
             end
           end
         end

--- a/lib/tapioca/dsl/compilers/json_api_client_resource.rb
+++ b/lib/tapioca/dsl/compilers/json_api_client_resource.rb
@@ -111,7 +111,7 @@ module Tapioca
           sig { override.returns(T::Enumerable[Module]) }
           def gather_constants
             all_modules.select do |c|
-              name_of(c) && c < ::JsonApiClient::Resource
+              name_of(c) && ::JsonApiClient::Resource > c
             end
           end
         end

--- a/lib/tapioca/dsl/compilers/sidekiq_worker.rb
+++ b/lib/tapioca/dsl/compilers/sidekiq_worker.rb
@@ -73,7 +73,7 @@ module Tapioca
 
           sig { override.returns(T::Enumerable[Module]) }
           def gather_constants
-            all_classes.select { |c| c < Sidekiq::Worker }
+            all_classes.select { |c| Sidekiq::Worker > c }
           end
         end
 

--- a/lib/tapioca/dsl/compilers/smart_properties.rb
+++ b/lib/tapioca/dsl/compilers/smart_properties.rb
@@ -86,8 +86,8 @@ module Tapioca
           def gather_constants
             all_modules.select do |c|
               name_of(c) &&
-                c != ::SmartProperties::Validations::Ancestor &&
-                c < ::SmartProperties && ::SmartProperties::ClassMethods === c
+                ::SmartProperties::Validations::Ancestor != c &&
+                ::SmartProperties > c && ::SmartProperties::ClassMethods === c
             end
           end
         end

--- a/lib/tapioca/dsl/compilers/smart_properties.rb
+++ b/lib/tapioca/dsl/compilers/smart_properties.rb
@@ -86,8 +86,9 @@ module Tapioca
           def gather_constants
             all_modules.select do |c|
               name_of(c) &&
+                ::SmartProperties > c &&
                 ::SmartProperties::Validations::Ancestor != c &&
-                ::SmartProperties > c && ::SmartProperties::ClassMethods === c
+                ::SmartProperties::ClassMethods === c
             end
           end
         end

--- a/lib/tapioca/dsl/compilers/state_machines.rb
+++ b/lib/tapioca/dsl/compilers/state_machines.rb
@@ -159,7 +159,7 @@ module Tapioca
 
           sig { override.returns(T::Enumerable[Module]) }
           def gather_constants
-            all_classes.select { |mod| mod < ::StateMachines::InstanceMethods }
+            all_classes.select { |mod| ::StateMachines::InstanceMethods > mod }
           end
         end
 


### PR DESCRIPTION
### Motivation

In my work on #1935, I discovered that `<` wasn't behaving as expected for some modules, which needs special handling like in #677

e.g.

```ruby
require "xpath"

class DefinitelyNotXPath; end

if XPath < DefinitelyNotXPath
  puts "This shouldn't be called, but it is"
end

# Happens because `XPath#<` is overridden, and always returns a truthy value:
XPath < DefinitelyNotXPath
# => #<XPath::Expression:0x0000000128f39c78
#  @arguments=[:<, #<XPath::Expression:0x0000000128f39e58 @arguments=[], @expression=:this_node>, String],
#  @expression=:binary_operator
# >
```

### Implementation

Just flip the operators around, so the receiver is always the known-good classes which don't override the `Module#>`.

### Tests

I haven't detected any concrete problems caused by this (other than the one already solved in #1935, so I haven't added any test cases.

## Other considerations

It would really be nice to have an automated way of detecting and preventing such cases, but. I can't think of a way to do so without too many false positives. E.g. blanket banning `<` with a RuboCop rule would be too aggressive.