### PR TITLE
Update Minitest for improved test running experience

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -197,7 +197,7 @@ GEM
       net-smtp
     marcel (1.0.4)
     mini_mime (1.1.5)
-    minitest (5.25.1)
+    minitest (5.25.2)
     minitest-hooks (1.5.2)
       minitest (> 5.3)
     minitest-reporters (1.7.1)

--- a/sorbet/rbi/gems/minitest@5.25.2.rbi
+++ b/sorbet/rbi/gems/minitest@5.25.2.rbi
@@ -7,7 +7,7 @@
 
 # Kernel extensions for minitest
 #
-# source://minitest//lib/minitest/spec.rb#46
+# source://minitest/lib/minitest/spec.rb#46
 module Kernel
   private
 
@@ -45,19 +45,20 @@ module Kernel
   #
   # For more information about expectations, see Minitest::Expectations.
   #
-  # source://minitest//lib/minitest/spec.rb#82
+  # source://minitest/lib/minitest/spec.rb#82
   def describe(desc, *additional_desc, &block); end
 end
 
-# :include: README.rdoc
+# The top-level namespace for Minitest. Also the location of the main
+# runtime. See +Minitest.run+ for more information.
 #
-# source://minitest//lib/minitest/parallel.rb#1
+# source://minitest/lib/minitest/parallel.rb#1
 module Minitest
   class << self
     # Internal run method. Responsible for telling all Runnable
     # sub-classes to run.
     #
-    # source://minitest//lib/minitest.rb#322
+    # source://minitest/lib/minitest.rb#323
     def __run(reporter, options); end
 
     # A simple hook allowing you to run a block of code after everything
@@ -65,74 +66,74 @@ module Minitest
     #
     #   Minitest.after_run { p $debugging_info }
     #
-    # source://minitest//lib/minitest.rb#96
+    # source://minitest/lib/minitest.rb#97
     def after_run(&block); end
 
-    # source://minitest//lib/minitest.rb#19
+    # source://minitest/lib/minitest.rb#20
     def allow_fork; end
 
-    # source://minitest//lib/minitest.rb#19
+    # source://minitest/lib/minitest.rb#20
     def allow_fork=(_arg0); end
 
     # Registers Minitest to run at process exit
     #
-    # source://minitest//lib/minitest.rb#69
+    # source://minitest/lib/minitest.rb#70
     def autorun; end
 
-    # source://minitest//lib/minitest.rb#19
+    # source://minitest/lib/minitest.rb#20
     def backtrace_filter; end
 
-    # source://minitest//lib/minitest.rb#19
+    # source://minitest/lib/minitest.rb#20
     def backtrace_filter=(_arg0); end
 
-    # source://minitest//lib/minitest.rb#18
+    # source://minitest/lib/minitest.rb#19
     def cattr_accessor(name); end
 
-    # source://minitest//lib/minitest.rb#1215
+    # source://minitest/lib/minitest.rb#1216
     def clock_time; end
 
-    # source://minitest//lib/minitest.rb#302
+    # source://minitest/lib/minitest.rb#303
     def empty_run!(options); end
 
-    # source://minitest//lib/minitest.rb#19
+    # source://minitest/lib/minitest.rb#20
     def extensions; end
 
-    # source://minitest//lib/minitest.rb#19
+    # source://minitest/lib/minitest.rb#20
     def extensions=(_arg0); end
 
-    # source://minitest//lib/minitest.rb#335
+    # source://minitest/lib/minitest.rb#336
     def filter_backtrace(bt); end
 
-    # source://minitest//lib/minitest.rb#19
+    # source://minitest/lib/minitest.rb#20
     def info_signal; end
 
-    # source://minitest//lib/minitest.rb#19
+    # source://minitest/lib/minitest.rb#20
     def info_signal=(_arg0); end
 
-    # source://minitest//lib/minitest.rb#124
+    # source://minitest/lib/minitest.rb#125
     def init_plugins(options); end
 
-    # source://minitest//lib/minitest.rb#108
+    # source://minitest/lib/minitest.rb#109
     def load_plugins; end
 
-    # source://minitest//lib/minitest.rb#19
+    # source://minitest/lib/minitest.rb#20
     def parallel_executor; end
 
-    # source://minitest//lib/minitest.rb#19
+    # source://minitest/lib/minitest.rb#20
     def parallel_executor=(_arg0); end
 
-    # source://minitest//lib/minitest.rb#142
+    # source://minitest/lib/minitest.rb#143
     def process_args(args = T.unsafe(nil)); end
 
     # Register a plugin to be used. Does NOT require / load it.
     #
-    # source://minitest//lib/minitest.rb#103
+    # source://minitest/lib/minitest.rb#104
     def register_plugin(name_or_mod); end
 
-    # source://minitest//lib/minitest.rb#19
+    # source://minitest/lib/minitest.rb#20
     def reporter; end
 
-    # source://minitest//lib/minitest.rb#19
+    # source://minitest/lib/minitest.rb#20
     def reporter=(_arg0); end
 
     # This is the top-level run method. Everything starts from here. It
@@ -154,16 +155,16 @@ module Minitest
     #                 Minitest.run_one_method(klass, runnable_method)
     #                   klass.new(runnable_method).run
     #
-    # source://minitest//lib/minitest.rb#268
+    # source://minitest/lib/minitest.rb#269
     def run(args = T.unsafe(nil)); end
 
-    # source://minitest//lib/minitest.rb#1206
+    # source://minitest/lib/minitest.rb#1207
     def run_one_method(klass, method_name); end
 
-    # source://minitest//lib/minitest.rb#19
+    # source://minitest/lib/minitest.rb#20
     def seed; end
 
-    # source://minitest//lib/minitest.rb#19
+    # source://minitest/lib/minitest.rb#20
     def seed=(_arg0); end
   end
 end
@@ -171,24 +172,24 @@ end
 # Defines the API for Reporters. Subclass this and override whatever
 # you want. Go nuts.
 #
-# source://minitest//lib/minitest.rb#686
+# source://minitest/lib/minitest.rb#687
 class Minitest::AbstractReporter
   # @return [AbstractReporter] a new instance of AbstractReporter
   #
-  # source://minitest//lib/minitest.rb#688
+  # source://minitest/lib/minitest.rb#689
   def initialize; end
 
   # Did this run pass?
   #
   # @return [Boolean]
   #
-  # source://minitest//lib/minitest.rb#723
+  # source://minitest/lib/minitest.rb#724
   def passed?; end
 
   # About to start running a test. This allows a reporter to show
   # that it is starting or that we are in the middle of a test run.
   #
-  # source://minitest//lib/minitest.rb#702
+  # source://minitest/lib/minitest.rb#703
   def prerecord(klass, name); end
 
   # Output and record the result of the test. Call
@@ -196,43 +197,43 @@ class Minitest::AbstractReporter
   # result character string. Stores the result of the run if the run
   # did not pass.
   #
-  # source://minitest//lib/minitest.rb#711
+  # source://minitest/lib/minitest.rb#712
   def record(result); end
 
   # Outputs the summary of the run.
   #
-  # source://minitest//lib/minitest.rb#717
+  # source://minitest/lib/minitest.rb#718
   def report; end
 
   # Starts reporting on the run.
   #
-  # source://minitest//lib/minitest.rb#695
+  # source://minitest/lib/minitest.rb#696
   def start; end
 
-  # source://minitest//lib/minitest.rb#727
+  # source://minitest/lib/minitest.rb#728
   def synchronize(&block); end
 end
 
 # Represents run failures.
 #
-# source://minitest//lib/minitest.rb#1019
+# source://minitest/lib/minitest.rb#1020
 class Minitest::Assertion < ::Exception
-  # source://minitest//lib/minitest.rb#1022
+  # source://minitest/lib/minitest.rb#1023
   def error; end
 
   # Where was this run before an assertion was raised?
   #
-  # source://minitest//lib/minitest.rb#1029
+  # source://minitest/lib/minitest.rb#1030
   def location; end
 
-  # source://minitest//lib/minitest.rb#1037
+  # source://minitest/lib/minitest.rb#1038
   def result_code; end
 
-  # source://minitest//lib/minitest.rb#1041
+  # source://minitest/lib/minitest.rb#1042
   def result_label; end
 end
 
-# source://minitest//lib/minitest.rb#1020
+# source://minitest/lib/minitest.rb#1021
 Minitest::Assertion::RE = T.let(T.unsafe(nil), Regexp)
 
 # Minitest Assertions.  All assertion methods accept a +msg+ which is
@@ -244,22 +245,22 @@ Minitest::Assertion::RE = T.let(T.unsafe(nil), Regexp)
 # provided by the thing including Assertions. See Minitest::Runnable
 # for an example.
 #
-# source://minitest//lib/minitest/assertions.rb#16
+# source://minitest/lib/minitest/assertions.rb#16
 module Minitest::Assertions
-  # source://minitest//lib/minitest/assertions.rb#181
+  # source://minitest/lib/minitest/assertions.rb#181
   def _synchronize; end
 
-  # source://minitest//lib/minitest/assertions.rb#194
+  # source://minitest/lib/minitest/assertions.rb#194
   def _where; end
 
   # Fails unless +test+ is truthy.
   #
-  # source://minitest//lib/minitest/assertions.rb#171
+  # source://minitest/lib/minitest/assertions.rb#171
   def assert(test, msg = T.unsafe(nil)); end
 
   # Fails unless +obj+ is empty.
   #
-  # source://minitest//lib/minitest/assertions.rb#188
+  # source://minitest/lib/minitest/assertions.rb#188
   def assert_empty(obj, msg = T.unsafe(nil)); end
 
   # Fails unless <tt>exp == act</tt> printing the difference between
@@ -274,7 +275,7 @@ module Minitest::Assertions
   #
   # See also: Minitest::Assertions.diff
   #
-  # source://minitest//lib/minitest/assertions.rb#214
+  # source://minitest/lib/minitest/assertions.rb#214
   def assert_equal(exp, act, msg = T.unsafe(nil)); end
 
   # For comparing Floats.  Fails unless +exp+ and +act+ are within +delta+
