### PR TITLE
[Tapioca Add-on] Trigger `ActiveSupport::TestCase` DSL compiler on fixture changes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ gem "rubocop-shopify"
 gem "rubocop-sorbet", ">= 0.4.1"
 gem "rubocop-rspec" # useful even though we use minitest/spec
 gem "ruby-lsp", ">= 0.23.1"
-gem "ruby-lsp-rails", ">= 0.3.28"
+gem "ruby-lsp-rails", ">= 0.3.31"
 
 group :deployment, :development do
   gem "rake"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -402,7 +402,7 @@ DEPENDENCIES
   rubocop-shopify
   rubocop-sorbet (>= 0.4.1)
   ruby-lsp (>= 0.23.1)
-  ruby-lsp-rails (>= 0.3.28)
+  ruby-lsp-rails (>= 0.3.31)
   shopify-money
   sidekiq
   smart_properties

--- a/lib/ruby_lsp/tapioca/server_addon.rb
+++ b/lib/ruby_lsp/tapioca/server_addon.rb
@@ -3,6 +3,7 @@
 
 require "tapioca/internal"
 require "tapioca/dsl/compilers/url_helpers"
+require "tapioca/dsl/compilers/active_record_fixtures"
 
 module RubyLsp
   module Tapioca
@@ -28,6 +29,11 @@ module RubyLsp
           fork do
             constants = ::Tapioca::Dsl::Compilers::UrlHelpers.gather_constants
             dsl(constants.map(&:name), "--only=Tapioca::Dsl::Compilers::UrlHelpers", "ActiveSupportConcern")
+          end
+        when "fixtures_dsl"
+          fork do
+            constants = ::Tapioca::Dsl::Compilers::ActiveRecordFixtures.gather_constants
+            dsl(constants.map(&:name), "--only=Tapioca::Dsl::Compilers::ActiveRecordFixtures")
           end
         end
       end

--- a/spec/dummy/app/models/user.rb
+++ b/spec/dummy/app/models/user.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class User < ActiveRecord::Base
+end

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -6,6 +6,7 @@ require "bundler/setup" if File.exist?(ENV["BUNDLE_GEMFILE"])
 $LOAD_PATH.unshift(File.expand_path("../../../lib", __dir__))
 
 require "rails" # minimal, instead of "rails/all"
+require "active_record/railtie" # need for testing fixtures
 require "active_job/railtie"
 
 Bundler.require(*Rails.groups)

--- a/spec/dummy/config/database.yml
+++ b/spec/dummy/config/database.yml
@@ -1,0 +1,5 @@
+development:
+  adapter: sqlite3
+  pool: 5
+  timeout: 5000
+  database: ":memory:"


### PR DESCRIPTION
Addresses https://github.com/Shopify/team-ruby-dx/issues/1305

TODO:

- [x] Point to ruby-lsp-rails once released (and update RBI)
- [ ] ~Verify performance in Core~

Note: This doesn't work on Core because the fixtures is compiler is disabled and Core uses a custom compiler.