### PR TITLE
Avoid writing gitattributes file unless necessary

### DIFF
--- a/lib/tapioca/helpers/git_attributes.rb
+++ b/lib/tapioca/helpers/git_attributes.rb
@@ -28,7 +28,8 @@ class GitAttributes
       # exist, we just return.
       return unless path.exist?
 
-      File.write(path.join(".gitattributes"), content)
+      git_attributes_path = path.join(".gitattributes")
+      File.write(git_attributes_path, content) unless git_attributes_path.exist?
     end
   end
 end


### PR DESCRIPTION
### Motivation

When studying the memory bloat for the Tapioca add-on, `ObjectSpace.dump_all` consistently reports the `File.write` line for writing the git attributes file as the place in the code retaining the most memory.

I did a few tests and it's something to do with the content. If I get rid of the content variable and just use an empty string, then this line no longer appears in the dump as the top retained memory.

I cannot explain why this is the case given that the heredocs used for the content are frozen strings. I honestly have no idea what's happening here. But avoiding writing the file if it's already there removes this line from the top offenders and no longer retains memory.

### Implementation

Started checking if the file exists before writing it.