### PR TITLE
Don't assume nilable when `#__tapioca_type` is provided

### DIFF
--- a/lib/tapioca/dsl/compilers/active_model_attributes.rb
+++ b/lib/tapioca/dsl/compilers/active_model_attributes.rb
@@ -101,26 +101,26 @@ module Tapioca
 
         sig { params(attribute_type_value: T.untyped).returns(::String) }
         def type_for(attribute_type_value)
-          type = case attribute_type_value
+          case attribute_type_value
           when ActiveModel::Type::Boolean
-            "T::Boolean"
+            as_nilable_type("T::Boolean")
           when ActiveModel::Type::Date
-            "::Date"
+            as_nilable_type("::Date")
           when ActiveModel::Type::DateTime, ActiveModel::Type::Time
-            "::Time"
+            as_nilable_type("::Time")
           when ActiveModel::Type::Decimal
-            "::BigDecimal"
+            as_nilable_type("::BigDecimal")
           when ActiveModel::Type::Float
-            "::Float"
+            as_nilable_type("::Float")
           when ActiveModel::Type::Integer
-            "::Integer"
+            as_nilable_type("::Integer")
           when ActiveModel::Type::String
-            "::String"
+            as_nilable_type("::String")
           else
-            Helpers::ActiveModelTypeHelper.type_for(attribute_type_value)
+            type = Helpers::ActiveModelTypeHelper.type_for(attribute_type_value)
+            type = as_nilable_type(type) if Helpers::ActiveModelTypeHelper.assume_nilable?(attribute_type_value)
+            type
           end
-
-          as_nilable_type(type)
         end
 
         sig { params(klass: RBI::Scope, method: String, type: String).void }

--- a/lib/tapioca/dsl/helpers/active_model_type_helper.rb
+++ b/lib/tapioca/dsl/helpers/active_model_type_helper.rb
@@ -23,6 +23,11 @@ module Tapioca
             type.to_s
           end
 
+          sig { params(type_value: T.untyped).returns(T::Boolean) }
+          def assume_nilable?(type_value)
+            !type_value.respond_to?(:__tapioca_type)
+          end
+
           private
 
           MEANINGLESS_TYPES = T.let(

--- a/spec/tapioca/dsl/helpers/active_model_type_helper_spec.rb
+++ b/spec/tapioca/dsl/helpers/active_model_type_helper_spec.rb
@@ -295,6 +295,31 @@ module Tapioca
             )
           end
         end
+
+        describe "assume_nilable?" do
+          it "assumes the type is nilable when `#__tapioca_type` is not defined" do
+            klass = Class.new(ActiveModel::Type::Value)
+
+            assert_equal(
+              true,
+              Tapioca::Dsl::Helpers::ActiveModelTypeHelper.assume_nilable?(klass.new),
+            )
+          end
+
+          it "does not assume the type is nilable when `#__tapioca_type` is defined" do
+            klass = Class.new(ActiveModel::Type::Value) do
+              extend T::Sig
+
+              sig { returns(Module) }
+              def __tapioca_type = String
+            end
+
+            assert_equal(
+              false,
+              Tapioca::Dsl::Helpers::ActiveModelTypeHelper.assume_nilable?(klass.new),
+            )
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
…apioca_type`

### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->

`#__tapioca_type` is meant to serve as an escape hatch to define arbitrary types for ActiveModel attributes. Currently, this escape hatch is limited, because it still assumes that all attributes are nilable.

The `#__tapioca_type` method should have full control over what type is emitted to the RBI file.

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->

This PR adds `.assume_nilable?` to `ActiveModelTypeHelper`. This method will only return false if the ActiveModel type implements `#__tapioca_type`.

It is the responsibility of the person who defined `#__tapioca_type` to wrap the type in `T.nilable`.

Alternatives:
1. Call `.as_nilable_type` in `ActiveModelTypeHelper.type_for` to avoid adding another public method.
2. Allow subclasses of `ActiveModel::Type::Value` to implement `#__tapioca_nilable?`.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->

This PR includes tests.
