### PR TITLE
Call `to_a` on cached `ObjectSpace` enumerator

### DIFF
--- a/lib/tapioca/dsl/compiler.rb
+++ b/lib/tapioca/dsl/compiler.rb
@@ -74,11 +74,7 @@ module Tapioca
         sig { returns(T::Enumerable[T::Class[T.anything]]) }
         def all_classes
           @all_classes ||= T.let(
-            if @@requested_constants.any?
-              @@requested_constants.grep(Class)
-            else
-              ObjectSpace.each_object(Class)
-            end,
+            all_modules.grep(Class).freeze,
             T.nilable(T::Enumerable[T::Class[T.anything]]),
           )
         end
@@ -87,10 +83,10 @@ module Tapioca
         def all_modules
           @all_modules ||= T.let(
             if @@requested_constants.any?
-              @@requested_constants.select { |k| k.is_a?(Module) }
+              @@requested_constants.grep(Module)
             else
-              ObjectSpace.each_object(Module)
-            end,
+              ObjectSpace.each_object(Module).to_a
+            end.freeze,
             T.nilable(T::Enumerable[Module]),
           )
         end


### PR DESCRIPTION
Based on the existence of the `@@requested_contants` code path, it seems safe for this method to return an `Array` in some cases, so simply caching the array of all `Modules` rather than the enumerator should be safe. Also, I have included the recommended optimization to derive `all_classes` from `all_modules`, which both simplifies things (no need for the `@@requested_constants` code path in both methods), as well as improves performance by skipping a full ObjectSpace traversal again.

### Motivation
Closes #1974

### Tests
This is simply an optimization to an existing tested behavior.