@@ -282,45 +283,45 @@ module Minitest::Assertions
   #
   #   assert_in_delta Math::PI, (22.0 / 7.0), 0.01
   #
-  # source://minitest//lib/minitest/assertions.rb#235
+  # source://minitest/lib/minitest/assertions.rb#235
   def assert_in_delta(exp, act, delta = T.unsafe(nil), msg = T.unsafe(nil)); end
 
   # For comparing Floats.  Fails unless +exp+ and +act+ have a relative
   # error less than +epsilon+.
   #
-  # source://minitest//lib/minitest/assertions.rb#247
+  # source://minitest/lib/minitest/assertions.rb#247
   def assert_in_epsilon(exp, act, epsilon = T.unsafe(nil), msg = T.unsafe(nil)); end
 
   # Fails unless +collection+ includes +obj+.
   #
-  # source://minitest//lib/minitest/assertions.rb#254
+  # source://minitest/lib/minitest/assertions.rb#254
   def assert_includes(collection, obj, msg = T.unsafe(nil)); end
 
   # Fails unless +obj+ is an instance of +cls+.
   #
-  # source://minitest//lib/minitest/assertions.rb#265
+  # source://minitest/lib/minitest/assertions.rb#265
   def assert_instance_of(cls, obj, msg = T.unsafe(nil)); end
 
   # Fails unless +obj+ is a kind of +cls+.
   #
-  # source://minitest//lib/minitest/assertions.rb#276
+  # source://minitest/lib/minitest/assertions.rb#276
   def assert_kind_of(cls, obj, msg = T.unsafe(nil)); end
 
   # Fails unless +matcher+ <tt>=~</tt> +obj+.
   #
-  # source://minitest//lib/minitest/assertions.rb#287
+  # source://minitest/lib/minitest/assertions.rb#287
   def assert_match(matcher, obj, msg = T.unsafe(nil)); end
 
   # Fails unless +obj+ is nil
   #
-  # source://minitest//lib/minitest/assertions.rb#299
+  # source://minitest/lib/minitest/assertions.rb#299
   def assert_nil(obj, msg = T.unsafe(nil)); end
 
   # For testing with binary operators. Eg:
   #
   #   assert_operator 5, :<=, 4
   #
-  # source://minitest//lib/minitest/assertions.rb#309
+  # source://minitest/lib/minitest/assertions.rb#309
   def assert_operator(o1, op, o2 = T.unsafe(nil), msg = T.unsafe(nil)); end
 
   # Fails if stdout or stderr do not output the expected results.
@@ -334,12 +335,12 @@ module Minitest::Assertions
   #
   # See also: #assert_silent
   #
-  # source://minitest//lib/minitest/assertions.rb#327
+  # source://minitest/lib/minitest/assertions.rb#327
   def assert_output(stdout = T.unsafe(nil), stderr = T.unsafe(nil)); end
 
   # Fails unless +path+ exists.
   #
-  # source://minitest//lib/minitest/assertions.rb#351
+  # source://minitest/lib/minitest/assertions.rb#351
   def assert_path_exists(path, msg = T.unsafe(nil)); end
 
   # For testing with pattern matching (only supported with Ruby 3.0 and later)
@@ -357,7 +358,7 @@ module Minitest::Assertions
   #
   # @raise [NotImplementedError]
   #
-  # source://minitest//lib/minitest/assertions.rb#370
+  # source://minitest/lib/minitest/assertions.rb#370
   def assert_pattern; end
 
   # For testing with predicates. Eg:
@@ -368,7 +369,7 @@ module Minitest::Assertions
   #
   #   str.must_be :empty?
   #
-  # source://minitest//lib/minitest/assertions.rb#391
+  # source://minitest/lib/minitest/assertions.rb#391
   def assert_predicate(o1, op, msg = T.unsafe(nil)); end
 
   # Fails unless the block raises one of +exp+. Returns the
@@ -392,37 +393,37 @@ module Minitest::Assertions
   #
   #   assert_equal 'This is really bad', error.message
   #
-  # source://minitest//lib/minitest/assertions.rb#418
+  # source://minitest/lib/minitest/assertions.rb#418
   def assert_raises(*exp); end
 
   # Fails unless +obj+ responds to +meth+.
   # include_all defaults to false to match Object#respond_to?
   #
-  # source://minitest//lib/minitest/assertions.rb#450
+  # source://minitest/lib/minitest/assertions.rb#450
   def assert_respond_to(obj, meth, msg = T.unsafe(nil), include_all: T.unsafe(nil)); end
 
   # Fails unless +exp+ and +act+ are #equal?
   #
-  # source://minitest//lib/minitest/assertions.rb#460
+  # source://minitest/lib/minitest/assertions.rb#460
   def assert_same(exp, act, msg = T.unsafe(nil)); end
 
   # +send_ary+ is a receiver, message and arguments.
   #
   # Fails unless the call returns a true value
   #
-  # source://minitest//lib/minitest/assertions.rb#473
+  # source://minitest/lib/minitest/assertions.rb#473
   def assert_send(send_ary, m = T.unsafe(nil)); end
 
   # Fails if the block outputs anything to stderr or stdout.
   #
   # See also: #assert_output
   #
-  # source://minitest//lib/minitest/assertions.rb#488
+  # source://minitest/lib/minitest/assertions.rb#488
   def assert_silent; end
 
   # Fails unless the block throws +sym+
   #
-  # source://minitest//lib/minitest/assertions.rb#497
+  # source://minitest/lib/minitest/assertions.rb#497
   def assert_throws(sym, msg = T.unsafe(nil)); end
 
   # Captures $stdout and $stderr into strings:
@@ -439,7 +440,7 @@ module Minitest::Assertions
   # capture IO for subprocesses. Use #capture_subprocess_io for
   # that.
   #
-  # source://minitest//lib/minitest/assertions.rb#538
+  # source://minitest/lib/minitest/assertions.rb#538
   def capture_io; end
 
   # Captures $stdout and $stderr into strings, using Tempfile to
@@ -456,7 +457,7 @@ module Minitest::Assertions
   # NOTE: This method is approximately 10x slower than #capture_io so
   # only use it when you need to test the output of a subprocess.
   #
-  # source://minitest//lib/minitest/assertions.rb#571
+  # source://minitest/lib/minitest/assertions.rb#571
   def capture_subprocess_io; end
 
   # Returns a diff between +exp+ and +act+. If there is no known
@@ -466,29 +467,29 @@ module Minitest::Assertions
   #
   # See +things_to_diff+ for more info.
   #
-  # source://minitest//lib/minitest/assertions.rb#57
+  # source://minitest/lib/minitest/assertions.rb#57
   def diff(exp, act); end
 
   # Returns details for exception +e+
   #
-  # source://minitest//lib/minitest/assertions.rb#603
+  # source://minitest/lib/minitest/assertions.rb#603
   def exception_details(e, msg); end
 
   # Fails after a given date (in the local time zone). This allows
   # you to put time-bombs in your tests if you need to keep
   # something around until a later date lest you forget about it.
   #
-  # source://minitest//lib/minitest/assertions.rb#619
+  # source://minitest/lib/minitest/assertions.rb#619
   def fail_after(y, m, d, msg); end
 
   # Fails with +msg+.
   #
-  # source://minitest//lib/minitest/assertions.rb#626
+  # source://minitest/lib/minitest/assertions.rb#626
   def flunk(msg = T.unsafe(nil)); end
 
   # Returns a proc that will output +msg+ along with the default message.
   #
-  # source://minitest//lib/minitest/assertions.rb#634
+  # source://minitest/lib/minitest/assertions.rb#634
   def message(msg = T.unsafe(nil), ending = T.unsafe(nil), &default); end
 
   # This returns a human-readable version of +obj+. By default
@@ -497,7 +498,7 @@ module Minitest::Assertions
   #
   # See Minitest::Test.make_my_diffs_pretty!
   #
-  # source://minitest//lib/minitest/assertions.rb#127
+  # source://minitest/lib/minitest/assertions.rb#127
   def mu_pp(obj); end
 
   # This returns a diff-able more human-readable version of +obj+.
@@ -505,67 +506,67 @@ module Minitest::Assertions
   # newlines and makes hex-values (like object_ids) generic. This
   # uses mu_pp to do the first pass and then cleans it up.
   #
-  # source://minitest//lib/minitest/assertions.rb#145
+  # source://minitest/lib/minitest/assertions.rb#145
   def mu_pp_for_diff(obj); end
 
   # used for counting assertions
   #
-  # source://minitest//lib/minitest/assertions.rb#645
+  # source://minitest/lib/minitest/assertions.rb#645
   def pass(_msg = T.unsafe(nil)); end
 
   # Fails if +test+ is truthy.
   #
-  # source://minitest//lib/minitest/assertions.rb#652
+  # source://minitest/lib/minitest/assertions.rb#652
   def refute(test, msg = T.unsafe(nil)); end
 
   # Fails if +obj+ is empty.
   #
-  # source://minitest//lib/minitest/assertions.rb#660
+  # source://minitest/lib/minitest/assertions.rb#660
   def refute_empty(obj, msg = T.unsafe(nil)); end
 
   # Fails if <tt>exp == act</tt>.
   #
   # For floats use refute_in_delta.
   #
-  # source://minitest//lib/minitest/assertions.rb#671
+  # source://minitest/lib/minitest/assertions.rb#671
   def refute_equal(exp, act, msg = T.unsafe(nil)); end
 
   # For comparing Floats.  Fails if +exp+ is within +delta+ of +act+.
   #
   #   refute_in_delta Math::PI, (22.0 / 7.0)
   #
-  # source://minitest//lib/minitest/assertions.rb#683
+  # source://minitest/lib/minitest/assertions.rb#683
   def refute_in_delta(exp, act, delta = T.unsafe(nil), msg = T.unsafe(nil)); end
 
   # For comparing Floats.  Fails if +exp+ and +act+ have a relative error
   # less than +epsilon+.
   #
