### PR TITLE
Remove dead method: `Bootsnap::CompileCache::ISeq::InstructionSequenceMixin::load_iseq`

### DIFF
--- a/lib/tapioca/rbs/rewriter.rb
+++ b/lib/tapioca/rbs/rewriter.rb
@@ -24,10 +24,6 @@ begin
     module CompileCache
       module ISeq
         module InstructionSequenceMixin
-          #: (String) -> RubyVM::InstructionSequence
-          def load_iseq(path)
-            super
-          end
         end
       end
     end


### PR DESCRIPTION
This method appears to be unused and could be removed.

Before approving this pull-request, please double-check that it is indeed unused.

  - [Search for `load_iseq` on GitHub for this repo](https://github.com/search?q=repo:shopify/tapioca%20load_iseq&type=code)
  - [Search for `load_iseq` on GitHub for all Shopify repos](https://github.com/search?q=org:shopify%20load_iseq&type=code)

If this code is actually used, please add a comment explaining why and close this pull-request.

You can find more unused code in your project at: https://code.shopify.io/projects/shopify/tapioca/code_removals/spoom

_Note: closing this pull-request will mark the code as ignored and exclude it from future dead code detection._

