### PR TITLE
Pass lsp addon option to DSL loader

### DIFF
--- a/lib/tapioca/commands/abstract_dsl.rb
+++ b/lib/tapioca/commands/abstract_dsl.rb
@@ -123,6 +123,7 @@ module Tapioca
           eager_load: @requested_constants.empty? && @requested_paths.empty?,
           app_root: @app_root,
           halt_upon_load_error: @halt_upon_load_error,
+          lsp_addon: @lsp_addon,
         )
       end
 


### PR DESCRIPTION
### Motivation

We weren't passing this to the loader, which makes it reload the Rails app multiple times.