### PR TITLE
Fix broken CI on Ruby 3.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,9 @@ jobs:
       matrix:
         ruby: ["3.1", "3.2", "3.3", "head"]
         rails: ["7.0", "current", "main"]
+        exclude:
+          - ruby: "3.1"
+            rails: "main"
         include:
           - rails: "main"
             experimental: true

--- a/spec/tapioca/cli/gem_spec.rb
+++ b/spec/tapioca/cli/gem_spec.rb
@@ -1530,8 +1530,10 @@ module Tapioca
           # Note that this problem only happens if another gem somehow eager loads the engines. By default, Rails
           # would've not loaded those classes and they would have not been placed in the Rails RBI.
 
+          # This is pointing to the 7-2-stable branch because Rails 8 dropped support for Ruby 3.1. We can point
+          # it to main again once Tapioca drops support for Ruby 3.1 as well.
           @project.write_gemfile!(<<~GEMFILE, append: true)
-            gem("rails", git: "https://github.com/rails/rails", branch: "main")
+            gem("rails", git: "https://github.com/rails/rails", branch: "7-2-stable")
           GEMFILE
 
           # Create a gem that eager loads the ActionMailbox engine


### PR DESCRIPTION
We have a test that was pointing to rails#main; however, main / Rails 8 has dropped support for Ruby 3.1 so the test started failing. The test does seem valuable so we're pointing to rails#7-2-stable instead.

~This won't solve _everything_ though: the CI matrix combination of ruby 3.1 + rails main will be broken.~

~Another option here could be to remove 3.1 from CI; this might be OK given we no longer support that version at Shopify.~

https://github.com/Shopify/tapioca/pull/2029#issuecomment-2389487729