### PR TITLE
Fixes for AASM compiler

### DIFF
--- a/spec/tapioca/dsl/compilers/aasm_spec.rb
+++ b/spec/tapioca/dsl/compilers/aasm_spec.rb
@@ -125,32 +125,49 @@ module Tapioca
                     def event(name, options = nil, &block); end
 
                     class PrivateAASMEvent < AASM::Core::Event
-                      sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
+                      sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).params(opts: T.untyped).void)).returns(T.untyped) }
                       def after(symbol = nil, &block); end
 
-                      sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
+                      sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).params(opts: T.untyped).void)).returns(T.untyped) }
                       def after_commit(symbol = nil, &block); end
 
-                      sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
+                      sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).params(opts: T.untyped).void)).returns(T.untyped) }
                       def after_transaction(symbol = nil, &block); end
 
-                      sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
+                      sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).params(opts: T.untyped).void)).returns(T.untyped) }
                       def before(symbol = nil, &block); end
 
-                      sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
+                      sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).params(opts: T.untyped).void)).returns(T.untyped) }
                       def before_success(symbol = nil, &block); end
 
-                      sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
+                      sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).params(opts: T.untyped).void)).returns(T.untyped) }
                       def before_transaction(symbol = nil, &block); end
 
-                      sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
+                      sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).params(opts: T.untyped).void)).returns(T.untyped) }
                       def ensure(symbol = nil, &block); end
 
-                      sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
+                      sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).params(opts: T.untyped).void)).returns(T.untyped) }
                       def error(symbol = nil, &block); end
 
-                      sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
+                      sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).params(opts: T.untyped).void)).returns(T.untyped) }
                       def success(symbol = nil, &block); end
+
+                      sig { params(definitions: T.untyped, block: T.nilable(T.proc.bind(PrivateAASMTransition).void)).returns(T.untyped) }
+                      def transitions(definitions = nil, &block); end
+                    end
+
+                    class PrivateAASMTransition < AASM::Core::Transition
+                      sig { params(block: T.nilable(T.proc.bind(StateMachine).params(opts: T.untyped).void)).returns(T.untyped) }
+                      def after(&block); end
+
+                      sig { params(block: T.nilable(T.proc.bind(StateMachine).params(opts: T.untyped).void)).returns(T::Boolean) }
+                      def guard(&block); end
+
+                      sig { params(block: T.nilable(T.proc.bind(StateMachine).params(opts: T.untyped).void)).returns(T.untyped) }
+                      def on_transition(&block); end
+
+                      sig { params(block: T.nilable(T.proc.bind(StateMachine).params(opts: T.untyped).void)).returns(T.untyped) }
+                      def success(&block); end
                     end
                   end
 
@@ -249,32 +266,49 @@ module Tapioca
                     def event(name, options = nil, &block); end
 
                     class PrivateAASMEvent < AASM::Core::Event
-                      sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
+                      sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).params(opts: T.untyped).void)).returns(T.untyped) }
                       def after(symbol = nil, &block); end
 
-                      sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
+                      sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).params(opts: T.untyped).void)).returns(T.untyped) }
                       def after_commit(symbol = nil, &block); end
 
-                      sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
+                      sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).params(opts: T.untyped).void)).returns(T.untyped) }
                       def after_transaction(symbol = nil, &block); end
 
-                      sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
+                      sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).params(opts: T.untyped).void)).returns(T.untyped) }
                       def before(symbol = nil, &block); end
 
-                      sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
+                      sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).params(opts: T.untyped).void)).returns(T.untyped) }
                       def before_success(symbol = nil, &block); end
 
-                      sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
+                      sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).params(opts: T.untyped).void)).returns(T.untyped) }
                       def before_transaction(symbol = nil, &block); end
 
-                      sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
+                      sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).params(opts: T.untyped).void)).returns(T.untyped) }
                       def ensure(symbol = nil, &block); end
 
-                      sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
+                      sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).params(opts: T.untyped).void)).returns(T.untyped) }
                       def error(symbol = nil, &block); end
 
-                      sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
+                      sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).params(opts: T.untyped).void)).returns(T.untyped) }
                       def success(symbol = nil, &block); end
