### PR TITLE
Fix ActiveRecordRelation new defined out of class

### DIFF
--- a/lib/tapioca/dsl/compilers/active_record_relations.rb
+++ b/lib/tapioca/dsl/compilers/active_record_relations.rb
@@ -1029,7 +1029,7 @@ module Tapioca
           # it doesn't allow for an array to be passed. If we kept it as a blanket it
           # would mean the passing any `T.untyped` value to the method would assume
           # the result is `T::Array` which is not the case majority of the time.
-          model.create_method("new") do |method|
+          model.create_method("new", class_method: true) do |method|
             method.add_opt_param("attributes", "nil")
             method.add_block_param("block")
 

--- a/spec/tapioca/dsl/compilers/active_record_relations_spec.rb
+++ b/spec/tapioca/dsl/compilers/active_record_relations_spec.rb
@@ -85,13 +85,15 @@ module Tapioca
                   extend CommonRelationMethods
                   extend GeneratedRelationMethods
 
-                  sig { params(attributes: T.untyped, block: T.nilable(T.proc.params(object: ::Post).void)).returns(::Post) }
-                  def new(attributes = nil, &block); end
-
                   private
 
                   sig { returns(NilClass) }
                   def to_ary; end
+
+                  class << self
+                    sig { params(attributes: T.untyped, block: T.nilable(T.proc.params(object: ::Post).void)).returns(::Post) }
+                    def new(attributes = nil, &block); end
+                  end
 
                   module CommonRelationMethods
                     sig { params(block: T.nilable(T.proc.params(record: ::Post).returns(T.untyped))).returns(T::Boolean) }
@@ -794,13 +796,15 @@ module Tapioca
                   extend CommonRelationMethods
                   extend GeneratedRelationMethods
 
-                  sig { params(attributes: T.untyped, block: T.nilable(T.proc.params(object: ::Post).void)).returns(::Post) }
-                  def new(attributes = nil, &block); end
-
                   private
 
                   sig { returns(NilClass) }
                   def to_ary; end
+
+                  class << self
+                    sig { params(attributes: T.untyped, block: T.nilable(T.proc.params(object: ::Post).void)).returns(::Post) }
+                    def new(attributes = nil, &block); end
+                  end
 
                   module CommonRelationMethods
                     sig { params(block: T.nilable(T.proc.params(record: ::Post).returns(T.untyped))).returns(T::Boolean) }


### PR DESCRIPTION
### Motivation

Following this PR: https://github.com/Shopify/tapioca/pull/1983

### Implementation

This fixes the issue with the previous where the method of `new` was defined as an instance method instead of a class method.

### Tests

Updated tests to reflect.

