### PR TITLE
`PrivateRelation` needs to be aware of class methods

### DIFF
--- a/lib/tapioca/dsl/compilers/active_record_scope.rb
+++ b/lib/tapioca/dsl/compilers/active_record_scope.rb
@@ -46,9 +46,9 @@ module Tapioca
 
         sig { override.void }
         def decorate
-          method_names = scope_method_names
+          scope_method_names = gather_method_names
 
-          return if method_names.empty?
+          return if scope_method_names.empty?
 
           root.create_path(constant) do |model|
             relations_enabled = compiler_enabled?("ActiveRecordRelations")
@@ -56,7 +56,7 @@ module Tapioca
             relation_methods_module = model.create_module(RelationMethodsModuleName)
             assoc_relation_methods_mod = model.create_module(AssociationRelationMethodsModuleName) if relations_enabled
 
-            method_names.each do |scope_method|
+            scope_method_names.each do |scope_method|
               generate_scope_method(
                 relation_methods_module,
                 scope_method.to_s,
@@ -86,7 +86,7 @@ module Tapioca
         private
 
         sig { returns(T::Array[Symbol]) }
-        def scope_method_names
+        def gather_method_names
           scope_methods = T.let([], T::Array[Symbol])
           constant = self.constant
 

--- a/lib/tapioca/dsl/compilers/active_record_scope.rb
+++ b/lib/tapioca/dsl/compilers/active_record_scope.rb
@@ -46,30 +46,22 @@ module Tapioca
 
         sig { override.void }
         def decorate
-          scope_method_names = gather_method_names
+          scope_method_names, class_method_names = gather_method_names
 
-          return if scope_method_names.empty?
+          return if scope_method_names.empty? && class_method_names.empty?
 
           root.create_path(constant) do |model|
-            relations_enabled = compiler_enabled?("ActiveRecordRelations")
-
             relation_methods_module = model.create_module(RelationMethodsModuleName)
-            assoc_relation_methods_mod = model.create_module(AssociationRelationMethodsModuleName) if relations_enabled
 
-            scope_method_names.each do |scope_method|
-              generate_scope_method(
-                relation_methods_module,
-                scope_method.to_s,
-                relations_enabled ? RelationClassName : "T.untyped",
-              )
+            if compiler_enabled?("ActiveRecordRelations")
+              assoc_relation_methods_module = model.create_module(AssociationRelationMethodsModuleName)
 
-              next unless relations_enabled
-
-              generate_scope_method(
-                assoc_relation_methods_mod,
-                scope_method.to_s,
-                AssociationRelationClassName,
-              )
+              generate_scope_methods(relation_methods_module, scope_method_names, RelationClassName)
+              generate_class_methods(relation_methods_module, class_method_names)
+              generate_scope_methods(assoc_relation_methods_module, scope_method_names, AssociationRelationClassName)
+              generate_class_methods(assoc_relation_methods_module, class_method_names)
+            else
+              generate_scope_methods(relation_methods_module, scope_method_names, "T.untyped")
             end
 
             model.create_extend(RelationMethodsModuleName)
@@ -85,41 +77,51 @@ module Tapioca
 
         private
 
-        sig { returns(T::Array[Symbol]) }
+        sig { returns([T::Array[Symbol], T::Array[Symbol]]) }
         def gather_method_names
           scope_methods = T.let([], T::Array[Symbol])
+          class_methods = T.let([], T::Array[Symbol])
           constant = self.constant
 
           # Keep gathering scope methods until we hit "ActiveRecord::Base"
           until constant == ActiveRecord::Base
-            scope_methods.concat(constant.send(:generated_relation_methods).instance_methods(false))
-
-            superclass = superclass_of(constant)
-            break unless superclass
-
             # we are guaranteed to have a superclass that is of type "ActiveRecord::Base"
-            constant = T.cast(superclass, T.class_of(ActiveRecord::Base))
+            superclass = T.cast(T.must(superclass_of(constant)), T.class_of(ActiveRecord::Base))
+
+            scope_methods.concat(constant.send(:generated_relation_methods).instance_methods(false))
+            class_methods.concat(constant.methods(false) - superclass.methods(false) - scope_methods)
+
+            constant = superclass
           end
 
-          scope_methods.uniq
+          [scope_methods.uniq, class_methods.uniq]
         end
 
         sig do
           params(
             mod: RBI::Scope,
-            scope_method: String,
+            scope_methods: T::Array[Symbol],
             return_type: String,
           ).void
         end
-        def generate_scope_method(mod, scope_method, return_type)
-          mod.create_method(
-            scope_method,
-            parameters: [
-              create_rest_param("args", type: "T.untyped"),
-              create_block_param("blk", type: "T.untyped"),
-            ],
-            return_type: return_type,
-          )
+        def generate_scope_methods(mod, scope_methods, return_type)
+          scope_methods.each do |scope_method|
+            mod.create_method(
+              scope_method.to_s,
+              parameters: [
+                create_rest_param("args", type: "T.untyped"),
+                create_block_param("blk", type: "T.untyped"),
+              ],
+              return_type: return_type,
+            )
+          end
+        end
+
+        sig { params(mod: RBI::Scope, class_methods: T::Array[Symbol]).void }
+        def generate_class_methods(mod, class_methods)
+          class_methods.each do |class_method|
+            create_method_from_def(mod, constant.public_method(class_method))
+          end
         end
       end
     end


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->

See https://github.com/Shopify/tapioca/issues/2118

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->

This PR looks up the available class methods and copies them to the generated relation modules using `create_method_from_def`.

One possible issue with this PR is how it might interact with other compilers. For example, ActiveRecord's enum defines a class method `.statuses`. The enum compiler will define a class method for this enum with types, but this compiler will also define that class method without types.

A better solution would be to define a module `GeneratedClassMethods` and `include` it explicitly in `PrivateRelation`. I'm not totally sure how to achieve this.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->

This PR includes tests.