### PR TITLE
Properly type ActiveRecord::Type::Binary

### DIFF
--- a/lib/tapioca/dsl/helpers/active_record_column_type_helper.rb
+++ b/lib/tapioca/dsl/helpers/active_record_column_type_helper.rb
@@ -155,6 +155,8 @@ module Tapioca
             "::ActiveSupport::TimeWithZone"
           when ActiveRecord::Enum::EnumType
             "::String"
+          when ActiveRecord::Type::Binary
+            "::String"
           when ActiveRecord::Type::Serialized
             serialized_column_type(column_type)
           when ->(type) {

--- a/spec/tapioca/dsl/compilers/active_record_columns_spec.rb
+++ b/spec/tapioca/dsl/compilers/active_record_columns_spec.rb
@@ -416,6 +416,7 @@ module Tapioca
                         # Ideally this would also test t.enum but that is not supported by sqlite
                         t.integer :integer_enum_column
                         t.string :string_enum_column
+                        t.binary :binary_column
                       end
                     end
                   end
@@ -511,6 +512,18 @@ module Tapioca
                 expected = indented(<<~RBI, 4)
                   sig { params(value: T.nilable(T.any(::String, ::Symbol))).returns(T.nilable(T.any(::String, ::Symbol))) }
                   def string_enum_column=(value); end
+                RBI
+                assert_includes(output, expected)
+
+                expected = indented(<<~RBI, 4)
+                  sig { returns(T.nilable(::String)) }
+                  def binary_column; end
+                RBI
+                assert_includes(output, expected)
+
+                expected = indented(<<~RBI, 4)
+                  sig { params(value: T.nilable(::String)).returns(T.nilable(::String)) }
+                  def binary_column=(value); end
                 RBI
                 assert_includes(output, expected)
               end


### PR DESCRIPTION
### Motivation
Proper typing for ActiveRecord binary columns

### Implementation
Pretty self-explanatory: updated the ActiveRecord type conversion case statement.

### Tests
Added a column to the ActiveRecord column types test.
