### PR TITLE
Ignore `@requires_ancestor` in `YardDoc` listener

### DIFF
--- a/lib/tapioca/gem/listeners/yard_doc.rb
+++ b/lib/tapioca/gem/listeners/yard_doc.rb
@@ -16,6 +16,7 @@ module Tapioca
           "warn_indent:",
           "shareable_constant_value:",
           "rubocop:",
+          "@requires_ancestor:",
         ] #: Array[String]
 
         IGNORED_SIG_TAGS = ["param", "return"] #: Array[String]

--- a/spec/tapioca/gem/pipeline_spec.rb
+++ b/spec/tapioca/gem/pipeline_spec.rb
@@ -4652,6 +4652,23 @@ class Tapioca::Gem::PipelineSpec < Minitest::HooksSpec
       assert_equal(output, compile)
     end
 
+    it "does not compile RBS comments as yard documentation" do
+      add_ruby_file("foo.rb", <<~RUBY)
+        # typed: true
+
+        # @requires_ancestor: Kernel
+        class Foo; end
+      RUBY
+
+      output = template(<<~RBI)
+        class Foo
+          requires_ancestor { Kernel }
+        end
+      RBI
+
+      assert_equal(output, compile(include_doc: true))
+    end
+
     it "ignores RBS signatures that contain errors" do
       add_ruby_file("foo.rb", <<~RUBY)
         # typed: true


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
It's an RBS comment that will be translated in gem RBIs into a `requires_ancestor` call. We don't need it as part of documentation and it results in type checking errors.

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
Add it to the existing ignored comments list
### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->

