### PR TITLE
Don't attempt to generate DSL RBIs for test files

### DIFF
--- a/lib/ruby_lsp/tapioca/addon.rb
+++ b/lib/ruby_lsp/tapioca/addon.rb
@@ -67,6 +67,8 @@ module RubyLsp
 
         constants = changes.flat_map do |change|
           path = URI(change[:uri]).to_standardized_path
+          next if path.end_with?("_test.rb", "_spec.rb")
+
           entries = T.must(@index).entries_for(path)
           next unless entries
 

--- a/lib/ruby_lsp/tapioca/addon.rb
+++ b/lib/ruby_lsp/tapioca/addon.rb
@@ -73,7 +73,7 @@ module RubyLsp
           entries.filter_map do |entry|
             entry.name if entry.class == RubyIndexer::Entry::Class || entry.class == RubyIndexer::Entry::Module
           end
-        end
+        end.compact
 
         return if constants.empty?
 


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
Attempting to generate DSL RBIs for test files, which are not loaded in development mode, triggers exceptions and leads to unnecessary errors. By skipping test files in our watch configuration, we can prevent these issues.

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
- Updated `workspace_did_change_watched_files` to skip files ending with `_test.rb` and `_spec.rb`, preventing unnecessary processing and exceptions.

- Discovered a bug during pairing with @KaanOzkan: added `compact` to `flat_map` to remove `nil` elements from our array, ensuring the `empty?` check functions correctly and preventing `tapioca dsl` from running without arguments.


<!-- ### Tests -->
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->

