### PR TITLE
Drop support for EOL Ruby 3.1 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,12 +38,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.1", "3.2", "3.3", "3.4", "head"]
+        ruby: ["3.2", "3.3", "3.4", "head"]
         rails: ["7.0", "current", "main"]
         rubygems: ["3.6.2"]
         exclude:
-          - ruby: "3.1"
-            rails: "main"
           - ruby: "3.4"
             rails: "7.0"
         include:

--- a/spec/tapioca/dsl/compilers/action_mailer_spec.rb
+++ b/spec/tapioca/dsl/compilers/action_mailer_spec.rb
@@ -134,19 +134,11 @@ module Tapioca
 
                 class NotifierMailer
                   class << self
-                <% if ruby_version(">= 3.1.0") %>
                     sig { params(_arg0: T.untyped, _arg1: T.untyped, _arg2: T.untyped).returns(::ActionMailer::MessageDelivery) }
                     def notify_admin(*_arg0, **_arg1, &_arg2); end
 
                     sig { params(_arg0: T.untyped, _arg1: T.untyped, _arg2: T.untyped).returns(::ActionMailer::MessageDelivery) }
                     def notify_customer(*_arg0, **_arg1, &_arg2); end
-                <% else %>
-                    sig { params(_arg0: T.untyped, _arg1: T.untyped).returns(::ActionMailer::MessageDelivery) }
-                    def notify_admin(*_arg0, &_arg1); end
-
-                    sig { params(_arg0: T.untyped, _arg1: T.untyped).returns(::ActionMailer::MessageDelivery) }
-                    def notify_customer(*_arg0, &_arg1); end
-                <% end %>
                   end
                 end
               RBI

--- a/spec/tapioca/gem/pipeline_spec.rb
+++ b/spec/tapioca/gem/pipeline_spec.rb
@@ -493,11 +493,7 @@ class Tapioca::Gem::PipelineSpec < Minitest::HooksSpec
         module SomeEngine::SomeController::HelperMethods
           include ::ActionController::Base::HelperMethods
 
-        <% if ruby_version(">= 3.1") %>
           def foo(*args, **_arg1, &block); end
-        <% else %>
-          def foo(*args, &block); end
-        <% end %>
         end
       RBI
 
@@ -1673,9 +1669,7 @@ class Tapioca::Gem::PipelineSpec < Minitest::HooksSpec
           class << self
             def [](*_arg0); end
             def inspect; end
-        <% if ruby_version(">= 3.1") %>
             def keyword_init?; end
-        <% end %>
             def members; end
             def new(*_arg0); end
           end
@@ -1688,9 +1682,7 @@ class Tapioca::Gem::PipelineSpec < Minitest::HooksSpec
           class << self
             def [](*_arg0); end
             def inspect; end
-        <% if ruby_version(">= 3.1") %>
             def keyword_init?; end
-        <% end %>
             def members; end
             def new(*_arg0); end
           end

--- a/tapioca.gemspec
+++ b/tapioca.gemspec
@@ -33,5 +33,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency("thor", ">= 1.2.0")
   spec.add_dependency("yard-sorbet")
 
-  spec.required_ruby_version = ">= 3.1"
+  spec.required_ruby_version = ">= 3.2"
 end


### PR DESCRIPTION
### Motivation

Ruby 3.1 is EOL since 2025-03-26. See: https://www.ruby-lang.org/en/downloads/branches/.