### PR TITLE
Always reload routes in UrlHelpers

### DIFF
--- a/lib/tapioca/dsl/compilers/url_helpers.rb
+++ b/lib/tapioca/dsl/compilers/url_helpers.rb
@@ -102,9 +102,11 @@ module Tapioca
           def gather_constants
             return [] unless defined?(Rails.application) && Rails.application
 
-            # Load routes if they haven't been loaded yet (see https://github.com/rails/rails/pull/51614).
-            routes_reloader = Rails.application.routes_reloader
-            routes_reloader.execute_unless_loaded if routes_reloader&.respond_to?(:execute_unless_loaded)
+            # In rails 8, `Rails.application.routes_reloader.execute_unless_loaded`
+            # is not behaving as it did in Rails 7.
+            # With this workaround we force the routes to be reloaded regardless
+            # of whether they have been loaded or not
+            Rails.application.reload_routes!
 
             url_helpers_module = Rails.application.routes.named_routes.url_helpers_module
             path_helpers_module = Rails.application.routes.named_routes.path_helpers_module


### PR DESCRIPTION
### Motivation
We are upgrading to Rails 8 and the generated RBIs for `GeneratedUrlHelpersModule` and `GeneratedPathHelpersModule` did not include any of our configured routes. The previous version of the `UrlHelpers` compiler links to https://github.com/rails/rails/pull/52012, so I think the change was made to anticipate lazy loaded routes, but it does not seem to work in practice.

### Implementation
`Rails.application.reload_routes!` produced the result I was looking for and I found that this also worked in Rails 7.

### Tests
The old code did not break tests when CURRENT_RAILS_VERSION was set to 7.1 or 8.0.0, so some guidance on how to write a test for this would be appreciated. I am surprised that [these tests](https://github.com/shopify/tapioca/blob/main/spec/tapioca/dsl/compilers/url_helpers_spec.rb#L215) weren't breaking.

