### PR TITLE
Remove dead method: `SpecReporter::before_suite`

### DIFF
--- a/spec/spec_reporter.rb
+++ b/spec/spec_reporter.rb
@@ -2,13 +2,6 @@
 # frozen_string_literal: true
 
 class SpecReporter < Minitest::Reporters::SpecReporter
-  def before_suite(suite)
-    suite.name.split("::").reduce(0) do |padding, name|
-      puts pad(name, padding)
-      padding + TEST_PADDING
-    end
-  end
-
   def record(test)
     # Trim leading "test_dddd_" and replace it with "it "
     test.name = test.name.gsub(/^test_\d{4}_/, "it ")


### PR DESCRIPTION
This method appears to be unused and could be removed.

Before approving this pull-request, please double-check that it is indeed unused.

  - [Search for `before_suite` on GitHub for this repo](https://github.com/search?q=repo:shopify/tapioca%20before_suite&type=code)
  - [Search for `before_suite` on GitHub for all Shopify repos](https://github.com/search?q=org:shopify%20before_suite&type=code)

If this code is actually used, please add a comment explaining why and close this pull-request.

You can find more unused code in your project at: https://code.shopify.io/projects/shopify/tapioca/code_removals/spoom

_Note: closing this pull-request will mark the code as ignored and exclude it from future dead code detection._

