### PR TITLE
Add integration tests for add-on

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 /coverage/
 /doc/
 /pkg/
+/spec/dummy/log/
+/spec/dummy/tmp/
 /spec/examples.txt
 /spec/reports/
 /tmp/

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -47,6 +47,7 @@ Sorbet/TrueSigil:
     - "**/*.rake"
   Exclude:
     - "lib/ruby_lsp/tapioca/server_addon.rb"
+    - "spec/dummy/**/*.rb"
 
 Style/CaseEquality:
   Enabled: false

--- a/sorbet/rbi/shims/minitest.rbi
+++ b/sorbet/rbi/shims/minitest.rbi
@@ -1,0 +1,8 @@
+# typed: true
+
+# Can be removed once https://github.com/Shopify/rbi-central/pull/300 ships
+
+class Minitest::HooksSpec
+  sig { params(arg: Symbol, block: T.proc.bind(T.attached_class).void).void }
+  def self.after(arg, &block); end
+end

--- a/spec/dummy/app/jobs/notify_user_job.rb
+++ b/spec/dummy/app/jobs/notify_user_job.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class NotifyUserJob < ActiveJob::Base
+  def perform(user)
+  end
+end

--- a/spec/dummy/bin/rails
+++ b/spec/dummy/bin/rails
@@ -1,0 +1,14 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# This command will automatically be run when you run "rails" with Rails gems
+# installed from the root of your application.
+
+ENGINE_ROOT = File.expand_path("..", __dir__)
+APP_PATH = File.expand_path("../config/application", __dir__)
+
+# Set up gems listed in the Gemfile.
+ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)
+require "bundler/setup" if File.exist?(ENV["BUNDLE_GEMFILE"])
+
+require "rails/engine/commands"

--- a/spec/dummy/config.ru
+++ b/spec/dummy/config.ru
@@ -1,0 +1,7 @@
+# typed: strict
+# frozen_string_literal: true
+
+require_relative "config/environment"
+
+run Rails.application
+Rails.application.load_server

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../../../Gemfile", __dir__)
+
+require "bundler/setup" if File.exist?(ENV["BUNDLE_GEMFILE"])
+$LOAD_PATH.unshift(File.expand_path("../../../lib", __dir__))
+
+require "rails" # minimal, instead of "rails/all"
+require "active_job/railtie"
+
+Bundler.require(*Rails.groups)
+
+module Dummy
+  class Application < Rails::Application
+  end
+end

--- a/spec/dummy/config/environment.rb
+++ b/spec/dummy/config/environment.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+require_relative "application"
+
+Rails.application.initialize!

--- a/spec/spec_with_project.rb
+++ b/spec/spec_with_project.rb
@@ -11,7 +11,7 @@ module Tapioca
 
     # Spec lifecycle
 
-    # TODO: Replace by `before(:all)` once Sorbet understands it
+    # TODO: Replace with `before(:all)` once Sorbet understands it
     sig { params(args: T.untyped).void }
     def initialize(*args)
       super(*T.unsafe(args))

--- a/spec/tapioca/addon_spec.rb
+++ b/spec/tapioca/addon_spec.rb
@@ -1,0 +1,53 @@
+# typed: true
+# frozen_string_literal: true
+
+require "spec_helper"
+require "language_server-protocol"
+require "ruby_lsp/utils"
+require "ruby_lsp/ruby_lsp_rails/runner_client"
+require "minitest/hooks"
+
+module RubyLsp
+  module Tapioca
+    class AddonSpec < Minitest::HooksSpec
+      # The approach here is based on tests within the Ruby LSP Rails gem
+
+      # TODO: Replace with `before(:all)` once Sorbet understands it
+      def initialize(*args)
+        super(*T.unsafe(args))
+        @outgoing_queue = Thread::Queue.new
+        @client = T.let(nil, T.nilable(RubyLsp::Rails::RunnerClient))
+        FileUtils.chdir("spec/dummy") do
+          @client = RubyLsp::Rails::RunnerClient.new(@outgoing_queue)
+        end
+      end
+
+      after(:all) do
+        T.must(@client).shutdown
+
+        assert_predicate(@client, :stopped?)
+        @outgoing_queue.close
+      end
+
+      it "generates DSL RBIs for a given constant" do
+        addon_path = File.expand_path("lib/ruby_lsp/tapioca/server_addon.rb")
+        T.must(@client).register_server_addon(File.expand_path(addon_path))
+        T.must(@client).delegate_notification(
+          server_addon_name: "Tapioca",
+          request_name: "dsl",
+          constants: ["NotifyUserJob"],
+        )
+
+        begin
+          Timeout.timeout(10) do
+            sleep(1) until File.exist?("spec/dummy/sorbet/rbi/dsl/notify_user_job.rbi")
+          end
+        rescue Timeout::Error
+          flunk("RBI file was not generated")
+        end
+      ensure
+        FileUtils.rm_rf("spec/dummy/sorbet/rbi")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Closes https://github.com/Shopify/team-ruby-dx/issues/1327

This PR adds an integration test for the flow of generating DSL RBIs for a particular compiler.

I chose to use the ActiveJob compiler to avoid any database complexity.

I've tried to reduce the Rails files to the minimum possible.