### PR TITLE
Active Support `Module#delegate` DSL

### DIFF
--- a/lib/tapioca/dsl/compilers/delegate.rb
+++ b/lib/tapioca/dsl/compilers/delegate.rb
@@ -106,7 +106,6 @@ module Tapioca
         class UntypedDelegate < StandardError; end
 
         class DelegateMethod
-          include RBIHelper
           include Runtime::Reflection
           extend Runtime::Reflection
 

--- a/lib/tapioca/dsl/compilers/delegate.rb
+++ b/lib/tapioca/dsl/compilers/delegate.rb
@@ -1,0 +1,133 @@
+# typed: true
+# frozen_string_literal: true
+
+return unless Module.respond_to?(:delegate)
+
+require "tapioca/dsl/extensions/delegate"
+
+module Tapioca
+  module Dsl
+    module Compilers
+      # `Tapioca::Dsl::Compilers::Delegate` generates RBI files for classes that use the `delegate` method
+      # from ActiveSupport.
+      #
+      # For a class like:
+      #
+      # ```ruby
+      # class Delegator
+      #  sig { returns(Target) }
+      #  attr_reader :target
+      #
+      #  delegate :method, to: :target
+      # end
+      #
+      # class Target
+      #  sig { returns(String) }
+      #  def method = "hi"
+      # end
+      # ```
+      #
+      # This compiler will generate the following RBI file:
+      #
+      # ```rbi
+      # class Delegator
+      #  sig { returns(Target) }
+      #  attr_reader :target
+      #
+      #  sig { returns(String) }
+      #  def method; end
+      # end
+      # ```
+      #
+      # The `delegate` method can also take the `prefix`, `private` and `allow_nil` options but is not intelligent
+      # about discovering types from instance variables, class_variables and constants - if you delegate to a target
+      # whose type is not discoverable statically, the type will default to T.untyped
+      #
+      # Delegates that _themselves_ return a `T.untyped` value will not be generated in the RBI file, since Sorbet
+      # already generates a `T.untyped` return by default
+      #
+      class Delegate < Compiler
+        extend T::Sig
+
+        ConstantType = type_member { { fixed: T.all(::Module, Extensions::Module) } }
+
+        class << self
+          extend T::Sig
+
+          sig { override.returns(T::Enumerable[::Module]) }
+          def gather_constants
+            all_classes.select do |c|
+              c.singleton_class < Tapioca::Dsl::Compilers::Extensions::Module &&
+                T.unsafe(c).__tapioca_delegated_methods.any?
+            end
+          end
+        end
+
+        sig { override.void }
+        def decorate
+          root.create_path(constant) do |klass|
+            constant.__tapioca_delegated_methods.each do |delegated_method|
+              delegated_method[:methods].each do |method|
+                next if delegated_method[:to].to_s.match?(/^[@$]/)
+
+                constant_target = if delegated_method[:to] == :class
+                  constant
+                elsif delegated_method[:to].to_s.match?(/^[A-Z]/)
+                  target_klass = constant.const_get(delegated_method[:to])
+                  next unless target_klass.is_a?(Module)
+
+                  target_klass
+                else
+                  false
+                end
+
+                sig = if constant_target
+                  signature_of(constant_target.singleton_method(method))
+                else
+                  signature_of(constant.instance_method(delegated_method[:to]))
+                end
+
+                delegate_klass = if delegated_method[:allow_nil]
+                  sig.return_type.unwrap_nilable.raw_type
+                else
+                  sig.return_type.raw_type
+                end
+
+                next if delegate_klass == T.untyped
+
+                visibility = if delegated_method[:private]
+                  RBI::Private.new
+                else
+                  RBI::Public.new
+                end
+
+                method_def = if constant_target
+                  constant_target.singleton_method(method)
+                else
+                  delegate_klass.instance_method(method)
+                end
+
+                method_name = [delegated_method[:prefix], method.name.to_s].compact.join("_")
+
+                method_return_type = if delegated_method[:allow_nil]
+                  non_nilable = compile_method_return_type_to_rbi(method_def)
+                  "T.nilable(#{non_nilable})"
+                else
+                  compile_method_return_type_to_rbi(method_def)
+                end
+
+                klass.create_method(
+                  method_name,
+                  parameters: compile_method_parameters_to_rbi(method_def),
+                  return_type: method_return_type,
+                  class_method: false,
+                  visibility: visibility,
+                )
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/tapioca/dsl/compilers/delegate.rb
+++ b/lib/tapioca/dsl/compilers/delegate.rb
@@ -56,6 +56,8 @@ module Tapioca
 
           sig { override.returns(T::Enumerable[::Module]) }
           def gather_constants
