### PR TITLE
Use singleton method to verify if method name is valid

### DIFF
--- a/lib/tapioca/helpers/rbi_helper.rb
+++ b/lib/tapioca/helpers/rbi_helper.rb
@@ -107,17 +107,7 @@ module Tapioca
 
     sig { params(name: String).returns(T::Boolean) }
     def valid_method_name?(name)
-      # Special case: Prism supports parsing `def @foo; end`, but the Sorbet parser doesn't. This condition can go away
-      # once Sorbet is using Prism under the hood as it will no longer result in an RBI that Sorbet can't parse
-      return false if name.start_with?("@")
-
-      result = Prism.parse("def #{name}(a); end")
-      return false unless result.success?
-
-      # We don't consider `def foo.bar` as valid for generating RBIs since only `def self.bar` is supported
-      method_def = result.value.statements.body.first
-      receiver = method_def.receiver
-      !receiver || receiver.is_a?(Prism::SelfNode)
+      Prism.parse("def self.#{name}(a); end").success?
     end
 
     sig { params(name: String).returns(T::Boolean) }


### PR DESCRIPTION
### Motivation

@paracycle gave a great suggestion to further simplify this https://github.com/Shopify/tapioca/pull/2060#discussion_r1823150216.

We can just test method names as if they were singleton methods, which further constraints the results to only what's really possible as a method name.

### Implementation

Started testing with `def self.name(a); end`, which eliminates all of the rest of the implementation.

### Tests

Current tests cover it.