### PR TITLE
[Tapioca Add-on] Limit what we require from the Rails add-on

### DIFF
--- a/lib/ruby_lsp/tapioca/addon.rb
+++ b/lib/ruby_lsp/tapioca/addon.rb
@@ -7,7 +7,7 @@ begin
   # The Tapioca add-on depends on the Rails add-on to add a runtime component to the runtime server. We can allow the
   # add-on to work outside of a Rails context in the future, but that may require Tapioca spawning its own runtime
   # server
-  require "ruby-lsp-rails"
+  require "ruby_lsp/ruby_lsp_rails/runner_client"
 rescue LoadError
   return
 end


### PR DESCRIPTION
The Tapioca add-on was requiring the entire `ruby-lsp-rails` gem, which in turns requires `rails`. As @st0012 identified, this caused a change to the behaviour of `.to_json` which resulted in the Dependencies view not being displayed correctly.

Closes https://github.com/Shopify/team-ruby-dx/issues/1317

cc @KaanOzkan  