### PR TITLE
Infer the worker count for `tapioca dsl`

### DIFF
--- a/README.md
+++ b/README.md
@@ -489,8 +489,7 @@ Options:
                                                                                                    # Default: false
   -q,        [--quiet], [--no-quiet], [--skip-quiet]                                               # Suppresses file creation output
                                                                                                    # Default: false
-  -w,        [--workers=N]                                                                         # Number of parallel workers to use when generating RBIs (default: 2)
-                                                                                                   # Default: 2
+  -w,        [--workers=N]                                                                         # Number of parallel workers to use when generating RBIs (default: auto)
              [--rbi-max-line-length=N]                                                             # Set the max line length of generated RBIs. Signatures longer than the max line length will be wrapped
                                                                                                    # Default: 120
   -e,        [--environment=ENVIRONMENT]                                                           # The Rack/Rails environment to use when generating RBIs
@@ -949,7 +948,7 @@ dsl:
   exclude: []
   verify: false
   quiet: false
-  workers: 2
+  workers: 1
   rbi_max_line_length: 120
   environment: development
   list_compilers: false

--- a/lib/tapioca/cli.rb
+++ b/lib/tapioca/cli.rb
@@ -111,8 +111,7 @@ module Tapioca
     option :workers,
       aliases: ["-w"],
       type: :numeric,
-      desc: "Number of parallel workers to use when generating RBIs (default: 2)",
-      default: 2
+      desc: "Number of parallel workers to use when generating RBIs (default: auto)"
     option :rbi_max_line_length,
       type: :numeric,
       desc: "Set the max line length of generated RBIs. Signatures longer than the max line length will be wrapped",


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->

I want `tapioca dsl` to infer the appropriate number of workers automatically.

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->

I noticed the CLI is setting `default: 2` for the DSL command, but the other commands don't provide a default. The inference defined [here](https://github.com/Shopify/tapioca/blob/5434fa6a65d5111b2a7e0adf581a9a43ab6e1da9/lib/tapioca/executor.rb#L18) never runs.

I'm assuming this is a mistake, but there could be a good reason for this hardcoded default that I'm not aware of.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->

It would be difficult to write a test for this functionality because we'd need to assert on the assumed number of workers in a test for the CLI. The worker count determination happens deep in the stack.