### PR TITLE
`--exclude` should also exclude transitive dependencies

### DIFF
--- a/lib/tapioca/commands/abstract_gem.rb
+++ b/lib/tapioca/commands/abstract_gem.rb
@@ -77,7 +77,7 @@ module Tapioca
       def gems_to_generate(gem_names)
         return @bundle.dependencies if gem_names.empty?
 
-        gem_names.each_with_object([]) do |gem_name, gems|
+        (gem_names - @exclude).each_with_object([]) do |gem_name, gems|
           gem = @bundle.gem(gem_name)
 
           if gem.nil?

--- a/lib/tapioca/gemfile.rb
+++ b/lib/tapioca/gemfile.rb
@@ -66,7 +66,7 @@ module Tapioca
 
     sig { returns([T::Enumerable[Spec], T::Array[String]]) }
     def materialize_deps
-      deps = definition.locked_gems.dependencies.values
+      deps = definition.locked_gems.dependencies.except(*@excluded_gems).values
       materialized_dependencies = definition.resolve.materialize(deps)
       missing_spec_names = materialized_dependencies.missing_specs.map(&:name).to_set
       missing_specs = materialized_dependencies.missing_specs.map do |spec|

--- a/spec/spec_with_project.rb
+++ b/spec/spec_with_project.rb
@@ -108,13 +108,20 @@ module Tapioca
     # `Path` can include patterns such as `*`, useful for testing RBIs for real gems
     sig { params(path: String).void }
     def assert_project_file_match(path)
-      assert(Dir[path].any?)
+      assert(@project.glob(path).any?)
     end
 
     # Refute that `path` exists inside `@project`
     sig { params(path: String).void }
     def refute_project_file_exist(path)
       refute(@project.file?(path))
+    end
+
+    # Refute that `path` exists inside `@project`
+    # `Path` can include patterns such as `*`, useful for testing RBIs for real gems
+    sig { params(path: String).void }
+    def refute_project_file_match(path)
+      refute(@project.glob(path).any?)
     end
 
     sig { params(strictness: String, file: String).void }

--- a/spec/tapioca/cli/gem_spec.rb
+++ b/spec/tapioca/cli/gem_spec.rb
@@ -780,18 +780,20 @@ module Tapioca
 
         it "must respect exclude option" do
           @project.require_mock_gem(mock_gem("foo", "0.0.1"))
-          @project.require_mock_gem(mock_gem("bar", "0.3.0"))
+          @project.require_mock_gem(mock_gem("bar", "0.3.0", dependencies: ["actionpack"]))
           @project.require_mock_gem(mock_gem("baz", "0.0.2"))
           @project.bundle_install!
 
           result = @project.tapioca("gem --all --exclude foo bar")
 
           refute_includes(result.out, "Compiled bar")
+          refute_includes(result.out, "Compiled actionpack")
           assert_stdout_includes(result, "Compiled baz")
           refute_includes(result.out, "Compiled foo")
 
           refute_project_file_exist("sorbet/rbi/gems/foo@0.0.1.rbi")
           refute_project_file_exist("sorbet/rbi/gems/bar@0.3.0.rbi")
+          refute_project_file_exist("sorbet/rbi/gems/actionpack@7.0.6.rbi")
           assert_project_file_exist("sorbet/rbi/gems/baz@0.0.2.rbi")
 
           assert_empty_stderr(result)

--- a/spec/tapioca/cli/gem_spec.rb
+++ b/spec/tapioca/cli/gem_spec.rb
@@ -780,8 +780,8 @@ module Tapioca
 
         it "must respect exclude option" do
           @project.require_mock_gem(mock_gem("foo", "0.0.1"))
-          @project.require_mock_gem(mock_gem("bar", "0.3.0", dependencies: ["actionpack"]))
-          @project.require_mock_gem(mock_gem("baz", "0.0.2"))
+          @project.require_mock_gem(mock_gem("bar", "0.3.0", dependencies: ["activemodel", "actionpack"]))
+          @project.require_mock_gem(mock_gem("baz", "0.0.2", dependencies: ["activemodel"]))
           @project.bundle_install!
 
           result = @project.tapioca("gem --all --exclude foo bar")
@@ -789,12 +789,14 @@ module Tapioca
           refute_includes(result.out, "Compiled bar")
           refute_includes(result.out, "Compiled actionpack")
           assert_stdout_includes(result, "Compiled baz")
+          assert_stdout_includes(result, "Compiled activemodel")
           refute_includes(result.out, "Compiled foo")
 
           refute_project_file_exist("sorbet/rbi/gems/foo@0.0.1.rbi")
           refute_project_file_exist("sorbet/rbi/gems/bar@0.3.0.rbi")
-          refute_project_file_exist("sorbet/rbi/gems/actionpack@7.0.6.rbi")
+          refute_project_file_match("sorbet/rbi/gems/actionpack@*.rbi")
           assert_project_file_exist("sorbet/rbi/gems/baz@0.0.2.rbi")
+          assert_project_file_match("sorbet/rbi/gems/activemodel@*.rbi")
 
           assert_empty_stderr(result)
           assert_success_status(result)


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->

Given this gemfile:
```ruby
source 'https://rubygems.org'
gem 'rspec'
```

The following configuration should not generate any RBI files, but it does.
```yaml
gem:
  exclude:
  - rspec
```

This would generate RBI files for all of RSpec's transitive dependencies (e.g. `rspec-core`, `rspec-support`, `rspec-mocks`, `rspec-expectations`, `diff-lcs`).

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->

I just dropped all of the excluded gems from `definition.locked_gems.dependencies`.

I'm not sure if this is actually the right solution, because there's something going on with `BundlerExt::AutoRequireHook.override_require_false(exclude: @excluded_gems)` that I don't fully understand.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->

I updated the existing CLI test for the `--exclude` option. I've also test this against a real project, and it seems to work.
