### PR TITLE
Allow control over Thor's output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 /spec/reports/
 /tmp/
 /vendor/
+/*.log

--- a/lib/tapioca/cli.rb
+++ b/lib/tapioca/cli.rb
@@ -6,6 +6,7 @@ module Tapioca
     include CliHelper
     include ConfigHelper
     include EnvHelper
+    include Logging
 
     FILE_HEADER_OPTION_DESC = "Add a \"This file is generated\" header on top of each generated RBI file"
 
@@ -378,7 +379,7 @@ module Tapioca
     private
 
     def print_init_next_steps
-      say(<<~OUTPUT)
+      logger.info(<<~OUTPUT)
         #{set_color("This project is now set up for use with Sorbet and Tapioca", :bold)}
 
         The sorbet/ folder should exist and look something like this:

--- a/lib/tapioca/commands/abstract_dsl.rb
+++ b/lib/tapioca/commands/abstract_dsl.rb
@@ -128,7 +128,7 @@ module Tapioca
           requested_compilers: constantize_compilers(@only),
           excluded_compilers: constantize_compilers(@exclude),
           error_handler: ->(error) {
-            say_error(error, :bold, :red)
+            logger.error(error, :bold, :red)
           },
           skipped_constants: constantize(@skip_constant, ignore_missing: true),
           number_of_workers: @number_of_workers,
@@ -162,7 +162,7 @@ module Tapioca
 
         unless unprocessable_constants.empty? || ignore_missing
           unprocessable_constants.each do |name, _|
-            say("Error: Cannot find constant '#{name}'", :red)
+            logger.info("Error: Cannot find constant '#{name}'", :red)
             filename = dsl_rbi_filename(name)
             remove_file(filename) if File.file?(filename)
           end
@@ -186,8 +186,8 @@ module Tapioca
             set_color("Warning: Cannot find compiler '#{name}'", :yellow)
           end.join("\n")
 
-          say(message)
-          say("")
+          logger.info(message)
+          logger.info("")
         end
 
         T.cast(compiler_map.values, T::Array[T.class_of(Tapioca::Dsl::Compiler)])
@@ -243,12 +243,12 @@ module Tapioca
       sig { params(files: T::Set[Pathname]).void }
       def purge_stale_dsl_rbi_files(files)
         if files.any?
-          say("Removing stale RBI files...")
+          logger.info("Removing stale RBI files...")
 
           files.sort.each do |filename|
             remove_file(filename)
           end
-          say("")
+          logger.info("")
         end
       end
 
@@ -301,7 +301,7 @@ module Tapioca
       sig { params(diff: T::Hash[String, Symbol], command: Symbol).void }
       def report_diff_and_exit_if_out_of_date(diff, command)
         if diff.empty?
-          say("Nothing to do, all RBIs are up-to-date.")
+          logger.info("Nothing to do, all RBIs are up-to-date.")
         else
           reasons = diff.group_by(&:last).sort.map do |cause, diff_for_cause|
             build_error_for_files(cause, diff_for_cause.map(&:first))

--- a/lib/tapioca/commands/check_shims.rb
+++ b/lib/tapioca/commands/check_shims.rb
@@ -45,7 +45,7 @@ module Tapioca
         index = RBI::Index.new
 
         if (!Dir.exist?(@shim_rbi_dir) || Dir.empty?(@shim_rbi_dir)) && !File.exist?(@todo_rbi_file)
-          say("No shim RBIs to check", :green)
+          logger.info("No shim RBIs to check", :green)
 
           return
         end
@@ -99,7 +99,7 @@ module Tapioca
           raise Thor::Error, messages.join("\n")
         end
 
-        say("\nNo duplicates found in shim RBIs", :green)
+        logger.info("\nNo duplicates found in shim RBIs", :green)
       end
     end
   end

--- a/lib/tapioca/commands/command.rb
+++ b/lib/tapioca/commands/command.rb
@@ -6,6 +6,7 @@ module Tapioca
     class Command
       extend T::Sig
       extend T::Helpers
+      include Tapioca::Logging
 
       class FileWriter < Thor
         include Thor::Actions
@@ -51,6 +52,8 @@ module Tapioca
         ).void
       end
       def create_file(path, content, force: true, skip: false, verbose: true)
+        # TODO: decide how to handle this
+        verbose = false if ENV["TAPIOCA_DEVELOPMENT"]
         file_writer.create_file(path, force: force, skip: skip, verbose: verbose) { content }
       end
 
@@ -61,6 +64,8 @@ module Tapioca
         ).void
       end
       def remove_file(path, verbose: true)
+        # TODO: decide how to handle this
+        verbose = false if ENV["TAPIOCA_DEVELOPMENT"]
         file_writer.remove_file(path, verbose: verbose)
       end
     end

--- a/lib/tapioca/commands/command_without_tracker.rb
+++ b/lib/tapioca/commands/command_without_tracker.rb
@@ -4,6 +4,8 @@
 module Tapioca
   module Commands
     class CommandWithoutTracker < Command
+      include Tapioca::Logging
+
       extend T::Helpers
 
       abstract!

--- a/lib/tapioca/commands/dsl_compiler_list.rb
+++ b/lib/tapioca/commands/dsl_compiler_list.rb
@@ -10,9 +10,9 @@ module Tapioca
       def execute
         load_application
 
-        say("")
-        say("Loaded DSL compiler classes:")
-        say("")
+        logger.info("")
+        logger.info("Loaded DSL compiler classes:")
+        logger.info("")
 
         table = pipeline.compilers.map do |compiler|
           status = if pipeline.active_compilers.include?(compiler)

--- a/lib/tapioca/commands/dsl_generate.rb
+++ b/lib/tapioca/commands/dsl_generate.rb
@@ -10,17 +10,17 @@ module Tapioca
       def execute
         load_application
 
-        say("Compiling DSL RBI files...")
-        say("")
+        logger.info("Compiling DSL RBI files...")
+        logger.info("")
 
         rbi_files_to_purge = generate_dsl_rbi_files(@outpath, quiet: @quiet && !@verbose)
-        say("")
+        logger.info("")
 
         purge_stale_dsl_rbi_files(rbi_files_to_purge)
-        say("Done", :green)
+        logger.info("Done", :green)
 
         if @auto_strictness
-          say("")
+          logger.info("")
           validate_rbi_files(
             command: default_command(:dsl, all_requested_constants.join(" ")),
             gem_dir: @gem_dir,
@@ -30,8 +30,8 @@ module Tapioca
           )
         end
 
-        say("All operations performed in working directory.", [:green, :bold])
-        say("Please review changes and commit them.", [:green, :bold])
+        logger.info("All operations performed in working directory.", [:green, :bold])
+        logger.info("Please review changes and commit them.", [:green, :bold])
       ensure
         GitAttributes.create_generated_attribute_file(@outpath)
       end

--- a/lib/tapioca/commands/dsl_verify.rb
+++ b/lib/tapioca/commands/dsl_verify.rb
@@ -10,13 +10,13 @@ module Tapioca
       def execute
         load_application
 
-        say("Checking for out-of-date RBIs...")
-        say("")
+        logger.info("Checking for out-of-date RBIs...")
+        logger.info("")
 
         outpath = Pathname.new(Dir.mktmpdir)
 
         generate_dsl_rbi_files(outpath, quiet: true)
-        say("")
+        logger.info("")
 
         perform_dsl_verification(outpath)
       end

--- a/lib/tapioca/commands/gem_generate.rb
+++ b/lib/tapioca/commands/gem_generate.rb
@@ -38,10 +38,10 @@ module Tapioca
             gems: @bundle.dependencies,
           )
 
-          say("All operations performed in working directory.", [:green, :bold])
-          say("Please review changes and commit them.", [:green, :bold])
+          logger.info("All operations performed in working directory.", [:green, :bold])
+          logger.info("Please review changes and commit them.", [:green, :bold])
         else
-          say("No operations performed, all RBIs are up-to-date.", [:green, :bold])
+          logger.info("No operations performed, all RBIs are up-to-date.", [:green, :bold])
         end
       ensure
         GitAttributes.create_generated_attribute_file(@outpath)

--- a/lib/tapioca/commands/gem_sync.rb
+++ b/lib/tapioca/commands/gem_sync.rb
@@ -22,10 +22,10 @@ module Tapioca
             gems: @bundle.dependencies,
           )
 
-          say("All operations performed in working directory.", [:green, :bold])
-          say("Please review changes and commit them.", [:green, :bold])
+          logger.info("All operations performed in working directory.", [:green, :bold])
+          logger.info("Please review changes and commit them.", [:green, :bold])
         else
-          say("No operations performed, all RBIs are up-to-date.", [:green, :bold])
+          logger.info("No operations performed, all RBIs are up-to-date.", [:green, :bold])
         end
 
         puts

--- a/lib/tapioca/commands/gem_verify.rb
+++ b/lib/tapioca/commands/gem_verify.rb
@@ -8,8 +8,8 @@ module Tapioca
 
       sig { override.void }
       def execute
-        say("Checking for out-of-date RBIs...")
-        say("")
+        logger.info("Checking for out-of-date RBIs...")
+        logger.info("")
         perform_sync_verification
       end
 

--- a/lib/tapioca/commands/require.rb
+++ b/lib/tapioca/commands/require.rb
@@ -23,11 +23,11 @@ module Tapioca
       def execute
         compiler = Static::RequiresCompiler.new(@sorbet_config_path)
         name = set_color(@requires_path, :yellow, :bold)
-        say("Compiling #{name}, this may take a few seconds... ")
+        logger.info("Compiling #{name}, this may take a few seconds... ")
 
         rb_string = compiler.compile
         if rb_string.empty?
-          say("Nothing to do", :green)
+          logger.info("Nothing to do", :green)
           return
         end
 
@@ -41,11 +41,11 @@ module Tapioca
 
         create_file(@requires_path, content, verbose: false)
 
-        say("Done", :green)
+        logger.info("Done", :green)
 
-        say("All requires from this application have been written to #{name}.", [:green, :bold])
+        logger.info("All requires from this application have been written to #{name}.", [:green, :bold])
         cmd = set_color(default_command(:gem), :yellow, :bold)
-        say("Please review changes and commit them, then run `#{cmd}`.", [:green, :bold])
+        logger.info("Please review changes and commit them, then run `#{cmd}`.", [:green, :bold])
       end
     end
   end

--- a/lib/tapioca/commands/todo.rb
+++ b/lib/tapioca/commands/todo.rb
@@ -32,8 +32,8 @@ module Tapioca
 
       sig { void }
       def run_with_deprecation
-        say(DEPRECATION_MESSAGE, :red)
-        say("")
+        logger.info(DEPRECATION_MESSAGE, :red)
+        logger.info("")
 
         run
       end
@@ -42,7 +42,7 @@ module Tapioca
 
       sig { override.void }
       def execute
-        say("Finding all unresolved constants, this may take a few seconds... ")
+        logger.info("Finding all unresolved constants, this may take a few seconds... ")
 
         # Clean all existing unresolved constants before regenerating the list
         # so Sorbet won't grab them as already resolved.
@@ -51,17 +51,17 @@ module Tapioca
         constants = unresolved_constants
 
         if constants.empty?
-          say("Nothing to do", :green)
+          logger.info("Nothing to do", :green)
           return
         end
 
-        say("Done", :green)
+        logger.info("Done", :green)
         contents = rbi(constants, command: default_command(:todo))
         create_file(@todo_file, contents.string, verbose: false)
 
         name = set_color(@todo_file, :yellow, :bold)
-        say("\nAll unresolved constants have been written to #{name}.", [:green, :bold])
-        say("Please review changes and commit them.", [:green, :bold])
+        logger.info("\nAll unresolved constants have been written to #{name}.", [:green, :bold])
+        logger.info("Please review changes and commit them.", [:green, :bold])
       end
 
       sig { params(constants: T::Array[String], command: String).returns(RBI::File) }

--- a/lib/tapioca/internal.rb
+++ b/lib/tapioca/internal.rb
@@ -24,6 +24,8 @@ require "thor"
 require "yaml"
 require "yard-sorbet"
 
+require "tapioca/logging"
+
 require "tapioca/runtime/dynamic_mixin_compiler"
 require "tapioca/sorbet_ext/backcompat_patches"
 require "tapioca/sorbet_ext/name_patch"

--- a/lib/tapioca/loaders/dsl.rb
+++ b/lib/tapioca/loaders/dsl.rb
@@ -46,7 +46,7 @@ module Tapioca
 
       sig { void }
       def load_dsl_extensions
-        say("Loading DSL extension classes... ")
+        logger.info("Loading DSL extension classes... ")
 
         Dir.glob(["#{@tapioca_path}/extensions/**/*.rb"]).each do |extension|
           require File.expand_path(extension)
