### PR TITLE
Provide a hook for custom `ActiveModel` types

### DIFF
--- a/lib/tapioca/dsl/helpers/active_model_type_helper.rb
+++ b/lib/tapioca/dsl/helpers/active_model_type_helper.rb
@@ -14,7 +14,8 @@ module Tapioca
           def type_for(type_value)
             return "T.untyped" if Runtime::GenericTypeRegistry.generic_type_instance?(type_value)
 
-            type = lookup_return_type_of_method(type_value, :deserialize) ||
+            type = lookup_sorbet_type(type_value) ||
+              lookup_return_type_of_method(type_value, :deserialize) ||
               lookup_return_type_of_method(type_value, :cast) ||
               lookup_return_type_of_method(type_value, :cast_value) ||
               lookup_arg_type_of_method(type_value, :serialize) ||
@@ -37,6 +38,11 @@ module Tapioca
           sig { params(type: T.untyped).returns(T::Boolean) }
           def meaningful_type?(type)
             !MEANINGLESS_TYPES.include?(type)
+          end
+
+          sig { params(obj: T.untyped).returns(T.nilable(T::Types::Base)) }
+          def lookup_sorbet_type(obj)
+            T::Utils.coerce(obj.__sorbet_type) if obj.respond_to?(:__sorbet_type)
           end
 
           sig { params(obj: T.untyped, method: Symbol).returns(T.nilable(T::Types::Base)) }

--- a/lib/tapioca/dsl/helpers/active_model_type_helper.rb
+++ b/lib/tapioca/dsl/helpers/active_model_type_helper.rb
@@ -14,7 +14,7 @@ module Tapioca
           def type_for(type_value)
             return "T.untyped" if Runtime::GenericTypeRegistry.generic_type_instance?(type_value)
 
-            type = lookup_sorbet_type(type_value) ||
+            type = lookup_tapioca_type(type_value) ||
               lookup_return_type_of_method(type_value, :deserialize) ||
               lookup_return_type_of_method(type_value, :cast) ||
               lookup_return_type_of_method(type_value, :cast_value) ||
@@ -41,8 +41,8 @@ module Tapioca
           end
 
           sig { params(obj: T.untyped).returns(T.nilable(T::Types::Base)) }
-          def lookup_sorbet_type(obj)
-            T::Utils.coerce(obj.__sorbet_type) if obj.respond_to?(:__sorbet_type)
+          def lookup_tapioca_type(obj)
+            T::Utils.coerce(obj.__tapioca_type) if obj.respond_to?(:__tapioca_type)
           end
 
           sig { params(obj: T.untyped, method: Symbol).returns(T.nilable(T::Types::Base)) }

--- a/spec/tapioca/dsl/compilers/active_model_attributes_spec.rb
+++ b/spec/tapioca/dsl/compilers/active_model_attributes_spec.rb
@@ -190,17 +190,17 @@ module Tapioca
               assert_equal(expected, rbi_for(:Shop))
             end
 
-            it "generates method sigs for attribute type with `#__sorbet_type`" do
+            it "generates method sigs for attribute type with `#__tapioca_type`" do
               add_ruby_file("shop.rb", <<~RUBY)
                 class GenericType < ActiveModel::Type::Value
                   extend T::Sig
 
-                  def initialize(sorbet_type)
-                    @sorbet_type = sorbet_type
+                  def initialize(tapioca_type)
+                    @tapioca_type = tapioca_type
                   end
 
-                  def __sorbet_type
-                    @sorbet_type
+                  def __tapioca_type
+                    @tapioca_type
                   end
                 end
 

--- a/spec/tapioca/dsl/helpers/active_model_type_helper_spec.rb
+++ b/spec/tapioca/dsl/helpers/active_model_type_helper_spec.rb
@@ -28,12 +28,12 @@ module Tapioca
         end
 
         describe "type_for" do
-          it "discovers custom type from __sorbet_type method" do
+          it "discovers custom type from __tapioca_type method" do
             klass = Class.new(ActiveModel::Type::Value) do
               extend T::Sig
 
               sig { returns(T.untyped) }
-              def __sorbet_type
+              def __tapioca_type
                 T.any(Integer, String)
               end
 
@@ -61,7 +61,7 @@ module Tapioca
             assert_equal(
               "T.any(::Integer, ::String)",
               Tapioca::Dsl::Helpers::ActiveModelTypeHelper.type_for(klass.new),
-              "The type returned from `__sorbet_type` has the highest priority.",
+              "The type returned from `__tapioca_type` has the highest priority.",
             )
           end
 


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->

We use `ActiveModel::Attributes` extensively. In many cases, we're passing complex values to these models, such as a `User`. It wouldn't be practical in our situation to define an `ActiveModel::Type` class for each and every possible value that gets passed into a model.

Any of the following solutions would solve my issue:
1. Explicitly tell Tapioca the type of a given attribute.
2. Explicitly tell Tapioca to skip type generation for a given attribute, which would allow me to write my own compiler for these specific attributes.
3. Allow compilers to override the types defined by other compilers (similar to #1965).

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->

This PR allows instances of `ActiveModel::Type::Value` to define an optional method `#__tapioca_type`. It returns a type.

For example, you could use this hook to implement an interface like this:

```ruby
class GenericType < ActiveModel::Type::Value
  def initialize(type)
    @type = type
  end

  def __tapioca_type = @type
end

class User
end

class Foo
  include ActiveModel::Attributes

  attribute :user, GenericType.new(User)
end
```

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->

Tests are included.