### PR TITLE
Remove deprecated reviewers field from deoendabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,6 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    reviewers:
-      - "Shopify/sorbet"
     labels:
       - "dependencies"
       - "ruby"
@@ -21,8 +19,6 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    reviewers:
-      - "Shopify/sorbet"
     labels:
       - "dependencies"
       - "gh-actions"


### PR DESCRIPTION
In favour of the CODEOWNERS file https://github.com/Shopify/tapioca/pull/2289#issuecomment-2910635701

