### PR TITLE
Remove dead method: `T::Generic::TypeStoragePatch::has_attached_class!`

### DIFF
--- a/lib/tapioca/sorbet_ext/generic_name_patch.rb
+++ b/lib/tapioca/sorbet_ext/generic_name_patch.rb
@@ -43,18 +43,6 @@ module T
           Tapioca::Runtime::GenericTypeRegistry.register_type_variable(self, type_variable)
         end
       end
-
-      def has_attached_class!(variance = :invariant, &bounds_proc)
-        Tapioca::Runtime::GenericTypeRegistry.register_type_variable(
-          self,
-          Tapioca::TypeVariableModule.new(
-            T.cast(self, Module),
-            Tapioca::TypeVariableModule::Type::HasAttachedClass,
-            variance,
-            bounds_proc,
-          ),
-        )
-      end
     end
 
     prepend TypeStoragePatch


### PR DESCRIPTION
This method appears to be unused and could be removed.

Before approving this pull-request, please double-check that it is indeed unused.

  - [Search for `has_attached_class!` on GitHub for this repo](https://github.com/search?q=repo:shopify/tapioca%20has_attached_class!&type=code)
  - [Search for `has_attached_class!` on GitHub for all Shopify repos](https://github.com/search?q=org:shopify%20has_attached_class!&type=code)

If this code is actually used, please add a comment explaining why and close this pull-request.

You can find more unused code in your project at: https://code.shopify.io/projects/shopify/tapioca/code_removals/spoom

_Note: closing this pull-request will mark the code as ignored and exclude it from future dead code detection._