+            return [] unless defined?(Tapioca::Dsl::Compilers::Extensions::Module)
+
             all_classes.select do |c|
               c.singleton_class < Tapioca::Dsl::Compilers::Extensions::Module &&
                 T.unsafe(c).__tapioca_delegated_methods.any?
@@ -86,6 +88,8 @@ module Tapioca
                 else
                   signature_of(constant.instance_method(delegated_method[:to]))
                 end
+
+                next unless sig
 
                 delegate_klass = if delegated_method[:allow_nil]
                   sig.return_type.unwrap_nilable.raw_type

--- a/lib/tapioca/dsl/extensions/delegate.rb
+++ b/lib/tapioca/dsl/extensions/delegate.rb
@@ -7,8 +7,6 @@ rescue LoadError
   return
 end
 
-return unless Module.respond_to?(:delegate)
-
 module Tapioca
   module Dsl
     module Compilers

--- a/lib/tapioca/dsl/extensions/delegate.rb
+++ b/lib/tapioca/dsl/extensions/delegate.rb
@@ -1,0 +1,42 @@
+# typed: true
+# frozen_string_literal: true
+
+begin
+  require "active_support"
+rescue LoadError
+  return
+end
+
+return unless Module.respond_to?(:delegate)
+
+module Tapioca
+  module Dsl
+    module Compilers
+      module Extensions
+        module Module
+          def __tapioca_delegated_methods
+            @__tapioca_delegated_methods ||= []
+          rescue FrozenError
+            # Some classes are frozen - so we can't define instance variables on them
+            # In that case, we'll just give up
+            []
+          end
+
+          def delegate(*methods, to:, prefix: nil, allow_nil: nil, private: false)
+            __tapioca_delegated_methods << {
+              methods: methods,
+              to: to,
+              prefix: prefix,
+              allow_nil: allow_nil,
+              private: private,
+            }
+
+            super
+          end
+
+          ::Module.prepend(self)
+        end
+      end
+    end
+  end
+end

--- a/manual/compiler_delegate.md
+++ b/manual/compiler_delegate.md
@@ -1,0 +1,39 @@
+## Delegate
+
+`Tapioca::Dsl::Compilers::Delegate` generates RBI files for classes that use the `delegate` method
+from ActiveSupport.
+
+For a class like:
+
+```ruby
+class Delegator
+ sig { returns(Target) }
+ attr_reader :target
+
+ delegate :method, to: :target
+end
+
+class Target
+ sig { returns(String) }
+ def method = "hi"
+end
+```
+
+This compiler will generate the following RBI file:
+
+```rbi
+class Delegator
+ sig { returns(Target) }
+ attr_reader :target
+
+ sig { returns(String) }
+ def method; end
+end
+```
+
+The `delegate` method can also take the `prefix`, `private` and `allow_nil` options but is not intelligent
+about discovering types from instance variables, class_variables and constants - if you delegate to a target
+whose type is not discoverable statically, the type will default to T.untyped
+
+Delegates that _themselves_ return a `T.untyped` value will not be generated in the RBI file, since Sorbet
+already generates a `T.untyped` return by default

--- a/manual/compilers.md
+++ b/manual/compilers.md
@@ -27,6 +27,7 @@ In the following section you will find all available DSL compilers:
 * [ActiveSupportCurrentAttributes](compiler_activesupportcurrentattributes.md)
 * [ActiveSupportTimeExt](compiler_activesupporttimeext.md)
 * [Config](compiler_config.md)
+* [Delegate](compiler_delegate.md)
 * [FrozenRecord](compiler_frozenrecord.md)
 * [GraphqlInputObject](compiler_graphqlinputobject.md)
 * [GraphqlMutation](compiler_graphqlmutation.md)