@@ -56,12 +56,12 @@ module Tapioca
           require File.expand_path(extension)
         end
 
-        say("Done", :green)
+        logger.info("Done", :green)
       end
 
       sig { void }
       def load_dsl_compilers
-        say("Loading DSL compiler classes... ")
+        logger.info("Loading DSL compiler classes... ")
 
         # Load all built-in compilers
         Dir.glob("#{Tapioca::LIB_ROOT_DIR}/tapioca/dsl/compilers/*.rb").each do |compiler|
@@ -81,12 +81,12 @@ module Tapioca
           require File.expand_path(compiler)
         end
 
-        say("Done", :green)
+        logger.info("Done", :green)
       end
 
       sig { void }
       def load_application
-        say("Loading Rails application... ")
+        logger.info("Loading Rails application... ")
 
         load_rails_application(
           environment_load: true,
@@ -95,7 +95,7 @@ module Tapioca
           halt_upon_load_error: @halt_upon_load_error,
         )
 
-        say("Done", :green)
+        logger.info("Done", :green)
       end
     end
   end

--- a/lib/tapioca/loaders/gem.rb
+++ b/lib/tapioca/loaders/gem.rb
@@ -58,7 +58,7 @@ module Tapioca
 
       sig { void }
       def require_gem_file
-        say("Requiring all gems to prepare for compiling... ")
+        logger.info("Requiring all gems to prepare for compiling... ")
         begin
           load_bundle(@bundle, @prerequire, @postrequire, @halt_upon_load_error)
         rescue LoadError => e
