### PR TITLE
Move gems_to_generate to subclass

### DIFF
--- a/lib/tapioca/commands/abstract_gem.rb
+++ b/lib/tapioca/commands/abstract_gem.rb
@@ -73,39 +73,6 @@ module Tapioca
 
       private
 
-      sig { params(gem_names: T::Array[String]).returns(T::Array[Gemfile::GemSpec]) }
-      def gems_to_generate(gem_names)
-        return @bundle.dependencies if gem_names.empty?
-
-        (gem_names - @exclude).each_with_object([]) do |gem_name, gems|
-          gem = @bundle.gem(gem_name)
-
-          if gem.nil?
-            raise Thor::Error, set_color("Error: Cannot find gem '#{gem_name}'", :red)
-          end
-
-          gems.concat(gem_dependencies(gem)) if @include_dependencies
-          gems << gem
-        end
-      end
-
-      sig do
-        params(
-          gem: Gemfile::GemSpec,
-          dependencies: T::Array[Gemfile::GemSpec],
-        ).returns(T::Array[Gemfile::GemSpec])
-      end
-      def gem_dependencies(gem, dependencies = [])
-        direct_dependencies = gem.dependencies.filter_map { |dependency| @bundle.gem(dependency.name) }
-        gems = dependencies | direct_dependencies
-
-        if direct_dependencies.empty?
-          gems
-        else
-          direct_dependencies.reduce(gems) { |result, gem| gem_dependencies(gem, result) }
-        end
-      end
-
       sig { params(gem: Gemfile::GemSpec).void }
       def compile_gem_rbi(gem)
         gem_name = set_color(gem.name, :yellow, :bold)

--- a/lib/tapioca/commands/gem_generate.rb
+++ b/lib/tapioca/commands/gem_generate.rb
@@ -46,6 +46,39 @@ module Tapioca
       ensure
         GitAttributes.create_generated_attribute_file(@outpath)
       end
+
+      sig { params(gem_names: T::Array[String]).returns(T::Array[Gemfile::GemSpec]) }
+      def gems_to_generate(gem_names)
+        return @bundle.dependencies if gem_names.empty?
+
+        (gem_names - @exclude).each_with_object([]) do |gem_name, gems|
+          gem = @bundle.gem(gem_name)
+
+          if gem.nil?
+            raise Thor::Error, set_color("Error: Cannot find gem '#{gem_name}'", :red)
+          end
+
+          gems.concat(gem_dependencies(gem)) if @include_dependencies
+          gems << gem
+        end
+      end
+
+      sig do
+        params(
+          gem: Gemfile::GemSpec,
+          dependencies: T::Array[Gemfile::GemSpec],
+        ).returns(T::Array[Gemfile::GemSpec])
+      end
+      def gem_dependencies(gem, dependencies = [])
+        direct_dependencies = gem.dependencies.filter_map { |dependency| @bundle.gem(dependency.name) }
+        gems = dependencies | direct_dependencies
+
+        if direct_dependencies.empty?
+          gems
+        else
+          direct_dependencies.reduce(gems) { |result, gem| gem_dependencies(gem, result) }
+        end
+      end
     end
   end
 end


### PR DESCRIPTION

### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
The `gems_to_generate` method is only relevant to the `gem_generate` command, so it's more cohesive to have it defined there rather than on the parent abstract class.

 ### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
Pushed down the `gems_to_generate` and `gem_dependencies` methods from `Tapioca::Commands::AbstractGem` to the subclass `Tapioca::Commands::GemGenerate`.

<!-- ### Tests
 We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->

