### PR TITLE
Migrate Ruby LSP add-on to RBS comments

### DIFF
--- a/spec/tapioca/addon_spec.rb
+++ b/spec/tapioca/addon_spec.rb
@@ -2,7 +2,6 @@
 # frozen_string_literal: true
 
 require "spec_helper"
-require "language_server-protocol"
 require "ruby_lsp/internal"
 require "ruby_lsp/ruby_lsp_rails/addon"
 require "ruby_lsp/tapioca/addon"


### PR DESCRIPTION
### Motivation

Migrate all of the Tapioca add-on to RBS comments since we're going to remove the Ruby LSP's dependency on the `sorbet-runtime` gem. This will make sure that Tapioca is ready for the breaking change ahead of time.

### Implementation

Just migrated everything to the RBS comment syntax. I also made some minor style modifications.

### Tests

Current tests should cover it.