-  # source://minitest//lib/minitest/assertions.rb#695
+  # source://minitest/lib/minitest/assertions.rb#695
   def refute_in_epsilon(a, b, epsilon = T.unsafe(nil), msg = T.unsafe(nil)); end
 
   # Fails if +collection+ includes +obj+.
   #
-  # source://minitest//lib/minitest/assertions.rb#702
+  # source://minitest/lib/minitest/assertions.rb#702
   def refute_includes(collection, obj, msg = T.unsafe(nil)); end
 
   # Fails if +obj+ is an instance of +cls+.
   #
-  # source://minitest//lib/minitest/assertions.rb#713
+  # source://minitest/lib/minitest/assertions.rb#713
   def refute_instance_of(cls, obj, msg = T.unsafe(nil)); end
 
   # Fails if +obj+ is a kind of +cls+.
   #
-  # source://minitest//lib/minitest/assertions.rb#723
+  # source://minitest/lib/minitest/assertions.rb#723
   def refute_kind_of(cls, obj, msg = T.unsafe(nil)); end
 
   # Fails if +matcher+ <tt>=~</tt> +obj+.
   #
-  # source://minitest//lib/minitest/assertions.rb#731
+  # source://minitest/lib/minitest/assertions.rb#731
   def refute_match(matcher, obj, msg = T.unsafe(nil)); end
 
   # Fails if +obj+ is nil.
   #
-  # source://minitest//lib/minitest/assertions.rb#741
+  # source://minitest/lib/minitest/assertions.rb#741
   def refute_nil(obj, msg = T.unsafe(nil)); end
 
   # Fails if +o1+ is not +op+ +o2+. Eg:
@@ -573,12 +574,12 @@ module Minitest::Assertions
   #   refute_operator 1, :>, 2 #=> pass
   #   refute_operator 1, :<, 2 #=> fail
   #
-  # source://minitest//lib/minitest/assertions.rb#776
+  # source://minitest/lib/minitest/assertions.rb#776
   def refute_operator(o1, op, o2 = T.unsafe(nil), msg = T.unsafe(nil)); end
 
   # Fails if +path+ exists.
   #
-  # source://minitest//lib/minitest/assertions.rb#785
+  # source://minitest/lib/minitest/assertions.rb#785
   def refute_path_exists(path, msg = T.unsafe(nil)); end
 
   # For testing with pattern matching (only supported with Ruby 3.0 and later)
@@ -594,7 +595,7 @@ module Minitest::Assertions
   #
   # @raise [NotImplementedError]
   #
-  # source://minitest//lib/minitest/assertions.rb#758
+  # source://minitest/lib/minitest/assertions.rb#758
   def refute_pattern; end
 
   # For testing with predicates.
@@ -605,18 +606,18 @@ module Minitest::Assertions
   #
   #   str.wont_be :empty?
   #
-  # source://minitest//lib/minitest/assertions.rb#799
+  # source://minitest/lib/minitest/assertions.rb#799
   def refute_predicate(o1, op, msg = T.unsafe(nil)); end
 
   # Fails if +obj+ responds to the message +meth+.
   # include_all defaults to false to match Object#respond_to?
   #
-  # source://minitest//lib/minitest/assertions.rb#808
+  # source://minitest/lib/minitest/assertions.rb#808
   def refute_respond_to(obj, meth, msg = T.unsafe(nil), include_all: T.unsafe(nil)); end
 
   # Fails if +exp+ is the same (by object identity) as +act+.
   #
-  # source://minitest//lib/minitest/assertions.rb#817
+  # source://minitest/lib/minitest/assertions.rb#817
   def refute_same(exp, act, msg = T.unsafe(nil)); end
 
   # Skips the current run. If run in verbose-mode, the skipped run
@@ -625,7 +626,7 @@ module Minitest::Assertions
   #
   # @raise [Minitest::Skip]
   #
-  # source://minitest//lib/minitest/assertions.rb#830
+  # source://minitest/lib/minitest/assertions.rb#830
   def skip(msg = T.unsafe(nil), _ignored = T.unsafe(nil)); end
 
   # Skips the current run until a given date (in the local time
@@ -633,14 +634,14 @@ module Minitest::Assertions
   # date, but still holds you accountable and prevents you from
   # forgetting it.
   #
-  # source://minitest//lib/minitest/assertions.rb#842
+  # source://minitest/lib/minitest/assertions.rb#842
   def skip_until(y, m, d, msg); end
 
   # Was this testcase skipped? Meant for #teardown.
   #
   # @return [Boolean]
   #
-  # source://minitest//lib/minitest/assertions.rb#851
+  # source://minitest/lib/minitest/assertions.rb#851
   def skipped?; end
 
   # Returns things to diff [expect, butwas], or [nil, nil] if nothing to diff.
@@ -652,224 +653,224 @@ module Minitest::Assertions
   # 3. or:  Strings are equal to each other (but maybe different encodings?).
   # 4. and: we found a diff executable.
   #
-  # source://minitest//lib/minitest/assertions.rb#102
+  # source://minitest/lib/minitest/assertions.rb#102
   def things_to_diff(exp, act); end
 
   class << self
     # Returns the diff command to use in #diff. Tries to intelligently
     # figure out what diff to use.
     #
-    # source://minitest//lib/minitest/assertions.rb#27
+    # source://minitest/lib/minitest/assertions.rb#27
     def diff; end
 
     # Set the diff command to use in #diff.
     #
-    # source://minitest//lib/minitest/assertions.rb#45
+    # source://minitest/lib/minitest/assertions.rb#45
     def diff=(o); end
   end
 end
 
-# source://minitest//lib/minitest/assertions.rb#199
+# source://minitest/lib/minitest/assertions.rb#199
 Minitest::Assertions::E = T.let(T.unsafe(nil), String)
 
-# source://minitest//lib/minitest/assertions.rb#17
+# source://minitest/lib/minitest/assertions.rb#17
 Minitest::Assertions::UNDEFINED = T.let(T.unsafe(nil), Object)
 
 # The standard backtrace filter for minitest.
 #
 # See Minitest.backtrace_filter=.
 #
-# source://minitest//lib/minitest.rb#1174
+# source://minitest/lib/minitest.rb#1175
 class Minitest::BacktraceFilter
   # @return [BacktraceFilter] a new instance of BacktraceFilter
   #
-  # source://minitest//lib/minitest.rb#1183
+  # source://minitest/lib/minitest.rb#1184
   def initialize(regexp = T.unsafe(nil)); end
 
   # Filter +bt+ to something useful. Returns the whole thing if
   # $DEBUG (ruby) or $MT_DEBUG (env).
   #
-  # source://minitest//lib/minitest.rb#1191
+  # source://minitest/lib/minitest.rb#1192
   def filter(bt); end
 
   # The regular expression to use to filter backtraces. Defaults to +MT_RE+.
   #
-  # source://minitest//lib/minitest.rb#1181
+  # source://minitest/lib/minitest.rb#1182
   def regexp; end
 
   # The regular expression to use to filter backtraces. Defaults to +MT_RE+.
   #
-  # source://minitest//lib/minitest.rb#1181
+  # source://minitest/lib/minitest.rb#1182
   def regexp=(_arg0); end
 end
 
-# source://minitest//lib/minitest.rb#1176
+# source://minitest/lib/minitest.rb#1177
 Minitest::BacktraceFilter::MT_RE = T.let(T.unsafe(nil), Regexp)
 
 # Dispatch to multiple reporters as one.
 #
-# source://minitest//lib/minitest.rb#968
+# source://minitest/lib/minitest.rb#969
 class Minitest::CompositeReporter < ::Minitest::AbstractReporter
   # @return [CompositeReporter] a new instance of CompositeReporter
   #
-  # source://minitest//lib/minitest.rb#974
+  # source://minitest/lib/minitest.rb#975
   def initialize(*reporters); end
 
   # Add another reporter to the mix.
   #
-  # source://minitest//lib/minitest.rb#986
+  # source://minitest/lib/minitest.rb#987
   def <<(reporter); end
 
-  # source://minitest//lib/minitest.rb#979
+  # source://minitest/lib/minitest.rb#980
   def io; end
 
   # @return [Boolean]
   #
-  # source://minitest//lib/minitest.rb#990
+  # source://minitest/lib/minitest.rb#991
   def passed?; end
 
-  # source://minitest//lib/minitest.rb#998
+  # source://minitest/lib/minitest.rb#999
   def prerecord(klass, name); end
 
-  # source://minitest//lib/minitest.rb#1005
+  # source://minitest/lib/minitest.rb#1006
   def record(result); end
 
-  # source://minitest//lib/minitest.rb#1011
+  # source://minitest/lib/minitest.rb#1012
   def report; end
 
   # The list of reporters to dispatch to.
   #
-  # source://minitest//lib/minitest.rb#972
+  # source://minitest/lib/minitest.rb#973
   def reporters; end
 
   # The list of reporters to dispatch to.
   #
-  # source://minitest//lib/minitest.rb#972
+  # source://minitest/lib/minitest.rb#973
   def reporters=(_arg0); end
 
-  # source://minitest//lib/minitest.rb#994
+  # source://minitest/lib/minitest.rb#995
   def start; end
 end
 
 # Compresses backtraces.
 #
-# source://minitest//lib/minitest/compress.rb#5
+# source://minitest/lib/minitest/compress.rb#5
 module Minitest::Compress
   # Takes a backtrace (array of strings) and compresses repeating
   # cycles in it to make it more readable.
   #
-  # source://minitest//lib/minitest/compress.rb#11
+  # source://minitest/lib/minitest/compress.rb#11
   def compress(orig); end
 end
 
-# source://minitest//lib/minitest/spec.rb#41
+# source://minitest/lib/minitest/spec.rb#41
 class Minitest::Expectation < ::Struct
   def ctx; end
   def ctx=(_); end
 
-  # source://minitest//lib/minitest/spec.rb#25
+  # source://minitest/lib/minitest/spec.rb#25
   def must_be(*args, **_arg1); end
 
-  # source://minitest//lib/minitest/spec.rb#25
+  # source://minitest/lib/minitest/spec.rb#25
   def must_be_close_to(*args, **_arg1); end
 
