### PR TITLE
Iterate over requested_constants in DSL helpers

### DIFF
--- a/lib/tapioca/dsl/pipeline.rb
+++ b/lib/tapioca/dsl/pipeline.rb
@@ -145,6 +145,7 @@ module Tapioca
         ).returns(T::Set[Module])
       end
       def gather_constants(requested_constants, requested_paths, skipped_constants)
+        Compiler.requested_constants = requested_constants
         constants = Set.new.compare_by_identity
         active_compilers.each do |compiler|
           constants.merge(compiler.processable_constants)


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
Speedup gather_constants performance when a constant is supplied by not iterating over the ObjectSpace. This PR shouldn't change the functionality because we intersect the constants received from the ObjectSpace iteration with the requested ones https://github.com/Shopify/tapioca/blob/df6e272f4b4dcab5d1a21b2f9aabab1741743603/lib/tapioca/dsl/pipeline.rb#L156

Running `tapioca dsl Constant` before and after in the monolith:
<img width="883" alt="hyperfine tapioca dsl Shop (main)" src="https://github.com/user-attachments/assets/c158393a-586e-4723-84bd-fa24f9981b83">

<img width="893" alt="hyperfine tapioca dsl Shop (perf branch)" src="https://github.com/user-attachments/assets/9228154e-4e24-4d4c-aa5c-8fcdd76f4f26">

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->
Most of the tests in the dsl_spec supply arguments to `tapioca dsl` command.

