### PR TITLE
Ensure delegated type with single type generates safely

### DIFF
--- a/lib/tapioca/dsl/compilers/active_record_delegated_types.rb
+++ b/lib/tapioca/dsl/compilers/active_record_delegated_types.rb
@@ -117,7 +117,7 @@ module Tapioca
           mod.create_method(
             "build_#{role}",
             parameters: [create_rest_param("args", type: "T.untyped")],
-            return_type: "T.any(#{types.join(", ")})",
+            return_type: types.size > 1 ? "T.any(#{types.join(", ")})" : types[0],
           )
         end
 

--- a/spec/tapioca/dsl/compilers/active_record_delegated_types_spec.rb
+++ b/spec/tapioca/dsl/compilers/active_record_delegated_types_spec.rb
@@ -204,6 +204,60 @@ module Tapioca
 
               assert_equal(expected, rbi_for(:Entry))
             end
+
+            it "generates RBI file for delegated_type with single type" do
+              add_ruby_file("schema.rb", <<~RUBY)
+                ActiveRecord::Migration.suppress_messages do
+                  ActiveRecord::Schema.define do
+                    create_table :entries do |t|
+                      t.string :entryable_type
+                      t.integer :entryable_id
+                    end
+                  end
+                end
+              RUBY
+
+              add_ruby_file("message.rb", <<~RUBY)
+                class Message < ActiveRecord::Base
+                end
+              RUBY
+
+              add_ruby_file("entry.rb", <<~RUBY)
+                class Entry < ActiveRecord::Base
+                  delegated_type :entryable, types: %w[ Message ]
+                end
+              RUBY
+
+              expected = <<~RBI
+                # typed: strong
+
+                class Entry
+                  include GeneratedDelegatedTypeMethods
+
+                  module GeneratedDelegatedTypeMethods
+                    sig { params(args: T.untyped).returns(Message) }
+                    def build_entryable(*args); end
+
+                    sig { returns(T::Class[T.anything]) }
+                    def entryable_class; end
+
+                    sig { returns(ActiveSupport::StringInquirer) }
+                    def entryable_name; end
+
+                    sig { returns(T.nilable(Message)) }
+                    def message; end
+
+                    sig { returns(T::Boolean) }
+                    def message?; end
+
+                    sig { returns(T.nilable(::Integer)) }
+                    def message_id; end
+                  end
+                end
+              RBI
+
+              assert_equal(expected, rbi_for(:Entry))
+            end
           end
         end
       end


### PR DESCRIPTION
### Motivation
If a delegated type is defined with a single type class, the RBI that is generated fails because the `T.any` has only one argument.

### Implementation
A simple condition to either place `T.any` or the singular class name, depending on the number of types provided.

### Tests
I added a test case to confirm the expected outcome for a singular delegated type.