-  # source://minitest//lib/minitest/spec.rb#25
+  # source://minitest/lib/minitest/spec.rb#25
   def must_be_empty(*args, **_arg1); end
 
-  # source://minitest//lib/minitest/spec.rb#25
+  # source://minitest/lib/minitest/spec.rb#25
   def must_be_instance_of(*args, **_arg1); end
 
-  # source://minitest//lib/minitest/spec.rb#25
+  # source://minitest/lib/minitest/spec.rb#25
   def must_be_kind_of(*args, **_arg1); end
 
-  # source://minitest//lib/minitest/spec.rb#25
+  # source://minitest/lib/minitest/spec.rb#25
   def must_be_nil(*args, **_arg1); end
 
-  # source://minitest//lib/minitest/spec.rb#25
+  # source://minitest/lib/minitest/spec.rb#25
   def must_be_same_as(*args, **_arg1); end
 
-  # source://minitest//lib/minitest/spec.rb#25
+  # source://minitest/lib/minitest/spec.rb#25
   def must_be_silent(*args, **_arg1); end
 
-  # source://minitest//lib/minitest/spec.rb#25
+  # source://minitest/lib/minitest/spec.rb#25
   def must_be_within_delta(*args, **_arg1); end
 
-  # source://minitest//lib/minitest/spec.rb#25
+  # source://minitest/lib/minitest/spec.rb#25
   def must_be_within_epsilon(*args, **_arg1); end
 
-  # source://minitest//lib/minitest/spec.rb#25
+  # source://minitest/lib/minitest/spec.rb#25
   def must_equal(*args, **_arg1); end
 
-  # source://minitest//lib/minitest/spec.rb#25
+  # source://minitest/lib/minitest/spec.rb#25
   def must_include(*args, **_arg1); end
 
-  # source://minitest//lib/minitest/spec.rb#25
+  # source://minitest/lib/minitest/spec.rb#25
   def must_match(*args, **_arg1); end
 
-  # source://minitest//lib/minitest/spec.rb#25
+  # source://minitest/lib/minitest/spec.rb#25
   def must_output(*args, **_arg1); end
 
-  # source://minitest//lib/minitest/spec.rb#25
+  # source://minitest/lib/minitest/spec.rb#25
   def must_pattern_match(*args, **_arg1); end
 
-  # source://minitest//lib/minitest/spec.rb#25
+  # source://minitest/lib/minitest/spec.rb#25
   def must_raise(*args, **_arg1); end
 
-  # source://minitest//lib/minitest/spec.rb#25
+  # source://minitest/lib/minitest/spec.rb#25
   def must_respond_to(*args, **_arg1); end
 
-  # source://minitest//lib/minitest/spec.rb#25
+  # source://minitest/lib/minitest/spec.rb#25
   def must_throw(*args, **_arg1); end
 
-  # source://minitest//lib/minitest/spec.rb#25
+  # source://minitest/lib/minitest/spec.rb#25
   def path_must_exist(*args, **_arg1); end
 
-  # source://minitest//lib/minitest/spec.rb#25
+  # source://minitest/lib/minitest/spec.rb#25
   def path_wont_exist(*args, **_arg1); end
 
   def target; end
   def target=(_); end
 
-  # source://minitest//lib/minitest/spec.rb#25
+  # source://minitest/lib/minitest/spec.rb#25
   def wont_be(*args, **_arg1); end
 
-  # source://minitest//lib/minitest/spec.rb#25
+  # source://minitest/lib/minitest/spec.rb#25
   def wont_be_close_to(*args, **_arg1); end
 
-  # source://minitest//lib/minitest/spec.rb#25
+  # source://minitest/lib/minitest/spec.rb#25
   def wont_be_empty(*args, **_arg1); end
 
-  # source://minitest//lib/minitest/spec.rb#25
+  # source://minitest/lib/minitest/spec.rb#25
   def wont_be_instance_of(*args, **_arg1); end
 
-  # source://minitest//lib/minitest/spec.rb#25
+  # source://minitest/lib/minitest/spec.rb#25
   def wont_be_kind_of(*args, **_arg1); end
 
-  # source://minitest//lib/minitest/spec.rb#25
+  # source://minitest/lib/minitest/spec.rb#25
   def wont_be_nil(*args, **_arg1); end
 
-  # source://minitest//lib/minitest/spec.rb#25
+  # source://minitest/lib/minitest/spec.rb#25
   def wont_be_same_as(*args, **_arg1); end
 
-  # source://minitest//lib/minitest/spec.rb#25
+  # source://minitest/lib/minitest/spec.rb#25
   def wont_be_within_delta(*args, **_arg1); end
 
-  # source://minitest//lib/minitest/spec.rb#25
+  # source://minitest/lib/minitest/spec.rb#25
   def wont_be_within_epsilon(*args, **_arg1); end
 
-  # source://minitest//lib/minitest/spec.rb#25
+  # source://minitest/lib/minitest/spec.rb#25
   def wont_equal(*args, **_arg1); end
 
-  # source://minitest//lib/minitest/spec.rb#25
+  # source://minitest/lib/minitest/spec.rb#25
   def wont_include(*args, **_arg1); end
 
-  # source://minitest//lib/minitest/spec.rb#25
+  # source://minitest/lib/minitest/spec.rb#25
   def wont_match(*args, **_arg1); end
 
-  # source://minitest//lib/minitest/spec.rb#25
+  # source://minitest/lib/minitest/spec.rb#25
   def wont_pattern_match(*args, **_arg1); end
 
-  # source://minitest//lib/minitest/spec.rb#25
+  # source://minitest/lib/minitest/spec.rb#25
   def wont_respond_to(*args, **_arg1); end
 
   class << self
@@ -899,108 +900,108 @@ end
 #       end
 #     end
 #
-# source://minitest//lib/minitest/expectations.rb#20
+# source://minitest/lib/minitest/expectations.rb#20
 module Minitest::Expectations
-  # source://minitest//lib/minitest/spec.rb#15
+  # source://minitest/lib/minitest/spec.rb#15
   def must_be(*args, **_arg1); end
 
-  # source://minitest//lib/minitest/spec.rb#15
+  # source://minitest/lib/minitest/spec.rb#15
   def must_be_close_to(*args, **_arg1); end
 
-  # source://minitest//lib/minitest/spec.rb#15
+  # source://minitest/lib/minitest/spec.rb#15
   def must_be_empty(*args, **_arg1); end
 
-  # source://minitest//lib/minitest/spec.rb#15
+  # source://minitest/lib/minitest/spec.rb#15
   def must_be_instance_of(*args, **_arg1); end
 
-  # source://minitest//lib/minitest/spec.rb#15
+  # source://minitest/lib/minitest/spec.rb#15
   def must_be_kind_of(*args, **_arg1); end
 
-  # source://minitest//lib/minitest/spec.rb#15
+  # source://minitest/lib/minitest/spec.rb#15
   def must_be_nil(*args, **_arg1); end
 
-  # source://minitest//lib/minitest/spec.rb#15
+  # source://minitest/lib/minitest/spec.rb#15
   def must_be_same_as(*args, **_arg1); end
 
-  # source://minitest//lib/minitest/spec.rb#15
+  # source://minitest/lib/minitest/spec.rb#15
   def must_be_silent(*args, **_arg1); end
 
-  # source://minitest//lib/minitest/spec.rb#15
+  # source://minitest/lib/minitest/spec.rb#15
   def must_be_within_delta(*args, **_arg1); end
 
-  # source://minitest//lib/minitest/spec.rb#15
+  # source://minitest/lib/minitest/spec.rb#15
   def must_be_within_epsilon(*args, **_arg1); end
 
-  # source://minitest//lib/minitest/spec.rb#15
+  # source://minitest/lib/minitest/spec.rb#15
   def must_equal(*args, **_arg1); end
 
-  # source://minitest//lib/minitest/spec.rb#15
+  # source://minitest/lib/minitest/spec.rb#15
   def must_include(*args, **_arg1); end
 
-  # source://minitest//lib/minitest/spec.rb#15
+  # source://minitest/lib/minitest/spec.rb#15
   def must_match(*args, **_arg1); end
 
-  # source://minitest//lib/minitest/spec.rb#15
+  # source://minitest/lib/minitest/spec.rb#15
   def must_output(*args, **_arg1); end
 
-  # source://minitest//lib/minitest/spec.rb#15
+  # source://minitest/lib/minitest/spec.rb#15
   def must_pattern_match(*args, **_arg1); end
 
-  # source://minitest//lib/minitest/spec.rb#15
+  # source://minitest/lib/minitest/spec.rb#15
   def must_raise(*args, **_arg1); end
 
-  # source://minitest//lib/minitest/spec.rb#15
+  # source://minitest/lib/minitest/spec.rb#15
   def must_respond_to(*args, **_arg1); end
 
-  # source://minitest//lib/minitest/spec.rb#15
+  # source://minitest/lib/minitest/spec.rb#15
   def must_throw(*args, **_arg1); end
 
-  # source://minitest//lib/minitest/spec.rb#15
+  # source://minitest/lib/minitest/spec.rb#15
   def path_must_exist(*args, **_arg1); end
 
-  # source://minitest//lib/minitest/spec.rb#15
+  # source://minitest/lib/minitest/spec.rb#15
   def path_wont_exist(*args, **_arg1); end
 
-  # source://minitest//lib/minitest/spec.rb#15
+  # source://minitest/lib/minitest/spec.rb#15
   def wont_be(*args, **_arg1); end
 
-  # source://minitest//lib/minitest/spec.rb#15
+  # source://minitest/lib/minitest/spec.rb#15
   def wont_be_close_to(*args, **_arg1); end
 
-  # source://minitest//lib/minitest/spec.rb#15
+  # source://minitest/lib/minitest/spec.rb#15
   def wont_be_empty(*args, **_arg1); end
 
-  # source://minitest//lib/minitest/spec.rb#15
+  # source://minitest/lib/minitest/spec.rb#15
   def wont_be_instance_of(*args, **_arg1); end
 
