### PR TITLE
Introduce `addon_mode` ivar to Tapioca::Cli

### DIFF
--- a/lib/ruby_lsp/tapioca/server_addon.rb
+++ b/lib/ruby_lsp/tapioca/server_addon.rb
@@ -62,11 +62,13 @@ module RubyLsp
       def dsl(constants, *args)
         load("tapioca/cli.rb") # Reload the CLI to reset thor defaults between requests
 
+        ::Tapioca::Cli.addon_mode!
+
         # Order here is important to avoid having Thor confuse arguments. Do not put an array argument at the end before
         # the list of constants
         arguments = ["dsl"]
         arguments.concat(args)
-        arguments.push("--lsp_addon", "--workers=1")
+        arguments.push("--workers=1")
         arguments.concat(constants)
 
         ::Tapioca::Cli.start(arguments)

--- a/lib/tapioca/cli.rb
+++ b/lib/tapioca/cli.rb
@@ -143,11 +143,6 @@ module Tapioca
       type: :hash,
       desc: "Options to pass to the DSL compilers",
       default: {}
-    option :lsp_addon,
-      type: :boolean,
-      desc: "Generate DSL RBIs from the LSP add-on. Internal to Tapioca and not intended for end-users",
-      default: false,
-      hide: true
     def dsl(*constant_or_paths)
       set_environment(options)
 
@@ -170,7 +165,7 @@ module Tapioca
         app_root: options[:app_root],
         halt_upon_load_error: options[:halt_upon_load_error],
         compiler_options: options[:compiler_options],
-        lsp_addon: options[:lsp_addon],
+        lsp_addon: self.class.addon_mode,
       }
 
       command = if options[:verify]
@@ -379,9 +374,22 @@ module Tapioca
     end
 
     no_commands do
+      @addon_mode = false
+
       class << self
+        extend T::Sig
+
+        # Indicates that we are running from the LSP, set using the `addon_mode!` method
+        attr_reader :addon_mode
+
+        sig { void }
+        def addon_mode!
+          @addon_mode = true
+        end
+
+        sig { returns(T::Boolean) }
         def exit_on_failure?
-          true
+          !@addon_mode
         end
       end
     end


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
`exit_on_failure?` is used by [Thor](https://github.com/rails/thor/blob/3178667e1727504bf4fb693bf4ac74a5ca6c691e/lib/thor/base.rb#L587C24-L587C39) to exit the process upon observing a `Thor::Error`. Tapioca does raise `Thor::Error`, most notably when we can't find a specified constant during DSL generation. Killing the process prevents the [notification wrapper](https://github.com/Shopify/tapioca/blob/055d7a0ef9d595e7b117f507d982533ccf343079/lib/ruby_lsp/tapioca/server_addon.rb#L56-L60) from completing and users are stuck with a "Generating DSL RBIs" editor notification . 
### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
Introduce a new class instance variable that can be controlled by the tapioca add-on that'll determine the `exit_on_failure?` behaviour. This also means we can get rid of the CLI option on `dsl` method.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->
Tested manually
