### PR TITLE
Add support for `ActiveSupport` classes in `Sidekiq::Worker` methods

### DIFF
--- a/manual/compiler_sidekiqworker.md
+++ b/manual/compiler_sidekiqworker.md
@@ -30,3 +30,8 @@ class NotifierWorker
   def self.perform_in(interval, customer_id); end
 end
 ~~~
+
+If your project uses `ActiveSupport` as well, then the compiler will automatically add its classes
+as accepted values for the `interval` parameter:
+* `self.perform_at` will also accept a `ActiveSupport::TimeWithZone` value
+* `self.perform_in` will also accept a `ActiveSupport::Duration` value


### PR DESCRIPTION
### Motivation
The currently tapioca-generated signatures for `Sidekiq::Worker` methods do not support `ActiveSupport` classes.
But reading the [code comments](https://github.com/sidekiq/sidekiq/blob/e411ffc78713099a90b348930d0b664d2ee41279/lib/sidekiq/job.rb#L256-L261) and testing the behaviour at runtime, the methods should indeed be able to support them.
> "+interval+ must be a timestamp, numeric or something that
> acts numeric (like an activesupport time interval).


### Implementation
`ActiveSupport` classes have been added to `#perform_at` and `#perform_in` methods, keeping their semantic difference despite these being aliased:
* Add `ActiveSupport::TimeWithZone` as an allowed type to `#perform_at`
* Add `ActiveSupport::Duration` as an allowed type to `#perform_in`

This is based on the assumption that projects using Sidekiq are most likely Rails application and therefore have access to ActiveSupport. If we don't want to rely on that assumption, the implementation will need to be tweaked to check if the ActiveSupport classes are defined when generating the signatures.

### Tests
No new tests, just amended the existing tests to make sure the signatures are generated correctly

