### PR TITLE
Correct type annotation in `ActiveRecordColumnTypeHelper's`

### DIFF
--- a/lib/tapioca/dsl/helpers/active_record_column_type_helper.rb
+++ b/lib/tapioca/dsl/helpers/active_record_column_type_helper.rb
@@ -105,7 +105,7 @@ module Tapioca
           end
         end
 
-        sig { params(column_name: String).returns([String, String]) }
+        sig { params(column_name: T.nilable(String)).returns([String, String]) }
         def column_type_for(column_name)
           return ["T.untyped", "T.untyped"] if @column_type_option.untyped?
 


### PR DESCRIPTION
ActiveRecordColumnTypeHelper's `@constant.primary_key` can be `nil` for models that don't have a primary key.

### Motivation

Closes #1997

### Tests
This is a change to the type annotation, so not test is necessary.