--- a/spec/tapioca/cli/dsl_spec.rb
+++ b/spec/tapioca/cli/dsl_spec.rb
@@ -2847,6 +2847,7 @@ module Tapioca
               Tapioca::Dsl::Compilers::ActiveRecordStore                   enabled
               Tapioca::Dsl::Compilers::ActiveSupportConcern                enabled
               Tapioca::Dsl::Compilers::ActiveSupportCurrentAttributes      enabled
+              Tapioca::Dsl::Compilers::Delegate                            enabled
               Tapioca::Dsl::Compilers::MixedInClassAttributes              enabled
               Tapioca::Dsl::Compilers::SidekiqWorker                       enabled
               Tapioca::Dsl::Compilers::SmartProperties                     enabled
@@ -2882,6 +2883,7 @@ module Tapioca
               Tapioca::Dsl::Compilers::ActiveRecordStore                   enabled
               Tapioca::Dsl::Compilers::ActiveSupportConcern                enabled
               Tapioca::Dsl::Compilers::ActiveSupportCurrentAttributes      enabled
+              Tapioca::Dsl::Compilers::Delegate                            enabled
               Tapioca::Dsl::Compilers::MixedInClassAttributes              enabled
               Tapioca::Dsl::Compilers::SidekiqWorker                       enabled
               Tapioca::Dsl::Compilers::SmartProperties                     disabled
@@ -2917,6 +2919,7 @@ module Tapioca
               Tapioca::Dsl::Compilers::ActiveRecordStore                   disabled
               Tapioca::Dsl::Compilers::ActiveSupportConcern                disabled
               Tapioca::Dsl::Compilers::ActiveSupportCurrentAttributes      disabled
+              Tapioca::Dsl::Compilers::Delegate                            disabled
               Tapioca::Dsl::Compilers::MixedInClassAttributes              disabled
               Tapioca::Dsl::Compilers::SidekiqWorker                       disabled
               Tapioca::Dsl::Compilers::SmartProperties                     enabled

--- a/spec/tapioca/dsl/compilers/delegate_spec.rb
+++ b/spec/tapioca/dsl/compilers/delegate_spec.rb
@@ -155,12 +155,23 @@ module Tapioca
                   def string_method; end
                 end
 
+                class OtherTarget
+                  extend T::Sig
+
+                  sig { params(step: Integer).returns(Integer) }
+                  def echo_integer(step); step; end
+                end
+
                 class Delegate
                   extend T::Sig
                   sig { returns(Target) }
                   attr_reader :target
 
+                  sig { returns(OtherTarget) }
+                  attr_reader :other_target
+
                   delegate :string_method, to: :target, prefix: "target"
+                  delegate :echo_integer, to: :other_target, prefix: true
                 end
               RUBY
 
@@ -168,6 +179,9 @@ module Tapioca
                 # typed: strong
 
                 class Delegate
+                  sig { params(step: ::Integer).returns(::Integer) }
+                  def other_target_echo_integer(step); end
+
                   sig { returns(::String) }
                   def target_string_method; end
                 end