-  # source://minitest//lib/minitest/spec.rb#15
+  # source://minitest/lib/minitest/spec.rb#15
   def wont_be_kind_of(*args, **_arg1); end
 
-  # source://minitest//lib/minitest/spec.rb#15
+  # source://minitest/lib/minitest/spec.rb#15
   def wont_be_nil(*args, **_arg1); end
 
-  # source://minitest//lib/minitest/spec.rb#15
+  # source://minitest/lib/minitest/spec.rb#15
   def wont_be_same_as(*args, **_arg1); end
 
-  # source://minitest//lib/minitest/spec.rb#15
+  # source://minitest/lib/minitest/spec.rb#15
   def wont_be_within_delta(*args, **_arg1); end
 
-  # source://minitest//lib/minitest/spec.rb#15
+  # source://minitest/lib/minitest/spec.rb#15
   def wont_be_within_epsilon(*args, **_arg1); end
 
-  # source://minitest//lib/minitest/spec.rb#15
+  # source://minitest/lib/minitest/spec.rb#15
   def wont_equal(*args, **_arg1); end
 
-  # source://minitest//lib/minitest/spec.rb#15
+  # source://minitest/lib/minitest/spec.rb#15
   def wont_include(*args, **_arg1); end
 
-  # source://minitest//lib/minitest/spec.rb#15
+  # source://minitest/lib/minitest/spec.rb#15
   def wont_match(*args, **_arg1); end
 
-  # source://minitest//lib/minitest/spec.rb#15
+  # source://minitest/lib/minitest/spec.rb#15
   def wont_pattern_match(*args, **_arg1); end
 
-  # source://minitest//lib/minitest/spec.rb#15
+  # source://minitest/lib/minitest/spec.rb#15
   def wont_respond_to(*args, **_arg1); end
 end
 
@@ -1018,100 +1019,100 @@ end
 #     # ... lots of test methods ...
 #   end
 #
-# source://minitest//lib/minitest.rb#1118
+# source://minitest/lib/minitest.rb#1119
 module Minitest::Guard
   # Is this running on jruby?
   #
   # @return [Boolean]
   #
-  # source://minitest//lib/minitest.rb#1123
+  # source://minitest/lib/minitest.rb#1124
   def jruby?(platform = T.unsafe(nil)); end
 
   # Is this running on maglev?
   #
   # @return [Boolean]
   #
-  # source://minitest//lib/minitest.rb#1130
+  # source://minitest/lib/minitest.rb#1131
   def maglev?(platform = T.unsafe(nil)); end
 
   # Is this running on mri?
   #
   # @return [Boolean]
   #
-  # source://minitest//lib/minitest.rb#1140
+  # source://minitest/lib/minitest.rb#1141
   def mri?(platform = T.unsafe(nil)); end
 
   # Is this running on macOS?
   #
   # @return [Boolean]
   #
-  # source://minitest//lib/minitest.rb#1147
+  # source://minitest/lib/minitest.rb#1148
   def osx?(platform = T.unsafe(nil)); end
 
   # Is this running on rubinius?
   #
   # @return [Boolean]
   #
-  # source://minitest//lib/minitest.rb#1154
+  # source://minitest/lib/minitest.rb#1155
   def rubinius?(platform = T.unsafe(nil)); end
 
   # Is this running on windows?
   #
   # @return [Boolean]
   #
-  # source://minitest//lib/minitest.rb#1164
+  # source://minitest/lib/minitest.rb#1165
   def windows?(platform = T.unsafe(nil)); end
 end
 
-# source://minitest//lib/minitest/parallel.rb#2
+# source://minitest/lib/minitest/parallel.rb#2
 module Minitest::Parallel; end
 
 # The engine used to run multiple tests in parallel.
 #
-# source://minitest//lib/minitest/parallel.rb#7
+# source://minitest/lib/minitest/parallel.rb#7
 class Minitest::Parallel::Executor
   # Create a parallel test executor of with +size+ workers.
   #
   # @return [Executor] a new instance of Executor
   #
-  # source://minitest//lib/minitest/parallel.rb#17
+  # source://minitest/lib/minitest/parallel.rb#17
   def initialize(size); end
 
   # Add a job to the queue
   #
-  # source://minitest//lib/minitest/parallel.rb#43
+  # source://minitest/lib/minitest/parallel.rb#43
   def <<(work); end
 
   # Shuts down the pool of workers by signalling them to quit and
   # waiting for them all to finish what they're currently working
   # on.
   #
-  # source://minitest//lib/minitest/parallel.rb#50
+  # source://minitest/lib/minitest/parallel.rb#50
   def shutdown; end
 
   # The size of the pool of workers.
   #
-  # source://minitest//lib/minitest/parallel.rb#12
+  # source://minitest/lib/minitest/parallel.rb#12
   def size; end
 
   # Start the executor
   #
-  # source://minitest//lib/minitest/parallel.rb#26
+  # source://minitest/lib/minitest/parallel.rb#26
   def start; end
 end
 
-# source://minitest//lib/minitest/parallel.rb#56
+# source://minitest/lib/minitest/parallel.rb#56
 module Minitest::Parallel::Test
-  # source://minitest//lib/minitest/parallel.rb#57
+  # source://minitest/lib/minitest/parallel.rb#57
   def _synchronize; end
 end
 
-# source://minitest//lib/minitest/parallel.rb#59
+# source://minitest/lib/minitest/parallel.rb#59
 module Minitest::Parallel::Test::ClassMethods
-  # source://minitest//lib/minitest/parallel.rb#60
+  # source://minitest/lib/minitest/parallel.rb#60
   def run_one_method(klass, method_name, reporter); end
 
-  # source://minitest//lib/minitest/parallel.rb#64
+  # source://minitest/lib/minitest/parallel.rb#64
   def test_order; end
 end
 
@@ -1122,36 +1123,36 @@ end
 # plugin, pull this out of the composite and replace it with your
 # own.
 #
-# source://minitest//lib/minitest.rb#758
+# source://minitest/lib/minitest.rb#759
 class Minitest::ProgressReporter < ::Minitest::Reporter
-  # source://minitest//lib/minitest.rb#759
+  # source://minitest/lib/minitest.rb#760
   def prerecord(klass, name); end
 
-  # source://minitest//lib/minitest.rb#766
+  # source://minitest/lib/minitest.rb#767
   def record(result); end
 end
 
 # Shared code for anything that can get passed to a Reporter. See
 # Minitest::Test & Minitest::Result.
 #
-# source://minitest//lib/minitest.rb#580
+# source://minitest/lib/minitest.rb#581
 module Minitest::Reportable
   # @raise [NotImplementedError]
   #
-  # source://minitest//lib/minitest.rb#602
+  # source://minitest/lib/minitest.rb#603
   def class_name; end
 
   # Did this run error?
   #
   # @return [Boolean]
   #
-  # source://minitest//lib/minitest.rb#623
+  # source://minitest/lib/minitest.rb#624
   def error?; end
 
   # The location identifier of this test. Depends on a method
   # existing called class_name.
   #
-  # source://minitest//lib/minitest.rb#597
+  # source://minitest/lib/minitest.rb#598
   def location; end
 
   # Did this run pass?
@@ -1161,50 +1162,50 @@ module Minitest::Reportable
   #
   # @return [Boolean]
   #
-  # source://minitest//lib/minitest.rb#587
+  # source://minitest/lib/minitest.rb#588
   def passed?; end
 
   # Returns ".", "F", or "E" based on the result of the run.
   #
-  # source://minitest//lib/minitest.rb#609
+  # source://minitest/lib/minitest.rb#610
   def result_code; end
 
   # Was this run skipped?
   #
   # @return [Boolean]
   #
-  # source://minitest//lib/minitest.rb#616
+  # source://minitest/lib/minitest.rb#617
   def skipped?; end
 end
 
-# source://minitest//lib/minitest.rb#591
+# source://minitest/lib/minitest.rb#592
 Minitest::Reportable::BASE_DIR = T.let(T.unsafe(nil), String)
 
-# source://minitest//lib/minitest.rb#734
+# source://minitest/lib/minitest.rb#735
 class Minitest::Reporter < ::Minitest::AbstractReporter
   # @return [Reporter] a new instance of Reporter
   #
-  # source://minitest//lib/minitest.rb#743
+  # source://minitest/lib/minitest.rb#744
   def initialize(io = T.unsafe(nil), options = T.unsafe(nil)); end
 
   # The IO used to report.
   #
-  # source://minitest//lib/minitest.rb#736
+  # source://minitest/lib/minitest.rb#737
   def io; end
 
   # The IO used to report.
   #
-  # source://minitest//lib/minitest.rb#736
+  # source://minitest/lib/minitest.rb#737
   def io=(_arg0); end
 
   # Command-line options for this run.
   #
-  # source://minitest//lib/minitest.rb#741
+  # source://minitest/lib/minitest.rb#742
   def options; end
 
   # Command-line options for this run.
   #
-  # source://minitest//lib/minitest.rb#741
+  # source://minitest/lib/minitest.rb#742
   def options=(_arg0); end
 end
 
@@ -1214,80 +1215,80 @@ end
 # blow up. By using Result.from(a_test) you can be reasonably sure
 # that the test result can be marshalled.
 #
-# source://minitest//lib/minitest.rb#635
+# source://minitest/lib/minitest.rb#636
 class Minitest::Result < ::Minitest::Runnable
   include ::Minitest::Reportable
 
-  # source://minitest//lib/minitest.rb#669
+  # source://minitest/lib/minitest.rb#670
   def class_name; end
 
   # The class name of the test result.
   #
-  # source://minitest//lib/minitest.rb#644
+  # source://minitest/lib/minitest.rb#645
   def klass; end
 
   # The class name of the test result.
   #
-  # source://minitest//lib/minitest.rb#644
+  # source://minitest/lib/minitest.rb#645
   def klass=(_arg0); end
 
   # The location of the test method.
   #
-  # source://minitest//lib/minitest.rb#649
+  # source://minitest/lib/minitest.rb#650
   def source_location; end
 
   # The location of the test method.
   #
