### PR TITLE
Replace Instances of Thor::Error with Tapioca::Error

### DIFF
--- a/exe/tapioca
+++ b/exe/tapioca
@@ -27,4 +27,9 @@ end
 
 require_relative "../lib/tapioca/internal"
 
-Tapioca::Cli.start(ARGV)
+begin
+  Tapioca::Cli.start(ARGV)
+rescue Tapioca::Error => e
+  warn(e.message)
+  exit(1)
+end

--- a/lib/tapioca/cli.rb
+++ b/lib/tapioca/cli.rb
@@ -353,7 +353,7 @@ module Tapioca
       default: {}
     def annotations
       if !options[:netrc] && options[:netrc_file]
-        raise Thor::Error, set_color("Options `--no-netrc` and `--netrc-file` can't be used together", :bold, :red)
+        raise Tapioca::Error, set_color("Options `--no-netrc` and `--netrc-file` can't be used together", :bold, :red)
       end
 
       command = Commands::Annotations.new(

--- a/lib/tapioca/commands/abstract_dsl.rb
+++ b/lib/tapioca/commands/abstract_dsl.rb
@@ -160,7 +160,7 @@ module Tapioca
             remove_file(filename) if File.file?(filename)
           end
 
-          raise Thor::Error, ""
+          raise Tapioca::Error, ""
         end
 
         processable_constants
@@ -295,7 +295,7 @@ module Tapioca
             build_error_for_files(cause, diff_for_cause.map(&:first))
           end.join("\n")
 
-          raise Thor::Error, <<~ERROR
+          raise Tapioca::Error, <<~ERROR
             #{set_color("RBI files are out-of-date. In your development environment, please run:", :green)}
               #{set_color("`#{default_command(command)}`", :green, :bold)}
             #{set_color("Once it is complete, be sure to commit and push any changes", :green)}

--- a/lib/tapioca/commands/abstract_gem.rb
+++ b/lib/tapioca/commands/abstract_gem.rb
@@ -201,7 +201,7 @@ module Tapioca
             build_error_for_files(cause, diff_for_cause.map(&:first))
           end.join("\n")
 
-          raise Thor::Error, <<~ERROR
+          raise Tapioca::Error, <<~ERROR
             #{set_color("RBI files are out-of-date. In your development environment, please run:", :green)}
               #{set_color("`#{default_command(command)}`", :green, :bold)}
             #{set_color("Once it is complete, be sure to commit and push any changes", :green)}

--- a/lib/tapioca/commands/annotations.rb
+++ b/lib/tapioca/commands/annotations.rb
@@ -85,7 +85,7 @@ module Tapioca
         end
 
         if indexes.empty?
-          raise Thor::Error, set_color("Can't fetch annotations without sources (no index fetched)", :bold, :red)
+          raise Tapioca::Error, set_color("Can't fetch annotations without sources (no index fetched)", :bold, :red)
         end
 
         indexes

--- a/lib/tapioca/commands/check_shims.rb
+++ b/lib/tapioca/commands/check_shims.rb
@@ -49,7 +49,7 @@ module Tapioca
             result = sorbet("--no-config --print=payload-sources:#{payload_path}")
 
             unless result.status
-              raise Thor::Error, <<~ERROR
+              raise Tapioca::Error, <<~ERROR
                 "Sorbet failed to dump payload"
                 #{result.err}
               ERROR
@@ -87,7 +87,7 @@ module Tapioca
             "\nPlease remove the duplicated definitions from #{@shim_rbi_dir} and #{@todo_rbi_file}", :red
           )
 
-          raise Thor::Error, messages.join("\n")
+          raise Tapioca::Error, messages.join("\n")
         end
 
         say("\nNo duplicates found in shim RBIs", :green)

--- a/lib/tapioca/commands/gem_generate.rb
+++ b/lib/tapioca/commands/gem_generate.rb
@@ -58,7 +58,7 @@ module Tapioca
           if gem.nil?
             next if @lsp_addon
 
-            raise Thor::Error, set_color("Error: Cannot find gem '#{gem_name}'", :red)
+            raise Tapioca::Error, set_color("Error: Cannot find gem '#{gem_name}'", :red)
           end
 
           gems.concat(gem_dependencies(gem)) if @include_dependencies

--- a/lib/tapioca/dsl/pipeline.rb
+++ b/lib/tapioca/dsl/pipeline.rb
@@ -60,7 +60,7 @@ module Tapioca
             No classes/modules can be matched for RBI generation.
             Please check that the requested classes/modules include processable DSL methods.
           ERROR
-          raise Thor::Error, ""
+          raise Tapioca::Error, ""
         end
 
         if defined?(::ActiveRecord::Base) && constants_to_process.any? { |c| ::ActiveRecord::Base > c }
@@ -82,7 +82,7 @@ module Tapioca
             report_error(msg)
           end
 
-          raise Thor::Error, ""
+          raise Tapioca::Error, ""
         end
 
         result.compact

--- a/lib/tapioca/helpers/config_helper.rb
+++ b/lib/tapioca/helpers/config_helper.rb
@@ -83,7 +83,7 @@ module Tapioca
       end.compact
 
       unless errors.empty?
-        raise Thor::Error, build_error_message(config_file, errors)
+        raise Tapioca::Error, build_error_message(config_file, errors)
       end
     ensure
       @validating_config = false

--- a/lib/tapioca/helpers/rbi_files_helper.rb
+++ b/lib/tapioca/helpers/rbi_files_helper.rb
@@ -128,7 +128,7 @@ module Tapioca
         update_gem_rbis_strictnesses(redef_errors, gem_dir)
       end
 
-      Kernel.raise Thor::Error, error_messages.join("\n") if parse_errors.any?
+      Kernel.raise Tapioca::Error, error_messages.join("\n") if parse_errors.any?
     end
 
     private

--- a/spec/tapioca/dsl/compilers/protobuf_spec.rb
+++ b/spec/tapioca/dsl/compilers/protobuf_spec.rb
@@ -527,7 +527,7 @@ module Tapioca
             end
 
             it "handles map types regardless of their name" do
-              # This is test is based on this definition from `google-cloud-bigtable` gem that was causing issues:
+              # This test is based on this definition from `google-cloud-bigtable` gem that was causing issues:
               # https://github.com/googleapis/google-cloud-ruby/blob/9de1ce5bf74105383fc46060600d5293f8692035/google-cloud-bigtable-admin-v2/lib/google/bigtable/admin/v2/bigtable_instance_admin_pb.rb#L20
               add_ruby_file("protobuf.rb", <<~RUBY)
                 require "base64"


### PR DESCRIPTION
### Motivation

This PR addresses #2208 which suggested replacing `Thor::Error` with a custom `Tapioca::Error`. 

### Implementation

- I feel my implementation may be naive in thinking that I would simply need to rename `Thor::Error`s to `Tapioca::Error` and am wondering if instead `exit_on_failure?` should be replaced or defined elsewhere.
  - I’m still getting familiar with Tapioca and Thor and I’m not yet confident that my approach fully captures what’s intended around the replacement of `exit_on_failure?`. I’d really appreciate any feedback or pointers on what is expected here.

- Replaced usage of `Thor::Error` with `Tapioca::Error` (which was already defined) across codebase.
- In `CLI` mode we should be exiting (used `exit_on_failure?`)
- In `addon_mode` we should be silently terminating RBI Generation (again using `exit_on_failure?`)
- Updated typo in comment going through some of the protobuf spec

### Tests

- I haven’t added any tests yet. If tests are expected for this change, I’d be happy to add them. I would just need a hand with telling me where they should go. I'm still getting familiar with the codebase and would appreciate any help.

