### PR TITLE
Don't attempt to load built-in compilers multiple times

### DIFF
--- a/lib/tapioca/loaders/dsl.rb
+++ b/lib/tapioca/loaders/dsl.rb
@@ -63,12 +63,7 @@ module Tapioca
       def load_dsl_compilers
         say("Loading DSL compiler classes... ")
 
-        # Load all built-in compilers
-        Dir.glob("#{Tapioca::LIB_ROOT_DIR}/tapioca/dsl/compilers/*.rb").each do |compiler|
-          require File.expand_path(compiler)
-        end
-
-        # Load all custom compilers exported from gems
+        # Load built-in compilers and custom compilers exported from gems
         ::Gem.find_files("tapioca/dsl/compilers/*.rb").each do |compiler|
           require File.expand_path(compiler)
         end


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
Compilers live under `tapioca/dsl/compilers/` and are being picked up by the `Gem.find_files` below.

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->

