### PR TITLE
Pass LSP add-on option to DSL

### DIFF
--- a/lib/tapioca/cli.rb
+++ b/lib/tapioca/cli.rb
@@ -170,6 +170,7 @@ module Tapioca
         app_root: options[:app_root],
         halt_upon_load_error: options[:halt_upon_load_error],
         compiler_options: options[:compiler_options],
+        lsp_addon: options[:lsp_addon],
       }
 
       command = if options[:verify]


### PR DESCRIPTION
### Motivation

We were not actually passing down the option for the LSP add-on, which means it was always false everywhere.

### Implementation

Started passing it down.