+
+                      sig { params(definitions: T.untyped, block: T.nilable(T.proc.bind(PrivateAASMTransition).void)).returns(T.untyped) }
+                      def transitions(definitions = nil, &block); end
+                    end
+
+                    class PrivateAASMTransition < AASM::Core::Transition
+                      sig { params(block: T.nilable(T.proc.bind(StateMachine).params(opts: T.untyped).void)).returns(T.untyped) }
+                      def after(&block); end
+
+                      sig { params(block: T.nilable(T.proc.bind(StateMachine).params(opts: T.untyped).void)).returns(T::Boolean) }
+                      def guard(&block); end
+
+                      sig { params(block: T.nilable(T.proc.bind(StateMachine).params(opts: T.untyped).void)).returns(T.untyped) }
+                      def on_transition(&block); end
+
+                      sig { params(block: T.nilable(T.proc.bind(StateMachine).params(opts: T.untyped).void)).returns(T.untyped) }
+                      def success(&block); end
                     end
                   end
 
@@ -376,32 +410,49 @@ module Tapioca
                     def event(name, options = nil, &block); end
 
                     class PrivateAASMEvent < AASM::Core::Event
-                      sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
+                      sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).params(opts: T.untyped).void)).returns(T.untyped) }
                       def after(symbol = nil, &block); end
 
-                      sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
+                      sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).params(opts: T.untyped).void)).returns(T.untyped) }
                       def after_commit(symbol = nil, &block); end
 
-                      sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
+                      sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).params(opts: T.untyped).void)).returns(T.untyped) }
                       def after_transaction(symbol = nil, &block); end
 
-                      sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
+                      sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).params(opts: T.untyped).void)).returns(T.untyped) }
                       def before(symbol = nil, &block); end
 
-                      sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
+                      sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).params(opts: T.untyped).void)).returns(T.untyped) }
                       def before_success(symbol = nil, &block); end
 
-                      sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
+                      sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).params(opts: T.untyped).void)).returns(T.untyped) }
                       def before_transaction(symbol = nil, &block); end
 
-                      sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
+                      sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).params(opts: T.untyped).void)).returns(T.untyped) }
                       def ensure(symbol = nil, &block); end
 
-                      sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
+                      sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).params(opts: T.untyped).void)).returns(T.untyped) }
                       def error(symbol = nil, &block); end
 
-                      sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
+                      sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).params(opts: T.untyped).void)).returns(T.untyped) }
                       def success(symbol = nil, &block); end
+
+                      sig { params(definitions: T.untyped, block: T.nilable(T.proc.bind(PrivateAASMTransition).void)).returns(T.untyped) }
+                      def transitions(definitions = nil, &block); end
+                    end
+
+                    class PrivateAASMTransition < AASM::Core::Transition
+                      sig { params(block: T.nilable(T.proc.bind(StateMachine).params(opts: T.untyped).void)).returns(T.untyped) }
+                      def after(&block); end
+
+                      sig { params(block: T.nilable(T.proc.bind(StateMachine).params(opts: T.untyped).void)).returns(T::Boolean) }
+                      def guard(&block); end
+
+                      sig { params(block: T.nilable(T.proc.bind(StateMachine).params(opts: T.untyped).void)).returns(T.untyped) }
+                      def on_transition(&block); end
+
+                      sig { params(block: T.nilable(T.proc.bind(StateMachine).params(opts: T.untyped).void)).returns(T.untyped) }
+                      def success(&block); end
                     end
                   end
 


### PR DESCRIPTION
### Motivation

1. Transition methods (after, guard, on_transition, success) were not found and would result in a failed type check if used.
2. Events can support arguments when being fired, and those arguments are passed to the PrivateAASMEvent method blocks. If we don't have any params arguments for the block, the default behavior of that block argument is not T.untyped, but rather NilClass, which will cause a type error if we try to reference those arguments. So as a result we need to change the proc signature to show one argument of T.untyped rather than no arguments. 

### Implementation
Added transition callbacks similar to how the events are added. PrivateAASMTransition class is used as the allowed methods are distinct from the allowed methods in the parent PrivateAASMEvent context.

### Tests
Yes

