### PR TITLE
Make check-shims test more robust

### DIFF
--- a/spec/tapioca/cli/check_shims_spec.rb
+++ b/spec/tapioca/cli/check_shims_spec.rb
@@ -426,23 +426,18 @@ module Tapioca
           Looking for duplicates...  Done
         OUT
 
-        assert_stderr_equals(<<~ERR, result)
+        sections = T.must(result.err).split("\n\n").map(&:strip)
+        duplicates_for_object = sections[0]&.split("\n")
+        assert_includes(duplicates_for_object, "Duplicated RBI for ::Object:")
+        assert_includes(duplicates_for_object, " * sorbet/rbi/shims/core/object.rbi:1:0-1:17")
 
-          Duplicated RBI for ::Object:
-           * https://github.com/sorbet/sorbet/tree/master/rbi/core/object.rbi#L27
-           * https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/json.rbi#L1062
-           * sorbet/rbi/shims/core/object.rbi:1:0-1:17
+        duplicates_for_string_capitalize = sections[1]&.split("\n")
+        assert_includes(duplicates_for_string_capitalize, "Duplicated RBI for ::String#capitalize:")
+        assert_includes(duplicates_for_string_capitalize, " * sorbet/rbi/shims/core/string.rbi:3:2-3:23")
 
-          Duplicated RBI for ::String#capitalize:
-           * https://github.com/sorbet/sorbet/tree/master/rbi/core/string.rbi#L572
-           * sorbet/rbi/shims/core/string.rbi:3:2-3:23
-
-          Duplicated RBI for ::Base64::decode64:
-           * https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/base64.rbi#L37
-           * sorbet/rbi/shims/stdlib/base64.rbi:3:2-3:29
-
-          Please remove the duplicated definitions from sorbet/rbi/shims and sorbet/rbi/todo.rbi
-        ERR
+        duplicates_for_base64_decode64 = sections[2]&.split("\n")
+        assert_includes(duplicates_for_base64_decode64, "Duplicated RBI for ::Base64::decode64:")
+        assert_includes(duplicates_for_base64_decode64, " * sorbet/rbi/shims/stdlib/base64.rbi:3:2-3:29")
 
         refute_success_status(result)
       end


### PR DESCRIPTION
### Motivation

This should reduce the flakiness of the test by avoiding matching the duplication from Sorbet's payload.


### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->

