### PR TITLE
Fix type generation for types named AttachedClass that are not `T::Types::AttachedClassType`

### DIFF
--- a/lib/tapioca/runtime/reflection.rb
+++ b/lib/tapioca/runtime/reflection.rb
@@ -143,7 +143,7 @@ module Tapioca
 
       sig { params(type: T::Types::Base).returns(String) }
       def name_of_type(type)
-        type.to_s.gsub(/\bAttachedClass\b/, "T.attached_class")
+        type.to_s
       end
 
       sig { params(constant: Module, method: Symbol).returns(Method) }

--- a/sorbet/rbi/shims/sorbet.rbi
+++ b/sorbet/rbi/shims/sorbet.rbi
@@ -56,6 +56,8 @@ module T::Private
   end
 end
 
+class T::Types::AttachedClassType < T::Types::Base; end
+
 class T::Enum
   def values; end
 end

--- a/spec/tapioca/gem/pipeline_spec.rb
+++ b/spec/tapioca/gem/pipeline_spec.rb
@@ -3949,6 +3949,7 @@ class Tapioca::Gem::PipelineSpec < Minitest::HooksSpec
       add_ruby_file("foo.rb", <<~RUBY)
         class Foo
           class FooAttachedClass; end
+          class AttachedClass; end
           class << self
             extend(T::Sig)
 
@@ -3962,7 +3963,7 @@ class Tapioca::Gem::PipelineSpec < Minitest::HooksSpec
               { Foo.new => [Foo.new] }
             end
 
-            sig { returns(FooAttachedClass) }
+            sig { returns(T.any(FooAttachedClass, AttachedClass)) }
             def c
               FooAttachedClass.new
             end
@@ -3979,11 +3980,12 @@ class Tapioca::Gem::PipelineSpec < Minitest::HooksSpec
             sig { returns(T::Hash[T.attached_class, T::Array[T.attached_class]]) }
             def b; end
 
-            sig { returns(::Foo::FooAttachedClass) }
+            sig { returns(T.any(::Foo::AttachedClass, ::Foo::FooAttachedClass)) }
             def c; end
           end
         end
 
+        class Foo::AttachedClass; end
         class Foo::FooAttachedClass; end
       RBI
 

--- a/spec/tapioca/runtime/reflection_spec.rb
+++ b/spec/tapioca/runtime/reflection_spec.rb
@@ -8,6 +8,8 @@ module Tapioca
     class LyingFoo < BasicObject
       include ::Kernel
 
+      class AttachedClass; end
+
       class << self
         def constants
           [::Symbol, ::String]
@@ -106,7 +108,7 @@ module Tapioca
         it "return the correct results with Reflection helpers" do
           foo = LyingFoo.new
 
-          assert_equal([], Runtime::Reflection.constants_of(LyingFoo))
+          assert_equal([:AttachedClass], Runtime::Reflection.constants_of(LyingFoo))
           assert_equal("Tapioca::Runtime::LyingFoo", Runtime::Reflection.name_of(LyingFoo))
           assert_equal([Tapioca::Runtime::LyingFoo, Kernel, BasicObject], Runtime::Reflection.ancestors_of(LyingFoo))
           assert_equal(BasicObject, Runtime::Reflection.superclass_of(LyingFoo))
@@ -133,6 +135,17 @@ module Tapioca
 
         it "returns top level anchored name for named class" do
           assert_equal("::Tapioca::Runtime::LyingFoo", Runtime::Reflection.qualified_name_of(LyingFoo))
+        end
+
+        it "returns the right name for attached classes" do
+          assert_equal(
+            "::Tapioca::Runtime::LyingFoo::AttachedClass",
+            Runtime::Reflection.name_of_type(T::Types::Simple.new(LyingFoo::AttachedClass)),
+          )
+          assert_equal(
+            "T.attached_class",
+            Runtime::Reflection.name_of_type(T::Types::AttachedClassType.new),
+          )
         end
 
         describe "signature_for" do


### PR DESCRIPTION
### Motivation

When defining a class named `AttachedClass`, Tapioca is incorrectly generating it as if it was the type `T.attached_class`.

So for the following Ruby code:

```rb
class Foo
  class AttachedClass; end

  sig { returns(AttachedClass) }
  def foo; end
end
```

Tapioca would generate the following RBI which is incorrect:

```rb
class Foo
  class AttachedClass; end

  sig { returns(::Foo::T.attached_class) }
  def foo; end
end
```

### Implementation

The `gsub` on the type name was a workaround until we merged https://github.com/sorbet/sorbet/pull/3380 in `sorbet-runtime`, this is now unnecessary and is actually broken. We can just remove it.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->

See automated tests.