### PR TITLE
ActiveRecord `select` block returns `BasicObject`

### DIFF
--- a/lib/tapioca/dsl/compilers/active_record_relations.rb
+++ b/lib/tapioca/dsl/compilers/active_record_relations.rb
@@ -597,7 +597,7 @@ module Tapioca
                     sig.return_type = mod == relation_methods_module ? RelationClassName : AssociationRelationClassName
                   end
                   method.add_sig do |sig|
-                    sig.add_param("blk", "T.proc.params(record: #{constant_name}).returns(T::Boolean)")
+                    sig.add_param("blk", "T.proc.params(record: #{constant_name}).returns(BasicObject)")
                     sig.return_type = "T::Array[#{constant_name}]"
                   end
                 end

--- a/spec/tapioca/dsl/compilers/active_record_relations_spec.rb
+++ b/spec/tapioca/dsl/compilers/active_record_relations_spec.rb
@@ -433,7 +433,7 @@ module Tapioca
                     def rewhere(*args, &blk); end
 
                     sig { params(args: T.untyped).returns(PrivateAssociationRelation) }
-                    sig { params(blk: T.proc.params(record: ::Post).returns(T::Boolean)).returns(T::Array[::Post]) }
+                    sig { params(blk: T.proc.params(record: ::Post).returns(BasicObject)).returns(T::Array[::Post]) }
                     def select(*args, &blk); end
 
                     sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
@@ -594,7 +594,7 @@ module Tapioca
                     def rewhere(*args, &blk); end
 
                     sig { params(args: T.untyped).returns(PrivateRelation) }
-                    sig { params(blk: T.proc.params(record: ::Post).returns(T::Boolean)).returns(T::Array[::Post]) }
+                    sig { params(blk: T.proc.params(record: ::Post).returns(BasicObject)).returns(T::Array[::Post]) }
                     def select(*args, &blk); end
 
                     sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
@@ -1159,7 +1159,7 @@ module Tapioca
                     def rewhere(*args, &blk); end
 
                     sig { params(args: T.untyped).returns(PrivateAssociationRelation) }
-                    sig { params(blk: T.proc.params(record: ::Post).returns(T::Boolean)).returns(T::Array[::Post]) }
+                    sig { params(blk: T.proc.params(record: ::Post).returns(BasicObject)).returns(T::Array[::Post]) }
                     def select(*args, &blk); end
 
                     sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
@@ -1320,7 +1320,7 @@ module Tapioca
                     def rewhere(*args, &blk); end
 
                     sig { params(args: T.untyped).returns(PrivateRelation) }
-                    sig { params(blk: T.proc.params(record: ::Post).returns(T::Boolean)).returns(T::Array[::Post]) }
+                    sig { params(blk: T.proc.params(record: ::Post).returns(BasicObject)).returns(T::Array[::Post]) }
                     def select(*args, &blk); end
 
                     sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }


### PR DESCRIPTION
### Motivation

This change matches the block return value to that of the [sig](https://github.com/sorbet/sorbet/blob/104d0cee5299e5cb19c731945f5a52634b78951b/rbi/core/array.rbi#L2304) on `Array#select`.

In practice, updating our large Rails app surfaced many violations of this sig that would cause (in my opinion) undesirable code changes in order to satisfy the `T::Boolean` return type. It does seem quite historically idiomatic for Ruby code to rely on the implicit truthiness/falsiness check, rather than coerce it explicitly.

### Implementation

Continuing the original [implementation](https://github.com/Shopify/tapioca/pull/2103), this is just a change to the return type of the block sig.

### Tests

Existing tests are updated to reflect this change and seem to have sufficient coverage.