### PR TITLE
Sort the gathered controller helper includes in dsl/compilers/action_controller_helpers.rb

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 /spec/reports/
 /tmp/
 /vendor/
+/.idea/

--- a/lib/tapioca/dsl/compilers/action_controller_helpers.rb
+++ b/lib/tapioca/dsl/compilers/action_controller_helpers.rb
@@ -156,7 +156,7 @@ module Tapioca
           mod.ancestors
             .reject { |ancestor| ancestor.is_a?(Class) || ancestor == mod || name_of(ancestor).nil? }
             .map { |ancestor| T.must(qualified_name_of(ancestor)) }
-            .reverse
+            .sort
         end
       end
     end


### PR DESCRIPTION
### Motivation

We run `tapioca dsl` as part of our CI process. We noticed that when we made a change to one Rails controller, we would sometimes get different include orderings being generated in completely unrelated controllers. The only thing that would change is the ordering of the helper `include`'s.

Tapioca should sort the gathered `include`'s so that the output is deterministic here.

I'm not sure about the initial motivation of doing the `reverse` here, is there any risk to making this change? Like, is there a reason the includes were ordered in this fashion to begin with? I believe the ordering is completely arbitrary; for our project, after making this change, there were a TON of RBI file updates, but `srb tc` still passed fine. So it seems like the ordering is arbitrary for our project, at least.

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->

Call `.sort` on the array of qualified names at the end of `def gather_includes(mod)`.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->

I have included a new test which sorts `Bravo/Alpha/Charlie` helpers to => `Alpha/Bravo/Charlie`.

---

Note: I'm using IntelliJ, and so I've also included a change to `.gitignore` to omit my editor's files. Please let me know if you need that to go into its own separate PR instead!