### PR TITLE
Support Postgres Enum

### DIFF
--- a/lib/tapioca/dsl/helpers/active_record_column_type_helper.rb
+++ b/lib/tapioca/dsl/helpers/active_record_column_type_helper.rb
@@ -216,6 +216,11 @@ module Tapioca
                    ActiveRecord::Locking::LockingType === type
                }
             as_non_nilable_if_persisted_and_not_nullable("::Integer", column_nullability:)
+          when ->(type) {
+                 defined?(ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Enum) &&
+                   ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Enum === type
+               }
+            "::String"
           else
             as_non_nilable_if_persisted_and_not_nullable(
               ActiveModelTypeHelper.type_for(column_type),

--- a/sorbet/rbi/shims/activerecord_postgresql.rbi
+++ b/sorbet/rbi/shims/activerecord_postgresql.rbi
@@ -9,3 +9,4 @@ module ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Interval; end
 module ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Range; end
 module ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Bit; end
 module ActiveRecord::ConnectionAdapters::PostgreSQL::OID::BitVarying; end
+module ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Enum; end


### PR DESCRIPTION
### Motivation

Currently Postgres Enums are T.untyped in `tapioca dsl`

### Implementation

I followed the pattern of the other Postgres column implementations.

### Tests

I didn't add tests as there isn't currently a way to do that in the repo for Postgres but I did test it against our codebase where it produced the correct output.
