### PR TITLE
Bump Ruby LSP upper bound to < 0.25

### DIFF
--- a/lib/ruby_lsp/tapioca/addon.rb
+++ b/lib/ruby_lsp/tapioca/addon.rb
@@ -1,7 +1,7 @@
 # typed: strict
 # frozen_string_literal: true
 
-RubyLsp::Addon.depend_on_ruby_lsp!(">= 0.23.10", "< 0.24")
+RubyLsp::Addon.depend_on_ruby_lsp!(">= 0.23.10", "< 0.25")
 
 begin
   # The Tapioca add-on depends on the Rails add-on to add a runtime component to the runtime server. We can allow the


### PR DESCRIPTION
### Motivation

The changes in https://github.com/Shopify/ruby-lsp/pull/3252 will be breaking because the return of `document.parse_result` will change. However, that doesn't impact Tapioca and we will not include any breaking changes that do impact Tapioca in v0.24.

Let's bump our upper requirement ahead of time, so that people can already start upgrading and so we can eliminate any windows where the Tapioca add-on wouldn't work.

### Implementation

Just bumped the upper bound to < 0.25.