### PR TITLE
Relax Ruby LSP constraints to allow for v0.25

### DIFF
--- a/lib/ruby_lsp/tapioca/addon.rb
+++ b/lib/ruby_lsp/tapioca/addon.rb
@@ -1,7 +1,7 @@
 # typed: strict
 # frozen_string_literal: true
 
-RubyLsp::Addon.depend_on_ruby_lsp!(">= 0.23.10", "< 0.25")
+RubyLsp::Addon.depend_on_ruby_lsp!(">= 0.23.10", "< 0.26")
 
 begin
   # The Tapioca add-on depends on the Rails add-on to add a runtime component to the runtime server. We can allow the


### PR DESCRIPTION
### Motivation

The breaking change we will include as part of v0.25 is dropping `sorbet-runtime`, which Tapioca is already ready for. Let's just relax the constraint so that the add-on can activate.

**Note**: we are due a discussion about whether these soft version requirements are working as well as we'd like and we might move Tapioca to a hard dependency strategy, but for now let's just make sure we don't disable the add-on.