--- a/spec/tapioca/dsl/compilers/delegate_spec.rb
+++ b/spec/tapioca/dsl/compilers/delegate_spec.rb
@@ -1,0 +1,329 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Tapioca
+  module Dsl
+    module Compilers
+      class DelegateSpec < ::DslSpec
+        describe "Tapoca::Dsl::Compilers::Delegate" do
+          sig { void }
+          def before_setup
+            require "tapioca/dsl/extensions/delegate"
+            require "active_support/core_ext/module/delegation"
+          end
+
+          describe "initialize" do
+            it "gathers any module that includes a call to `delegate`" do
+              add_ruby_file("content.rb", <<~RUBY)
+                class Delegate
+                  delegate :method, to: :target
+                end
+              RUBY
+
+              assert_equal(["Delegate"], gathered_constants)
+            end
+          end
+
+          describe "decorate" do
+            it "generates correct RBI for a simple delegation" do
+              add_ruby_file("content.rb", <<~RUBY)
+                class Target
+                  extend T::Sig
+
+                  sig { params(int: Integer).returns(Integer) }
+                  def param_method(int) = int
+
+                  sig { returns(String) }
+                  attr_reader :string_method
+
+                  sig { void }
+                  def void_method; end
+                end
+
+                class Delegate
+                  extend T::Sig
+
+                  sig { returns(Target) }
+                  attr_reader :target
+
+                  delegate :param_method, :string_method, :void_method, to: :target
+                end
+              RUBY
+
+              expected = <<~RBI
+                # typed: strong
+
+                class Delegate
+                  sig { params(int: ::Integer).returns(::Integer) }
+                  def param_method(int); end
+
+                  sig { returns(::String) }
+                  def string_method; end
+
+                  sig { void }
+                  def void_method; end
+                end
+              RBI
+
+              assert_equal(expected, rbi_for(:Delegate))
+            end
+
+            it "generates correct RBI for multiple delegations" do
+              add_ruby_file("content.rb", <<~RUBY)
+                class Target
+                  extend T::Sig
+
+                  sig { returns(String) }
+                  attr_reader :string_method
+                end
+
+                class Target2
+                  extend T::Sig
+                  sig { returns(Integer) }
+                  attr_reader :int_method
+                end
+
+                class Delegate
+                  extend T::Sig
+
+                  sig { returns(Target) }
+                  attr_reader :target
+
+                  sig { returns(Target2) }
+                  attr_reader :target2
+
+                  delegate :string_method, to: :target
+                  delegate :int_method, to: :target2
+                end
+              RUBY
+
+              expected = <<~RBI
+                # typed: strong
+
+                class Delegate
+                  sig { returns(::Integer) }
+                  def int_method; end
+
+                  sig { returns(::String) }
+                  def string_method; end
+                end
+              RBI
+
+              assert_equal(expected, rbi_for(:Delegate))
+            end
+
+            it "places private delegates in the private section" do
+              add_ruby_file("content.rb", <<~RUBY)
+                class Target
+                  extend T::Sig
+
+                  sig { returns(String) }
+                  def string_method; end
+                end
+
+                class Delegate
+                  extend T::Sig
+                  sig { returns(Target) }
+                  attr_reader :target
+
+                  delegate :string_method, to: :target, private: true
+                end
+              RUBY
+
+              expected = <<~RBI
+                # typed: strong
+
+                class Delegate
+                  private
+
+                  sig { returns(::String) }
+                  def string_method; end
+                end
+              RBI
+
+              assert_equal(expected, rbi_for(:Delegate))
+            end
+
+            it "generates correct RBI for a delegation with prefix" do
+              add_ruby_file("content.rb", <<~RUBY)
+                class Target
+                  extend T::Sig
+
+                  sig { returns(String) }
+                  def string_method; end
+                end
+
+                class Delegate
+                  extend T::Sig
+                  sig { returns(Target) }
+                  attr_reader :target
+
+                  delegate :string_method, to: :target, prefix: "target"
+                end
+              RUBY
+
+              expected = <<~RBI
+                # typed: strong
+
+                class Delegate
+                  sig { returns(::String) }
+                  def target_string_method; end
+                end
+              RBI
+
+              assert_equal(expected, rbi_for(:Delegate))
+            end
+
+            it "generates correct RBI for delegation with allow_nil" do
+              add_ruby_file("content.rb", <<~RUBY)
+                class Target
+                  extend T::Sig
+
+                  sig { returns(String) }
+                  def string_method; end
+                end
+
+                class Delegate
+                  extend T::Sig
+                  sig { returns(T.nilable(Target)) }
+                  attr_reader :target
+
+                  delegate :string_method, to: :target, allow_nil: true
+                end
+              RUBY
+
+              expected = <<~RBI
+                # typed: strong
+
+                class Delegate
+                  sig { returns(T.nilable(::String)) }
+                  def string_method; end
+                end
+              RBI
+
+              assert_equal(expected, rbi_for(:Delegate))
+            end
+
+            it "does not generate RBI for delegations to non-statically typed objects" do
+              add_ruby_file("content.rb", <<~RUBY)
+                class Delegate
+                  extend T::Sig
+
+                  @@string = T.let("world", String)
+
+                  CONSTANT = T.let(1, Integer)
+
+                  delegate :string_method, to: :@target
+                  delegate :size, to: :@@string
+                  delegate :succ, to: :CONSTANT
+
+                  def initialize
+                    @target = Target.new
+                  end
+                end
+              RUBY
+
+              expected = <<~RBI
+                # typed: strong
+
+                class Delegate; end
+              RBI
+
+              assert_equal(expected, rbi_for(:Delegate))
+            end
+
+            it "generates correct RBI for delegations to it's own class" do
+              add_ruby_file("content.rb", <<~RUBY)
+                class Delegate
+                  extend T::Sig
+
+                  class << self
+                    extend T::Sig
+
+                    sig { returns(String) }
+                    def string_method; end
+                  end
+
+                  delegate :string_method, to: :class
+                end
+              RUBY
+
+              expected = <<~RBI
+                # typed: strong
+
+                class Delegate
+                  sig { returns(::String) }
+                  def string_method; end
+                end
+              RBI
+
+              assert_equal(expected, rbi_for(:Delegate))
+            end
+
+            it "generates correct RBI for delegations to singleton methods of other classes" do
+              add_ruby_file("content.rb", <<~RUBY)
+                class Target
+                  extend T::Sig
+
+                  sig { returns(String) }
+                  def self.string_method; end
+                end
+
+                class Delegate
+                  extend T::Sig
+
+                  delegate :string_method, to: :Target
+                end
+              RUBY
+
+              expected = <<~RBI
+                # typed: strong
+
+                class Delegate
+                  sig { returns(::String) }
+                  def string_method; end
+                end
+              RBI
+
+              assert_equal(expected, rbi_for(:Delegate))
+            end
+
+            it "generates untyped delegates if the type of the target is untyped" do
+              add_ruby_file("content.rb", <<~RUBY)
+                class Target
+                  def param_method(int) = int
+                  def string_method; end
+                end
+
+                class Delegate
+                  extend T::Sig
+
+                  sig { returns(Target) }
+                  attr_reader :target
+
+                  delegate :string_method, :param_method, to: :target
+                end
+              RUBY
+
+              expected = <<~RBI
+                # typed: strong
+
+                class Delegate
+                  sig { params(int: T.untyped).returns(T.untyped) }
+                  def param_method(int); end
+
+                  sig { returns(T.untyped) }
+                  def string_method; end
+                end
+              RBI
+
+              assert_equal(expected, rbi_for(:Delegate))
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Motivation

