### PR TITLE
LSP: Remove handling of removed gems on server

### DIFF
--- a/lib/ruby_lsp/tapioca/lockfile_diff_parser.rb
+++ b/lib/ruby_lsp/tapioca/lockfile_diff_parser.rb
@@ -9,17 +9,14 @@ module RubyLsp
       GEM_NAME_PATTERN = /[\w\-]+/
       DIFF_LINE_PATTERN = /[+-](.*#{GEM_NAME_PATTERN})\s*\(/
       ADDED_LINE_PATTERN = /^\+.*#{GEM_NAME_PATTERN} \(.*\)/
-      REMOVED_LINE_PATTERN = /^-.*#{GEM_NAME_PATTERN} \(.*\)/
 
       attr_reader :added_or_modified_gems
-      attr_reader :removed_gems
 
       def initialize(diff_content, direct_dependencies: nil)
         @diff_content = diff_content.lines
         @current_dependencies = direct_dependencies ||
           Bundler::LockfileParser.new(Bundler.default_lockfile.read).dependencies.keys
         @added_or_modified_gems = parse_added_or_modified_gems
-        @removed_gems = parse_removed_gems
       end
 
       private
@@ -28,17 +25,6 @@ module RubyLsp
         @diff_content
           .filter_map { |line| extract_gem(line) if line.match?(ADDED_LINE_PATTERN) }
           .uniq
-      end
-
-      def parse_removed_gems
-        @diff_content.filter_map do |line|
-          next unless line.match?(REMOVED_LINE_PATTERN)
-
-          gem = extract_gem(line)
-          next if @current_dependencies.include?(gem)
-
-          gem
-        end.uniq
       end
 
       def extract_gem(line)

--- a/lib/ruby_lsp/tapioca/run_gem_rbi_check.rb
+++ b/lib/ruby_lsp/tapioca/run_gem_rbi_check.rb
@@ -67,15 +67,12 @@ module RubyLsp
       sig { void }
       def generate_gem_rbis
         parser = Tapioca::LockfileDiffParser.new(@lockfile_diff)
-        removed_gems = parser.removed_gems
         added_or_modified_gems = parser.added_or_modified_gems
 
-        if added_or_modified_gems.any?
-          log_message("Identified lockfile changes, attempting to generate gem RBIs...")
-          execute_tapioca_gem_command(added_or_modified_gems)
-        elsif removed_gems.any?
-          remove_rbis(removed_gems)
-        end
+        return if added_or_modified_gems.none?
+
+        log_message("Identified lockfile changes, attempting to generate gem RBIs...")
+        execute_tapioca_gem_command(added_or_modified_gems)
       end
 
       sig { params(gems: T::Array[String]).void }

--- a/spec/tapioca/ruby_lsp/tapioca/lockfile_diff_parser_spec.rb
+++ b/spec/tapioca/ruby_lsp/tapioca/lockfile_diff_parser_spec.rb
@@ -27,49 +27,22 @@ module RubyLsp
         end
       end
 
-      describe "#parse_removed_gems" do
-        it "parses removed gems from git diff" do
-          diff_output = <<~DIFF
-            +    new_gem (1.0.0)
-            -    removed_gem (1.0.0)
-            -    outdated_gem (2.3.4)
-          DIFF
-
-          lockfile_parser = RubyLsp::Tapioca::LockfileDiffParser.new(diff_output)
-          assert_equal ["removed_gem", "outdated_gem"], lockfile_parser.removed_gems
-        end
-
-        it "ignores direct dependencies" do
-          diff_output = <<~DIFF
-            foo (1.1.1)
-            bar (1.2.3)
-            -    foo (> 0)
-          DIFF
-
-          lockfile_parser = RubyLsp::Tapioca::LockfileDiffParser.new(
-            diff_output,
-            direct_dependencies: ["foo"],
-          )
-          assert_empty lockfile_parser.removed_gems
-        end
-      end
-
       it "handles gem names with hyphens and underscores" do
         diff_output = <<~DIFF
-          -    my-gem_extra2 (1.0.0.beta1)
+          +    my-gem_extra2 (1.0.0.beta1)
         DIFF
 
         lockfile_parser = RubyLsp::Tapioca::LockfileDiffParser.new(diff_output)
-        assert_equal ["my-gem_extra2"], lockfile_parser.removed_gems
+        assert_equal ["my-gem_extra2"], lockfile_parser.added_or_modified_gems
       end
 
       it "handles gem names with multiple hyphens" do
         diff_output = <<~DIFF
-          -    sorbet-static-and-runtime (0.5.0)
+          +    sorbet-static-and-runtime (0.5.0)
         DIFF
 
         lockfile_parser = RubyLsp::Tapioca::LockfileDiffParser.new(diff_output)
-        assert_equal ["sorbet-static-and-runtime"], lockfile_parser.removed_gems
+        assert_equal ["sorbet-static-and-runtime"], lockfile_parser.added_or_modified_gems
       end
     end
   end


### PR DESCRIPTION
We've made some changes so that removed gems are detected by the 'orphaned' checks upon startup. That means we no longer need those checks in the server.