### PR TITLE
Fix types for composite primary keys

### DIFF
--- a/lib/tapioca/dsl/helpers/active_record_column_type_helper.rb
+++ b/lib/tapioca/dsl/helpers/active_record_column_type_helper.rb
@@ -88,11 +88,18 @@ module Tapioca
         sig { returns([String, String]) }
         def id_type
           if @constant.respond_to?(:composite_primary_key?) && T.unsafe(@constant).composite_primary_key?
-            @constant.primary_key.map do |column|
-              column_type_for(column)
-            end.map do |tuple|
-              "[#{tuple.join(", ")}]"
+            primary_key_columns = @constant.primary_key
+
+            getters = []
+            setters = []
+
+            primary_key_columns.each do |column|
+              getter, setter = column_type_for(column)
+              getters << getter
+              setters << setter
             end
+
+            ["[#{getters.join(", ")}]", "[#{setters.join(", ")}]"]
           else
             column_type_for(@constant.primary_key)
           end

--- a/spec/tapioca/dsl/compilers/active_record_columns_spec.rb
+++ b/spec/tapioca/dsl/compilers/active_record_columns_spec.rb
@@ -240,28 +240,30 @@ module Tapioca
               end
 
               it "handles composite primary keys" do
-                add_ruby_file("schema.rb", <<~RUBY)
-                  ActiveRecord::Migration.suppress_messages do
-                    ActiveRecord::Schema.define do
-                      create_table :posts, primary_key: [:a, :b] do |t|
-                        t.string :a, null: false
-                        t.integer :b, null: false
+                if rails_version(">= 7.1")
+                  add_ruby_file("schema.rb", <<~RUBY)
+                    ActiveRecord::Migration.suppress_messages do
+                      ActiveRecord::Schema.define do
+                        create_table :posts, primary_key: [:a, :b] do |t|
+                          t.string :a, null: false
+                          t.integer :b, null: false
+                        end
                       end
                     end
-                  end
-                RUBY
+                  RUBY
 
-                add_ruby_file("post.rb", <<~RUBY)
-                  class Post < ActiveRecord::Base
-                  end
-                RUBY
+                  add_ruby_file("post.rb", <<~RUBY)
+                    class Post < ActiveRecord::Base
+                    end
+                  RUBY
 
-                expected = indented(<<~RBI, 4)
-                  sig { returns([::String, ::Integer]) }
-                  def id; end
-                RBI
+                  expected = indented(<<~RBI, 4)
+                    sig { returns([::String, ::Integer]) }
+                    def id; end
+                  RBI
 
-                assert_includes(rbi_for(:Post), expected)
+                  assert_includes(rbi_for(:Post), expected)
+                end
               end
 
               it "uses ActiveModel::Type::Value types when inheriting from EncryptedAttributeType" do

--- a/spec/tapioca/dsl/compilers/active_record_columns_spec.rb
+++ b/spec/tapioca/dsl/compilers/active_record_columns_spec.rb
@@ -239,6 +239,31 @@ module Tapioca
                 assert_includes(rbi_for(:Post), expected)
               end
 
+              it "handles composite primary keys" do
+                add_ruby_file("schema.rb", <<~RUBY)
+                  ActiveRecord::Migration.suppress_messages do
+                    ActiveRecord::Schema.define do
+                      create_table :posts, primary_key: [:a, :b] do |t|
+                        t.string :a, null: false
+                        t.integer :b, null: false
+                      end
+                    end
+                  end
+                RUBY
+
+                add_ruby_file("post.rb", <<~RUBY)
+                  class Post < ActiveRecord::Base
+                  end
+                RUBY
+
+                expected = indented(<<~RBI, 4)
+                  sig { returns([::String, ::Integer]) }
+                  def id; end
+                RBI
+
+                assert_includes(rbi_for(:Post), expected)
+              end
+
               it "uses ActiveModel::Type::Value types when inheriting from EncryptedAttributeType" do
                 add_ruby_file("schema.rb", <<~RUBY)
                   ActiveRecord::Migration.suppress_messages do


### PR DESCRIPTION
### Motivation

Types were being computed incorrectly. In the spec I added previously it was computed as `sig { returns([::String, ::String]) }`

### Implementation

Fixed the implementation.

### Tests

I've added tests.