### PR TITLE
Fix `chdir` issue for LSP

### DIFF
--- a/lib/ruby_lsp/tapioca/addon.rb
+++ b/lib/ruby_lsp/tapioca/addon.rb
@@ -153,7 +153,7 @@ module RubyLsp
 
       sig { void }
       def run_gem_rbi_check
-        gem_rbi_check = RunGemRbiCheck.new
+        gem_rbi_check = RunGemRbiCheck.new(T.must(@global_state).workspace_path)
         gem_rbi_check.run
 
         T.must(@outgoing_queue) << Notification.window_log_message(

--- a/spec/tapioca/ruby_lsp/run_gem_rbi_check_spec.rb
+++ b/spec/tapioca/ruby_lsp/run_gem_rbi_check_spec.rb
@@ -25,8 +25,8 @@ module Tapioca
           @project.require_mock_gem(foo)
 
           @project.bundle_install!
-          check = ::RubyLsp::Tapioca::RunGemRbiCheck.new
-          check.run(@project.absolute_path)
+          check = ::RubyLsp::Tapioca::RunGemRbiCheck.new(@project.absolute_path)
+          check.run
 
           assert check.stdout.include?("Not a git repository")
         end
@@ -55,8 +55,8 @@ module Tapioca
           @project.require_mock_gem(foo)
           @project.bundle_install!
 
-          check = ::RubyLsp::Tapioca::RunGemRbiCheck.new
-          check.run(@project.absolute_path)
+          check = ::RubyLsp::Tapioca::RunGemRbiCheck.new(@project.absolute_path)
+          check.run
 
           assert_project_file_exist("sorbet/rbi/gems/foo@0.0.1.rbi")
         end
@@ -68,8 +68,8 @@ module Tapioca
           @project.require_mock_gem(foo)
           @project.bundle_install!
 
-          check = ::RubyLsp::Tapioca::RunGemRbiCheck.new
-          check.run(@project.absolute_path)
+          check = ::RubyLsp::Tapioca::RunGemRbiCheck.new(@project.absolute_path)
+          check.run
 
           assert_project_file_exist("sorbet/rbi/gems/foo@0.0.1.rbi")
 
@@ -77,7 +77,7 @@ module Tapioca
           foo.update("0.0.2")
           @project.bundle_install!
 
-          check.run(@project.absolute_path)
+          check.run
 
           assert_project_file_exist("sorbet/rbi/gems/foo@0.0.2.rbi")
         end
@@ -89,15 +89,15 @@ module Tapioca
           @project.require_mock_gem(foo)
           @project.bundle_install!
 
-          check1 = ::RubyLsp::Tapioca::RunGemRbiCheck.new
-          check1.run(@project.absolute_path)
+          check1 = ::RubyLsp::Tapioca::RunGemRbiCheck.new(@project.absolute_path)
+          check1.run
 
           assert_project_file_exist("sorbet/rbi/gems/foo@0.0.1.rbi")
 
           @project.exec("git restore Gemfile Gemfile.lock")
 
-          check2 = ::RubyLsp::Tapioca::RunGemRbiCheck.new
-          check2.run(@project.absolute_path)
+          check2 = ::RubyLsp::Tapioca::RunGemRbiCheck.new(@project.absolute_path)
+          check2.run
 
           refute_project_file_exist("sorbet/rbi/gems/foo@0.0.1.rbi")
         end
@@ -110,8 +110,8 @@ module Tapioca
 
           assert_project_file_exist("/sorbet/rbi/gems/bar@0.0.1.rbi")
 
-          check = ::RubyLsp::Tapioca::RunGemRbiCheck.new
-          check.run(@project.absolute_path)
+          check = ::RubyLsp::Tapioca::RunGemRbiCheck.new(@project.absolute_path)
+          check.run
 
           refute_project_file_exist("sorbet/rbi/gems/bar@0.0.1.rbi")
         end
@@ -127,8 +127,8 @@ module Tapioca
 
           refute_project_file_exist("sorbet/rbi/gems/foo@0.0.1.rbi")
 
-          check = ::RubyLsp::Tapioca::RunGemRbiCheck.new
-          check.run(@project.absolute_path)
+          check = ::RubyLsp::Tapioca::RunGemRbiCheck.new(@project.absolute_path)
+          check.run
 
           assert_project_file_exist("sorbet/rbi/gems/foo@0.0.1.rbi")
 


### PR DESCRIPTION
### Motivation

After https://github.com/Shopify/tapioca/pull/2081, we began so to see an `Error loading add-ons: RuboCop: conflicting chdir during another chdir block`.

### Implementation

We don't want to run `chdir` since it may impact other things Ruby LSP is doing, since the path will be wrong.

### Tests

Updated.

@alexcrocha has verified on Core.
