### PR TITLE
Upgrade Rails add-on to v0.3.31

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -313,7 +313,7 @@ GEM
       prism (>= 1.2, < 2.0)
       rbs (>= 3, < 4)
       sorbet-runtime (>= 0.5.10782)
-    ruby-lsp-rails (0.3.30)
+    ruby-lsp-rails (0.3.31)
       ruby-lsp (>= 0.23.0, < 0.24.0)
     ruby-progressbar (1.13.0)
     securerandom (0.4.0)

--- a/sorbet/rbi/gems/ruby-lsp-rails@0.3.31.rbi
+++ b/sorbet/rbi/gems/ruby-lsp-rails@0.3.31.rbi
@@ -120,7 +120,11 @@ class RubyLsp::Rails::Addon < ::RubyLsp::Addon
   sig { params(id: ::String).void }
   def end_progress(id); end
 
-  # source://ruby-lsp-rails/lib/ruby_lsp/ruby_lsp_rails/addon.rb#240
+  # source://ruby-lsp-rails/lib/ruby_lsp/ruby_lsp_rails/addon.rb#243
+  sig { returns(::LanguageServer::Protocol::Interface::FileSystemWatcher) }
+  def fixture_file_watcher; end
+
+  # source://ruby-lsp-rails/lib/ruby_lsp/ruby_lsp_rails/addon.rb#251
   sig { void }
   def offer_to_run_pending_migrations; end
 
@@ -131,6 +135,10 @@ class RubyLsp::Rails::Addon < ::RubyLsp::Addon
   # source://ruby-lsp-rails/lib/ruby_lsp/ruby_lsp_rails/addon.rb#200
   sig { params(id: ::String, percentage: T.nilable(::Integer), message: T.nilable(::String)).void }
   def report_progress(id, percentage: T.unsafe(nil), message: T.unsafe(nil)); end
+
+  # source://ruby-lsp-rails/lib/ruby_lsp/ruby_lsp_rails/addon.rb#235
+  sig { returns(::LanguageServer::Protocol::Interface::FileSystemWatcher) }
+  def structure_sql_file_watcher; end
 end
 
 # source://ruby-lsp-rails/lib/ruby_lsp/ruby_lsp_rails/addon.rb#24


### PR DESCRIPTION
### Motivation

Upgrade to the latest Rails add-on so that we can get the fixture watching registration. 

There's no need to bump our minimum requirement though. If watching fixtures is not registered, we will simply not receive any notifications for it.

### Implementation

`bundle update ruby-lsp-rails && bin/tapioca gem`