### PR TITLE
Avoid a deprecation warning on Ruby 3.4 with the uri gem

### DIFF
--- a/lib/tapioca/helpers/source_uri.rb
+++ b/lib/tapioca/helpers/source_uri.rb
@@ -18,6 +18,13 @@ module URI
       T::Array[Symbol],
     )
 
+    # `uri` for Ruby 3.4 switched the default parser from RFC2396 to RFC3986. The new parser emits a deprecation
+    # warning on a few methods and delegates them to RFC2396, namely `extract`/`make_regexp`/`escape`/`unescape`.
+    # On earlier versions of the uri gem, the RFC2396_PARSER constant doesn't exist, so it needs some special
+    # handling to select a parser that doesn't emit deprecations. While it was backported to Ruby 3.1, users may
+    # have the uri gem in their own bundle and thus not use a compatible version.
+    PARSER = T.let(const_defined?(:RFC2396_PARSER) ? RFC2396_PARSER : DEFAULT_PARSER, RFC2396_Parser)
+
     alias_method(:gem_name, :host)
     alias_method(:line_number, :fragment)
 
@@ -40,7 +47,7 @@ module URI
           {
             scheme: "source",
             host: gem_name,
-            path: DEFAULT_PARSER.escape("/#{gem_version}/#{path}"),
+            path: PARSER.escape("/#{gem_version}/#{path}"),
             fragment: line_number,
           }
         )


### PR DESCRIPTION
### Motivation
Avoid a deprecation warning on ruby 3.4 with the uri gem.

> /home/user/code/tapioca/lib/tapioca/helpers/source_uri.rb:50: warning: URI::RFC3986_PARSER.escape is obsoleted. Use URI::RFC2396_PARSER.escape explicitly.

### Implementation
`uri` for Ruby 3.4 switched the default parser from RFC2396 to RFC3986. The new parser emits a deprecation
warning on a few methods and delegates them to RFC2396, namely `extract`/`make_regexp`/`escape`/`unescape`.
On earlier versions of the uri gem, the RFC2396_PARSER constant doesn't exist, so it needs some special
handling to select a parser that doesn't emit deprecations. While it was backported to Ruby 3.1, users may
have the uri gem in their own bundle and thus not use a compatible version.

Additional info:
* https://github.com/ruby/uri/pull/107
* https://github.com/ruby/uri/pull/114

### Tests
Not needed. You can verify this yourself by doing the following:
* Add `gem "uri", github: "ruby/uri"` to the gemfile
* Run `RUBYOPT="-w" bundle exec rake test TEST=spec/tapioca/gem/pipeline_spec.rb TESTOPTS="--name=/location/"`

