### PR TITLE
Warn when Tapioca is executed without Bundler

### DIFF
--- a/exe/tapioca
+++ b/exe/tapioca
@@ -20,6 +20,11 @@ unless ENV["ENFORCE_TYPECHECKING"] == "1"
   end
 end
 
+unless defined?(Bundler)
+  puts "Warning: You're running tapioca without Bundler. This isn't recommended and may cause issues. " \
+    "Please use the provided binstub through `bin/tapioca` instead."
+end
+
 require_relative "../lib/tapioca/internal"
 
 Tapioca::Cli.start(ARGV)


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
Addresses the finding in https://github.com/Shopify/tapioca/issues/1934#event-15304946498
### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
Print a warning as early as possible. Looking at various env variables `BUNDLER_VERSION` felt like a safe bet.
### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->
Tested manually. I can add it if wanted.
