### PR TITLE
Fix invalid byte sequence error

### DIFF
--- a/lib/tapioca/rbs/rewriter.rb
+++ b/lib/tapioca/rbs/rewriter.rb
@@ -43,7 +43,7 @@ Module.include(T::Sig)
 # Trigger the source transformation for each Ruby file being loaded.
 RequireHooks.source_transform(patterns: ["**/*.rb"]) do |path, source|
   # The source is most likely nil since no `source_transform` hook was triggered before this one.
-  source ||= File.read(path, encoding: 'UTF-8')
+  source ||= File.read(path, encoding: "UTF-8")
 
   # For performance reasons, we only rewrite files that use Sorbet.
   if source =~ /^\s*#\s*typed: (ignore|false|true|strict|strong|__STDLIB_INTERNAL)/


### PR DESCRIPTION
### Motivation

When we try to run tapioca dsl inside an ubuntu docker container, we get the following error:

```
/gems/ruby/3.3.0/gems/tapioca-0.17.5/lib/tapioca/rbs/rewriter.rb:49:in `=~': invalid byte sequence in US-ASCII (ArgumentError)
```

When I debugged which path it was having a problem with it was `/gems/ruby/3.3.0/gems/tapioca-0.17.5/lib/tapioca/cli.rb`.

### Implementation

I specified the encoding when reading the file.

### Tests

I didn't add tests as I believe I'd have to spin up a new environment to test this.

