### PR TITLE
Raise `Thor::Error` instead of `exit`

### DIFF
--- a/lib/tapioca/commands/abstract_dsl.rb
+++ b/lib/tapioca/commands/abstract_dsl.rb
@@ -131,15 +131,22 @@ module Tapioca
 
       sig { returns(Tapioca::Dsl::Pipeline) }
       def create_pipeline
+        error_handler = if @lsp_addon
+          ->(error) {
+            say(error)
+          }
+        else
+          ->(error) {
+            say_error(error, :bold, :red)
+          }
+        end
         Tapioca::Dsl::Pipeline.new(
           requested_constants:
             constantize(@requested_constants) + constantize(constants_from_requested_paths, ignore_missing: true),
           requested_paths: @requested_paths,
           requested_compilers: constantize_compilers(@only),
           excluded_compilers: constantize_compilers(@exclude),
-          error_handler: ->(error) {
-            say_error(error, :bold, :red)
-          },
+          error_handler: error_handler,
           skipped_constants: constantize(@skip_constant, ignore_missing: true),
           number_of_workers: @number_of_workers,
           compiler_options: @compiler_options,

--- a/lib/tapioca/dsl/pipeline.rb
+++ b/lib/tapioca/dsl/pipeline.rb
@@ -78,6 +78,7 @@ module Tapioca
             No classes/modules can be matched for RBI generation.
             Please check that the requested classes/modules include processable DSL methods.
           ERROR
+          raise Thor::Error, ""
         end
 
         if defined?(::ActiveRecord::Base) && constants_to_process.any? { |c| ::ActiveRecord::Base > c }
@@ -94,8 +95,12 @@ module Tapioca
           blk.call(constant, rbi)
         end
 
-        errors.each do |msg|
-          report_error(msg)
+        if errors.any?
+          errors.each do |msg|
+            report_error(msg)
+          end
+
+          raise Thor::Error, ""
         end
 
         result.compact
@@ -216,11 +221,10 @@ module Tapioca
         file
       end
 
-      sig { params(error: String).returns(T.noreturn) }
+      sig { params(error: String).void }
       def report_error(error)
         handler = error_handler
         handler.call(error)
-        exit(1)
       end
 
       sig { void }

--- a/spec/tapioca/cli/dsl_spec.rb
+++ b/spec/tapioca/cli/dsl_spec.rb
@@ -101,7 +101,7 @@ module Tapioca
         it "must not generate a .gitattributes file if the output folder is not created" do
           result = @project.tapioca("dsl --outdir output")
 
-          assert_stderr_equals(<<~ERR, result)
+          assert_stderr_includes(result, <<~ERR)
             No classes/modules can be matched for RBI generation.
             Please check that the requested classes/modules include processable DSL methods.
           ERR
@@ -124,15 +124,14 @@ module Tapioca
 
           result = @project.tapioca("dsl")
 
-          assert_stdout_equals(<<~OUT, result)
+          assert_stdout_includes(result, <<~OUT)
             Loading DSL extension classes... Done
             Loading Rails application... Done
             Loading DSL compiler classes... Done
             Compiling DSL RBI files...
-
           OUT
 
-          assert_stderr_equals(<<~ERR, result)
+          assert_stderr_includes(result, <<~ERR)
             No classes/modules can be matched for RBI generation.
             Please check that the requested classes/modules include processable DSL methods.
           ERR
@@ -147,15 +146,14 @@ module Tapioca
 
           result = @project.tapioca("dsl User")
 
-          assert_stdout_equals(<<~OUT, result)
+          assert_stdout_includes(result, <<~OUT)
             Loading DSL extension classes... Done
             Loading Rails application... Done
             Loading DSL compiler classes... Done
             Compiling DSL RBI files...
-
           OUT
 
-          assert_stderr_equals(<<~ERR, result)
+          assert_stderr_includes(result, <<~ERR)
             No classes/modules can be matched for RBI generation.
             Please check that the requested classes/modules include processable DSL methods.
           ERR
@@ -922,15 +920,14 @@ module Tapioca
 
           result = @project.tapioca("dsl path/to/nowhere.rb")
 
-          assert_stdout_equals(<<~OUT, result)
+          assert_stdout_includes(result, <<~OUT)
             Loading DSL extension classes... Done
             Loading Rails application... Done
             Loading DSL compiler classes... Done
             Compiling DSL RBI files...
-
           OUT
 
-          assert_stderr_equals(<<~ERR, result)
+          assert_stderr_includes(result, <<~ERR)
             No classes/modules can be matched for RBI generation.
             Please check that the requested classes/modules include processable DSL methods.
           ERR


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
Exiting in add-on mode causes progress notifications to not be cleaned up

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
Raise a `Thor::Error` instead. It's rescued by thor and we control its behaviour using `exit_on_failure?` [here](https://github.com/Shopify/tapioca/blob/73381f35d990302e61822a32b709e598912d29db/lib/tapioca/cli.rb#L392)

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->

