### PR TITLE
ActiveRecord `select` returns an `Array` when called on Relation with block given

### DIFF
--- a/lib/tapioca/dsl/compilers/active_record_relations.rb
+++ b/lib/tapioca/dsl/compilers/active_record_relations.rb
@@ -586,6 +586,22 @@ module Tapioca
                 parameters: parameters,
                 return_type: return_type,
               )
+            when :select
+              [relation_methods_module, association_relation_methods_module].each do |mod|
+                mod.create_method(method_name.to_s) do |method|
+                  method.add_rest_param("args")
+                  method.add_block_param("blk")
+
+                  method.add_sig do |sig|
+                    sig.add_param("args", "T.untyped")
+                    sig.return_type = mod == relation_methods_module ? RelationClassName : AssociationRelationClassName
+                  end
+                  method.add_sig do |sig|
+                    sig.add_param("blk", "T.proc.params(record: #{constant_name}).returns(T::Boolean)")
+                    sig.return_type = "T::Array[#{constant_name}]"
+                  end
+                end
+              end
             else
               create_relation_method(
                 method_name,

--- a/spec/tapioca/dsl/compilers/active_record_relations_spec.rb
+++ b/spec/tapioca/dsl/compilers/active_record_relations_spec.rb
@@ -432,7 +432,8 @@ module Tapioca
                     sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
                     def rewhere(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
+                    sig { params(args: T.untyped).returns(PrivateAssociationRelation) }
+                    sig { params(blk: T.proc.params(record: ::Post).returns(T::Boolean)).returns(T::Array[::Post]) }
                     def select(*args, &blk); end
 
                     sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
@@ -592,7 +593,8 @@ module Tapioca
                     sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
                     def rewhere(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
+                    sig { params(args: T.untyped).returns(PrivateRelation) }
+                    sig { params(blk: T.proc.params(record: ::Post).returns(T::Boolean)).returns(T::Array[::Post]) }
                     def select(*args, &blk); end
 
                     sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
@@ -1150,7 +1152,8 @@ module Tapioca
                     sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
                     def rewhere(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
+                    sig { params(args: T.untyped).returns(PrivateAssociationRelation) }
+                    sig { params(blk: T.proc.params(record: ::Post).returns(T::Boolean)).returns(T::Array[::Post]) }
                     def select(*args, &blk); end
 
                     sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
@@ -1310,7 +1313,8 @@ module Tapioca
                     sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
                     def rewhere(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
+                    sig { params(args: T.untyped).returns(PrivateRelation) }
+                    sig { params(blk: T.proc.params(record: ::Post).returns(T::Boolean)).returns(T::Array[::Post]) }
                     def select(*args, &blk); end
 
                     sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }


### PR DESCRIPTION
### Motivation

The `ActiveRecord::QueryMethods#select` method has two mutually exclusive forms:

```ruby
def select(*args); end
```

which performs a query selecting just the specified columns and returns a relation object, and

```ruby
def select(&blk); end
```

in which case ActiveRecord defers to `Enumerable`'s implementation and executes the `blk` on each element returned by the query and returns an `Array`. See code [here](https://github.com/rails/rails/blob/main/activerecord/lib/active_record/relation/query_methods.rb#L413).

Tapioca is only generating sigs for the first method signature, and not for the latter, which is forcing us to append an unnecessary `to_a` everywhere we call `select` with a block on a relation.

### Implementation

I've implemented this by defining overloaded `sig`s for the `select` method on the relations modules.

There's actually a bit of an annoyance here around how inflexible `create_relation_method` is; instead of updating it to awkwardly handle mutliple `sig`s, I opted to just define them inline, skipping the method 🙈 .

### Tests
Updated the tests accordingly. 

