### PR TITLE
Wrap loading DSL compilers in notification handler

### DIFF
--- a/lib/ruby_lsp/tapioca/server_addon.rb
+++ b/lib/ruby_lsp/tapioca/server_addon.rb
@@ -19,13 +19,15 @@ module RubyLsp
         when "load_compilers_and_extensions"
           # Load DSL extensions and compilers ahead of time, so that we don't have to pay the price of invoking
           # `Gem.find_files` on every execution, which is quite expensive
-          @loader = ::Tapioca::Loaders::Dsl.new(
-            tapioca_path: ::Tapioca::TAPIOCA_DIR,
-            eager_load: false,
-            app_root: params[:workspace_path],
-            halt_upon_load_error: false,
-          )
-          @loader.load_dsl_extensions_and_compilers
+          with_notification_wrapper("load_compilers_and_extensions", "Loading DSL compilers") do
+            @loader = ::Tapioca::Loaders::Dsl.new(
+              tapioca_path: ::Tapioca::TAPIOCA_DIR,
+              eager_load: false,
+              app_root: params[:workspace_path],
+              halt_upon_load_error: false,
+            )
+            @loader.load_dsl_extensions_and_compilers
+          end
         when "dsl"
           fork do
             with_notification_wrapper("dsl", "Generating DSL RBIs") do


### PR DESCRIPTION
### Motivation

Loading DSL compilers can also fail and we just had a case of this which was tricky to debug. Let's wrap this operation in our standard handler, so that errors are reported in the output tab.

### Implementation

Wrapped the load of compilers in the notification handler.