### PR TITLE
Remove polymorphic check when generating associating methods

### DIFF
--- a/lib/tapioca/dsl/compilers/active_record_associations.rb
+++ b/lib/tapioca/dsl/compilers/active_record_associations.rb
@@ -287,7 +287,7 @@ module Tapioca
         def type_for(reflection)
           validate_reflection!(reflection)
 
-          return "T.untyped" if !constant.table_exists? || polymorphic_association?(reflection)
+          return "T.untyped" if !constant.table_exists?
 
           T.must(qualified_name_of(reflection.klass))
         end
@@ -383,31 +383,11 @@ module Tapioca
           validate_reflection!(reflection)
 
           relations_enabled = compiler_enabled?("ActiveRecordRelations")
-          polymorphic_association = !constant.table_exists? || polymorphic_association?(reflection)
 
           if relations_enabled
-            if polymorphic_association
-              "ActiveRecord::Associations::CollectionProxy"
-            else
-              "#{qualified_name_of(reflection.klass)}::#{AssociationsCollectionProxyClassName}"
-            end
-          elsif polymorphic_association
-            "ActiveRecord::Associations::CollectionProxy[T.untyped]"
+            "#{qualified_name_of(reflection.klass)}::#{AssociationsCollectionProxyClassName}"
           else
             "::ActiveRecord::Associations::CollectionProxy[#{qualified_name_of(reflection.klass)}]"
-          end
-        end
-
-        sig do
-          params(
-            reflection: ReflectionType,
-          ).returns(T::Boolean)
-        end
-        def polymorphic_association?(reflection)
-          if reflection.through_reflection?
-            polymorphic_association?(reflection.source_reflection)
-          else
-            !!reflection.polymorphic?
           end
         end
       end

--- a/spec/tapioca/dsl/compilers/active_record_associations_spec.rb
+++ b/spec/tapioca/dsl/compilers/active_record_associations_spec.rb
@@ -265,7 +265,7 @@ module Tapioca
 
                         # This method is created by ActiveRecord on the `Employee` class because it declared `has_many :pictures`.
                         # 🔗 [Rails guide for `has_many` association](https://guides.rubyonrails.org/association_basics.html#the-has-many-association)
-                        sig { returns(ActiveRecord::Associations::CollectionProxy) }
+                        sig { returns(::Picture::PrivateCollectionProxy) }
                         def pictures; end
 
                         sig { params(value: T::Enumerable[T.untyped]).void }
@@ -1036,7 +1036,7 @@ module Tapioca
 
                         # This method is created by ActiveRecord on the `Employee` class because it declared `has_many :pictures`.
                         # 🔗 [Rails guide for `has_many` association](https://guides.rubyonrails.org/association_basics.html#the-has-many-association)
-                        sig { returns(ActiveRecord::Associations::CollectionProxy[T.untyped]) }
+                        sig { returns(::ActiveRecord::Associations::CollectionProxy[::Picture]) }
                         def pictures; end
 
                         sig { params(value: T::Enumerable[T.untyped]).void }


### PR DESCRIPTION
### Motivation
We noticed when adding some typing to our code that association methods for polymorphic associations were returning a generic `ActiveRecord::Associations::CollectionProxy` instead of the `Model::PrivateCollectionProxy` that is used elsewhere in tapioca.

### Implementation
I believe checking for the polymorphicness of the association is actually unnecessary since it shouldn't ever be the case that the association for a has_many would return a collection of different types.

### Tests
I updated the existing tests to reflect the updated behavior. I don't think I'm missing a test case but thats mostly because I can't think of a case where you woudn't be able to pin the method to a specific model/type.
