### PR TITLE
Rescue `ActiveRecord::ConnectionNotEstablished` errors during `const_get`

### DIFF
--- a/lib/tapioca/runtime/reflection.rb
+++ b/lib/tapioca/runtime/reflection.rb
@@ -50,6 +50,12 @@ module Tapioca
         namespace.const_get(symbol, inherit)
       rescue NameError, LoadError, RuntimeError, ArgumentError, TypeError
         UNDEFINED_CONSTANT
+      rescue => e
+        if defined?(ActiveRecord) && defined?(ActiveRecord::ConnectionNotEstablished) && e.is_a?(ActiveRecord::ConnectionNotEstablished)
+          UNDEFINED_CONSTANT
+        else
+          raise
+        end
       end
 
       sig { params(object: BasicObject).returns(T::Class[T.anything]).checked(:never) }


### PR DESCRIPTION
Resolves https://github.com/Shopify/tapioca/issues/2004

### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->

