### PR TITLE
Load the runtime patches before Spoom

### DIFF
--- a/lib/tapioca/internal.rb
+++ b/lib/tapioca/internal.rb
@@ -7,6 +7,13 @@ require "tapioca"
 require "tapioca/runtime/reflection"
 require "tapioca/runtime/trackers"
 
+require "tapioca/runtime/dynamic_mixin_compiler"
+require "tapioca/sorbet_ext/backcompat_patches"
+require "tapioca/sorbet_ext/name_patch"
+require "tapioca/sorbet_ext/generic_name_patch"
+require "tapioca/sorbet_ext/proc_bind_patch"
+require "tapioca/runtime/generic_type_registry"
+
 # The rewriter needs to be loaded very early so RBS comments within Tapioca itself are rewritten
 require "spoom"
 require "tapioca/rbs/rewriter"
@@ -29,13 +36,6 @@ require "thor"
 require "yaml"
 require "yard-sorbet"
 require "prism"
-
-require "tapioca/runtime/dynamic_mixin_compiler"
-require "tapioca/sorbet_ext/backcompat_patches"
-require "tapioca/sorbet_ext/name_patch"
-require "tapioca/sorbet_ext/generic_name_patch"
-require "tapioca/sorbet_ext/proc_bind_patch"
-require "tapioca/runtime/generic_type_registry"
 
 require "tapioca/helpers/gem_helper"
 require "tapioca/helpers/git_attributes"


### PR DESCRIPTION
### Motivation

We need these to be loaded before, if not generating the RBI for `Spoom` won't contain generics.

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->