-  # source://minitest//lib/minitest.rb#649
+  # source://minitest/lib/minitest.rb#650
   def source_location=(_arg0); end
 
-  # source://minitest//lib/minitest.rb#673
+  # source://minitest/lib/minitest.rb#674
   def to_s; end
 
   class << self
     # Create a new test result from a Runnable instance.
     #
-    # source://minitest//lib/minitest.rb#654
+    # source://minitest/lib/minitest.rb#655
     def from(runnable); end
   end
 end
 
 # re-open
 #
-# source://minitest//lib/minitest.rb#348
+# source://minitest/lib/minitest.rb#349
 class Minitest::Runnable
   # @return [Runnable] a new instance of Runnable
   #
-  # source://minitest//lib/minitest.rb#511
+  # source://minitest/lib/minitest.rb#512
   def initialize(name); end
 
   # Number of assertions executed in this run.
   #
-  # source://minitest//lib/minitest.rb#352
+  # source://minitest/lib/minitest.rb#353
   def assertions; end
 
   # Number of assertions executed in this run.
   #
-  # source://minitest//lib/minitest.rb#352
+  # source://minitest/lib/minitest.rb#353
   def assertions=(_arg0); end
 
-  # source://minitest//lib/minitest.rb#507
+  # source://minitest/lib/minitest.rb#508
   def failure; end
 
   # An assertion raised during the run, if any.
   #
-  # source://minitest//lib/minitest.rb#357
+  # source://minitest/lib/minitest.rb#358
   def failures; end
 
   # An assertion raised during the run, if any.
   #
-  # source://minitest//lib/minitest.rb#357
+  # source://minitest/lib/minitest.rb#358
   def failures=(_arg0); end
 
-  # source://minitest//lib/minitest.rb#493
+  # source://minitest/lib/minitest.rb#494
   def marshal_dump; end
 
-  # source://minitest//lib/minitest.rb#503
+  # source://minitest/lib/minitest.rb#504
   def marshal_load(ary); end
 
   # Metadata you attach to the test results that get sent to the reporter.
@@ -1297,29 +1298,29 @@ class Minitest::Runnable
   # NOTE: this data *must* be plain (read: marshal-able) data!
   # Hashes! Arrays! Strings!
   #
-  # source://minitest//lib/minitest.rb#526
+  # source://minitest/lib/minitest.rb#527
   def metadata; end
 
   # Sets metadata, mainly used for +Result.from+.
   #
-  # source://minitest//lib/minitest.rb#533
+  # source://minitest/lib/minitest.rb#534
   def metadata=(_arg0); end
 
   # Returns true if metadata exists.
   #
   # @return [Boolean]
   #
-  # source://minitest//lib/minitest.rb#538
+  # source://minitest/lib/minitest.rb#539
   def metadata?; end
 
   # Name of the run.
   #
-  # source://minitest//lib/minitest.rb#375
+  # source://minitest/lib/minitest.rb#376
   def name; end
 
   # Set the name of the run.
   #
-  # source://minitest//lib/minitest.rb#382
+  # source://minitest/lib/minitest.rb#383
   def name=(o); end
 
   # Did this run pass?
@@ -1330,7 +1331,7 @@ class Minitest::Runnable
   # @raise [NotImplementedError]
   # @return [Boolean]
   #
-  # source://minitest//lib/minitest.rb#555
+  # source://minitest/lib/minitest.rb#556
   def passed?; end
 
   # Returns a single character string to print based on the result
@@ -1339,14 +1340,14 @@ class Minitest::Runnable
   #
   # @raise [NotImplementedError]
   #
-  # source://minitest//lib/minitest.rb#564
+  # source://minitest/lib/minitest.rb#565
   def result_code; end
 
   # Runs a single method. Needs to return self.
   #
   # @raise [NotImplementedError]
   #
-  # source://minitest//lib/minitest.rb#545
+  # source://minitest/lib/minitest.rb#546
   def run; end
 
   # Was this run skipped? See #passed? for more information.
@@ -1354,42 +1355,42 @@ class Minitest::Runnable
   # @raise [NotImplementedError]
   # @return [Boolean]
   #
-  # source://minitest//lib/minitest.rb#571
+  # source://minitest/lib/minitest.rb#572
   def skipped?; end
 
   # The time it took to run.
   #
-  # source://minitest//lib/minitest.rb#362
+  # source://minitest/lib/minitest.rb#363
   def time; end
 
   # The time it took to run.
   #
-  # source://minitest//lib/minitest.rb#362
+  # source://minitest/lib/minitest.rb#363
   def time=(_arg0); end
 
-  # source://minitest//lib/minitest.rb#364
+  # source://minitest/lib/minitest.rb#365
   def time_it; end
 
   class << self
-    # source://minitest//lib/minitest.rb#1225
+    # source://minitest/lib/minitest.rb#1226
     def inherited(klass); end
 
     # Returns all instance methods matching the pattern +re+.
     #
-    # source://minitest//lib/minitest.rb#389
+    # source://minitest/lib/minitest.rb#390
     def methods_matching(re); end
 
-    # source://minitest//lib/minitest.rb#463
+    # source://minitest/lib/minitest.rb#464
     def on_signal(name, action); end
 
-    # source://minitest//lib/minitest.rb#393
+    # source://minitest/lib/minitest.rb#394
     def reset; end
 
     # Responsible for running all runnable methods in a given class,
     # each in its own instance. Each instance is passed to the
     # reporter to record.
     #
-    # source://minitest//lib/minitest.rb#404
+    # source://minitest/lib/minitest.rb#405
     def run(reporter, options = T.unsafe(nil)); end
 
     # Runs a single method and has the reporter record the result.
@@ -1397,7 +1398,7 @@ class Minitest::Runnable
     # that subclasses can specialize the running of an individual
     # test. See Minitest::ParallelTest::ClassMethods for an example.
     #
-    # source://minitest//lib/minitest.rb#444
+    # source://minitest/lib/minitest.rb#445
     def run_one_method(klass, method_name, reporter); end
 
     # Each subclass of Runnable is responsible for overriding this
@@ -1405,33 +1406,33 @@ class Minitest::Runnable
     #
     # @raise [NotImplementedError]
     #
-    # source://minitest//lib/minitest.rb#480
+    # source://minitest/lib/minitest.rb#481
     def runnable_methods; end
 
     # Returns all subclasses of Runnable.
     #
-    # source://minitest//lib/minitest.rb#487
+    # source://minitest/lib/minitest.rb#488
     def runnables; end
 
     # Defines the order to run tests (:random by default). Override
     # this or use a convenience method to change it for your tests.
     #
-    # source://minitest//lib/minitest.rb#453
+    # source://minitest/lib/minitest.rb#454
     def test_order; end
 
-    # source://minitest//lib/minitest.rb#457
+    # source://minitest/lib/minitest.rb#458
     def with_info_handler(reporter, &block); end
   end
 end
 
-# source://minitest//lib/minitest.rb#461
+# source://minitest/lib/minitest.rb#462
 Minitest::Runnable::SIGNALS = T.let(T.unsafe(nil), Hash)
 
 # Assertion raised when skipping a run.
 #
-# source://minitest//lib/minitest.rb#1049
+# source://minitest/lib/minitest.rb#1050
 class Minitest::Skip < ::Minitest::Assertion
-  # source://minitest//lib/minitest.rb#1050
+  # source://minitest/lib/minitest.rb#1051
   def result_label; end
 end
 
@@ -1439,25 +1440,25 @@ end
 #
 # For a list of expectations, see Minitest::Expectations.
 #
-# source://minitest//lib/minitest/spec.rb#106
+# source://minitest/lib/minitest/spec.rb#107
 class Minitest::Spec < ::Minitest::Test
   include ::Minitest::Spec::DSL::InstanceMethods
   extend ::Minitest::Spec::DSL
 
   # @return [Spec] a new instance of Spec
   #
-  # source://minitest//lib/minitest/spec.rb#112
+  # source://minitest/lib/minitest/spec.rb#113
   def initialize(name); end
 
   class << self
-    # source://minitest//lib/minitest/spec.rb#108
+    # source://minitest/lib/minitest/spec.rb#109
     def current; end
   end
 end
 
 # Oh look! A Minitest::Spec::DSL module! Eat your heart out DHH.
 #
-# source://minitest//lib/minitest/spec.rb#120
+# source://minitest/lib/minitest/spec.rb#121
 module Minitest::Spec::DSL
   # Define an 'after' action. Inherits the way normal methods should.
   #
@@ -1465,7 +1466,7 @@ module Minitest::Spec::DSL
   #
   # Equivalent to Minitest::Test#teardown.
   #
-  # source://minitest//lib/minitest/spec.rb#205
+  # source://minitest/lib/minitest/spec.rb#206
   def after(_type = T.unsafe(nil), &block); end
 
   # Define a 'before' action. Inherits the way normal methods should.
@@ -1474,19 +1475,19 @@ module Minitest::Spec::DSL
   #
   # Equivalent to Minitest::Test#setup.
   #
-  # source://minitest//lib/minitest/spec.rb#191
+  # source://minitest/lib/minitest/spec.rb#192
   def before(_type = T.unsafe(nil), &block); end
 
-  # source://minitest//lib/minitest/spec.rb#174
+  # source://minitest/lib/minitest/spec.rb#175
   def children; end
 
-  # source://minitest//lib/minitest/spec.rb#270
+  # source://minitest/lib/minitest/spec.rb#271
   def create(name, desc); end
 
-  # source://minitest//lib/minitest/spec.rb#291
+  # source://minitest/lib/minitest/spec.rb#292
   def desc; end
 
-  # source://minitest//lib/minitest/spec.rb#170
+  # source://minitest/lib/minitest/spec.rb#171
   def describe_stack; end
 
   # Define an expectation with name +desc+. Name gets morphed to a
@@ -1499,7 +1500,7 @@ module Minitest::Spec::DSL
   # Hint: If you _do_ want inheritance, use minitest/test. You can mix
   # and match between assertions and expectations as much as you want.
   #