@@ -68,23 +68,26 @@ module Tapioca
 
         Runtime::Trackers::Autoload.eager_load_all!
 
-        say(" Done", :green)
+        logger.info(" Done", :green)
         unless @bundle.missing_specs.empty?
-          say("  completed with missing specs: ")
-          say(@bundle.missing_specs.join(", "), :yellow)
+          logger.info("  completed with missing specs: ")
+          logger.info(@bundle.missing_specs.join(", "), :yellow)
         end
         puts
       end
 
       sig { params(file: String, error: LoadError).void }
       def explain_failed_require(file, error)
-        say_error("\n\nLoadError: #{error}", :bold, :red)
-        say_error("\nTapioca could not load all the gems required by your application.", :yellow)
-        say_error("If you populated ", :yellow)
-        say_error("#{file} ", :bold, :blue)
-        say_error("with ", :yellow)
-        say_error("`#{@default_command}`", :bold, :blue)
-        say_error("you should probably review it and remove the faulty line.", :yellow)
+        logger.error("\n\nLoadError: #{error}", :bold, :red)
+        logger.error(
+          "\nTapioca could not load all the gems required by your application.",
+          :yellow,
+        )
+        logger.error("If you populated ", :yellow)
+        logger.error("#{file} ", :bold, :blue)
+        logger.error("with ", :yellow)
+        logger.error("`#{@default_command}`", :bold, :blue)
+        logger.error("you should probably review it and remove the faulty line.", :yellow)
       end
     end
   end

