### PR TITLE
Add a sig with no args for ActiveRecordRelations builder methods

### DIFF
--- a/lib/tapioca/dsl/compilers/active_record_relations.rb
+++ b/lib/tapioca/dsl/compilers/active_record_relations.rb
@@ -1004,6 +1004,11 @@ module Tapioca
               method.add_opt_param("attributes", "nil")
               method.add_block_param("block")
 
+              method.add_sig do |sig|
+                sig.add_param("block", "T.nilable(T.proc.params(object: #{constant_name}).void)")
+                sig.return_type = constant_name
+              end
+
               # `T.untyped` matches `T::Array[T.untyped]` so the array signature
               # must be defined first for Sorbet to pick it, if valid.
               method.add_sig do |sig|

--- a/spec/tapioca/dsl/compilers/active_record_relations_spec.rb
+++ b/spec/tapioca/dsl/compilers/active_record_relations_spec.rb
@@ -97,6 +97,7 @@ module Tapioca
                     sig { params(column_name: T.any(String, Symbol)).returns(T.any(Integer, Float, BigDecimal)) }
                     def average(column_name); end
 
+                    sig { params(block: T.nilable(T.proc.params(object: ::Post).void)).returns(::Post) }
                     sig { params(attributes: T::Array[T.untyped], block: T.nilable(T.proc.params(object: ::Post).void)).returns(T::Array[::Post]) }
                     sig { params(attributes: T.untyped, block: T.nilable(T.proc.params(object: ::Post).void)).returns(::Post) }
                     def build(attributes = nil, &block); end
@@ -108,10 +109,12 @@ module Tapioca
                     sig { params(column_name: NilClass, block: T.proc.params(object: ::Post).void).returns(Integer) }
                     def count(column_name = nil, &block); end
 
+                    sig { params(block: T.nilable(T.proc.params(object: ::Post).void)).returns(::Post) }
                     sig { params(attributes: T::Array[T.untyped], block: T.nilable(T.proc.params(object: ::Post).void)).returns(T::Array[::Post]) }
                     sig { params(attributes: T.untyped, block: T.nilable(T.proc.params(object: ::Post).void)).returns(::Post) }
                     def create(attributes = nil, &block); end
 
+                    sig { params(block: T.nilable(T.proc.params(object: ::Post).void)).returns(::Post) }
                     sig { params(attributes: T::Array[T.untyped], block: T.nilable(T.proc.params(object: ::Post).void)).returns(T::Array[::Post]) }
                     sig { params(attributes: T.untyped, block: T.nilable(T.proc.params(object: ::Post).void)).returns(::Post) }
                     def create!(attributes = nil, &block); end
@@ -232,6 +235,7 @@ module Tapioca
                     sig { params(column_name: T.any(String, Symbol)).returns(T.untyped) }
                     def minimum(column_name); end
 
+                    sig { params(block: T.nilable(T.proc.params(object: ::Post).void)).returns(::Post) }
                     sig { params(attributes: T::Array[T.untyped], block: T.nilable(T.proc.params(object: ::Post).void)).returns(T::Array[::Post]) }
                     sig { params(attributes: T.untyped, block: T.nilable(T.proc.params(object: ::Post).void)).returns(::Post) }
                     def new(attributes = nil, &block); end
@@ -799,6 +803,7 @@ module Tapioca
                     sig { params(column_name: T.any(String, Symbol)).returns(T.any(Integer, Float, BigDecimal)) }
                     def average(column_name); end
 
+                    sig { params(block: T.nilable(T.proc.params(object: ::Post).void)).returns(::Post) }
                     sig { params(attributes: T::Array[T.untyped], block: T.nilable(T.proc.params(object: ::Post).void)).returns(T::Array[::Post]) }
                     sig { params(attributes: T.untyped, block: T.nilable(T.proc.params(object: ::Post).void)).returns(::Post) }
                     def build(attributes = nil, &block); end
@@ -810,10 +815,12 @@ module Tapioca
                     sig { params(column_name: NilClass, block: T.proc.params(object: ::Post).void).returns(Integer) }
                     def count(column_name = nil, &block); end
 
+                    sig { params(block: T.nilable(T.proc.params(object: ::Post).void)).returns(::Post) }
                     sig { params(attributes: T::Array[T.untyped], block: T.nilable(T.proc.params(object: ::Post).void)).returns(T::Array[::Post]) }
                     sig { params(attributes: T.untyped, block: T.nilable(T.proc.params(object: ::Post).void)).returns(::Post) }
                     def create(attributes = nil, &block); end
 
+                    sig { params(block: T.nilable(T.proc.params(object: ::Post).void)).returns(::Post) }
                     sig { params(attributes: T::Array[T.untyped], block: T.nilable(T.proc.params(object: ::Post).void)).returns(T::Array[::Post]) }
                     sig { params(attributes: T.untyped, block: T.nilable(T.proc.params(object: ::Post).void)).returns(::Post) }
                     def create!(attributes = nil, &block); end
@@ -939,6 +946,7 @@ module Tapioca
                     sig { params(column_name: T.any(String, Symbol)).returns(T.untyped) }
                     def minimum(column_name); end
 
+                    sig { params(block: T.nilable(T.proc.params(object: ::Post).void)).returns(::Post) }
                     sig { params(attributes: T::Array[T.untyped], block: T.nilable(T.proc.params(object: ::Post).void)).returns(T::Array[::Post]) }
                     sig { params(attributes: T.untyped, block: T.nilable(T.proc.params(object: ::Post).void)).returns(::Post) }
                     def new(attributes = nil, &block); end


### PR DESCRIPTION
### Motivation

When a model's builder methods are called with no arguments it will default to the first signature that is now `T::Array` param and return. This is obviously incorrect as it will only be instantiating one object. 

### Implementation

I've added a new sig for these methods that omits the `attributes` param, handling this first.

As `#create!` is a part of the builders this will also create the sig for that method. I'm _sure_ there is a way to have a valid call to `#create!` with no params, but even if not I think that it's fine to keep generating this sig for the method.

### Tests

Updated existing tests to reflect changes.