### PR TITLE
Use method overloading to improve WhereChain definition

### DIFF
--- a/spec/tapioca/dsl/compilers/active_record_relations_spec.rb
+++ b/spec/tapioca/dsl/compilers/active_record_relations_spec.rb
@@ -455,8 +455,9 @@ module Tapioca
                     sig { params(attributes: T::Array[Hash], returning: T.nilable(T.any(T::Array[Symbol], FalseClass)), unique_by: T.nilable(T.any(T::Array[Symbol], Symbol))).returns(ActiveRecord::Result) }
                     def upsert_all(attributes, returning: nil, unique_by: nil); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelationWhereChain) }
-                    def where(*args, &blk); end
+                    sig { returns(PrivateAssociationRelationWhereChain) }
+                    sig { params(args: T.untyped).returns(PrivateAssociationRelation) }
+                    def where(*args); end
                 <% if rails_version(">= 7.1") %>
 
                     sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
@@ -608,8 +609,9 @@ module Tapioca
                     sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
                     def unscope(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelationWhereChain) }
-                    def where(*args, &blk); end
+                    sig { returns(PrivateRelationWhereChain) }
+                    sig { params(args: T.untyped).returns(PrivateRelation) }
+                    def where(*args); end
                 <% if rails_version(">= 7.1") %>
 
                     sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
@@ -660,7 +662,7 @@ module Tapioca
                     def sum(column_name = nil, &block); end
                   end
 
-                  class PrivateAssociationRelationWhereChain < PrivateAssociationRelation
+                  class PrivateAssociationRelationWhereChain
                     Elem = type_member { { fixed: ::Post } }
 
                 <% if rails_version(">= 7.0") %>
@@ -762,7 +764,7 @@ module Tapioca
                     def sum(column_name = nil, &block); end
                   end
 
-                  class PrivateRelationWhereChain < PrivateRelation
+                  class PrivateRelationWhereChain
                     Elem = type_member { { fixed: ::Post } }
 
                 <% if rails_version(">= 7.0") %>
@@ -1171,8 +1173,9 @@ module Tapioca
                     sig { params(attributes: T::Array[Hash], returning: T.nilable(T.any(T::Array[Symbol], FalseClass)), unique_by: T.nilable(T.any(T::Array[Symbol], Symbol))).returns(ActiveRecord::Result) }
                     def upsert_all(attributes, returning: nil, unique_by: nil); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelationWhereChain) }
-                    def where(*args, &blk); end
+                    sig { returns(PrivateAssociationRelationWhereChain) }
+                    sig { params(args: T.untyped).returns(PrivateAssociationRelation) }
+                    def where(*args); end
                 <% if rails_version(">= 7.1") %>
 
                     sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
@@ -1324,8 +1327,9 @@ module Tapioca
                     sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
                     def unscope(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelationWhereChain) }
-                    def where(*args, &blk); end
+                    sig { returns(PrivateRelationWhereChain) }
+                    sig { params(args: T.untyped).returns(PrivateRelation) }
+                    def where(*args); end
                 <% if rails_version(">= 7.1") %>
 
                     sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
@@ -1376,7 +1380,7 @@ module Tapioca
                     def sum(column_name = nil, &block); end
                   end
 
-                  class PrivateAssociationRelationWhereChain < PrivateAssociationRelation
+                  class PrivateAssociationRelationWhereChain
                     Elem = type_member { { fixed: ::Post } }
 
                 <% if rails_version(">= 7.0") %>
@@ -1478,7 +1482,7 @@ module Tapioca
                     def sum(column_name = nil, &block); end
                   end
 
-                  class PrivateRelationWhereChain < PrivateRelation
+                  class PrivateRelationWhereChain
                     Elem = type_member { { fixed: ::Post } }
 
                 <% if rails_version(">= 7.0") %>


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
`ActiveRecord::QueryMethods#where` returns a `ActiveRecord::QueryMethods::WhereChain` instance only when it is called with no arguments. When called with arguments, it returns the same `ActiveRecord::Relation` instance.

Previously, we didn't have proper overloading support in RBI files, so the best thing we could do was act like `ActiveRecord::QueryMethods::WhereChain` was a subclass of the related relation class. This was not ideal because it would allow users to call methods on `WhereChain` that were not actually defined on it. For example, one could do `User.all.where(name: "John").not` which is not valid.

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
Now that we have support for overloading, we can define `where` to return a `WhereChain` instance only when called with no arguments, and in all other cases, we can say that it returns the same relation instance.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->
Updated existing tests.
