### PR TITLE
Support Bundler 2.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
-          rubygems: 3.5.23
+          rubygems: 3.6.2
       - name: Run type check
         run: bin/typecheck
       - name: Lint Ruby files
@@ -36,6 +36,7 @@ jobs:
       matrix:
         ruby: ["3.1", "3.2", "3.3", "head"]
         rails: ["7.0", "current", "main"]
+        rubygems: ["3.6.2"]
         exclude:
           - ruby: "3.1"
             rails: "main"
@@ -44,6 +45,9 @@ jobs:
             experimental: true
           - ruby: "head"
             experimental: true
+          - rails: "current"
+            ruby: "3.3"
+            rubygems: "3.5.23"
     name: Ruby ${{ matrix.ruby }} - Rails ${{ matrix.rails }}
     env:
       RAILS_VERSION: ${{ matrix.rails }}
@@ -63,7 +67,7 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
-          rubygems: 3.5.23
+          rubygems: ${{ matrix.rubygems }}
       - name: Run tests
         run: bin/test
         continue-on-error: ${{ !!matrix.experimental }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
-          rubygems: 3.5.11
+          rubygems: 3.5.23
       - name: Run type check
         run: bin/typecheck
       - name: Lint Ruby files
@@ -63,7 +63,7 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
-          rubygems: 3.5.11
+          rubygems: 3.5.23
       - name: Run tests
         run: bin/test
         continue-on-error: ${{ !!matrix.experimental }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,6 @@ jobs:
         with:
           bundler-cache: true
           rubygems: 3.5.11
-          bundler: 2.5.11
       - name: Run type check
         run: bin/typecheck
       - name: Lint Ruby files
@@ -65,7 +64,6 @@ jobs:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
           rubygems: 3.5.11
-          bundler: 2.5.11
       - name: Run tests
         run: bin/test
         continue-on-error: ${{ !!matrix.experimental }}

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -406,4 +406,4 @@ DEPENDENCIES
   xpath
 
 BUNDLED WITH
-   2.5.23
+   2.6.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -406,4 +406,4 @@ DEPENDENCIES
   xpath
 
 BUNDLED WITH
-   2.5.0
+   2.5.11

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -406,4 +406,4 @@ DEPENDENCIES
   xpath
 
 BUNDLED WITH
-   2.5.11
+   2.5.23

--- a/spec/tapioca/gem/pipeline_spec.rb
+++ b/spec/tapioca/gem/pipeline_spec.rb
@@ -42,11 +42,11 @@ class Tapioca::Gem::PipelineSpec < Minitest::HooksSpec
       end
 
       # add spec to the list of gem specification stubs
-      Gem::Specification.stubs[gem_name] = spec
+      Gem::Specification.add_spec(spec)
     end
 
     # wrap it in our gemspec wrapper
-    gem = Tapioca::Gemfile::GemSpec.new(Gem::Specification.stubs[gem_name].first)
+    gem = Tapioca::Gemfile::GemSpec.new(Gem::Specification.find_by_name(gem_name))
 
     # clear out previously reported errors
     reported_errors.clear


### PR DESCRIPTION
### Motivation

Bundler 2.6 has just been released and unfortunately I noticed that it does not play well with tapioca.

### Implementation

The main incompatibility I noticed was introduced at https://github.com/rubygems/rubygems/pull/8251.

In that PR, missing specs were moved from the spec set of materialized specifications to the spec set holding the original resolution.

Unfortunately, that's necessary to fix the issue I wanted to solve, and I'm not sure how to fix the original issue while making the change backwards compatible with what tapioca was doing here. So I'm trying to change tapioca instead to play nice with Bundler 2.6.

I also found another test only incompatibility introduced by https://github.com/rubygems/rubygems/pull/8165 in Bundler 2.5.23. That's because `Gem::Specification.stubs` would hold a `Bundler::SpecSet` before that PR (similar to a hash) while after the PR it was change to hold an array of specs (the same thing it holds when `bundler/setup` has not been loaded). Since this only affects specs, I changed the specs to play nice with that change as well.

### Tests

My hope is to run CI with the latest Bundler and get tests green.

I'm also planning to introduce a basic tapioca CLI check to Bundler's CI so that I can detect this issue in advance in the future.

This PR closes #2132.