--- a/lib/tapioca/loaders/loader.rb
+++ b/lib/tapioca/loaders/loader.rb
@@ -10,6 +10,7 @@ module Tapioca
       include Thor::Base
       include CliHelper
       include Tapioca::GemHelper
+      include Tapioca::Logging
 
       abstract!
 
@@ -58,7 +59,7 @@ module Tapioca
         require File.expand_path(load_path, app_root)
 
         unless defined?(Rails)
-          say(
+          logger.info(
             "\nTried to load the app from `#{load_path}` as a Rails application " \
               "but the `Rails` constant wasn't defined after loading the file.",
             :yellow,
@@ -68,7 +69,7 @@ module Tapioca
 
         eager_load_rails_app if eager_load
       rescue LoadError, StandardError => e
-        say(
+        logger.info(
           "\nTapioca attempted to load the Rails application after encountering a `config/application.rb` file, " \
             "but it failed. If your application uses Rails please ensure it can be loaded correctly before " \
             "generating RBIs. If your application does not use Rails and you wish to continue RBI generation " \
@@ -80,9 +81,9 @@ module Tapioca
 
         if e.backtrace
           backtrace = T.must(e.backtrace).join("\n")
-          say(backtrace, :cyan) # TODO: Check verbose flag to print backtrace.
+          logger.info(backtrace, :cyan) # TODO: Check verbose flag to print backtrace.
         end
-        say("Continuing RBI generation without loading the Rails application.")
+        logger.info("Continuing RBI generation without loading the Rails application.")
       end
 
       sig { void }

--- a/lib/tapioca/logging.rb
+++ b/lib/tapioca/logging.rb
@@ -1,0 +1,48 @@
+# typed: true
+# frozen_string_literal: true
+
+require "thor"
+require "tapioca/helpers/cli_helper"
+
+module Tapioca
+  module Logging
+    def logger
+      @logger ||= if ENV["TAPIOCA_DEVELOPMENT"]
+        logger = Logger.new("tapioca.log")
+        Tapioca::LoggerAdapter.new(logger)
+      else
+        Tapioca::ThorLogger.new
+      end
+    end
+  end
+end
+
+module Tapioca
+  class LoggerAdapter
+    def initialize(logger)
+      @logger = logger
+    end
+
+    def info(message = "", *_color)
+      @logger.info(message)
+    end
+
+    def error(message = "", *_color)
+      @logger.error(message)
+    end
+  end
+
+  class ThorLogger < Logger
+    include Thor::Base
+    include CliHelper
+
+    def info(...)
+      say(...)
+    end
+
+    def error(...)
+      # This is Tapioca's `say_error`, not Thor's `say_error`
+      say_error(...)
+    end
+  end
+end

--- a/spec/tapioca/cli/gem_spec.rb
+++ b/spec/tapioca/cli/gem_spec.rb
@@ -1458,10 +1458,11 @@ module Tapioca
           refute_includes(result.out, "remove ")
           refute_includes(result.out, "-> Moving:")
 
+          # TODO: why is this whitespace changed needed for the tests?
           assert_stdout_includes(result, <<~OUT)
             Removing RBI files of gems that have been removed:
 
-              Nothing to do.
+            Nothing to do.
           OUT
 
           assert_project_file_exist("sorbet/rbi/gems/foo@0.0.1.rbi")
@@ -1485,10 +1486,11 @@ module Tapioca
           assert_stdout_includes(result, "force  sorbet/rbi/gems/baz@0.0.2.rbi\n")
           refute_includes(result.out, "remove ")
 
+          # TODO: why is this whitespace changed needed for the tests?
           assert_stdout_includes(result, <<~OUT)
             Removing RBI files of gems that have been removed:
 
-              Nothing to do.
+            Nothing to do.
           OUT
 
           assert_project_file_exist("sorbet/rbi/gems/foo@0.0.1.rbi")


### PR DESCRIPTION
Addresses https://github.com/Shopify/team-ruby-dx/issues/1297

See `lib/tapioca/logging.rb` for the important parts.

Notes:

* We might want to introduce a RuboCop cop to prevent accidental use of `puts`, `say`, `say_error` etc.
* There are still some places where the output is generated from within Thor, e.g. `create_file` and `remove_file`. I'm setting `verbose: false` if `TAPIOCA_DEVELOPMENT` is set, but this isn't ideal.
* There were a couple of places in the tests where the whitespace had to change, need to look into why.
* There is a type failure for argument forwarding (`...`) that I need still address.
* It would be nice if the tests could help us validate that we are always outputting to the logger and never directly to stdout, but that could be tricky.

Here is an example of the output written to the logs:

```
# Logfile created on 2024-10-08 12:54:33 -0400 by logger.rb/v1.6.1
I, [2024-10-08T12:54:33.421152 #10336]  INFO -- : Removing RBI files of gems that have been removed:
I, [2024-10-08T12:54:33.422190 #10336]  INFO -- : Nothing to do.
I, [2024-10-08T12:54:33.422234 #10336]  INFO -- : Generating RBI files of gems that are added or updated:
I, [2024-10-08T12:54:33.422327 #10336]  INFO -- : Nothing to do.
I, [2024-10-08T12:54:33.422427 #10336]  INFO -- : Checking generated RBI files... 
I, [2024-10-08T12:54:33.805008 #10336]  INFO -- :  Done
I, [2024-10-08T12:54:33.805374 #10336]  INFO -- :   No errors found


I, [2024-10-08T12:54:33.805389 #10336]  INFO -- : All operations performed in working directory.
I, [2024-10-08T12:54:33.805397 #10336]  INFO -- : Please review changes and commit them.
```