### PR TITLE
Remove dead method: `FakeShell::terminal_width`

### DIFF
--- a/tasks/readme.rake
+++ b/tasks/readme.rake
@@ -102,10 +102,6 @@ task :readme do
       @stdout = StringIO.new
       self
     end
-
-    def terminal_width
-      DEFAULT_TERMINAL_WIDTH
-    end
   end
 
   def print_help(contents)


### PR DESCRIPTION
This method appears to be unused and could be removed.

Before approving this pull-request, please double-check that it is indeed unused.

  - [Search for `terminal_width` on GitHub for this repo](https://github.com/search?q=repo:shopify/tapioca%20terminal_width&type=code)
  - [Search for `terminal_width` on GitHub for all Shopify repos](https://github.com/search?q=org:shopify%20terminal_width&type=code)

If this code is actually used, please add a comment explaining why and close this pull-request.

You can find more unused code in your project at: https://code.shopify.io/projects/shopify/tapioca/code_removals/spoom

_Note: closing this pull-request will mark the code as ignored and exclude it from future dead code detection._

