### PR TITLE
Fix handling of anonymous types in generic arguments

### DIFF
--- a/lib/tapioca/sorbet_ext/name_patch.rb
+++ b/lib/tapioca/sorbet_ext/name_patch.rb
@@ -16,7 +16,7 @@ module T
         def qualified_name_of(constant)
           name = NAME_METHOD.bind_call(constant)
           name = nil if name&.start_with?("#<")
-          return if name.nil?
+          return "::T.untyped" if name.nil?
 
           if name.start_with?("::")
             name

--- a/spec/tapioca/gem/pipeline_spec.rb
+++ b/spec/tapioca/gem/pipeline_spec.rb
@@ -3795,6 +3795,32 @@ class Tapioca::Gem::PipelineSpec < Minitest::HooksSpec
       assert_equal(output, compile)
     end
 
+    it "compiles generics with anonymous type arguments" do
+      add_ruby_file("foo.rb", <<~RUBY)
+        class Foo
+          class << self
+            extend T::Sig
+
+            class Bar; end
+
+            sig { returns(T::Array[Bar]) }
+            def foo; end
+          end
+        end
+      RUBY
+
+      output = template(<<~RBI)
+        class Foo
+          class << self
+            sig { returns(T::Array[::T.untyped]) }
+            def foo; end
+          end
+        end
+      RBI
+
+      assert_equal(output, compile)
+    end
+
     it "compiles structs with default values" do
       add_ruby_file("foo.rb", <<~RUBY)
         class Foo < T::Struct


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
If the argument to a generic type was an anonymous type, the name of the type as returned by our `T::Types::Simple#name` patch was `nil`. But that meant that Tapioca was generating a type that was broken, like `T::Array[]`.

Fixes #2341 

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
The right thing to do is to return `T.untyped` for anonymous types, and not `nil`. So that we at least have a valid type, like `T::Array[::T.untyped]`, if not the original type.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->
Added a test case exhibiting the problem.
