### PR TITLE
Log Sorbet signature block errors that lead to misleading RBI signatures generated

### DIFF
--- a/lib/tapioca/commands/abstract_gem.rb
+++ b/lib/tapioca/commands/abstract_gem.rb
@@ -119,7 +119,14 @@ module Tapioca
         ) if @file_header
 
         rbi.root = Runtime::Trackers::Autoload.with_disabled_exits do
-          Tapioca::Gem::Pipeline.new(gem, include_doc: @include_doc, include_loc: @include_loc).compile
+          Tapioca::Gem::Pipeline.new(
+            gem,
+            include_doc: @include_doc,
+            include_loc: @include_loc,
+            error_handler: ->(error) {
+              say_error(error, :bold, :red)
+            },
+          ).compile
         end
 
         merge_with_exported_rbi(gem, rbi) if @include_exported_rbis

--- a/lib/tapioca/gem/pipeline.rb
+++ b/lib/tapioca/gem/pipeline.rb
@@ -13,12 +13,28 @@ module Tapioca
       sig { returns(Gemfile::GemSpec) }
       attr_reader :gem
 
-      sig { params(gem: Gemfile::GemSpec, include_doc: T::Boolean, include_loc: T::Boolean).void }
-      def initialize(gem, include_doc: false, include_loc: false)
+      sig { returns(T.proc.params(error: String).void) }
+      attr_reader :error_handler
+
+      sig do
+        params(
+          gem: Gemfile::GemSpec,
+          error_handler: T.proc.params(error: String).void,
+          include_doc: T::Boolean,
+          include_loc: T::Boolean,
+        ).void
+      end
+      def initialize(
+        gem,
+        error_handler:,
+        include_doc: false,
+        include_loc: false
+      )
         @root = T.let(RBI::Tree.new, RBI::Tree)
         @gem = gem
         @seen = T.let(Set.new, T::Set[String])
         @alias_namespace = T.let(Set.new, T::Set[String])
+        @error_handler = error_handler
 
         @events = T.let([], T::Array[Gem::Event])
 

--- a/lib/tapioca/loaders/loader.rb
+++ b/lib/tapioca/loaders/loader.rb
@@ -230,7 +230,7 @@ module Tapioca
       # The `eager_load_paths` method still exists, but doesn't return all paths anymore and causes Tapioca to miss some
       # engine paths. The following commit is the change:
       # https://github.com/rails/rails/commit/ebfca905db14020589c22e6937382e6f8f687664
-      sig { params(engine: T.class_of(Rails::Engine)).returns(T::Array[String]) }
+      T::Sig::WithoutRuntime.sig { params(engine: T.class_of(Rails::Engine)).returns(T::Array[String]) }
       def eager_load_paths(engine)
         config = engine.config
 

--- a/lib/tapioca/runtime/reflection.rb
+++ b/lib/tapioca/runtime/reflection.rb
@@ -130,8 +130,13 @@ module Tapioca
       end
 
       sig { params(method: T.any(UnboundMethod, Method)).returns(T.untyped) }
-      def signature_of(method)
+      def signature_of!(method)
         T::Utils.signature_for_method(method)
+      end
+
+      sig { params(method: T.any(UnboundMethod, Method)).returns(T.untyped) }
+      def signature_of(method)
+        signature_of!(method)
       rescue LoadError, StandardError
         nil
       end

--- a/lib/tapioca/static/symbol_loader.rb
+++ b/lib/tapioca/static/symbol_loader.rb
@@ -65,7 +65,7 @@ module Tapioca
 
         private
 
-        sig { returns(T::Array[T.class_of(Rails::Engine)]) }
+        T::Sig::WithoutRuntime.sig { returns(T::Array[T.class_of(Rails::Engine)]) }
         def engines
           @engines ||= T.let(
             if Object.const_defined?("Rails::Engine")


### PR DESCRIPTION
### Motivation
When a sorbet signature block ends up throwing an exception, it gets swallowed up by the `signature_for(method)` in the `Tapioca::Runtime::Reflection` utilities, and an incorrect signature is generated. This has created some confusion for my team when the sorbet type checking failed, even though it appeared as if the signature was implemented correctly.

**Example**
_Sorbet Interface in upstream gem_
NOTE: the dependency/require statements on the `ExampleContracts::WidgetDto` had a simple bug that led to it being defined in most scenarios, but was not happing in the tapioca run downstream from these packages.

```ruby
module Example::WidgetAdapter
  extend T::Sig
  extend T::Helpers
  interface!

  sig do 
    abstract
      .params(widget: ExampleContracts::WidgetDto)
      .returns(T::Boolean)
  end
  def create(widget); end
end
```


_Tapioca generated RBI for interface defined upstream_
NOTE: Tapioca does not log any errors or warnings when generating this RBI.
```ruby
module Example::WidgetAdapter
  interface!

  # source://sorbet-runtime/0.5.11481/lib/types/private/methods/_methods.rb#257
  def create(*args, **_arg1, &blk); end
end
```

_Example sorbet error_
```
sorbet/rbi/gems/example@0.1.0.rbi:221: All methods in an interface must be declared abstract https://srb.help/5022
     221 |  def create(*args, **_arg1, &blk); end
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

sorbet/rbi/gems/example@0.1.0.rbi:265: All methods in an interface must be declared abstract https://srb.help/5022
     265 |  def call(*args, **_arg1, &blk); end
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Errors: 2
```

As you can see, the original implementation of the `Example::WidgetAdapter` indeed seemingly does have a signature defined, but the swallowed exception in Tapioca leads to a misleading RBI generated and a sorbet type-checking error.


### Implementation
Log any errors raised to `$stderr` when reflecting on method signatures to increase developer visibility + understanding.

With this change in place, you will now see a logged error message like the following:
```
Unable to compile signature for method: Example::WidgetsAdapter#create
  Exception raised when loading signature: #<NameError: uninitialized constant ExampleContracts::WidgetDto>
```

### Tests
Tests have been added and/or modified to check for the reported errors.
