### PR TITLE
add state machine class method includes to relation methods modules

### DIFF
--- a/lib/tapioca/dsl/compilers/state_machines.rb
+++ b/lib/tapioca/dsl/compilers/state_machines.rb
@@ -114,6 +114,11 @@ module Tapioca
 
         ConstantType = type_member { { fixed: T.all(Module, ::StateMachines::ClassMethods) } }
 
+        ACTIVE_RECORD_RELATION_MODULE_NAMES = [
+          "GeneratedRelationMethods",
+          "GeneratedAssociationRelationMethods",
+        ].freeze
+
         sig { override.void }
         def decorate
           return if constant.state_machines.empty?
@@ -147,6 +152,10 @@ module Tapioca
             case matching_integration_name
             when :active_record
               define_activerecord_methods(instance_module)
+
+              ACTIVE_RECORD_RELATION_MODULE_NAMES.each do |module_name|
+                klass.create_module(module_name).create_include(class_module_name)
+              end
             end
 
             klass.create_include(instance_module_name)


### PR DESCRIPTION
### Motivation
Currently the StateMachines DSL compiler generates a class methods module `StateMachineClassHelperModule` which the model class extends. However, when using active record models, the generated relation modules do not include this class. This means that a query like
```
Model.with_state(...).where(...)
```
works fine, when a query like
```
Model.where(...).with_state(...)
```
does not. 

### Implementation
Honestly, I don't know the proper way to do this. I think in an ideal implementation we could guarantee order of generation somehow, so that one could detect if the corresponding AR modules existing and append the includes to them directly. We don't have that, so somehow we need to detect whether the ActiveRecordAssociations compiler _will_ run and include these modules if so. I dropped this into block with the active_record integration because that seems similar, but I'm not sure. 


### Tests
Will add testing
