### PR TITLE
Prevent CI from running on both `push` and `pull_request` events

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,10 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+    - main
+  pull_request:
 
 env:
   SRB_SKIP_GEM_RBIS: true


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
Duplicate CI runs waste resources

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
 Push events will only be triggered on `main`. As a result pushes to your branches without a PR will not trigger a build.
### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->