-  # source://minitest//lib/minitest/spec.rb#223
+  # source://minitest/lib/minitest/spec.rb#224
   def it(desc = T.unsafe(nil), &block); end
 
   # Essentially, define an accessor for +name+ with +block+.
@@ -1508,13 +1509,13 @@ module Minitest::Spec::DSL
   #
   # @raise [ArgumentError]
   #
-  # source://minitest//lib/minitest/spec.rb#247
+  # source://minitest/lib/minitest/spec.rb#248
   def let(name, &block); end
 
-  # source://minitest//lib/minitest/spec.rb#283
+  # source://minitest/lib/minitest/spec.rb#284
   def name; end
 
-  # source://minitest//lib/minitest/spec.rb#178
+  # source://minitest/lib/minitest/spec.rb#179
   def nuke_test_methods!; end
 
   # Register a new type of spec that matches the spec's description.
@@ -1532,14 +1533,14 @@ module Minitest::Spec::DSL
   #       desc.superclass == ActiveRecord::Base
   #     end
   #
-  # source://minitest//lib/minitest/spec.rb#146
+  # source://minitest/lib/minitest/spec.rb#147
   def register_spec_type(*args, &block); end
 
   # Figure out the spec class to use based on a spec's description. Eg:
   #
   #     spec_type("BlahController") # => Minitest::Spec::Rails
   #
-  # source://minitest//lib/minitest/spec.rb#160
+  # source://minitest/lib/minitest/spec.rb#161
   def spec_type(desc, *additional); end
 
   # Define an expectation with name +desc+. Name gets morphed to a
@@ -1552,27 +1553,27 @@ module Minitest::Spec::DSL
   # Hint: If you _do_ want inheritance, use minitest/test. You can mix
   # and match between assertions and expectations as much as you want.
   #
-  # source://minitest//lib/minitest/spec.rb#223
+  # source://minitest/lib/minitest/spec.rb#224
   def specify(desc = T.unsafe(nil), &block); end
 
   # Another lazy man's accessor generator. Made even more lazy by
   # setting the name for you to +subject+.
   #
-  # source://minitest//lib/minitest/spec.rb#266
+  # source://minitest/lib/minitest/spec.rb#267
   def subject(&block); end
 
-  # source://minitest//lib/minitest/spec.rb#287
+  # source://minitest/lib/minitest/spec.rb#288
   def to_s; end
 
   class << self
-    # source://minitest//lib/minitest/spec.rb#335
+    # source://minitest/lib/minitest/spec.rb#336
     def extended(obj); end
   end
 end
 
 # Rdoc... why are you so dumb?
 #
-# source://minitest//lib/minitest/spec.rb#297
+# source://minitest/lib/minitest/spec.rb#298
 module Minitest::Spec::DSL::InstanceMethods
   # Takes a value or a block and returns a value monad that has
   # all of Expectations methods available to it.
@@ -1597,10 +1598,10 @@ module Minitest::Spec::DSL::InstanceMethods
   #     value(1 + 1).must_equal 2
   #    expect(1 + 1).must_equal 2
   #
-  # source://minitest//lib/minitest/spec.rb#322
+  # source://minitest/lib/minitest/spec.rb#323
   def _(value = T.unsafe(nil), &block); end
 
-  # source://minitest//lib/minitest/spec.rb#329
+  # source://minitest/lib/minitest/spec.rb#330
   def before_setup; end
 
   # Takes a value or a block and returns a value monad that has
@@ -1626,7 +1627,7 @@ module Minitest::Spec::DSL::InstanceMethods
   #     value(1 + 1).must_equal 2
   #    expect(1 + 1).must_equal 2
   #
-  # source://minitest//lib/minitest/spec.rb#322
+  # source://minitest/lib/minitest/spec.rb#323
   def expect(value = T.unsafe(nil), &block); end
 
   # Takes a value or a block and returns a value monad that has
@@ -1652,7 +1653,7 @@ module Minitest::Spec::DSL::InstanceMethods
   #     value(1 + 1).must_equal 2
   #    expect(1 + 1).must_equal 2
   #
-  # source://minitest//lib/minitest/spec.rb#322
+  # source://minitest/lib/minitest/spec.rb#323
   def value(value = T.unsafe(nil), &block); end
 end
 
@@ -1662,10 +1663,10 @@ end
 #
 # See: register_spec_type and spec_type
 #
-# source://minitest//lib/minitest/spec.rb#128
+# source://minitest/lib/minitest/spec.rb#129
 Minitest::Spec::DSL::TYPES = T.let(T.unsafe(nil), Array)
 
-# source://minitest//lib/minitest/spec.rb#342
+# source://minitest/lib/minitest/spec.rb#343
 Minitest::Spec::TYPES = T.let(T.unsafe(nil), Array)
 
 # A reporter that gathers statistics about a test run. Does not do
@@ -1688,123 +1689,123 @@ Minitest::Spec::TYPES = T.let(T.unsafe(nil), Array)
 #     end
 #   end
 #
-# source://minitest//lib/minitest.rb#794
+# source://minitest/lib/minitest.rb#795
 class Minitest::StatisticsReporter < ::Minitest::Reporter
   # @return [StatisticsReporter] a new instance of StatisticsReporter
   #
-  # source://minitest//lib/minitest.rb#843
+  # source://minitest/lib/minitest.rb#844
   def initialize(io = T.unsafe(nil), options = T.unsafe(nil)); end
 
   # Total number of assertions.
   #
-  # source://minitest//lib/minitest.rb#798
+  # source://minitest/lib/minitest.rb#799
   def assertions; end
 
   # Total number of assertions.
   #
-  # source://minitest//lib/minitest.rb#798
+  # source://minitest/lib/minitest.rb#799
   def assertions=(_arg0); end
 
   # Total number of test cases.
   #
-  # source://minitest//lib/minitest.rb#803
+  # source://minitest/lib/minitest.rb#804
   def count; end
 
   # Total number of test cases.
   #
-  # source://minitest//lib/minitest.rb#803
+  # source://minitest/lib/minitest.rb#804
   def count=(_arg0); end
 
   # Total number of tests that erred.
   #
-  # source://minitest//lib/minitest.rb#831
+  # source://minitest/lib/minitest.rb#832
   def errors; end
 
   # Total number of tests that erred.
   #
-  # source://minitest//lib/minitest.rb#831
+  # source://minitest/lib/minitest.rb#832
   def errors=(_arg0); end
 
   # Total number of tests that failed.
   #
-  # source://minitest//lib/minitest.rb#826
+  # source://minitest/lib/minitest.rb#827
   def failures; end
 
   # Total number of tests that failed.
   #
-  # source://minitest//lib/minitest.rb#826
+  # source://minitest/lib/minitest.rb#827
   def failures=(_arg0); end
 
   # @return [Boolean]
   #
-  # source://minitest//lib/minitest.rb#857
+  # source://minitest/lib/minitest.rb#858
   def passed?; end
 
-  # source://minitest//lib/minitest.rb#865
+  # source://minitest/lib/minitest.rb#866
   def record(result); end
 
   # Report on the tracked statistics.
   #
-  # source://minitest//lib/minitest.rb#875
+  # source://minitest/lib/minitest.rb#876
   def report; end
 
   # An +Array+ of test cases that failed or were skipped.
   #
-  # source://minitest//lib/minitest.rb#808
+  # source://minitest/lib/minitest.rb#809
   def results; end
 
   # An +Array+ of test cases that failed or were skipped.
   #
-  # source://minitest//lib/minitest.rb#808
+  # source://minitest/lib/minitest.rb#809
   def results=(_arg0); end
 
   # Total number of tests that where skipped.
   #
-  # source://minitest//lib/minitest.rb#841
+  # source://minitest/lib/minitest.rb#842
   def skips; end
 
   # Total number of tests that where skipped.
   #
-  # source://minitest//lib/minitest.rb#841
+  # source://minitest/lib/minitest.rb#842
   def skips=(_arg0); end
 
-  # source://minitest//lib/minitest.rb#861
+  # source://minitest/lib/minitest.rb#862
   def start; end
 
   # Time the test run started. If available, the monotonic clock is
   # used and this is a +Float+, otherwise it's an instance of
   # +Time+.
   #
-  # source://minitest//lib/minitest.rb#815
+  # source://minitest/lib/minitest.rb#816
   def start_time; end
 
   # Time the test run started. If available, the monotonic clock is
   # used and this is a +Float+, otherwise it's an instance of
   # +Time+.
   #
-  # source://minitest//lib/minitest.rb#815
+  # source://minitest/lib/minitest.rb#816
   def start_time=(_arg0); end
 
   # Test run time. If available, the monotonic clock is used and
   # this is a +Float+, otherwise it's an instance of +Time+.
   #
-  # source://minitest//lib/minitest.rb#821
+  # source://minitest/lib/minitest.rb#822
   def total_time; end
 
   # Test run time. If available, the monotonic clock is used and
   # this is a +Float+, otherwise it's an instance of +Time+.
   #
-  # source://minitest//lib/minitest.rb#821
+  # source://minitest/lib/minitest.rb#822
   def total_time=(_arg0); end
 
   # Total number of tests that warned.
   #
-  # source://minitest//lib/minitest.rb#836
+  # source://minitest/lib/minitest.rb#837
   def warnings; end
 
   # Total number of tests that warned.
   #
-  # source://minitest//lib/minitest.rb#836
+  # source://minitest/lib/minitest.rb#837
   def warnings=(_arg0); end
 end
 
@@ -1816,36 +1817,36 @@ end
 # plugin, pull this out of the composite and replace it with your
 # own.
 #
-# source://minitest//lib/minitest.rb#896
+# source://minitest/lib/minitest.rb#897
 class Minitest::SummaryReporter < ::Minitest::StatisticsReporter
-  # source://minitest//lib/minitest.rb#929
+  # source://minitest/lib/minitest.rb#930
   def aggregated_results(io); end
 
-  # source://minitest//lib/minitest.rb#898
+  # source://minitest/lib/minitest.rb#899
   def old_sync; end
 
