### PR TITLE
Fix ActiveRecordRelations Model.new typing

### DIFF
--- a/lib/tapioca/dsl/compilers/active_record_relations.rb
+++ b/lib/tapioca/dsl/compilers/active_record_relations.rb
@@ -1024,6 +1024,21 @@ module Tapioca
               end
             end
           end
+
+          # We are creating `#new` on the class itself since when called as `Model.new`
+          # it doesn't allow for an array to be passed. If we kept it as a blanket it
+          # would mean the passing any `T.untyped` value to the method would assume
+          # the result is `T::Array` which is not the case majority of the time.
+          model.create_method("new") do |method|
+            method.add_opt_param("attributes", "nil")
+            method.add_block_param("block")
+
+            method.add_sig do |sig|
+              sig.add_param("attributes", "T.untyped")
+              sig.add_param("block", "T.nilable(T.proc.params(object: #{constant_name}).void)")
+              sig.return_type = constant_name
+            end
+          end
         end
 
         sig do

--- a/spec/tapioca/dsl/compilers/active_record_relations_spec.rb
+++ b/spec/tapioca/dsl/compilers/active_record_relations_spec.rb
@@ -85,6 +85,9 @@ module Tapioca
                   extend CommonRelationMethods
                   extend GeneratedRelationMethods
 
+                  sig { params(attributes: T.untyped, block: T.nilable(T.proc.params(object: ::Post).void)).returns(::Post) }
+                  def new(attributes = nil, &block); end
+
                   private
 
                   sig { returns(NilClass) }
@@ -790,6 +793,9 @@ module Tapioca
                 class Post
                   extend CommonRelationMethods
                   extend GeneratedRelationMethods
+
+                  sig { params(attributes: T.untyped, block: T.nilable(T.proc.params(object: ::Post).void)).returns(::Post) }
+                  def new(attributes = nil, &block); end
 
                   private
 


### PR DESCRIPTION
### Motivation

As pointed out in this issue: https://github.com/Shopify/tapioca/issues/1981

The typing for `Model.new` accepts an `T::Array` which it never actually does. The original discussion was around this being acceptable, but after trying to fix issues from this change to the compiler I'm now thinking that it is better to type this appropriately.

Consider:
```ruby
def some_untyped_method
  {
    a: 1,
    b: 1,
    c: 1,
  }
end

SomeModel.new(some_untyped_method)
#             ^^^^^^^^^^^^^^^^^^^ T.untyped = return type becomes `T::Array`
```

Because of how Sorbet selects the signature in the case of `T.untyped` and overloaded signatures, it will tend to pick the first viable, which in the case of `#new` will be `T::Array`. This then implicitly means that any arguments to `SomeModel.new` will have to be typed otherwise it picks a type that is never possible for this method.

### Implementation

I'm aware this may not be the correct approach, but I want to stat a conversation so we can best solve it. As for what I have here I've added a new with the removal of the `T::Array` signature to the model class after the extend. This will make it so that it overrides the signatures in `CommonRelationMethods` and avoid the `T::Array` issue.

### Tests

Updated tests to reflect change.

