### PR TITLE
Do not load DSL compilers before extensions in add-on mode

### DIFF
--- a/lib/ruby_lsp/tapioca/server_addon.rb
+++ b/lib/ruby_lsp/tapioca/server_addon.rb
@@ -2,8 +2,6 @@
 # frozen_string_literal: true
 
 require "tapioca/internal"
-require "tapioca/dsl/compilers/url_helpers"
-require "tapioca/dsl/compilers/active_record_fixtures"
 
 module RubyLsp
   module Tapioca


### PR DESCRIPTION
Extensions may override DSL compilers and should be loaded before so that abstract methods such as `gather_constants` and `decorate` of the original compilers take precedence

These `require` calls were loading the compilers before the extensions which isn't the case for using tapioca from the CLI.

Without the requires the code should still work since `addon.rb` will dispatch `load_compilers_and_extensions` request before `route_dsl` or `fixtures_dsl`.
