### PR TITLE
Avoid naming conflict for `URI::Source`

### DIFF
--- a/lib/tapioca/gem/listeners/source_location.rb
+++ b/lib/tapioca/gem/listeners/source_location.rb
@@ -57,7 +57,7 @@ module Tapioca
           # we can clear the gem version if the gem is the same one we are processing
           version = "" if gem == @pipeline.gem
 
-          uri = URI::Source.build(
+          uri = SourceURI.build(
             gem_name: gem.name,
             gem_version: version,
             path: path.to_s,

--- a/lib/tapioca/helpers/source_uri.rb
+++ b/lib/tapioca/helpers/source_uri.rb
@@ -3,8 +3,8 @@
 
 require "uri/file"
 
-module URI
-  class Source < URI::File
+module Tapioca
+  class SourceURI < URI::File
     extend T::Sig
 
     COMPONENT = T.let(
@@ -37,7 +37,7 @@ module URI
           gem_version: T.nilable(String),
           path: String,
           line_number: T.nilable(String),
-        ).returns(URI::Source)
+        ).returns(T.attached_class)
       end
       def build(gem_name:, gem_version:, path:, line_number:)
         super(


### PR DESCRIPTION
### Motivation

The implementation of `URI::Source` is shared between Tapioca and the Ruby LSP, but using the exact same name leads to weird conflicts and unnecessary warnings.

I propose we rename the class to `Tapioca::SourceURI`, just to avoid the conflict.

### Implementation

Rename the class and occurrences.

### Tests

There are no functional changes. Current tests should cover it.