### PR TITLE
Allow Active Record `select` to return nilable

### DIFF
--- a/lib/tapioca/dsl/compilers/active_record_relations.rb
+++ b/lib/tapioca/dsl/compilers/active_record_relations.rb
@@ -597,7 +597,7 @@ module Tapioca
                     sig.return_type = mod == relation_methods_module ? RelationClassName : AssociationRelationClassName
                   end
                   method.add_sig do |sig|
-                    sig.add_param("blk", "T.proc.params(record: #{constant_name}).returns(T::Boolean)")
+                    sig.add_param("blk", "T.proc.params(record: #{constant_name}).returns(T.nilable(T::Boolean))")
                     sig.return_type = "T::Array[#{constant_name}]"
                   end
                 end

--- a/spec/tapioca/dsl/compilers/active_record_relations_spec.rb
+++ b/spec/tapioca/dsl/compilers/active_record_relations_spec.rb
@@ -433,7 +433,7 @@ module Tapioca
                     def rewhere(*args, &blk); end
 
                     sig { params(args: T.untyped).returns(PrivateAssociationRelation) }
-                    sig { params(blk: T.proc.params(record: ::Post).returns(T::Boolean)).returns(T::Array[::Post]) }
+                    sig { params(blk: T.proc.params(record: ::Post).returns(T.nilable(T::Boolean))).returns(T::Array[::Post]) }
                     def select(*args, &blk); end
 
                     sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
@@ -594,7 +594,7 @@ module Tapioca
                     def rewhere(*args, &blk); end
 
                     sig { params(args: T.untyped).returns(PrivateRelation) }
-                    sig { params(blk: T.proc.params(record: ::Post).returns(T::Boolean)).returns(T::Array[::Post]) }
+                    sig { params(blk: T.proc.params(record: ::Post).returns(T.nilable(T::Boolean))).returns(T::Array[::Post]) }
                     def select(*args, &blk); end
 
                     sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
@@ -1159,7 +1159,7 @@ module Tapioca
                     def rewhere(*args, &blk); end
 
                     sig { params(args: T.untyped).returns(PrivateAssociationRelation) }
-                    sig { params(blk: T.proc.params(record: ::Post).returns(T::Boolean)).returns(T::Array[::Post]) }
+                    sig { params(blk: T.proc.params(record: ::Post).returns(T.nilable(T::Boolean))).returns(T::Array[::Post]) }
                     def select(*args, &blk); end
 
                     sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
@@ -1320,7 +1320,7 @@ module Tapioca
                     def rewhere(*args, &blk); end
 
                     sig { params(args: T.untyped).returns(PrivateRelation) }
-                    sig { params(blk: T.proc.params(record: ::Post).returns(T::Boolean)).returns(T::Array[::Post]) }
+                    sig { params(blk: T.proc.params(record: ::Post).returns(T.nilable(T::Boolean))).returns(T::Array[::Post]) }
                     def select(*args, &blk); end
 
                     sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }


### PR DESCRIPTION
Follow-up to https://github.com/Shopify/tapioca/pull/2103; it turns out you can send a nilable to `select`.

`QueryMethods#select`:

```ruby
> model.features.class
=> Feature::ActiveRecord_Associations_CollectionProxy
> model.features.select { nil }
=> []
```

`Enumerable#select`:

```ruby
> a = T.let([1, nil, 3], T::Array[T.nilable(Integer)])
>
> T.reveal_type(a)
>
* a.select do |num|
*   num.to_c
> end
=> [1, nil, 3]
```