When using ActiveSupport `Module` gains a `delegate` method that creates methods delegated to targets - very much like Stdlib's `Forwardable` module.   Unfortunately - Sorbet does not understand either `delegate` or `Forwardable` and all delegated methods return `T.untyped` - even if the delegate can be statically analyzed.   In order to retain typing information, you need to implement "stub" methods like `def delegated = target.delegated`: this actually runs afoul of Rubocop style guidelines (the Ruby/Delegate cop.)

Because`Module#delegate` actually creates methods on the receiver class, it's fairly straightforward to put these generated methods into an RBI file and get typing support for methods called through delegation. 

### Implementation

The meta-programming done by `Module#delegate` doesn't leave any _obvious_ markers on the method - so we prepend an override for `delegate` to Module so that we can both detect Classes which contain delegation as well as keep track of which methods have been delegated and to where.

Perfect typing is not a goal - so we only do the lowest hanging fruit of the DSL:  methods delegated to either other methods within the receiving class, or to other classes.   AFAICT it's not possible to determine the type of instance variables or non-class constants without executing the method bodies or re-parsing the source code.   That's a little bit extra - so if you attempt to delegate to a class, meta-programmed method, or runtime-only value - the DSL will not generate a method stub in the RBI file.

The `delegate` method has a number of different behaviors like `allow_nil` and `prefix` - which are covered by the DSL and shown in the tests.   The same ActiveSupport extension _also_ defines `delegate_missing_to` - which delegates all methods not responded to by a receiver to a given target.   `method_missing` shenanigans are poorly supported by Sorbet - so rather than hack "support" for this in via RBI files, we'll [leave it to Sorbet to support](https://github.com/sorbet/sorbet/issues/8129)

### Tests

Tests are completed - additional thoughts about uncovered cases are welcome!