### PR TITLE
Fix type order for first|last|take

### DIFF
--- a/lib/tapioca/dsl/compilers/active_record_relations.rb
+++ b/lib/tapioca/dsl/compilers/active_record_relations.rb
@@ -755,7 +755,6 @@ module Tapioca
                 method.add_opt_param("limit", "nil")
 
                 method.add_sig do |sig|
-                  sig.add_param("limit", "NilClass")
                   sig.return_type = as_nilable_type(constant_name)
                 end
 

--- a/spec/tapioca/dsl/compilers/active_record_relations_spec.rb
+++ b/spec/tapioca/dsl/compilers/active_record_relations_spec.rb
@@ -178,7 +178,7 @@ module Tapioca
                     def find_sole_by(arg, *args); end
 
                 <% end %>
-                    sig { params(limit: NilClass).returns(T.nilable(::Post)) }
+                    sig { returns(T.nilable(::Post)) }
                     sig { params(limit: Integer).returns(T::Array[::Post]) }
                     def first(limit = nil); end
 
@@ -213,7 +213,7 @@ module Tapioca
                     sig { params(record: T.untyped).returns(T::Boolean) }
                     def include?(record); end
 
-                    sig { params(limit: NilClass).returns(T.nilable(::Post)) }
+                    sig { returns(T.nilable(::Post)) }
                     sig { params(limit: Integer).returns(T::Array[::Post]) }
                     def last(limit = nil); end
 
@@ -269,7 +269,7 @@ module Tapioca
                     sig { type_parameters(:U).params(initial_value_or_column: T.nilable(T.type_parameter(:U)), block: T.proc.params(object: ::Post).returns(T.type_parameter(:U))).returns(T.type_parameter(:U)) }
                     def sum(initial_value_or_column = nil, &block); end
 
-                    sig { params(limit: NilClass).returns(T.nilable(::Post)) }
+                    sig { returns(T.nilable(::Post)) }
                     sig { params(limit: Integer).returns(T::Array[::Post]) }
                     def take(limit = nil); end
 
@@ -885,7 +885,7 @@ module Tapioca
                     def find_sole_by(arg, *args); end
 
                 <% end %>
-                    sig { params(limit: NilClass).returns(T.nilable(::Post)) }
+                    sig { returns(T.nilable(::Post)) }
                     sig { params(limit: Integer).returns(T::Array[::Post]) }
                     def first(limit = nil); end
 
@@ -920,7 +920,7 @@ module Tapioca
                     sig { params(record: T.untyped).returns(T::Boolean) }
                     def include?(record); end
 
-                    sig { params(limit: NilClass).returns(T.nilable(::Post)) }
+                    sig { returns(T.nilable(::Post)) }
                     sig { params(limit: Integer).returns(T::Array[::Post]) }
                     def last(limit = nil); end
 
@@ -976,7 +976,7 @@ module Tapioca
                     sig { type_parameters(:U).params(initial_value_or_column: T.nilable(T.type_parameter(:U)), block: T.proc.params(object: ::Post).returns(T.type_parameter(:U))).returns(T.type_parameter(:U)) }
                     def sum(initial_value_or_column = nil, &block); end
 
-                    sig { params(limit: NilClass).returns(T.nilable(::Post)) }
+                    sig { returns(T.nilable(::Post)) }
                     sig { params(limit: Integer).returns(T::Array[::Post]) }
                     def take(limit = nil); end
 


### PR DESCRIPTION
### Motivation

At the moment the types of the `#first`,  `#last`, and `#take` methods don't accurately disambiguate between `some_model.last` and `some_model.last(some_variable)` when `some_variable` results in `T.untyped`. It will always assume whichever signature is defined first is the correct one. 

### Implementation

It is possible to define a signature that doesn't take a parameter, relying instead on the default argument being set to nil to work as expected. This then clears up the disambiguation letting values, especially untyped values passed into the method to act as it likely should.

### Tests

Updated tests to reflect new change.

