### PR TITLE
Update active record relations DSL count to accept a block argument

### DIFF
--- a/lib/tapioca/dsl/compilers/active_record_relations.rb
+++ b/lib/tapioca/dsl/compilers/active_record_relations.rb
@@ -402,6 +402,7 @@ module Tapioca
                 "count",
                 parameters: [
                   create_opt_param("column_name", type: "T.untyped", default: "nil"),
+                  create_block_param("block", type: "T.nilable(T.proc.params(record: T.untyped).returns(T.untyped))"),
                 ],
                 return_type: "T::Hash[T.untyped, Integer]",
               )

--- a/spec/tapioca/dsl/compilers/active_record_relations_spec.rb
+++ b/spec/tapioca/dsl/compilers/active_record_relations_spec.rb
@@ -648,8 +648,8 @@ module Tapioca
                     sig { params(operation: Symbol, column_name: T.any(String, Symbol)).returns(T::Hash[T.untyped, T.any(Integer, Float, BigDecimal)]) }
                     def calculate(operation, column_name); end
 
-                    sig { params(column_name: T.untyped).returns(T::Hash[T.untyped, Integer]) }
-                    def count(column_name = nil); end
+                    sig { params(column_name: T.untyped, block: T.nilable(T.proc.params(record: T.untyped).returns(T.untyped))).returns(T::Hash[T.untyped, Integer]) }
+                    def count(column_name = nil, &block); end
 
                     sig { params(args: T.untyped, blk: T.untyped).returns(T.self_type) }
                     def having(*args, &blk); end
@@ -753,8 +753,8 @@ module Tapioca
                     sig { params(operation: Symbol, column_name: T.any(String, Symbol)).returns(T::Hash[T.untyped, T.any(Integer, Float, BigDecimal)]) }
                     def calculate(operation, column_name); end
 
-                    sig { params(column_name: T.untyped).returns(T::Hash[T.untyped, Integer]) }
-                    def count(column_name = nil); end
+                    sig { params(column_name: T.untyped, block: T.nilable(T.proc.params(record: T.untyped).returns(T.untyped))).returns(T::Hash[T.untyped, Integer]) }
+                    def count(column_name = nil, &block); end
 
                     sig { params(args: T.untyped, blk: T.untyped).returns(T.self_type) }
                     def having(*args, &blk); end
@@ -1374,8 +1374,8 @@ module Tapioca
                     sig { params(operation: Symbol, column_name: T.any(String, Symbol)).returns(T::Hash[T.untyped, T.any(Integer, Float, BigDecimal)]) }
                     def calculate(operation, column_name); end
 
-                    sig { params(column_name: T.untyped).returns(T::Hash[T.untyped, Integer]) }
-                    def count(column_name = nil); end
+                    sig { params(column_name: T.untyped, block: T.nilable(T.proc.params(record: T.untyped).returns(T.untyped))).returns(T::Hash[T.untyped, Integer]) }
+                    def count(column_name = nil, &block); end
 
                     sig { params(args: T.untyped, blk: T.untyped).returns(T.self_type) }
                     def having(*args, &blk); end
@@ -1479,8 +1479,8 @@ module Tapioca
                     sig { params(operation: Symbol, column_name: T.any(String, Symbol)).returns(T::Hash[T.untyped, T.any(Integer, Float, BigDecimal)]) }
                     def calculate(operation, column_name); end
 
-                    sig { params(column_name: T.untyped).returns(T::Hash[T.untyped, Integer]) }
-                    def count(column_name = nil); end
+                    sig { params(column_name: T.untyped, block: T.nilable(T.proc.params(record: T.untyped).returns(T.untyped))).returns(T::Hash[T.untyped, Integer]) }
+                    def count(column_name = nil, &block); end
 
                     sig { params(args: T.untyped, blk: T.untyped).returns(T.self_type) }
                     def having(*args, &blk); end


### PR DESCRIPTION
### Motivation

While working on a Rails application, I have code that is of the format `Model.count {|m| m.foo_relation.boolean?}`.

I don't want to write this as `.select{}.count` as that would violate the [Rubocop::Cop::Performance::Cop](https://github.com/rubocop/rubocop-performance/blob/master/lib/rubocop/cop/performance/count.rb#L6-L48)

The fix is to update the type signatures DSL for active record relations to allow `count` to accept an optional block argument.

see https://edgeapi.rubyonrails.org/classes/ActiveRecord/Calculations.html#method-i-count

### Implementation

Added to a `create_block_param` call for active record relations `count` method, `lib/tapioca/dsl/compilers/active_record_relations.rb`

### Tests

Updated existing tests for active record relations `count` method to accept an optional block parameter.