### PR TITLE
Remove dead method: `T::Private::Methods::ProcBindPatch::finalize_proc`

### DIFF
--- a/lib/tapioca/sorbet_ext/proc_bind_patch.rb
+++ b/lib/tapioca/sorbet_ext/proc_bind_patch.rb
@@ -27,11 +27,6 @@ module T
   module Private
     module Methods
       module ProcBindPatch
-        def finalize_proc(decl)
-          super
-
-          T.unsafe(T::Types::Proc).new(decl.params, decl.returns, decl.bind)
-        end
       end
 
       singleton_class.prepend(ProcBindPatch)


### PR DESCRIPTION
This method appears to be unused and could be removed.

Before approving this pull-request, please double-check that it is indeed unused.

  - [Search for `finalize_proc` on GitHub for this repo](https://github.com/search?q=repo:shopify/tapioca%20finalize_proc&type=code)
  - [Search for `finalize_proc` on GitHub for all Shopify repos](https://github.com/search?q=org:shopify%20finalize_proc&type=code)

If this code is actually used, please add a comment explaining why and close this pull-request.

You can find more unused code in your project at: https://code.shopify.io/projects/shopify/tapioca/code_removals/spoom

_Note: closing this pull-request will mark the code as ignored and exclude it from future dead code detection._

