### PR TITLE
Only call `load_iseq` if it's defined

### DIFF
--- a/lib/tapioca/rbs/rewriter.rb
+++ b/lib/tapioca/rbs/rewriter.rb
@@ -26,7 +26,7 @@ begin
         module InstructionSequenceMixin
           #: (String) -> RubyVM::InstructionSequence
           def load_iseq(path)
-            super
+            super if defined?(super)
           end
         end
       end


### PR DESCRIPTION
In some cases such as loading `netrc` from the add-on the `super` call is erroring with `super: no superclass method 'load_iseq' for class RubyVM::InstructionSequence (NoMethodError)`

### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
I haven't done a thorough investigation, I'm not sure why this is an issue but confirmed this fixes it.
### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->

