### PR TITLE
Rename `#sorbet_type` → `#__tapioca_type`

### DIFF
--- a/lib/tapioca/dsl/compilers/json_api_client_resource.rb
+++ b/lib/tapioca/dsl/compilers/json_api_client_resource.rb
@@ -147,7 +147,17 @@ module Tapioca
           return "T.untyped" if type.nil?
 
           sorbet_type = if type.respond_to?(:sorbet_type)
+            line, file = type.method(:sorbet_type).source_location
+
+            $stderr.puts <<~MESSAGE
+              WARNING: `#sorbet_type` is deprecated. Please rename your method to `#__tapioca_type`."
+
+              Defined on line #{line} of #{file}
+            MESSAGE
+
             type.sorbet_type
+          elsif type.respond_to?(:__tapioca_type)
+            type.__tapioca_type
           elsif type == ::JsonApiClient::Schema::Types::Integer
             "::Integer"
           elsif type == ::JsonApiClient::Schema::Types::String

--- a/spec/tapioca/dsl/compilers/json_api_client_resource_spec.rb
+++ b/spec/tapioca/dsl/compilers/json_api_client_resource_spec.rb
@@ -330,7 +330,46 @@ module Tapioca
                 assert_equal(expected, rbi_for(:Post))
               end
 
-              it "honours types that declare sorbet_type" do
+              it "honours types that respond to #__tapioca_type" do
+                add_ruby_file("post.rb", <<~RUBY)
+                  class CustomType
+                    def self.__tapioca_type
+                      "Integer"
+                    end
+                  end
+
+                  class Post < JsonApiClient::Resource
+                    property :comment_count, type: :custom_type
+                    property :tag_count, type: :custom_type, default: 0
+                  end
+                RUBY
+
+                expected = <<~RBI
+                  # typed: strong
+
+                  class Post
+                    include JsonApiClientResourceGeneratedMethods
+
+                    module JsonApiClientResourceGeneratedMethods
+                      sig { returns(T.nilable(Integer)) }
+                      def comment_count; end
+
+                      sig { params(comment_count: T.nilable(Integer)).returns(T.nilable(Integer)) }
+                      def comment_count=(comment_count); end
+
+                      sig { returns(Integer) }
+                      def tag_count; end
+
+                      sig { params(tag_count: Integer).returns(Integer) }
+                      def tag_count=(tag_count); end
+                    end
+                  end
+                RBI
+
+                assert_equal(expected, rbi_for(:Post))
+              end
+
+              it "prints a warning that #sorbet_type is deprecated" do
                 add_ruby_file("post.rb", <<~RUBY)
                   class CustomType
                     def self.sorbet_type
@@ -366,7 +405,35 @@ module Tapioca
                   end
                 RBI
 
-                assert_equal(expected, rbi_for(:Post))
+                assert_output(nil, /WARNING: `#sorbet_type` is deprecated./) do
+                  assert_equal(expected, rbi_for(:Post))
+                end
+              end
+
+              it "does not crash if the source location #sorbet_type is unknown" do
+                add_ruby_file("post.rb", <<~RUBY)
+                  class CustomType
+                    def self.sorbet_type
+                      "Integer"
+                    end
+
+                    def self.method(name)
+                      m = super
+                      # Fake the source location, as if this was defined in a C extension.
+                      def m.source_location
+                        nil
+                      end
+                      m
+                    end
+                  end
+
+                  class Post < JsonApiClient::Resource
+                    property :comment_count, type: :custom_type
+                    property :tag_count, type: :custom_type, default: 0
+                  end
+                RUBY
+
+                rbi_for(:Post) # Should not raise
               end
             end
           end


### PR DESCRIPTION
### Motivation

Rename the `#sorbet_type` method called by the `JsonApiClient::Resource` compiler, to match our naming decision in #2112:

1. Prefixed with `__` to discourage the method from being called from regular user code (i.e. only Tapioca should be calling it).
2. Renamed to emphasize Tapioca over Sorbet, to clarify how this ends up being used. Should hopefully be an easier term to search for, with fewer false matches.

### Implementation

Print a warning when we find `#sorbet_type`, while still honouring it. If there's only a definition for `#__tapioca_type`, we'll use that instead.

After some migration time, we can drop support for `#sorbet_type`.

