### PR TITLE
[Tapioca Addon] Handle missing gems gracefully in tapioca gem command

### DIFF
--- a/lib/tapioca/cli.rb
+++ b/lib/tapioca/cli.rb
@@ -266,6 +266,11 @@ module Tapioca
       type: :boolean,
       desc: "Halt upon a load error while loading the Rails application",
       default: true
+    option :lsp_addon,
+      type: :boolean,
+      desc: "Generate Gem RBIs from the LSP addon. Internal to tapioca and not intended for end-users",
+      default: false,
+      hide: true
     def gem(*gems)
       set_environment(options)
 
@@ -300,6 +305,7 @@ module Tapioca
         dsl_dir: options[:dsl_dir],
         rbi_formatter: rbi_formatter(options),
         halt_upon_load_error: options[:halt_upon_load_error],
+        lsp_addon: options[:lsp_addon],
       }
 
       command = if verify

--- a/lib/tapioca/cli.rb
+++ b/lib/tapioca/cli.rb
@@ -145,7 +145,7 @@ module Tapioca
       default: {}
     option :lsp_addon,
       type: :boolean,
-      desc: "Generate DSL RBIs from the LSP addon. Internal to tapioca and not intended for end-users",
+      desc: "Generate DSL RBIs from the LSP add-on. Internal to Tapioca and not intended for end-users",
       default: false,
       hide: true
     def dsl(*constant_or_paths)
@@ -268,7 +268,7 @@ module Tapioca
       default: true
     option :lsp_addon,
       type: :boolean,
-      desc: "Generate Gem RBIs from the LSP addon. Internal to tapioca and not intended for end-users",
+      desc: "Generate Gem RBIs from the LSP add-on. Internal to Tapioca and not intended for end-users",
       default: false,
       hide: true
     def gem(*gems)

--- a/lib/tapioca/commands/abstract_gem.rb
+++ b/lib/tapioca/commands/abstract_gem.rb
@@ -27,6 +27,7 @@ module Tapioca
           dsl_dir: String,
           rbi_formatter: RBIFormatter,
           halt_upon_load_error: T::Boolean,
+          lsp_addon: T.nilable(T::Boolean),
         ).void
       end
       def initialize(
@@ -45,7 +46,8 @@ module Tapioca
         auto_strictness: true,
         dsl_dir: DEFAULT_DSL_DIR,
         rbi_formatter: DEFAULT_RBI_FORMATTER,
-        halt_upon_load_error: true
+        halt_upon_load_error: true,
+        lsp_addon: false
       )
         @gem_names = gem_names
         @exclude = exclude
@@ -59,6 +61,7 @@ module Tapioca
         @auto_strictness = auto_strictness
         @dsl_dir = dsl_dir
         @rbi_formatter = rbi_formatter
+        @lsp_addon = lsp_addon
 
         super()
 

--- a/lib/tapioca/commands/gem_generate.rb
+++ b/lib/tapioca/commands/gem_generate.rb
@@ -55,6 +55,8 @@ module Tapioca
           gem = @bundle.gem(gem_name)
 
           if gem.nil?
+            next if @lsp_addon
+
             raise Thor::Error, set_color("Error: Cannot find gem '#{gem_name}'", :red)
           end
 

--- a/spec/tapioca/cli/gem_spec.rb
+++ b/spec/tapioca/cli/gem_spec.rb
@@ -828,6 +828,20 @@ module Tapioca
           assert_success_status(result)
         end
 
+        it "skips missing gems and continues with warning when --lsp_addon is used" do
+          result = @project.tapioca("gem non_existent_gem --lsp_addon")
+
+          assert_empty_stderr(result)
+          assert_success_status(result)
+        end
+
+        it "fails with error when gem cannot be found" do
+          result = @project.tapioca("gem non_existent_gem")
+
+          assert_stderr_includes(result, "Error: Cannot find gem 'non_existent_gem'")
+          refute_success_status(result)
+        end
+
         it "does not crash when the extras gem is loaded" do
           foo = mock_gem("foo", "0.0.1") do
             write!("lib/foo.rb", FOO_RB)


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
Currently, when a gem specified in the `tapioca gem` command isn't found by bundler, the process fails with a `Thor::Error`. This creates a poor user experience on the rare instances when the Tapioca LSP Addon runs the command with multiple gems where some might not be available.

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
With this change, when the `--lsp_addon` flag is used, the command will now output a warning when a gem isn't found and continue processing other gems instead of crashing the process. This allows the Tapioca LSP Addon to handle missing gems gracefully while still generating RBIs for the available ones.

Without `--lsp_addon`, the command maintains its existing behaviour of failing with an error when a gem cannot be found.

<!-- ### Tests
We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->

