### PR TITLE
Disable minitest-reporters when running via Ruby LSP explorer

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,23 +5,25 @@ require "tapioca/internal"
 require "minitest/autorun"
 require "minitest/spec"
 require "minitest/hooks/default"
-require "minitest/reporters"
 require "rails/test_unit/line_filtering"
 
 require "tapioca/helpers/test/content"
 require "tapioca/helpers/test/template"
 require "tapioca/helpers/test/isolation"
-require "spec_reporter"
 require "dsl_spec_helper"
 require "spec_with_project"
 require "rails_spec_helper"
 
-backtrace_filter = Minitest::ExtensibleBacktraceFilter.default_filter
-backtrace_filter.add_filter(%r{gems/sorbet-runtime})
-backtrace_filter.add_filter(%r{gems/railties})
-backtrace_filter.add_filter(%r{tapioca/helpers/test/})
+unless ENV["RUBY_LSP_TEST_RUNNER"]
+  require "minitest/reporters"
+  require "spec_reporter"
+  backtrace_filter = Minitest::ExtensibleBacktraceFilter.default_filter
+  backtrace_filter.add_filter(%r{gems/sorbet-runtime})
+  backtrace_filter.add_filter(%r{gems/railties})
+  backtrace_filter.add_filter(%r{tapioca/helpers/test/})
 
-Minitest::Reporters.use!(SpecReporter.new(color: true), ENV, backtrace_filter)
+  Minitest::Reporters.use!(SpecReporter.new(color: true), ENV, backtrace_filter)
+end
 
 module Minitest
   class Test


### PR DESCRIPTION
### Motivation

We need to disable `minitest-reporters` when running through the Ruby LSP's test explorer, so that we can properly hook our custom reporters to Minitest ahead of time.

### Implementation

Just put all of the code under a conditional using the environment variable provided by the Ruby LSP.