### PR TITLE
Resolve warnings for gems that are no longer default gems in Ruby 3.3.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,7 +52,6 @@ group :development, :test do
   gem "bcrypt"
   gem "xpath"
   gem "kredis"
-  gem "ostruct"
 end
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -52,6 +52,7 @@ group :development, :test do
   gem "bcrypt"
   gem "xpath"
   gem "kredis"
+  gem "ostruct"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -348,7 +348,7 @@ GEM
     websocket-extensions (0.1.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    yard (0.9.36)
+    yard (0.9.37)
     yard-sorbet (0.9.0)
       sorbet-runtime
       yard

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,6 +10,7 @@ PATH
   specs:
     tapioca (0.16.2)
       bundler (>= 2.2.25)
+      logger
       netrc (>= 0.11.0)
       parallel (>= 1.21.0)
       rbi (~> 0.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -220,6 +220,7 @@ GEM
       racc (~> 1.4)
     nokogiri (1.16.7-x86_64-linux)
       racc (~> 1.4)
+    ostruct (0.6.0)
     parallel (1.26.3)
     parser (3.3.4.0)
       ast (~> 2.4.1)
@@ -381,6 +382,7 @@ DEPENDENCIES
   minitest-reporters
   mutex_m
   nokogiri
+  ostruct
   rails (~> 7.1.0)
   rake
   rubocop-rspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -220,7 +220,6 @@ GEM
       racc (~> 1.4)
     nokogiri (1.16.7-x86_64-linux)
       racc (~> 1.4)
-    ostruct (0.6.0)
     parallel (1.26.3)
     parser (3.3.4.0)
       ast (~> 2.4.1)
@@ -382,7 +381,6 @@ DEPENDENCIES
   minitest-reporters
   mutex_m
   nokogiri
-  ostruct
   rails (~> 7.1.0)
   rake
   rubocop-rspec

--- a/sorbet/rbi/gems/yard@0.9.37.rbi
+++ b/sorbet/rbi/gems/yard@0.9.37.rbi
@@ -3344,11 +3344,11 @@ YARD::CodeObjects::METHODNAMEMATCH = T.let(T.unsafe(nil), Regexp)
 #   # Extra data added to docstring
 #   property :bar
 #
-# source://yard//lib/yard/code_objects/macro_object.rb#30
+# source://yard//lib/yard/code_objects/macro_object.rb#29
 class YARD::CodeObjects::MacroObject < ::YARD::CodeObjects::Base
   # @return [Boolean] whether this macro is attached to a method
   #
-  # source://yard//lib/yard/code_objects/macro_object.rb#149
+  # source://yard//lib/yard/code_objects/macro_object.rb#148
   def attached?; end
 
   # Expands the macro using
@@ -3363,39 +3363,39 @@ class YARD::CodeObjects::MacroObject < ::YARD::CodeObjects::Base
   #   call, if there is a block.
   # @see expand
   #
-  # source://yard//lib/yard/code_objects/macro_object.rb#167
+  # source://yard//lib/yard/code_objects/macro_object.rb#166
   def expand(call_params = T.unsafe(nil), full_source = T.unsafe(nil), block_source = T.unsafe(nil)); end
 
   # @return [String] the macro data stored on the object
   #
-  # source://yard//lib/yard/code_objects/macro_object.rb#142
+  # source://yard//lib/yard/code_objects/macro_object.rb#141
   def macro_data; end
 
   # @return [String] the macro data stored on the object
   #
-  # source://yard//lib/yard/code_objects/macro_object.rb#142
+  # source://yard//lib/yard/code_objects/macro_object.rb#141
   def macro_data=(_arg0); end
 
   # @return [CodeObjects::Base] the method object that this macro is
   #   attached to.
   #
-  # source://yard//lib/yard/code_objects/macro_object.rb#146
+  # source://yard//lib/yard/code_objects/macro_object.rb#145
   def method_object; end
 
   # @return [CodeObjects::Base] the method object that this macro is
   #   attached to.
   #
-  # source://yard//lib/yard/code_objects/macro_object.rb#146
+  # source://yard//lib/yard/code_objects/macro_object.rb#145
   def method_object=(_arg0); end
 
   # Overrides {Base#path} so the macro path is ".macro.MACRONAME"
   #
-  # source://yard//lib/yard/code_objects/macro_object.rb#152
+  # source://yard//lib/yard/code_objects/macro_object.rb#151
   def path; end
 
   # Overrides the separator to be '.'
   #
-  # source://yard//lib/yard/code_objects/macro_object.rb#155
+  # source://yard//lib/yard/code_objects/macro_object.rb#154
   def sep; end
 
   class << self
@@ -3413,7 +3413,7 @@ class YARD::CodeObjects::MacroObject < ::YARD::CodeObjects::Base
     # @return [String] the expanded macro data
     # @see find_or_create
     #
-    # source://yard//lib/yard/code_objects/macro_object.rb#120
+    # source://yard//lib/yard/code_objects/macro_object.rb#119
     def apply(docstring, call_params = T.unsafe(nil), full_source = T.unsafe(nil), block_source = T.unsafe(nil), _method_object = T.unsafe(nil)); end
 
     # Applies a macro to a docstring, interpolating the macro's data on the
@@ -3429,7 +3429,7 @@ class YARD::CodeObjects::MacroObject < ::YARD::CodeObjects::Base
     #   interpolating the block data as a variable.
     # @return [String] the expanded macro data
     #
-    # source://yard//lib/yard/code_objects/macro_object.rb#136
+    # source://yard//lib/yard/code_objects/macro_object.rb#135
     def apply_macro(macro, docstring, call_params = T.unsafe(nil), full_source = T.unsafe(nil), block_source = T.unsafe(nil)); end
 
     # Creates a new macro and fills in the relevant properties.
@@ -3440,7 +3440,7 @@ class YARD::CodeObjects::MacroObject < ::YARD::CodeObjects::Base
     #   macro to. If supplied, {#attached?} will be true
     # @return [MacroObject] the newly created object
     #
-    # source://yard//lib/yard/code_objects/macro_object.rb#40
+    # source://yard//lib/yard/code_objects/macro_object.rb#39
     def create(macro_name, data, method_object = T.unsafe(nil)); end
 
     # Parses a given docstring and determines if the macro is "new" or
@@ -3460,7 +3460,7 @@ class YARD::CodeObjects::MacroObject < ::YARD::CodeObjects::Base
     # @return [nil] if the +data+ has no macro tag or if the macro is
     #   not new and no macro by the macro name is found.
     #
-    # source://yard//lib/yard/code_objects/macro_object.rb#71
+    # source://yard//lib/yard/code_objects/macro_object.rb#70
     def create_docstring(macro_name, data, method_object = T.unsafe(nil)); end
 
     # Expands +macro_data+ using the interpolation parameters.
@@ -3473,7 +3473,7 @@ class YARD::CodeObjects::MacroObject < ::YARD::CodeObjects::Base
     #
     # @param macro_data [String] the macro data to expand (taken from {#macro_data})
     #
-    # source://yard//lib/yard/code_objects/macro_object.rb#93
+    # source://yard//lib/yard/code_objects/macro_object.rb#92
     def expand(macro_data, call_params = T.unsafe(nil), full_source = T.unsafe(nil), block_source = T.unsafe(nil)); end
 
     # Finds a macro using +macro_name+
@@ -3482,7 +3482,7 @@ class YARD::CodeObjects::MacroObject < ::YARD::CodeObjects::Base
     # @return [MacroObject] if a macro is found
     # @return [nil] if there is no registered macro by that name
     #
-    # source://yard//lib/yard/code_objects/macro_object.rb#51
+    # source://yard//lib/yard/code_objects/macro_object.rb#50
     def find(macro_name); end
 
     # Parses a given docstring and determines if the macro is "new" or
@@ -3502,12 +3502,12 @@ class YARD::CodeObjects::MacroObject < ::YARD::CodeObjects::Base
     # @return [nil] if the +data+ has no macro tag or if the macro is
     #   not new and no macro by the macro name is found.
     #
-    # source://yard//lib/yard/code_objects/macro_object.rb#71
+    # source://yard//lib/yard/code_objects/macro_object.rb#70
     def find_or_create(macro_name, data, method_object = T.unsafe(nil)); end
   end
 end
 
-# source://yard//lib/yard/code_objects/macro_object.rb#31
+# source://yard//lib/yard/code_objects/macro_object.rb#30
 YARD::CodeObjects::MacroObject::MACRO_MATCH = T.let(T.unsafe(nil), Regexp)
 
 # Represents a Ruby method in source
@@ -4842,7 +4842,7 @@ YARD::Docstring::META_MATCH = T.let(T.unsafe(nil), Regexp)
 # @see #parse_content
 # @since 0.8.0
 #
-# source://yard//lib/yard/docstring_parser.rb#30
+# source://yard//lib/yard/docstring_parser.rb#29
 class YARD::DocstringParser
   # Creates a new parser to parse docstring data
   #
@@ -4851,7 +4851,7 @@ class YARD::DocstringParser
   # @return [DocstringParser] a new instance of DocstringParser
   # @since 0.8.0
   #
-  # source://yard//lib/yard/docstring_parser.rb#81
+  # source://yard//lib/yard/docstring_parser.rb#80
   def initialize(library = T.unsafe(nil)); end
 
   # Creates a new directive using the registered {#library}
@@ -4859,14 +4859,14 @@ class YARD::DocstringParser
   # @return [Tags::Directive] the directive object that is created
   # @since 0.8.0
   #
-  # source://yard//lib/yard/docstring_parser.rb#232
+  # source://yard//lib/yard/docstring_parser.rb#231
   def create_directive(tag_name, tag_buf); end
 
   # Creates a {Tags::RefTag}
   #
   # @since 0.8.0
   #
-  # source://yard//lib/yard/docstring_parser.rb#226
+  # source://yard//lib/yard/docstring_parser.rb#225
   def create_ref_tag(tag_name, name, object_name); end
 
   # Creates a tag from the {Tags::DefaultFactory tag factory}.
@@ -4878,7 +4878,7 @@ class YARD::DocstringParser
   # @return [Tags::Tag, Tags::RefTag] a tag
   # @since 0.8.0
   #
-  # source://yard//lib/yard/docstring_parser.rb#209
+  # source://yard//lib/yard/docstring_parser.rb#208
   def create_tag(tag_name, tag_buf = T.unsafe(nil)); end
 
   # @return [Array<Tags::Directive>] a list of directives identified
@@ -4886,7 +4886,7 @@ class YARD::DocstringParser
   #   Docstring object.
   # @since 0.8.0
   #
-  # source://yard//lib/yard/docstring_parser.rb#45
+  # source://yard//lib/yard/docstring_parser.rb#44
   def directives; end
 
   # @return [Array<Tags::Directive>] a list of directives identified
@@ -4894,7 +4894,7 @@ class YARD::DocstringParser
   #   Docstring object.
   # @since 0.8.0
   #
-  # source://yard//lib/yard/docstring_parser.rb#45
+  # source://yard//lib/yard/docstring_parser.rb#44
   def directives=(_arg0); end
 
   # @return [Handlers::Base, nil] the handler parsing this
@@ -4902,7 +4902,7 @@ class YARD::DocstringParser
   #   initialized through
   # @since 0.8.0
   #
-  # source://yard//lib/yard/docstring_parser.rb#66
+  # source://yard//lib/yard/docstring_parser.rb#65
   def handler; end
 
   # @return [Handlers::Base, nil] the handler parsing this
@@ -4910,21 +4910,21 @@ class YARD::DocstringParser
   #   initialized through
   # @since 0.8.0
   #
-  # source://yard//lib/yard/docstring_parser.rb#66
+  # source://yard//lib/yard/docstring_parser.rb#65
   def handler=(_arg0); end
 
   # @return [Tags::Library] the tag library being used to
   #   identify registered tags in the docstring.
   # @since 0.8.0
   #
-  # source://yard//lib/yard/docstring_parser.rb#70
+  # source://yard//lib/yard/docstring_parser.rb#69
   def library; end
 
   # @return [Tags::Library] the tag library being used to
   #   identify registered tags in the docstring.
   # @since 0.8.0
   #
-  # source://yard//lib/yard/docstring_parser.rb#70
+  # source://yard//lib/yard/docstring_parser.rb#69
   def library=(_arg0); end
 
   # @return [CodeObjects::Base, nil] the object associated with
@@ -4932,7 +4932,7 @@ class YARD::DocstringParser
   #   not attached to any object.
   # @since 0.8.0
   #
-  # source://yard//lib/yard/docstring_parser.rb#56
+  # source://yard//lib/yard/docstring_parser.rb#55
   def object; end
 
   # @return [CodeObjects::Base, nil] the object associated with
@@ -4940,7 +4940,7 @@ class YARD::DocstringParser
   #   not attached to any object.
   # @since 0.8.0
   #
-  # source://yard//lib/yard/docstring_parser.rb#56
+  # source://yard//lib/yard/docstring_parser.rb#55
   def object=(_arg0); end
 
   # Parses all content and returns itself.
@@ -4957,7 +4957,7 @@ class YARD::DocstringParser
   # @see #to_docstring
   # @since 0.8.0
   #
-  # source://yard//lib/yard/docstring_parser.rb#113
+  # source://yard//lib/yard/docstring_parser.rb#112
   def parse(content, object = T.unsafe(nil), handler = T.unsafe(nil)); end
 
   # Parses a given block of text.
@@ -4967,7 +4967,7 @@ class YARD::DocstringParser
   # @param content [String] the content to parse
   # @since 0.8.0
   #
-  # source://yard//lib/yard/docstring_parser.rb#129
+  # source://yard//lib/yard/docstring_parser.rb#128
   def parse_content(content); end
 
   # Call post processing callbacks on parser.
@@ -4977,19 +4977,19 @@ class YARD::DocstringParser
   # @return [void]
   # @since 0.8.0
   #
-  # source://yard//lib/yard/docstring_parser.rb#196
+  # source://yard//lib/yard/docstring_parser.rb#195
   def post_process; end
 
   # @return [String] the complete input string to the parser.
   # @since 0.8.0
   #
-  # source://yard//lib/yard/docstring_parser.rb#36
+  # source://yard//lib/yard/docstring_parser.rb#35
   def raw_text; end
 
   # @return [String] the complete input string to the parser.
   # @since 0.8.0
   #
-  # source://yard//lib/yard/docstring_parser.rb#36
+  # source://yard//lib/yard/docstring_parser.rb#35
   def raw_text=(_arg0); end
 
   # @return [CodeObjects::Base, nil] the object referenced by
@@ -4997,7 +4997,7 @@ class YARD::DocstringParser
   #   refer to any object.
   # @since 0.8.0
   #
-  # source://yard//lib/yard/docstring_parser.rb#61
+  # source://yard//lib/yard/docstring_parser.rb#60
   def reference; end
 
   # @return [CodeObjects::Base, nil] the object referenced by
@@ -5005,7 +5005,7 @@ class YARD::DocstringParser
   #   refer to any object.
   # @since 0.8.0
   #
-  # source://yard//lib/yard/docstring_parser.rb#61
+  # source://yard//lib/yard/docstring_parser.rb#60
   def reference=(_arg0); end
 
   # @return [OpenStruct] any arbitrary state to be passed between
@@ -5014,7 +5014,7 @@ class YARD::DocstringParser
   #   used in a docstring).
   # @since 0.8.0
   #
-  # source://yard//lib/yard/docstring_parser.rb#51
+  # source://yard//lib/yard/docstring_parser.rb#50
   def state; end
 
   # @return [OpenStruct] any arbitrary state to be passed between
@@ -5023,7 +5023,7 @@ class YARD::DocstringParser
   #   used in a docstring).
   # @since 0.8.0
   #
-  # source://yard//lib/yard/docstring_parser.rb#51
+  # source://yard//lib/yard/docstring_parser.rb#50
   def state=(_arg0); end
 
   # Backward compatibility to detect old tags that should be specified
@@ -5032,42 +5032,42 @@ class YARD::DocstringParser
   # @return [Boolean]
   # @since 0.8.0
   #
-  # source://yard//lib/yard/docstring_parser.rb#252
+  # source://yard//lib/yard/docstring_parser.rb#251
   def tag_is_directive?(tag_name); end
 
   # @return [Array<Tags::Tag>] the list of meta-data tags identified
   #   by the parser
   # @since 0.8.0
   #
-  # source://yard//lib/yard/docstring_parser.rb#40
+  # source://yard//lib/yard/docstring_parser.rb#39
   def tags; end
 
   # @return [Array<Tags::Tag>] the list of meta-data tags identified
   #   by the parser
   # @since 0.8.0
   #
-  # source://yard//lib/yard/docstring_parser.rb#40
+  # source://yard//lib/yard/docstring_parser.rb#39
   def tags=(_arg0); end
 
   # @return [String] the parsed text portion of the docstring,
   #   with tags removed.
   # @since 0.8.0
   #
-  # source://yard//lib/yard/docstring_parser.rb#33
+  # source://yard//lib/yard/docstring_parser.rb#32
   def text; end
 
   # @return [String] the parsed text portion of the docstring,
   #   with tags removed.
   # @since 0.8.0
   #
-  # source://yard//lib/yard/docstring_parser.rb#33
+  # source://yard//lib/yard/docstring_parser.rb#32
   def text=(_arg0); end
 
   # @return [Docstring] translates parsed text into
   #   a Docstring object.
   # @since 0.8.0
   #
-  # source://yard//lib/yard/docstring_parser.rb#95
+  # source://yard//lib/yard/docstring_parser.rb#94
   def to_docstring; end
 
   private
@@ -5076,7 +5076,7 @@ class YARD::DocstringParser
   #
   # @since 0.8.0
   #
-  # source://yard//lib/yard/docstring_parser.rb#324
+  # source://yard//lib/yard/docstring_parser.rb#323
   def call_after_parse_callbacks; end
 
   # Calls the {Tags::Directive#after_parse} callback on all the
@@ -5084,17 +5084,17 @@ class YARD::DocstringParser
   #
   # @since 0.8.0
   #
-  # source://yard//lib/yard/docstring_parser.rb#319
+  # source://yard//lib/yard/docstring_parser.rb#318
   def call_directives_after_parse; end
 
   # @since 0.8.0
   #
-  # source://yard//lib/yard/docstring_parser.rb#305
+  # source://yard//lib/yard/docstring_parser.rb#304
   def detect_reference(content); end
 
   # @since 0.8.0
   #
-  # source://yard//lib/yard/docstring_parser.rb#301
+  # source://yard//lib/yard/docstring_parser.rb#300
   def namespace; end
 
   class << self
@@ -5109,13 +5109,13 @@ class YARD::DocstringParser
     #   with all directives and tags created.
     # @yieldreturn [void]
     #
-    # source://yard//lib/yard/docstring_parser.rb#266
+    # source://yard//lib/yard/docstring_parser.rb#265
     def after_parse(&block); end
 
     # @return [Array<Proc>] the {after_parse} callback proc objects
     # @since 0.8.0
     #
-    # source://yard//lib/yard/docstring_parser.rb#271
+    # source://yard//lib/yard/docstring_parser.rb#270
     def after_parse_callbacks; end
   end
 end
@@ -5124,7 +5124,7 @@ end
 #
 # @since 0.8.0
 #
-# source://yard//lib/yard/docstring_parser.rb#73
+# source://yard//lib/yard/docstring_parser.rb#72
 YARD::DocstringParser::META_MATCH = T.let(T.unsafe(nil), Regexp)
 
 # source://yard//lib/yard/gem_index.rb#6
@@ -6033,14 +6033,14 @@ end
 #
 # @see Handlers::Base
 #
-# source://yard//lib/yard/handlers/processor.rb#20
+# source://yard//lib/yard/handlers/processor.rb#19
 class YARD::Handlers::Processor
   # Creates a new Processor for a +file+.
   #
   # @param parser [Parser::SourceParser] the parser used to initialize the processor
   # @return [Processor] a new instance of Processor
   #
-  # source://yard//lib/yard/handlers/processor.rb#92
+  # source://yard//lib/yard/handlers/processor.rb#91
   def initialize(parser); end
 
   # Share state across different handlers inside of a file.
@@ -6053,7 +6053,7 @@ class YARD::Handlers::Processor
   # @return [OpenStruct] an open structure that can store arbitrary data
   # @see #globals
   #
-  # source://yard//lib/yard/handlers/processor.rb#88
+  # source://yard//lib/yard/handlers/processor.rb#87
   def extra_state; end
 
   # Share state across different handlers inside of a file.
@@ -6066,17 +6066,17 @@ class YARD::Handlers::Processor
   # @return [OpenStruct] an open structure that can store arbitrary data
   # @see #globals
   #
-  # source://yard//lib/yard/handlers/processor.rb#88
+  # source://yard//lib/yard/handlers/processor.rb#87
   def extra_state=(_arg0); end
 
   # @return [String] the filename
   #
-  # source://yard//lib/yard/handlers/processor.rb#41
+  # source://yard//lib/yard/handlers/processor.rb#40
   def file; end
 
   # @return [String] the filename
   #
-  # source://yard//lib/yard/handlers/processor.rb#41
+  # source://yard//lib/yard/handlers/processor.rb#40
   def file=(_arg0); end
 
   # Searches for all handlers in {Base.subclasses} that match the +statement+
@@ -6084,7 +6084,7 @@ class YARD::Handlers::Processor
   # @param statement the statement object to match.
   # @return [Array<Base>] a list of handlers to process the statement with.
   #
-  # source://yard//lib/yard/handlers/processor.rb#151
+  # source://yard//lib/yard/handlers/processor.rb#150
   def find_handlers(statement); end
 
   # Handlers can share state for the entire post processing stage through
@@ -6104,7 +6104,7 @@ class YARD::Handlers::Processor
   # @return [OpenStruct] global shared state for post-processing stage
   # @see #extra_state
   #
-  # source://yard//lib/yard/handlers/processor.rb#77
+  # source://yard//lib/yard/handlers/processor.rb#76
   def globals; end
 
   # Handlers can share state for the entire post processing stage through
@@ -6124,17 +6124,17 @@ class YARD::Handlers::Processor
   # @return [OpenStruct] global shared state for post-processing stage
   # @see #extra_state
   #
-  # source://yard//lib/yard/handlers/processor.rb#77
+  # source://yard//lib/yard/handlers/processor.rb#76
   def globals=(_arg0); end
 
   # @return [CodeObjects::NamespaceObject] the current namespace
   #
-  # source://yard//lib/yard/handlers/processor.rb#44
+  # source://yard//lib/yard/handlers/processor.rb#43
   def namespace; end
 
   # @return [CodeObjects::NamespaceObject] the current namespace
   #
-  # source://yard//lib/yard/handlers/processor.rb#44
+  # source://yard//lib/yard/handlers/processor.rb#43
   def namespace=(_arg0); end
 
   # @return [CodeObjects::Base, nil] unlike the namespace, the owner
@@ -6142,7 +6142,7 @@ class YARD::Handlers::Processor
   #   For instance, when parsing a method body, the {CodeObjects::MethodObject}
   #   is set as the owner, in case any extra method information is processed.
   #
-  # source://yard//lib/yard/handlers/processor.rb#56
+  # source://yard//lib/yard/handlers/processor.rb#55
   def owner; end
 
   # @return [CodeObjects::Base, nil] unlike the namespace, the owner
@@ -6150,7 +6150,7 @@ class YARD::Handlers::Processor
   #   For instance, when parsing a method body, the {CodeObjects::MethodObject}
   #   is set as the owner, in case any extra method information is processed.
   #
-  # source://yard//lib/yard/handlers/processor.rb#56
+  # source://yard//lib/yard/handlers/processor.rb#55
   def owner=(_arg0); end
 
   # Continue parsing the remainder of the files in the +globals.ordered_parser+
@@ -6160,17 +6160,17 @@ class YARD::Handlers::Processor
   # @return [void]
   # @see Parser::OrderedParser
   #
-  # source://yard//lib/yard/handlers/processor.rb#140
+  # source://yard//lib/yard/handlers/processor.rb#139
   def parse_remaining_files; end
 
   # @return [Symbol] the parser type (:ruby, :ruby18, :c)
   #
-  # source://yard//lib/yard/handlers/processor.rb#59
+  # source://yard//lib/yard/handlers/processor.rb#58
   def parser_type; end
 
   # @return [Symbol] the parser type (:ruby, :ruby18, :c)
   #
-  # source://yard//lib/yard/handlers/processor.rb#59
+  # source://yard//lib/yard/handlers/processor.rb#58
   def parser_type=(_arg0); end
 
   # Processes a list of statements by finding handlers to process each
@@ -6179,27 +6179,27 @@ class YARD::Handlers::Processor
   # @param statements [Array] a list of statements
   # @return [void]
   #
-  # source://yard//lib/yard/handlers/processor.rb#110
+  # source://yard//lib/yard/handlers/processor.rb#109
   def process(statements); end
 
   # @return [Symbol] the current scope (class, instance)
   #
-  # source://yard//lib/yard/handlers/processor.rb#50
+  # source://yard//lib/yard/handlers/processor.rb#49
   def scope; end
 
   # @return [Symbol] the current scope (class, instance)
   #
-  # source://yard//lib/yard/handlers/processor.rb#50
+  # source://yard//lib/yard/handlers/processor.rb#49
   def scope=(_arg0); end
 
   # @return [Symbol] the current visibility (public, private, protected)
   #
-  # source://yard//lib/yard/handlers/processor.rb#47
+  # source://yard//lib/yard/handlers/processor.rb#46
   def visibility; end
 
   # @return [Symbol] the current visibility (public, private, protected)
   #
-  # source://yard//lib/yard/handlers/processor.rb#47
+  # source://yard//lib/yard/handlers/processor.rb#46
   def visibility=(_arg0); end
 
   private
@@ -6208,7 +6208,7 @@ class YARD::Handlers::Processor
   #
   # @return [Base] the base class
   #
-  # source://yard//lib/yard/handlers/processor.rb#172
+  # source://yard//lib/yard/handlers/processor.rb#171
   def handler_base_class; end
 
   # The module holding the handlers to be loaded
@@ -6216,12 +6216,12 @@ class YARD::Handlers::Processor
   # @return [Module] the module containing the handlers depending on
   #   {#parser_type}.
   #
-  # source://yard//lib/yard/handlers/processor.rb#180
+  # source://yard//lib/yard/handlers/processor.rb#179
   def handler_base_namespace; end
 
   # @return [Boolean]
   #
-  # source://yard//lib/yard/handlers/processor.rb#161
+  # source://yard//lib/yard/handlers/processor.rb#160
   def handles?(handler, statement); end
 
   # Loads handlers from {#handler_base_namespace}. This ensures that
@@ -6230,7 +6230,7 @@ class YARD::Handlers::Processor
   #
   # @return [void]
   #
-  # source://yard//lib/yard/handlers/processor.rb#188
+  # source://yard//lib/yard/handlers/processor.rb#187
   def load_handlers; end
 
   class << self
@@ -6238,14 +6238,14 @@ class YARD::Handlers::Processor
     # @return [Hash] a list of registered parser type extensions
     # @since 0.6.0
     #
-    # source://yard//lib/yard/handlers/processor.rb#33
+    # source://yard//lib/yard/handlers/processor.rb#32
     def namespace_for_handler; end
 
     # Registers a new namespace for handlers of the given type.
     #
     # @since 0.6.0
     #
-    # source://yard//lib/yard/handlers/processor.rb#24
+    # source://yard//lib/yard/handlers/processor.rb#23
     def register_handler_namespace(type, ns); end
   end
 end
@@ -7078,6 +7078,11 @@ end
 # source://yard//lib/yard/handlers/ruby/visibility_handler.rb#3
 class YARD::Handlers::Ruby::VisibilityHandler < ::YARD::Handlers::Ruby::Base
   include ::YARD::Handlers::Ruby::DecoratorHandlerMethods
+
+  # @return [Boolean]
+  #
+  # source://yard//lib/yard/handlers/ruby/visibility_handler.rb#31
+  def is_attribute_method?(node); end
 end
 
 # Handles 'yield' calls
@@ -7540,13 +7545,16 @@ end
 # Handles console logging for info, warnings and errors.
 # Uses the stdlib Logger class in Ruby for all the backend logic.
 #
-# source://yard//lib/yard/logging.rb#9
-class YARD::Logger < ::Logger
+# source://yard//lib/yard/logging.rb#8
+class YARD::Logger
+  include ::YARD::Logger::Severity
+
   # Creates a new logger
   #
+  # @private
   # @return [Logger] a new instance of Logger
   #
-  # source://yard//lib/yard/logging.rb#43
+  # source://yard//lib/yard/logging.rb#82
   def initialize(pipe, *args); end
 
   # Displays an unformatted line to the logger output stream.
@@ -7555,7 +7563,7 @@ class YARD::Logger < ::Logger
   # @return [void]
   # @since 0.8.2
   #
-  # source://yard//lib/yard/logging.rb#143
+  # source://yard//lib/yard/logging.rb#205
   def <<(msg = T.unsafe(nil)); end
 
   # Prints the backtrace +exc+ to the logger as error data.
@@ -7564,7 +7572,7 @@ class YARD::Logger < ::Logger
   # @param level_meth [Symbol] the level to log backtrace at
   # @return [void]
   #
-  # source://yard//lib/yard/logging.rb#154
+  # source://yard//lib/yard/logging.rb#216
   def backtrace(exc, level_meth = T.unsafe(nil)); end
 
   # Captures the duration of a block of code for benchmark analysis. Also
@@ -7577,7 +7585,7 @@ class YARD::Logger < ::Logger
   # @todo Implement capture storage for reporting of benchmarks
   # @yield a block of arbitrary code to benchmark
   #
-  # source://yard//lib/yard/logging.rb#80
+  # source://yard//lib/yard/logging.rb#234
   def capture(msg, nontty_log = T.unsafe(nil)); end
 
   # Clears the progress indicator in the TTY display.
@@ -7585,14 +7593,18 @@ class YARD::Logger < ::Logger
   # @return [void]
   # @since 0.8.2
   #
-  # source://yard//lib/yard/logging.rb#121
+  # source://yard//lib/yard/logging.rb#186
   def clear_progress; end
 
-  # Changes the debug level to DEBUG if $DEBUG is set
-  # and writes a debugging message.
+  # Changes the debug level to DEBUG if $DEBUG is set and writes a debugging message.
+  # Logs a message with the debug severity level.
   #
-  # source://yard//lib/yard/logging.rb#59
-  def debug(*args); end
+  # @param message [String] the message to log
+  # @return [void]
+  # @see #log
+  #
+  # source://yard//lib/yard/logging.rb#103
+  def debug(message); end
 
   # Sets the logger level for the duration of the block
   #
@@ -7604,17 +7616,65 @@ class YARD::Logger < ::Logger
   #   values can be found in Ruby's Logger class.
   # @yield the block with the logger temporarily set to +new_level+
   #
-  # source://yard//lib/yard/logging.rb#179
+  # source://yard//lib/yard/logging.rb#142
   def enter_level(new_level = T.unsafe(nil)); end
+
+  # Logs a message with the error severity level.
+  #
+  # @param message [String] the message to log
+  # @return [void]
+  # @see #log
+  #
+  # source://yard//lib/yard/logging.rb#103
+  def error(message); end
+
+  # Logs a message with the fatal severity level.
+  #
+  # @param message [String] the message to log
+  # @return [void]
+  # @see #log
+  #
+  # source://yard//lib/yard/logging.rb#103
+  def fatal(message); end
+
+  # Logs a message with the info severity level.
+  #
+  # @param message [String] the message to log
+  # @return [void]
+  # @see #log
+  #
+  # source://yard//lib/yard/logging.rb#103
+  def info(message); end
 
   # @return [IO] the IO object being logged to
   # @since 0.8.2
   #
-  # source://yard//lib/yard/logging.rb#17
+  # source://yard//lib/yard/logging.rb#49
   def io; end
 
-  # source://yard//lib/yard/logging.rb#18
-  def io=(pipe); end
+  # @return [IO] the IO object being logged to
+  # @since 0.8.2
+  #
+  # source://yard//lib/yard/logging.rb#49
+  def io=(_arg0); end
+
+  # @return [DEBUG, INFO, WARN, ERROR, FATAL, UNKNOWN] the logging level
+  #
+  # source://yard//lib/yard/logging.rb#57
+  def level; end
+
+  # @return [DEBUG, INFO, WARN, ERROR, FATAL, UNKNOWN] the logging level
+  #
+  # source://yard//lib/yard/logging.rb#57
+  def level=(_arg0); end
+
+  # Logs a message with a given severity
+  #
+  # @param severity [DEBUG, INFO, WARN, ERROR, FATAL, UNKNOWN] the severity level
+  # @param message [String] the message to log
+  #
+  # source://yard//lib/yard/logging.rb#122
+  def log(severity, message); end
 
   # Displays an unformatted line to the logger output stream.
   #
@@ -7622,7 +7682,7 @@ class YARD::Logger < ::Logger
   # @return [void]
   # @since 0.8.2
   #
-  # source://yard//lib/yard/logging.rb#143
+  # source://yard//lib/yard/logging.rb#205
   def print(msg = T.unsafe(nil)); end
 
   # Displays a progress indicator for a given message. This progress report
@@ -7635,7 +7695,7 @@ class YARD::Logger < ::Logger
   # @return [void]
   # @since 0.8.2
   #
-  # source://yard//lib/yard/logging.rb#96
+  # source://yard//lib/yard/logging.rb#161
   def progress(msg, nontty_log = T.unsafe(nil)); end
 
   # Displays an unformatted line to the logger output stream, adding
@@ -7645,86 +7705,91 @@ class YARD::Logger < ::Logger
   # @return [void]
   # @since 0.8.2
   #
-  # source://yard//lib/yard/logging.rb#132
+  # source://yard//lib/yard/logging.rb#197
   def puts(msg = T.unsafe(nil)); end
 
   # @return [Boolean] whether backtraces should be shown (by default
   #   this is on).
   #
-  # source://yard//lib/yard/logging.rb#22
+  # source://yard//lib/yard/logging.rb#53
   def show_backtraces; end
 
   # Sets the attribute show_backtraces
   #
   # @param value the value to set the attribute show_backtraces to.
   #
-  # source://yard//lib/yard/logging.rb#23
+  # source://yard//lib/yard/logging.rb#54
   def show_backtraces=(_arg0); end
 
   # @return [Boolean] whether progress indicators should be shown when
   #   logging CLIs (by default this is off).
   #
-  # source://yard//lib/yard/logging.rb#27
+  # source://yard//lib/yard/logging.rb#64
   def show_progress; end
 
   # Sets the attribute show_progress
   #
   # @param value the value to set the attribute show_progress to.
   #
-  # source://yard//lib/yard/logging.rb#34
+  # source://yard//lib/yard/logging.rb#70
   def show_progress=(_arg0); end
 
-  # Remembers when a warning occurs and writes a warning message.
+  # Logs a message with the unknown severity level.
   #
-  # source://yard//lib/yard/logging.rb#65
-  def warn(*args); end
+  # @param message [String] the message to log
+  # @return [void]
+  # @see #log
+  #
+  # source://yard//lib/yard/logging.rb#103
+  def unknown(message); end
+
+  # Remembers when a warning occurs and writes a warning message.
+  # Logs a message with the warn severity level.
+  #
+  # @param message [String] the message to log
+  # @return [void]
+  # @see #log
+  #
+  # source://yard//lib/yard/logging.rb#103
+  def warn(message); end
 
   # Warns that the Ruby environment does not support continuations. Applies
   # to JRuby, Rubinius and MacRuby. This warning will only display once
   # per Ruby process.
   #
   # @deprecated Continuations are no longer needed by YARD 0.8.0+.
+  # @private
   # @return [void]
   #
-  # source://yard//lib/yard/logging.rb#167
+  # source://yard//lib/yard/logging.rb#250
   def warn_no_continuations; end
 
-  # Returns the value of attribute warned.
+  # @return [Boolean] whether a warn message has been emitted. Used for status tracking.
   #
-  # source://yard//lib/yard/logging.rb#69
+  # source://yard//lib/yard/logging.rb#60
   def warned; end
 
-  # Sets the attribute warned
+  # @return [Boolean] whether a warn message has been emitted. Used for status tracking.
   #
-  # @param value the value to set the attribute warned to.
-  #
-  # source://yard//lib/yard/logging.rb#69
+  # source://yard//lib/yard/logging.rb#60
   def warned=(_arg0); end
 
   private
 
-  # Override this internal Logger method to clear line
-  #
-  # source://yard//lib/yard/logging.rb#190
-  def add(*args); end
-
-  # source://yard//lib/yard/logging.rb#195
+  # source://yard//lib/yard/logging.rb#255
   def clear_line; end
 
-  # Log format (from Logger implementation). Used by Logger internally
-  #
-  # source://yard//lib/yard/logging.rb#201
-  def format_log(sev, _time, _prog, msg); end
-
-  # source://logger/1.6.0/logger.rb#684
-  def print_no_newline(msg); end
-
   class << self
+    # @private
+    #
+    # source://yard//lib/yard/logging.rb#101
+    def create_log_method(name); end
+
     # The logger instance
     #
     # @return [Logger] the logger instance
     #
-    # source://yard//lib/yard/logging.rb#38
+    # source://yard//lib/yard/logging.rb#76
     def instance(pipe = T.unsafe(nil)); end
   end
 end
@@ -7734,8 +7799,96 @@ end
 #
 # @since 0.8.2
 #
-# source://yard//lib/yard/logging.rb#13
+# source://yard//lib/yard/logging.rb#45
 YARD::Logger::PROGRESS_INDICATORS = T.let(T.unsafe(nil), Array)
+
+# Log severity levels
+#
+# source://yard//lib/yard/logging.rb#10
+module YARD::Logger::Severity; end
+
+# Debugging log level
+#
+# source://yard//lib/yard/logging.rb#12
+YARD::Logger::Severity::DEBUG = T.let(T.unsafe(nil), Integer)
+
+# Error log level
+#
+# source://yard//lib/yard/logging.rb#21
+YARD::Logger::Severity::ERROR = T.let(T.unsafe(nil), Integer)
+
+# Fatal log level
+#
+# source://yard//lib/yard/logging.rb#24
+YARD::Logger::Severity::FATAL = T.let(T.unsafe(nil), Integer)
+
+# Information log level
+#
+# source://yard//lib/yard/logging.rb#15
+YARD::Logger::Severity::INFO = T.let(T.unsafe(nil), Integer)
+
+# @private
+#
+# source://yard//lib/yard/logging.rb#30
+YARD::Logger::Severity::SEVERITIES = T.let(T.unsafe(nil), Hash)
+
+# Unknown log level
+#
+# source://yard//lib/yard/logging.rb#27
+YARD::Logger::Severity::UNKNOWN = T.let(T.unsafe(nil), Integer)
+
+# Warning log level
+#
+# source://yard//lib/yard/logging.rb#18
+YARD::Logger::Severity::WARN = T.let(T.unsafe(nil), Integer)
+
+# An OpenStruct compatible struct class that allows for basic access of attributes
+# via +struct.attr_name+ and +struct.attr_name = value+.
+#
+# source://yard//lib/yard/open_struct.rb#4
+class YARD::OpenStruct
+  # @return [OpenStruct] a new instance of OpenStruct
+  #
+  # source://yard//lib/yard/open_struct.rb#5
+  def initialize(hash = T.unsafe(nil)); end
+
+  # source://yard//lib/yard/open_struct.rb#25
+  def ==(other); end
+
+  # source://yard//lib/yard/open_struct.rb#41
+  def [](key); end
+
+  # source://yard//lib/yard/open_struct.rb#37
+  def []=(key, value); end
+
+  # source://yard//lib/yard/open_struct.rb#33
+  def dig(*keys); end
+
+  # source://yard//lib/yard/open_struct.rb#45
+  def each_pair(&block); end
+
+  # source://yard//lib/yard/open_struct.rb#29
+  def hash; end
+
+  # source://yard//lib/yard/open_struct.rb#49
+  def marshal_dump; end
+
+  # source://yard//lib/yard/open_struct.rb#53
+  def marshal_load(data); end
+
+  # @private
+  #
+  # source://yard//lib/yard/open_struct.rb#10
+  def method_missing(name, *args); end
+
+  # source://yard//lib/yard/open_struct.rb#21
+  def to_h; end
+
+  private
+
+  # source://yard//lib/yard/open_struct.rb#59
+  def __cache_lookup__(name); end
+end
 
 # Generalized options class for passing around large amounts of options between objects.
 #
@@ -8288,7 +8441,7 @@ end
 #
 # @see Processor#parse_remaining_files
 #
-# source://yard//lib/yard/parser/source_parser.rb#21
+# source://yard//lib/yard/parser/source_parser.rb#20
 class YARD::Parser::OrderedParser
   # Creates a new OrderedParser with the global state and a list
   # of files to parse.
@@ -8300,30 +8453,30 @@ class YARD::Parser::OrderedParser
   # @param files [Array<String>] the list of files to parse
   # @return [OrderedParser] a new instance of OrderedParser
   #
-  # source://yard//lib/yard/parser/source_parser.rb#33
+  # source://yard//lib/yard/parser/source_parser.rb#32
   def initialize(global_state, files); end
 
   # @return [Array<String>] the list of remaining files to parse
   #
-  # source://yard//lib/yard/parser/source_parser.rb#23
+  # source://yard//lib/yard/parser/source_parser.rb#22
   def files; end
 
   # @return [Array<String>] the list of remaining files to parse
   #
-  # source://yard//lib/yard/parser/source_parser.rb#23
+  # source://yard//lib/yard/parser/source_parser.rb#22
   def files=(_arg0); end
 
   # Parses the remainder of the {#files} list.
   #
   # @see Processor#parse_remaining_files
   #
-  # source://yard//lib/yard/parser/source_parser.rb#42
+  # source://yard//lib/yard/parser/source_parser.rb#41
   def parse; end
 end
 
 # Raised when the parser sees a Ruby syntax error
 #
-# source://yard//lib/yard/parser/source_parser.rb#13
+# source://yard//lib/yard/parser/source_parser.rb#12
 class YARD::Parser::ParserSyntaxError < ::YARD::Parser::UndocumentableError; end
 
 # Ruby parsing components.
@@ -8768,6 +8921,9 @@ class YARD::Parser::Ruby::Legacy::RubyLex
   # source://yard//lib/yard/parser/ruby/legacy/ruby_lex.rb#430
   def continue; end
 
+  # source://yard//lib/yard/parser/ruby/legacy/ruby_lex.rb#1116
+  def dedent(str); end
+
   # Returns the value of attribute exception_on_syntax_error.
   #
   # source://yard//lib/yard/parser/ruby/legacy/ruby_lex.rb#463
@@ -8792,7 +8948,7 @@ class YARD::Parser::Ruby::Legacy::RubyLex
   # source://yard//lib/yard/parser/ruby/legacy/ruby_lex.rb#488
   def gets; end
 
-  # source://yard//lib/yard/parser/ruby/legacy/ruby_lex.rb#1257
+  # source://yard//lib/yard/parser/ruby/legacy/ruby_lex.rb#1272
   def identify_comment; end
 
   # source://yard//lib/yard/parser/ruby/legacy/ruby_lex.rb#945
@@ -8804,13 +8960,13 @@ class YARD::Parser::Ruby::Legacy::RubyLex
   # source://yard//lib/yard/parser/ruby/legacy/ruby_lex.rb#980
   def identify_identifier; end
 
-  # source://yard//lib/yard/parser/ruby/legacy/ruby_lex.rb#1130
+  # source://yard//lib/yard/parser/ruby/legacy/ruby_lex.rb#1145
   def identify_number(start); end
 
-  # source://yard//lib/yard/parser/ruby/legacy/ruby_lex.rb#1111
+  # source://yard//lib/yard/parser/ruby/legacy/ruby_lex.rb#1126
   def identify_quotation(initial_char); end
 
-  # source://yard//lib/yard/parser/ruby/legacy/ruby_lex.rb#1192
+  # source://yard//lib/yard/parser/ruby/legacy/ruby_lex.rb#1207
   def identify_string(ltype, quoted = T.unsafe(nil), opener = T.unsafe(nil), initial_char = T.unsafe(nil)); end
 
   # Returns the value of attribute indent.
@@ -8857,10 +9013,10 @@ class YARD::Parser::Ruby::Legacy::RubyLex
   # source://yard//lib/yard/parser/ruby/legacy/ruby_lex.rb#462
   def read_auto_clean_up=(_arg0); end
 
-  # source://yard//lib/yard/parser/ruby/legacy/ruby_lex.rb#1280
+  # source://yard//lib/yard/parser/ruby/legacy/ruby_lex.rb#1295
   def read_escape; end
 
-  # source://yard//lib/yard/parser/ruby/legacy/ruby_lex.rb#1242
+  # source://yard//lib/yard/parser/ruby/legacy/ruby_lex.rb#1257
   def skip_inner_expression; end
 
   # Returns the value of attribute skip_space.
@@ -11049,7 +11205,7 @@ end
 # @see Handlers::Base
 # @see CodeObjects::Base
 #
-# source://yard//lib/yard/parser/source_parser.rb#64
+# source://yard//lib/yard/parser/source_parser.rb#63
 class YARD::Parser::SourceParser
   # @overload initialize
   # @return [SourceParser] a new instance of SourceParser
@@ -11305,7 +11461,7 @@ class YARD::Parser::SourceParser
     #   {YARD::Logger}
     # @return [void]
     #
-    # source://yard//lib/yard/parser/source_parser.rb#100
+    # source://yard//lib/yard/parser/source_parser.rb#99
     def parse(paths = T.unsafe(nil), excluded = T.unsafe(nil), level = T.unsafe(nil)); end
 
     # Parses a string +content+
@@ -11319,10 +11475,10 @@ class YARD::Parser::SourceParser
 
     # @return [Symbol] the default parser type (defaults to :ruby)
     #
-    # source://yard//lib/yard/parser/source_parser.rb#86
+    # source://yard//lib/yard/parser/source_parser.rb#85
     def parser_type; end
 
-    # source://yard//lib/yard/parser/source_parser.rb#88
+    # source://yard//lib/yard/parser/source_parser.rb#87
     def parser_type=(value); end
 
     # @private
@@ -11403,30 +11559,30 @@ end
 #
 # @since 0.9.0
 #
-# source://yard//lib/yard/parser/source_parser.rb#71
+# source://yard//lib/yard/parser/source_parser.rb#70
 YARD::Parser::SourceParser::DEFAULT_PATH_GLOB = T.let(T.unsafe(nil), Array)
 
 # Byte order marks for various encodings
 #
 # @since 0.7.0
 #
-# source://yard//lib/yard/parser/source_parser.rb#75
+# source://yard//lib/yard/parser/source_parser.rb#74
 YARD::Parser::SourceParser::ENCODING_BYTE_ORDER_MARKS = T.let(T.unsafe(nil), Hash)
 
-# source://yard//lib/yard/parser/source_parser.rb#66
+# source://yard//lib/yard/parser/source_parser.rb#65
 YARD::Parser::SourceParser::ENCODING_LINE = T.let(T.unsafe(nil), Regexp)
 
-# source://yard//lib/yard/parser/source_parser.rb#67
+# source://yard//lib/yard/parser/source_parser.rb#66
 YARD::Parser::SourceParser::FROZEN_STRING_LINE = T.let(T.unsafe(nil), Regexp)
 
-# source://yard//lib/yard/parser/source_parser.rb#65
+# source://yard//lib/yard/parser/source_parser.rb#64
 YARD::Parser::SourceParser::SHEBANG_LINE = T.let(T.unsafe(nil), Regexp)
 
 # Raised when an object is recognized but cannot be documented. This
 # generally occurs when the Ruby syntax used to declare an object is
 # too dynamic in nature.
 #
-# source://yard//lib/yard/parser/source_parser.rb#10
+# source://yard//lib/yard/parser/source_parser.rb#9
 class YARD::Parser::UndocumentableError < ::RuntimeError; end
 
 # The root path for YARD source libraries
@@ -14813,42 +14969,42 @@ module YARD::Tags; end
 # @see tag:!method
 # @since 0.7.0
 #
-# source://yard//lib/yard/tags/directives.rb#461
+# source://yard//lib/yard/tags/directives.rb#460
 class YARD::Tags::AttributeDirective < ::YARD::Tags::MethodDirective
   # @since 0.7.0
   #
-  # source://yard//lib/yard/tags/directives.rb#462
+  # source://yard//lib/yard/tags/directives.rb#461
   def after_parse; end
 
   protected
 
   # @since 0.7.0
   #
-  # source://yard//lib/yard/tags/directives.rb#470
+  # source://yard//lib/yard/tags/directives.rb#469
   def method_name; end
 
   # @since 0.7.0
   #
-  # source://yard//lib/yard/tags/directives.rb#476
+  # source://yard//lib/yard/tags/directives.rb#475
   def method_signature; end
 
   private
 
   # @since 0.7.0
   #
-  # source://yard//lib/yard/tags/directives.rb#486
+  # source://yard//lib/yard/tags/directives.rb#485
   def create_attribute_data(object); end
 
   # @return [Boolean]
   # @since 0.7.0
   #
-  # source://yard//lib/yard/tags/directives.rb#516
+  # source://yard//lib/yard/tags/directives.rb#515
   def readable?; end
 
   # @return [Boolean]
   # @since 0.7.0
   #
-  # source://yard//lib/yard/tags/directives.rb#512
+  # source://yard//lib/yard/tags/directives.rb#511
   def writable?; end
 end
 
@@ -14982,14 +15138,14 @@ end
 # @see Library.define_directive
 # @since 0.8.0
 #
-# source://yard//lib/yard/tags/directives.rb#23
+# source://yard//lib/yard/tags/directives.rb#22
 class YARD::Tags::Directive
   # @param tag [Tag] the meta-data tag containing all input to the docstring
   # @param parser [DocstringParser] the docstring parser object
   # @return [Directive] a new instance of Directive
   # @since 0.8.0
   #
-  # source://yard//lib/yard/tags/directives.rb#55
+  # source://yard//lib/yard/tags/directives.rb#54
   def initialize(tag, parser); end
 
   # Called after parsing all directives and tags in the docstring. Used
@@ -14998,7 +15154,7 @@ class YARD::Tags::Directive
   # @return [void]
   # @since 0.8.0
   #
-  # source://yard//lib/yard/tags/directives.rb#74
+  # source://yard//lib/yard/tags/directives.rb#73
   def after_parse; end
 
   # Called when processing the directive. Subclasses should implement
@@ -15010,7 +15166,7 @@ class YARD::Tags::Directive
   # @return [void]
   # @since 0.8.0
   #
-  # source://yard//lib/yard/tags/directives.rb#69
+  # source://yard//lib/yard/tags/directives.rb#68
   def call; end
 
   # Set this field to replace the directive definition inside of a docstring
@@ -15022,7 +15178,7 @@ class YARD::Tags::Directive
   # @return [nil] if no expansion should take place for this directive
   # @since 0.8.0
   #
-  # source://yard//lib/yard/tags/directives.rb#34
+  # source://yard//lib/yard/tags/directives.rb#33
   def expanded_text; end
 
   # Set this field to replace the directive definition inside of a docstring
@@ -15034,7 +15190,7 @@ class YARD::Tags::Directive
   # @return [nil] if no expansion should take place for this directive
   # @since 0.8.0
   #
-  # source://yard//lib/yard/tags/directives.rb#34
+  # source://yard//lib/yard/tags/directives.rb#33
   def expanded_text=(_arg0); end
 
   # @return [Handlers::Base, nil] the handler object the docstring parser
@@ -15042,33 +15198,33 @@ class YARD::Tags::Directive
   #   through {Parser::SourceParser}.
   # @since 0.8.0
   #
-  # source://yard//lib/yard/tags/directives.rb#49
+  # source://yard//lib/yard/tags/directives.rb#48
   def handler; end
 
   # @return [CodeObjects::Base, nil] the object the parent docstring is
   #   attached to. May be nil.
   # @since 0.8.0
   #
-  # source://yard//lib/yard/tags/directives.rb#43
+  # source://yard//lib/yard/tags/directives.rb#42
   def object; end
 
   # @return [DocstringParser] the parser that is parsing all tag
   #   information out of the docstring
   # @since 0.8.0
   #
-  # source://yard//lib/yard/tags/directives.rb#38
+  # source://yard//lib/yard/tags/directives.rb#37
   def parser=(_arg0); end
 
   # @return [Tag] the meta-data tag containing data input to the directive
   # @since 0.8.0
   #
-  # source://yard//lib/yard/tags/directives.rb#25
+  # source://yard//lib/yard/tags/directives.rb#24
   def tag; end
 
   # @return [Tag] the meta-data tag containing data input to the directive
   # @since 0.8.0
   #
-  # source://yard//lib/yard/tags/directives.rb#25
+  # source://yard//lib/yard/tags/directives.rb#24
   def tag=(_arg0); end
 
   protected
@@ -15076,14 +15232,14 @@ class YARD::Tags::Directive
   # @return [Boolean]
   # @since 0.8.0
   #
-  # source://yard//lib/yard/tags/directives.rb#80
+  # source://yard//lib/yard/tags/directives.rb#79
   def inside_directive?; end
 
   # @return [DocstringParser] the parser that is parsing all tag
   #   information out of the docstring
   # @since 0.8.0
   #
-  # source://yard//lib/yard/tags/directives.rb#38
+  # source://yard//lib/yard/tags/directives.rb#37
   def parser; end
 end
 
@@ -15107,11 +15263,11 @@ end
 # @see tag:!group
 # @since 0.6.0
 #
-# source://yard//lib/yard/tags/directives.rb#105
+# source://yard//lib/yard/tags/directives.rb#104
 class YARD::Tags::EndGroupDirective < ::YARD::Tags::Directive
   # @since 0.6.0
   #
-  # source://yard//lib/yard/tags/directives.rb#106
+  # source://yard//lib/yard/tags/directives.rb#105
   def call; end
 end
 
@@ -15132,11 +15288,11 @@ end
 # @see tag:!endgroup
 # @since 0.6.0
 #
-# source://yard//lib/yard/tags/directives.rb#128
+# source://yard//lib/yard/tags/directives.rb#127
 class YARD::Tags::GroupDirective < ::YARD::Tags::Directive
   # @since 0.6.0
   #
-  # source://yard//lib/yard/tags/directives.rb#129
+  # source://yard//lib/yard/tags/directives.rb#128
   def call; end
 end
 
@@ -15901,12 +16057,12 @@ end
 #   end
 # @since 0.7.0
 #
-# source://yard//lib/yard/tags/directives.rb#258
+# source://yard//lib/yard/tags/directives.rb#257
 class YARD::Tags::MacroDirective < ::YARD::Tags::Directive
   # @raise [TagFormatError]
   # @since 0.7.0
   #
-  # source://yard//lib/yard/tags/directives.rb#259
+  # source://yard//lib/yard/tags/directives.rb#258
   def call; end
 
   private
@@ -15914,40 +16070,40 @@ class YARD::Tags::MacroDirective < ::YARD::Tags::Directive
   # @return [Boolean]
   # @since 0.7.0
   #
-  # source://yard//lib/yard/tags/directives.rb#288
+  # source://yard//lib/yard/tags/directives.rb#287
   def anonymous?; end
 
   # @return [Boolean]
   # @since 0.7.0
   #
-  # source://yard//lib/yard/tags/directives.rb#277
+  # source://yard//lib/yard/tags/directives.rb#276
   def attach?; end
 
   # @return [Boolean]
   # @since 0.7.0
   #
-  # source://yard//lib/yard/tags/directives.rb#283
+  # source://yard//lib/yard/tags/directives.rb#282
   def class_method?; end
 
   # @since 0.7.0
   #
-  # source://yard//lib/yard/tags/directives.rb#292
+  # source://yard//lib/yard/tags/directives.rb#291
   def expand(macro_data); end
 
   # @since 0.7.0
   #
-  # source://yard//lib/yard/tags/directives.rb#308
+  # source://yard//lib/yard/tags/directives.rb#307
   def find_or_create; end
 
   # @return [Boolean]
   # @since 0.7.0
   #
-  # source://yard//lib/yard/tags/directives.rb#272
+  # source://yard//lib/yard/tags/directives.rb#271
   def new?; end
 
   # @since 0.7.0
   #
-  # source://yard//lib/yard/tags/directives.rb#332
+  # source://yard//lib/yard/tags/directives.rb#331
   def warn; end
 end
 
@@ -15980,49 +16136,49 @@ end
 # @see tag:!attribute
 # @since 0.7.0
 #
-# source://yard//lib/yard/tags/directives.rb#368
+# source://yard//lib/yard/tags/directives.rb#367
 class YARD::Tags::MethodDirective < ::YARD::Tags::Directive
   # @since 0.7.0
   #
-  # source://yard//lib/yard/tags/directives.rb#373
+  # source://yard//lib/yard/tags/directives.rb#372
   def after_parse; end
 
   # @since 0.7.0
   #
-  # source://yard//lib/yard/tags/directives.rb#371
+  # source://yard//lib/yard/tags/directives.rb#370
   def call; end
 
   protected
 
   # @since 0.7.0
   #
-  # source://yard//lib/yard/tags/directives.rb#413
+  # source://yard//lib/yard/tags/directives.rb#412
   def create_object; end
 
   # @since 0.7.0
   #
-  # source://yard//lib/yard/tags/directives.rb#381
+  # source://yard//lib/yard/tags/directives.rb#380
   def method_name; end
 
   # @since 0.7.0
   #
-  # source://yard//lib/yard/tags/directives.rb#390
+  # source://yard//lib/yard/tags/directives.rb#389
   def method_signature; end
 
   # @since 0.7.0
   #
-  # source://yard//lib/yard/tags/directives.rb#394
+  # source://yard//lib/yard/tags/directives.rb#393
   def sanitized_tag_signature; end
 
   # @since 0.7.0
   #
-  # source://yard//lib/yard/tags/directives.rb#403
+  # source://yard//lib/yard/tags/directives.rb#402
   def use_indented_text; end
 end
 
 # @since 0.7.0
 #
-# source://yard//lib/yard/tags/directives.rb#369
+# source://yard//lib/yard/tags/directives.rb#368
 YARD::Tags::MethodDirective::SCOPE_MATCH = T.let(T.unsafe(nil), Regexp)
 
 # source://yard//lib/yard/tags/option_tag.rb#4
@@ -16134,11 +16290,11 @@ end
 #   #   }
 # @since 0.8.0
 #
-# source://yard//lib/yard/tags/directives.rb#545
+# source://yard//lib/yard/tags/directives.rb#544
 class YARD::Tags::ParseDirective < ::YARD::Tags::Directive
   # @since 0.8.0
   #
-  # source://yard//lib/yard/tags/directives.rb#546
+  # source://yard//lib/yard/tags/directives.rb#545
   def call; end
 end
 
@@ -16222,11 +16378,11 @@ end
 #   def method2; end
 # @since 0.7.0
 #
-# source://yard//lib/yard/tags/directives.rb#579
+# source://yard//lib/yard/tags/directives.rb#578
 class YARD::Tags::ScopeDirective < ::YARD::Tags::Directive
   # @since 0.7.0
   #
-  # source://yard//lib/yard/tags/directives.rb#580
+  # source://yard//lib/yard/tags/directives.rb#579
   def call; end
 end
 
@@ -16257,7 +16413,7 @@ class YARD::Tags::Tag
   # @param name [String] optional key name which the tag refers to
   # @return [Tag] a new instance of Tag
   #
-  # source://yard//lib/yard/tags/tag.rb#44
+  # source://yard//lib/yard/tags/tag.rb#45
   def initialize(tag_name, text, types = T.unsafe(nil), name = T.unsafe(nil)); end
 
   # Provides a plain English summary of the type specification, or nil
@@ -16266,27 +16422,29 @@ class YARD::Tags::Tag
   # @return [String] a plain English description of the associated types
   # @return [nil] if no types are provided or not parsable
   #
-  # source://yard//lib/yard/tags/tag.rb#65
+  # source://yard//lib/yard/tags/tag.rb#66
   def explain_types; end
 
   # @return [String] a name associated with the tag
+  # @return [nil] if no tag name is supplied
   #
-  # source://yard//lib/yard/tags/tag.rb#26
+  # source://yard//lib/yard/tags/tag.rb#27
   def name; end
 
   # @return [String] a name associated with the tag
+  # @return [nil] if no tag name is supplied
   #
-  # source://yard//lib/yard/tags/tag.rb#26
+  # source://yard//lib/yard/tags/tag.rb#27
   def name=(_arg0); end
 
   # @return [CodeObjects::Base] the associated object
   #
-  # source://yard//lib/yard/tags/tag.rb#29
+  # source://yard//lib/yard/tags/tag.rb#30
   def object; end
 
   # @return [CodeObjects::Base] the associated object
   #
-  # source://yard//lib/yard/tags/tag.rb#29
+  # source://yard//lib/yard/tags/tag.rb#30
   def object=(_arg0); end
 
   # @return [String] the name of the tag
@@ -16317,7 +16475,7 @@ class YARD::Tags::Tag
   # @return [String] the first of the list of specified types
   # @see #types
   #
-  # source://yard//lib/yard/tags/tag.rb#56
+  # source://yard//lib/yard/tags/tag.rb#57
   def type; end
 
   # @return [Array<String>] a list of types associated with the tag
@@ -16508,11 +16666,11 @@ end
 #   def method2; end
 # @since 0.7.0
 #
-# source://yard//lib/yard/tags/directives.rb#611
+# source://yard//lib/yard/tags/directives.rb#610
 class YARD::Tags::VisibilityDirective < ::YARD::Tags::Directive
   # @since 0.7.0
   #
-  # source://yard//lib/yard/tags/directives.rb#612
+  # source://yard//lib/yard/tags/directives.rb#611
   def call; end
 end
 
@@ -16528,7 +16686,7 @@ module YARD::Templates; end
 # * To render a template, call {render}.
 # * To register a template path in the lookup paths, call {register_template_path}.
 #
-# source://yard//lib/yard/templates/engine.rb#12
+# source://yard//lib/yard/templates/engine.rb#11
 module YARD::Templates::Engine
   class << self
     # Passes a set of objects to the +:fulldoc+ template for full documentation generation.
@@ -16540,7 +16698,7 @@ module YARD::Templates::Engine
     # @param options [Hash] (see {render})
     # @return [void]
     #
-    # source://yard//lib/yard/templates/engine.rb#101
+    # source://yard//lib/yard/templates/engine.rb#100
     def generate(objects, options = T.unsafe(nil)); end
 
     # Registers a new template path in {template_paths}
@@ -16548,7 +16706,7 @@ module YARD::Templates::Engine
     # @param path [String] a new template path
     # @return [void]
     #
-    # source://yard//lib/yard/templates/engine.rb#21
+    # source://yard//lib/yard/templates/engine.rb#20
     def register_template_path(path); end
 
     # Renders a template on a {CodeObjects::Base code object} using
@@ -16569,7 +16727,7 @@ module YARD::Templates::Engine
     # @param options [Hash] the options hash
     # @return [String] the rendered template
     #
-    # source://yard//lib/yard/templates/engine.rb#82
+    # source://yard//lib/yard/templates/engine.rb#81
     def render(options = T.unsafe(nil)); end
 
     # Creates a template module representing the path. Searches on disk
@@ -16583,7 +16741,7 @@ module YARD::Templates::Engine
     #   {template_paths} on disk.
     # @return [Template] the module representing the template
     #
-    # source://yard//lib/yard/templates/engine.rb#35
+    # source://yard//lib/yard/templates/engine.rb#34
     def template(*path); end
 
     # Forces creation of a template at +path+ within a +full_path+.
@@ -16592,17 +16750,17 @@ module YARD::Templates::Engine
     # @param full_paths [Array<String>] the full path on disk of the template
     # @return [Template] the template module representing the +path+
     #
-    # source://yard//lib/yard/templates/engine.rb#53
+    # source://yard//lib/yard/templates/engine.rb#52
     def template!(path, full_paths = T.unsafe(nil)); end
 
     # @return [Array<String>] the list of registered template paths
     #
-    # source://yard//lib/yard/templates/engine.rb#15
+    # source://yard//lib/yard/templates/engine.rb#14
     def template_paths; end
 
     # @return [Array<String>] the list of registered template paths
     #
-    # source://yard//lib/yard/templates/engine.rb#15
+    # source://yard//lib/yard/templates/engine.rb#14
     def template_paths=(_arg0); end
 
     # Serializes the results of a block with a +serializer+ object.
@@ -16613,7 +16771,7 @@ module YARD::Templates::Engine
     # @yield a block whose result will be serialize
     # @yieldreturn [String] the contents to serialize
     #
-    # source://yard//lib/yard/templates/engine.rb#115
+    # source://yard//lib/yard/templates/engine.rb#114
     def with_serializer(object, serializer); end
 
     private
@@ -16628,7 +16786,7 @@ module YARD::Templates::Engine
     # @return [Array<String>] a list of full paths that are existing
     #   candidates for a template module
     #
-    # source://yard//lib/yard/templates/engine.rb#161
+    # source://yard//lib/yard/templates/engine.rb#160
     def find_template_paths(from_template, path); end
 
     # Sets default options on the options hash
@@ -16639,7 +16797,7 @@ module YARD::Templates::Engine
     # @param options [Hash] the options hash
     # @return [void]
     #
-    # source://yard//lib/yard/templates/engine.rb#141
+    # source://yard//lib/yard/templates/engine.rb#140
     def set_default_options(options = T.unsafe(nil)); end
 
     # The name of the module that represents a +path+
@@ -16647,7 +16805,7 @@ module YARD::Templates::Engine
     # @param path [String] the path to generate a module name for
     # @return [String] the module name
     #
-    # source://yard//lib/yard/templates/engine.rb#176
+    # source://yard//lib/yard/templates/engine.rb#175
     def template_module_name(path); end
   end
 end
@@ -18058,7 +18216,7 @@ end
 #
 # @see CLI::YardocOptions
 #
-# source://yard//lib/yard/templates/template_options.rb#10
+# source://yard//lib/yard/templates/template_options.rb#9
 class YARD::Templates::TemplateOptions < ::YARD::Options
   # @return [OpenStruct] an open struct containing any global state across all
   #   generated objects in a template.
@@ -18101,7 +18259,7 @@ class YARD::Templates::TemplateOptions < ::YARD::Options
   # @return [Boolean] whether a mixin matches the embed_mixins list
   # @return [nil] if the mixin is not a module object
   #
-  # source://yard//lib/yard/templates/template_options.rb#78
+  # source://yard//lib/yard/templates/template_options.rb#77
   def embed_mixins_match?(mixin); end
 
   # @return [Symbol] the template output format
@@ -18148,12 +18306,12 @@ class YARD::Templates::TemplateOptions < ::YARD::Options
 
   # @return [Boolean] whether the page is the "index"
   #
-  # source://yard//lib/yard/templates/template_options.rb#64
+  # source://yard//lib/yard/templates/template_options.rb#63
   def index; end
 
   # @return [Boolean] whether the page is the "index"
   #
-  # source://yard//lib/yard/templates/template_options.rb#64
+  # source://yard//lib/yard/templates/template_options.rb#63
   def index=(_arg0); end
 
   # @return [Symbol] the markup format to use when parsing docstrings
@@ -18168,51 +18326,51 @@ class YARD::Templates::TemplateOptions < ::YARD::Options
 
   # @return [Class] the markup provider class for the markup format
   #
-  # source://yard//lib/yard/templates/template_options.rb#30
+  # source://yard//lib/yard/templates/template_options.rb#29
   def markup_provider; end
 
   # @return [Class] the markup provider class for the markup format
   #
-  # source://yard//lib/yard/templates/template_options.rb#30
+  # source://yard//lib/yard/templates/template_options.rb#29
   def markup_provider=(_arg0); end
 
   # @deprecated use {#highlight} instead.
   # @return [Boolean] whether highlighting should be ignored
   #
-  # source://yard//lib/yard/templates/template_options.rb#57
+  # source://yard//lib/yard/templates/template_options.rb#56
   def no_highlight; end
 
-  # source://yard//lib/yard/templates/template_options.rb#58
+  # source://yard//lib/yard/templates/template_options.rb#57
   def no_highlight=(value); end
 
   # @return [CodeObjects::Base] the main object being generated in the template
   #
-  # source://yard//lib/yard/templates/template_options.rb#38
+  # source://yard//lib/yard/templates/template_options.rb#37
   def object; end
 
   # @return [CodeObjects::Base] the main object being generated in the template
   #
-  # source://yard//lib/yard/templates/template_options.rb#38
+  # source://yard//lib/yard/templates/template_options.rb#37
   def object=(_arg0); end
 
   # @return [CodeObjects::Base] the owner of the generated object
   #
-  # source://yard//lib/yard/templates/template_options.rb#41
+  # source://yard//lib/yard/templates/template_options.rb#40
   def owner; end
 
   # @return [CodeObjects::Base] the owner of the generated object
   #
-  # source://yard//lib/yard/templates/template_options.rb#41
+  # source://yard//lib/yard/templates/template_options.rb#40
   def owner=(_arg0); end
 
   # @return [String] the title of a given page
   #
-  # source://yard//lib/yard/templates/template_options.rb#61
+  # source://yard//lib/yard/templates/template_options.rb#60
   def page_title; end
 
   # @return [String] the title of a given page
   #
-  # source://yard//lib/yard/templates/template_options.rb#61
+  # source://yard//lib/yard/templates/template_options.rb#60
   def page_title=(_arg0); end
 
   # @return [Boolean] whether serialization should be performed
@@ -18228,13 +18386,13 @@ class YARD::Templates::TemplateOptions < ::YARD::Options
   # @return [Serializers::Base] the serializer used to generate links and serialize
   #   output. Serialization output only occurs if {#serialize} is +true+.
   #
-  # source://yard//lib/yard/templates/template_options.rb#51
+  # source://yard//lib/yard/templates/template_options.rb#50
   def serializer; end
 
   # @return [Serializers::Base] the serializer used to generate links and serialize
   #   output. Serialization output only occurs if {#serialize} is +true+.
   #
-  # source://yard//lib/yard/templates/template_options.rb#51
+  # source://yard//lib/yard/templates/template_options.rb#50
   def serializer=(_arg0); end
 
   # @return [Symbol] the template name used to render output
@@ -18249,22 +18407,22 @@ class YARD::Templates::TemplateOptions < ::YARD::Options
 
   # @return [Symbol] the template type used to generate output
   #
-  # source://yard//lib/yard/templates/template_options.rb#44
+  # source://yard//lib/yard/templates/template_options.rb#43
   def type; end
 
   # @return [Symbol] the template type used to generate output
   #
-  # source://yard//lib/yard/templates/template_options.rb#44
+  # source://yard//lib/yard/templates/template_options.rb#43
   def type=(_arg0); end
 
   # @return [Verifier] the verifier object
   #
-  # source://yard//lib/yard/templates/template_options.rb#89
+  # source://yard//lib/yard/templates/template_options.rb#88
   def verifier; end
 
   # @return [Verifier] the verifier object
   #
-  # source://yard//lib/yard/templates/template_options.rb#89
+  # source://yard//lib/yard/templates/template_options.rb#88
   def verifier=(_arg0); end
 end
 

--- a/spec/helpers/mock_project.rb
+++ b/spec/helpers/mock_project.rb
@@ -38,6 +38,7 @@ module Tapioca
         source("https://rubygems.org")
 
         gemspec name: "tapioca", path: "#{TAPIOCA_PATH}"
+        gem "json", ">= 2.7.2"
       GEMFILE
     end
 

--- a/spec/tapioca/cli/gem_spec.rb
+++ b/spec/tapioca/cli/gem_spec.rb
@@ -1022,11 +1022,9 @@ module Tapioca
           @project.require_mock_gem(foo)
           # We know RDoc is problematic with respect to calling `abort` in an autoload
           @project.require_real_gem("rdoc")
-          # Just so that we have something else we can generate for.
-          @project.require_real_gem("json")
           @project.bundle_install!
 
-          result = @project.tapioca("gem json")
+          result = @project.tapioca("gem rdoc")
           assert_empty_stderr(result)
           assert_success_status(result)
         end

--- a/spec/tapioca/cli/gem_spec.rb
+++ b/spec/tapioca/cli/gem_spec.rb
@@ -266,8 +266,8 @@ module Tapioca
         end
 
         it "must generate RBI for a default gem" do
-          gem_name = "ostruct"
-          gem_top_level_constant = "class OpenStruct"
+          gem_name = "base64"
+          gem_top_level_constant = "module Base64"
 
           gem_spec = ::Gem::Specification.default_stubs("*.gemspec").find do |spec|
             spec.name == gem_name && spec.default_gem?

--- a/tapioca.gemspec
+++ b/tapioca.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |spec|
   spec.metadata["allowed_push_host"] = "https://rubygems.org"
 
   spec.add_dependency("bundler", ">= 2.2.25")
+  spec.add_dependency("logger")
   spec.add_dependency("netrc", ">= 0.11.0")
   spec.add_dependency("parallel", ">= 1.21.0")
   spec.add_dependency("rbi", "~> 0.2")


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
Fix CI https://github.com/Shopify/tapioca/actions/runs/10711399821/job/29700012289#step:6:68

```
cli
  version
    it must display the version when passing -v                     FAIL (0.82s)
        ########## STDOUT ##########
        Tapioca v0.16.2
        
        ########## STDERR ##########
        /opt/hostedtoolcache/Ruby/3.3.5/x[64](https://github.com/Shopify/tapioca/actions/runs/10711399821/job/29700012289#step:6:65)/lib/ruby/3.3.0/json/common.rb:3: warning: ostruct was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
        You can add ostruct to your Gemfile or gemspec to silence this warning.
        logger was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
        You can add logger to your Gemfile or gemspec to silence this warning.
        
        ########## STATUS: true ##########
        .
        Expected "/opt/hostedtoolcache/Ruby/3.3.5/x64/lib/ruby/3.3.0/json/common.rb:3: warning: ostruct was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.\nYou can add ostruct to your Gemfile or gemspec to silence this warning.\nlogger was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.\nYou can add logger to your Gemfile or gemspec to silence this warning.\n" to be empty.
        /home/runner/work/tapioca/tapioca/spec/spec_with_project.rb:125:in `assert_empty_stderr'
        /home/runner/work/tapioca/tapioca/spec/tapioca/cli/version_spec.rb:23:in `block (2 levels) in <class:VersionSpec>'
```

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
Doesn't look like we directly depend on it so I added it to `Gemfile` instead of gemspec
### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->