-  # source://minitest//lib/minitest.rb#898
+  # source://minitest/lib/minitest.rb#899
   def old_sync=(_arg0); end
 
-  # source://minitest//lib/minitest.rb#912
+  # source://minitest/lib/minitest.rb#913
   def report; end
 
-  # source://minitest//lib/minitest.rb#900
+  # source://minitest/lib/minitest.rb#901
   def start; end
 
-  # source://minitest//lib/minitest.rb#924
+  # source://minitest/lib/minitest.rb#925
   def statistics; end
 
-  # source://minitest//lib/minitest.rb#949
+  # source://minitest/lib/minitest.rb#950
   def summary; end
 
-  # source://minitest//lib/minitest.rb#897
+  # source://minitest/lib/minitest.rb#898
   def sync; end
 
-  # source://minitest//lib/minitest.rb#897
+  # source://minitest/lib/minitest.rb#898
   def sync=(_arg0); end
 
-  # source://minitest//lib/minitest.rb#945
+  # source://minitest/lib/minitest.rb#946
   def to_s; end
 end
 
@@ -1854,7 +1855,7 @@ end
 #
 # See Minitest::Assertions
 #
-# source://minitest//lib/minitest/test.rb#10
+# source://minitest/lib/minitest/test.rb#10
 class Minitest::Test < ::Minitest::Runnable
   include ::Minitest::Assertions
   include ::Minitest::Reportable
@@ -1864,24 +1865,24 @@ class Minitest::Test < ::Minitest::Runnable
 
   # LifecycleHooks
   #
-  # source://minitest//lib/minitest/test.rb#189
+  # source://minitest/lib/minitest/test.rb#189
   def capture_exceptions; end
 
-  # source://minitest//lib/minitest/test.rb#15
+  # source://minitest/lib/minitest/test.rb#15
   def class_name; end
 
-  # source://minitest//lib/minitest/test.rb#206
+  # source://minitest/lib/minitest/test.rb#206
   def neuter_exception(e); end
 
-  # source://minitest//lib/minitest/test.rb#217
+  # source://minitest/lib/minitest/test.rb#217
   def new_exception(klass, msg, bt, kill = T.unsafe(nil)); end
 
   # Runs a single test with setup/teardown hooks.
   #
-  # source://minitest//lib/minitest/test.rb#87
+  # source://minitest/lib/minitest/test.rb#87
   def run; end
 
-  # source://minitest//lib/minitest/test.rb#199
+  # source://minitest/lib/minitest/test.rb#199
   def sanitize_exception(e); end
 
   class << self
@@ -1889,19 +1890,19 @@ class Minitest::Test < ::Minitest::Runnable
     # positively need to have ordered tests. In doing so, you're
     # admitting that you suck and your tests are weak.
     #
-    # source://minitest//lib/minitest/test.rb#35
+    # source://minitest/lib/minitest/test.rb#35
     def i_suck_and_my_tests_are_order_dependent!; end
 
     # Returns the value of attribute io_lock.
     #
-    # source://minitest//lib/minitest/test.rb#26
+    # source://minitest/lib/minitest/test.rb#26
     def io_lock; end
 
     # Sets the attribute io_lock
     #
     # @param value the value to set the attribute io_lock to.
     #
-    # source://minitest//lib/minitest/test.rb#26
+    # source://minitest/lib/minitest/test.rb#26
     def io_lock=(_arg0); end
 
     # Make diffs for this Test use #pretty_inspect so that diff
@@ -1909,7 +1910,7 @@ class Minitest::Test < ::Minitest::Runnable
     # than the regular inspect but much more usable for complex
     # objects.
     #
-    # source://minitest//lib/minitest/test.rb#48
+    # source://minitest/lib/minitest/test.rb#48
     def make_my_diffs_pretty!; end
 
     # Call this at the top of your tests (inside the +Minitest::Test+
@@ -1917,14 +1918,14 @@ class Minitest::Test < ::Minitest::Runnable
     # parallel. In doing so, you're admitting that you rule and your
     # tests are awesome.
     #
-    # source://minitest//lib/minitest/test.rb#60
+    # source://minitest/lib/minitest/test.rb#60
     def parallelize_me!; end
 
     # Returns all instance methods starting with "test_". Based on
     # #test_order, the methods are either sorted, randomized
     # (default), or run in parallel.
     #
-    # source://minitest//lib/minitest/test.rb#70
+    # source://minitest/lib/minitest/test.rb#70
     def runnable_methods; end
   end
 end
@@ -1933,7 +1934,7 @@ end
 # meant for library writers, NOT for regular test authors. See
 # #before_setup for an example.
 #
-# source://minitest//lib/minitest/test.rb#112
+# source://minitest/lib/minitest/test.rb#112
 module Minitest::Test::LifecycleHooks
   # Runs before every test, after setup. This hook is meant for
   # libraries to extend minitest. It is not meant to be used by
@@ -1941,7 +1942,7 @@ module Minitest::Test::LifecycleHooks
   #
   # See #before_setup for an example.
   #
-  # source://minitest//lib/minitest/test.rb#162
+  # source://minitest/lib/minitest/test.rb#162
   def after_setup; end
 
   # Runs after every test, after teardown. This hook is meant for
@@ -1950,7 +1951,7 @@ module Minitest::Test::LifecycleHooks
   #
   # See #before_setup for an example.
   #
-  # source://minitest//lib/minitest/test.rb#186
+  # source://minitest/lib/minitest/test.rb#186
   def after_teardown; end
 
   # Runs before every test, before setup. This hook is meant for
@@ -1985,7 +1986,7 @@ module Minitest::Test::LifecycleHooks
   #     include MyMinitestPlugin
   #   end
   #
-  # source://minitest//lib/minitest/test.rb#147
+  # source://minitest/lib/minitest/test.rb#147
   def before_setup; end
 
   # Runs after every test, before teardown. This hook is meant for
@@ -1994,83 +1995,83 @@ module Minitest::Test::LifecycleHooks
   #
   # See #before_setup for an example.
   #
-  # source://minitest//lib/minitest/test.rb#171
+  # source://minitest/lib/minitest/test.rb#171
   def before_teardown; end
 
   # Runs before every test. Use this to set up before each test
   # run.
   #
-  # source://minitest//lib/minitest/test.rb#153
+  # source://minitest/lib/minitest/test.rb#153
   def setup; end
 
   # Runs after every test. Use this to clean up after each test
   # run.
   #
-  # source://minitest//lib/minitest/test.rb#177
+  # source://minitest/lib/minitest/test.rb#177
   def teardown; end
 end
 
-# source://minitest//lib/minitest/test.rb#19
+# source://minitest/lib/minitest/test.rb#19
 Minitest::Test::PASSTHROUGH_EXCEPTIONS = T.let(T.unsafe(nil), Array)
 
-# source://minitest//lib/minitest/test.rb#21
+# source://minitest/lib/minitest/test.rb#21
 Minitest::Test::SETUP_METHODS = T.let(T.unsafe(nil), Array)
 
-# source://minitest//lib/minitest/test.rb#23
+# source://minitest/lib/minitest/test.rb#23
 Minitest::Test::TEARDOWN_METHODS = T.let(T.unsafe(nil), Array)
 
 # Assertion wrapping an unexpected error that was raised during a run.
 #
-# source://minitest//lib/minitest.rb#1058
+# source://minitest/lib/minitest.rb#1059
 class Minitest::UnexpectedError < ::Minitest::Assertion
   include ::Minitest::Compress
 
   # @return [UnexpectedError] a new instance of UnexpectedError
   #
-  # source://minitest//lib/minitest.rb#1064
+  # source://minitest/lib/minitest.rb#1065
   def initialize(error); end
 
-  # source://minitest//lib/minitest.rb#1077
+  # source://minitest/lib/minitest.rb#1078
   def backtrace; end
 
   # TODO: figure out how to use `cause` instead
   #
-  # source://minitest//lib/minitest.rb#1062
+  # source://minitest/lib/minitest.rb#1063
   def error; end
 
   # TODO: figure out how to use `cause` instead
   #
-  # source://minitest//lib/minitest.rb#1062
+  # source://minitest/lib/minitest.rb#1063
   def error=(_arg0); end
 
-  # source://minitest//lib/minitest.rb#1083
+  # source://minitest/lib/minitest.rb#1084
   def message; end
 
-  # source://minitest//lib/minitest.rb#1089
+  # source://minitest/lib/minitest.rb#1090
   def result_label; end
 end
 
-# source://minitest//lib/minitest.rb#1081
+# source://minitest/lib/minitest.rb#1082
 Minitest::UnexpectedError::BASE_RE = T.let(T.unsafe(nil), Regexp)
 
 # Assertion raised on warning when running in -Werror mode.
 #
-# source://minitest//lib/minitest.rb#1097
+# source://minitest/lib/minitest.rb#1098
 class Minitest::UnexpectedWarning < ::Minitest::Assertion
-  # source://minitest//lib/minitest.rb#1098
+  # source://minitest/lib/minitest.rb#1099
   def result_label; end
 end
 
-# source://minitest//lib/minitest.rb#12
+# source://minitest/lib/minitest.rb#13
 Minitest::VERSION = T.let(T.unsafe(nil), String)
 
-# source://minitest//lib/minitest/spec.rb#3
+# source://minitest/lib/minitest/spec.rb#3
 class Module
-  # source://minitest//lib/minitest/spec.rb#4
+  # source://minitest/lib/minitest/spec.rb#4
   def infect_an_assertion(meth, new_name, dont_flip = T.unsafe(nil)); end
 end
 
-# source://minitest//lib/minitest/spec.rb#347
+# source://minitest/lib/minitest/spec.rb#348
 class Object < ::BasicObject
   include ::Kernel
   include ::PP::ObjectMixin


### PR DESCRIPTION
In combination with https://github.com/Shopify/ruby-lsp/pull/2706, this will allow Ruby LSP's test runner code lenses to work with minitest/spec.

Thanks goes to @thomasmarshall, who also fixed https://github.com/minitest/minitest/pull/1017 in minitest.