### PR TITLE
Eager load autoloads that are registered before the RBS rewriter is loaded

### DIFF
--- a/lib/tapioca/internal.rb
+++ b/lib/tapioca/internal.rb
@@ -16,6 +16,12 @@ require "tapioca/runtime/generic_type_registry"
 
 # The rewriter needs to be loaded very early so RBS comments within Tapioca itself are rewritten
 require "spoom"
+# Eager load all the autoloads at this point, so that we don't enter into
+# a weird loop when the autoloads get triggered and we try to require the file.
+# This is especially important since Prism has a few autoloaded constants that
+# should NOT be rewritten (since they are needed for the rewriting itself), so
+# should be loaded as early as possible.
+Tapioca::Runtime::Trackers::Autoload.eager_load_all!
 require "tapioca/rbs/rewriter"
 # ^ Do not change the order of these requires
 

--- a/lib/tapioca/rbs/rewriter.rb
+++ b/lib/tapioca/rbs/rewriter.rb
@@ -49,7 +49,7 @@ RequireHooks.source_transform(patterns: ["**/*.rb"]) do |path, source|
   if source =~ /^\s*#\s*typed: (ignore|false|true|strict|strong|__STDLIB_INTERNAL)/
     Spoom::Sorbet::Translate.rbs_comments_to_sorbet_sigs(source, file: path)
   end
-rescue RBI::RBS::MethodTypeTranslator::Error
+rescue Spoom::Sorbet::Translate::Error
   # If we can't translate the RBS comments back into Sorbet's signatures, we just skip the file.
   source
 end

--- a/lib/tapioca/runtime/trackers/autoload.rb
+++ b/lib/tapioca/runtime/trackers/autoload.rb
@@ -43,7 +43,9 @@ module Tapioca
               Kernel.define_method(:abort, NOOP_METHOD)
               Kernel.define_method(:exit, NOOP_METHOD)
 
-              block.call
+              Tapioca.silence_warnings do
+                block.call
+              end
             ensure
               Kernel.define_method(:exit, original_exit)
               Kernel.define_method(:abort, original_abort)


### PR DESCRIPTION
We need to eager load all the autoloads registered before we load the RBS rewriter, since we might enter into a weird loop when those constants are used for rewriting, which triggers their autoloads which tries to require their file, which we will try to rewrite, but fail since we need the constant to do the rewriting in the first place.

This is especially important since Prism has a few autoloaded constants whose associated file should NOT be rewritten (since they are needed for the rewriting itself), so should be loaded as early as possible.

Using the `AutoloadTracker` like this is appropriate since we continue to register autoloads even after the `eager_load_all!` is triggered, which makes calling `eager_load_all!` multiple times a safe operation.