### PR TITLE
Compilers can define their execution order

### DIFF
--- a/lib/tapioca/dsl.rb
+++ b/lib/tapioca/dsl.rb
@@ -3,6 +3,7 @@
 
 require "rbi"
 require "spoom"
+require "tsort"
 
 require "tapioca"
 require "tapioca/runtime/reflection"

--- a/lib/tapioca/dsl/compiler.rb
+++ b/lib/tapioca/dsl/compiler.rb
@@ -38,6 +38,11 @@ module Tapioca
         sig { abstract.returns(T::Enumerable[Module]) }
         def gather_constants; end
 
+        sig { overridable.returns(T::Array[T.class_of(Compiler)]) }
+        def run_after_compilers
+          []
+        end
+
         sig { returns(T::Set[Module]) }
         def processable_constants
           @processable_constants ||= T.let(

--- a/lib/tapioca/rbi_ext/model.rb
+++ b/lib/tapioca/rbi_ext/model.rb
@@ -112,6 +112,12 @@ module RBI
       self << method
     end
 
+    sig { params(name: String).void }
+    def remove_method(name)
+      method = nodes.grep(RBI::Method).find { |node| node.name == name }
+      nodes.delete(method) if method
+    end
+
     private
 
     sig { returns(T::Hash[String, RBI::Node]) }

--- a/spec/tapioca/dsl/pipeline_spec.rb
+++ b/spec/tapioca/dsl/pipeline_spec.rb
@@ -1,0 +1,39 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Tapioca
+  module Dsl
+    class PipelineSpec < Minitest::Spec
+      include Tapioca::Helpers::Test::Content
+      include Tapioca::Helpers::Test::Isolation
+
+      describe Tapioca::Dsl::Pipeline do
+        describe "#active_compilers" do
+          it "sorts the list of active compilers using `.run_after_compilers`" do
+            add_ruby_file("sorbet/tapioca/compilers/cherry.rb", <<~RUBY)
+              class Tapioca::Dsl::Cherry < Tapioca::Dsl::Compiler; end
+            RUBY
+
+            add_ruby_file("sorbet/tapioca/compilers/banana.rb", <<~RUBY)
+              class Tapioca::Dsl::Banana < Tapioca::Dsl::Compiler; end
+            RUBY
+
+            add_ruby_file("sorbet/tapioca/compilers/apple.rb", <<~RUBY)
+              require_relative 'banana'
+
+              class Tapioca::Dsl::Apple < Tapioca::Dsl::Compiler
+                def self.run_after_compilers = [Tapioca::Dsl::Banana]
+              end
+            RUBY
+
+            expected_compilers = ["Tapioca::Dsl::Banana", "Tapioca::Dsl::Apple", "Tapioca::Dsl::Cherry"]
+            actual_compilers = Pipeline.new(requested_constants: []).active_compilers.map(&:name)
+            assert_equal(expected_compilers, actual_compilers)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/tapioca/rbi_builder_spec.rb
+++ b/spec/tapioca/rbi_builder_spec.rb
@@ -17,6 +17,9 @@ module RBI
         rbi.create_type_variable("G", type: "type_member")
         rbi.create_type_variable("H", type: "type_template", variance: :in, fixed: "Foo")
         rbi.create_method("foo")
+        rbi.create_method("bar", return_type: "String")
+        rbi.remove_method("bar")
+        rbi.create_method("bar", return_type: "Integer")
 
         assert_equal(<<~RBI, rbi.string)
           class A; end
@@ -30,6 +33,9 @@ module RBI
 
           sig { returns(T.untyped) }
           def foo; end
+
+          sig { returns(Integer) }
+          def bar; end
         RBI
       end
 
@@ -119,6 +125,12 @@ module RBI
             module Bar; end
           end
         RBI
+      end
+
+      it "does not raise an nonexistent method is removed" do
+        rbi = RBI::Tree.new
+        rbi.remove_method("garbage")
+        assert_equal("", rbi.string)
       end
     end
   end


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->

Tapioca generates types for ActiveModel and ActiveRecord attributes, and usually does the right thing. However, there are some cases where more flexibility is necessary. It would be useful to be able to override the definitions provided by Tapioca's default compilers in very special cases.

#### Example 1: ActiveModel attributes without a type

Not all ActiveModel attributes can be represented with ActiveModel's built-in types. It also isn't practical to define an `ActiveModel::Type` for every type of value that might be passed to an ActiveModel.

For example, many ActiveModel instances take a `User` as a parameter (e.g. `attribute :user`). I'd like to be able to tell Sorbet that this is a `User`. Unfortunately, the Tapioca compiler defines this field as `T.untyped`. Without forking the ActiveModel compiler, I have no way of overriding the type defined by Tapioca.

#### Example 2: Column types don't necessarily represent method return types

We use a gem called [`steady_state`](https://github.com/Betterment/steady_state). It defines a state machine and stores the state in a string column on the record.

This gem overrides the attribute reader to return an instance of [`SteadyState::Attribute::State`](https://github.com/Betterment/steady_state/blob/main/lib/steady_state/attribute/state.rb), which is basically an [`ActiveSupport::StringInquirer`](https://api.rubyonrails.org/classes/ActiveSupport/StringInquirer.html).

Without forking the ActiveRecordColumns compiler, I have no way of overriding the type defined by Tapioca.

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->

#### Step 1: Allow DSL compilers to control execution order

This PR implements an optional compiler method `.run_after_compilers`. Compilers can tell Tapioca which other compilers they expect to precede them.

So, for example, my SteadyState compiler could say:

```ruby
class Tapioca::Dsl::Compilers::SteadyState < Tapoica::Dsl::Compiler
  def self.run_after_compilers
    [Tapioca::Dsl::Compilers::ActiveRecordColumns]
  end

  # ... etc ...
end
```

Tapioca can use [`TSort`](https://docs.ruby-lang.org/en/3.3/TSort.html) to ensure that the steady state compiler runs after `ActiveRecordColumns`.

#### Step 2: Allow DSL compilers to redefine methods

This PR implements `RBI::Tree#remove_method`, which removes a method from the tree by name.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->

This PR includes tests.
