### PR TITLE
Add hash return type for relation groupchain size

### DIFF
--- a/lib/tapioca/dsl/compilers/active_record_relations.rb
+++ b/lib/tapioca/dsl/compilers/active_record_relations.rb
@@ -372,7 +372,7 @@ module Tapioca
             return_type: "T.self_type",
           )
 
-          CALCULATION_METHODS.each do |method_name|
+          (CALCULATION_METHODS + [:size]).each do |method_name|
             case method_name
             when :average, :maximum, :minimum
               klass.create_method(
@@ -400,9 +400,9 @@ module Tapioca
                 ],
                 return_type: "T::Hash[T.untyped, Integer]",
               )
-            when :sum
+            when :sum, :size
               klass.create_method(
-                "sum",
+                method_name.to_s,
                 parameters: [
                   create_opt_param("column_name", type: "T.nilable(T.any(String, Symbol))", default: "nil"),
                   create_block_param("block", type: "T.nilable(T.proc.params(record: T.untyped).returns(T.untyped))"),

--- a/spec/tapioca/dsl/compilers/active_record_relations_spec.rb
+++ b/spec/tapioca/dsl/compilers/active_record_relations_spec.rb
@@ -659,6 +659,9 @@ module Tapioca
                     def minimum(column_name); end
 
                     sig { params(column_name: T.nilable(T.any(String, Symbol)), block: T.nilable(T.proc.params(record: T.untyped).returns(T.untyped))).returns(T::Hash[T.untyped, T.any(Integer, Float, BigDecimal)]) }
+                    def size(column_name = nil, &block); end
+
+                    sig { params(column_name: T.nilable(T.any(String, Symbol)), block: T.nilable(T.proc.params(record: T.untyped).returns(T.untyped))).returns(T::Hash[T.untyped, T.any(Integer, Float, BigDecimal)]) }
                     def sum(column_name = nil, &block); end
                   end
 
@@ -759,6 +762,9 @@ module Tapioca
 
                     sig { params(column_name: T.any(String, Symbol)).returns(T::Hash[T.untyped, T.untyped]) }
                     def minimum(column_name); end
+
+                    sig { params(column_name: T.nilable(T.any(String, Symbol)), block: T.nilable(T.proc.params(record: T.untyped).returns(T.untyped))).returns(T::Hash[T.untyped, T.any(Integer, Float, BigDecimal)]) }
+                    def size(column_name = nil, &block); end
 
                     sig { params(column_name: T.nilable(T.any(String, Symbol)), block: T.nilable(T.proc.params(record: T.untyped).returns(T.untyped))).returns(T::Hash[T.untyped, T.any(Integer, Float, BigDecimal)]) }
                     def sum(column_name = nil, &block); end
@@ -1377,6 +1383,9 @@ module Tapioca
                     def minimum(column_name); end
 
                     sig { params(column_name: T.nilable(T.any(String, Symbol)), block: T.nilable(T.proc.params(record: T.untyped).returns(T.untyped))).returns(T::Hash[T.untyped, T.any(Integer, Float, BigDecimal)]) }
+                    def size(column_name = nil, &block); end
+
+                    sig { params(column_name: T.nilable(T.any(String, Symbol)), block: T.nilable(T.proc.params(record: T.untyped).returns(T.untyped))).returns(T::Hash[T.untyped, T.any(Integer, Float, BigDecimal)]) }
                     def sum(column_name = nil, &block); end
                   end
 
@@ -1477,6 +1486,9 @@ module Tapioca
 
                     sig { params(column_name: T.any(String, Symbol)).returns(T::Hash[T.untyped, T.untyped]) }
                     def minimum(column_name); end
+
+                    sig { params(column_name: T.nilable(T.any(String, Symbol)), block: T.nilable(T.proc.params(record: T.untyped).returns(T.untyped))).returns(T::Hash[T.untyped, T.any(Integer, Float, BigDecimal)]) }
+                    def size(column_name = nil, &block); end
 
                     sig { params(column_name: T.nilable(T.any(String, Symbol)), block: T.nilable(T.proc.params(record: T.untyped).returns(T.untyped))).returns(T::Hash[T.untyped, T.any(Integer, Float, BigDecimal)]) }
                     def sum(column_name = nil, &block); end


### PR DESCRIPTION
### Motivation
`Model.where(...).group(...).size` returns a hash, not a scalar number. 

### Implementation
This is a special case where `ActiveRecord::Calculations` doesn't handle the size method. 

https://github.com/rails/rails/blob/6f57590388ca38ed2b83bc1207a8be13a9ba2aef/activerecord/lib/active_record/relation.rb#L273-L280

```ruby
# activerecord-7.1.4/lib/active_record/relation.rb
def size
  if loaded?
    records.length
  else
    count(:all)
  end
end
```

```ruby
Model.group('created_at').count(:all) == Model.group('created_at').size
=> true
```

We can handle this by adding a special case for the size method as we can't rely on the Calculations class to provide the name of the method.

### Tests
Yes

