### PR TITLE
Skip validating RBIs when running under add-on mode

### DIFF
--- a/lib/tapioca/commands/dsl_generate.rb
+++ b/lib/tapioca/commands/dsl_generate.rb
@@ -19,7 +19,7 @@ module Tapioca
         purge_stale_dsl_rbi_files(rbi_files_to_purge)
         say("Done", :green)
 
-        if @auto_strictness
+        if @auto_strictness && !@lsp_addon
           say("")
           validate_rbi_files(
             command: default_command(:dsl, all_requested_constants.join(" ")),


### PR DESCRIPTION
### Motivation

The RBI validation is to prevent conflicts between gem RBIs and DSL RBIs coming from those gems. That scenario is not relevant for the add-on because the user would only be editing files like models and not files inside gems.

That scenario is more important for when you're bumping a gem manually, but that's not covered by the add-on and I think it should be fine to not validate the RBIs.

The reason this is relevant is because to validate them, we shell out to Sorbet, which consumes more than 2x the amount of time it takes to actually generate the DSL RBIs.

### Implementation

Simply started skipping validation when in add-on mode.