### PR TITLE
Switch gem RBI regeneration to RubyGems plugin

### DIFF
--- a/lib/ruby_lsp/tapioca/addon.rb
+++ b/lib/ruby_lsp/tapioca/addon.rb
@@ -53,7 +53,7 @@ module RubyLsp
           )
 
           send_usage_telemetry("activated")
-          run_gem_rbi_check
+          # run_gem_rbi_check
         rescue IncompatibleApiError
           send_usage_telemetry("incompatible_api_error")
 

--- a/lib/rubygems_plugin.rb
+++ b/lib/rubygems_plugin.rb
@@ -1,0 +1,41 @@
+# typed: true
+# frozen_string_literal: true
+
+# If we're not running a bundler command, skip registering the plugin
+return unless $PROGRAM_NAME.end_with?("bundle", "bundler")
+
+# If the command is not update or lock, skip registering the plugin
+return unless ["update", "lock"].include?(ARGV.first)
+
+# Use a RubyGems plugin to run gem RBI synchronization when gems are updated
+# This file gets required before actually installing gems, which gives us a chance to compare the lockfile and know
+# if gems have actually changed
+
+# We use this global variable to ensure that the plugin is only registered once since RubyGems / Bundler will actually
+# load this multiple times
+# rubocop:disable Style/GlobalVars
+return if $registered_tapioca_rubygems_plugin
+
+$registered_tapioca_rubygems_plugin = true
+# rubocop:enable Style/GlobalVars
+
+lockfile = begin
+  Bundler.default_lockfile
+rescue Bundler::GemfileNotFound
+  nil
+end
+return unless lockfile
+
+# Get the state of the lockfile before any changes are committed
+current_lockfile = File.read(lockfile)
+
+# This is a RubyGems and not a Bundler plugin, so it would get invoked multiple times during a bundle update. We workaround
+# that by registering an at_exit hook to generate the RBIs once Bundler is fully done
+at_exit do
+  new_lockfile = File.read(lockfile)
+
+  if current_lockfile != new_lockfile
+    puts "Detected gem updates, regenerating gem RBIs"
+    system("bundle exec tapioca gem")
+  end
+end


### PR DESCRIPTION
## Motivation

### Current implementation

The current implementation  has a few issues:

1. Relies on git, which is an external tool and not at all required to use Tapioca
2. Relies on the Ruby LSP's life cycle, which is not a great point to hook onto since when dependencies change the LSP is fully killed and respawned
3. We end up doing the work to check dependencies every time the LSP is booted, even though that's not really tied to a gem upgrade

### Bundler plugins

In the past, we explored Bundler plugins and couldn't make it work. We tried again and indeed something is quite odd about how the Bundler plugin hooks are emitted. The plugin seems to be required too late in the process and the `before-install-all` event is never invoked either during bundle install or bundle update.

## Implementation

We found another way that we might be able to make this work with the experience we want to provide, which is RubyGems plugins. These are similar to Bundler plugins, but associated to RubyGems events. To create a plugin, we just need to export a file ending with `_plugin.rb` and then we can hook to whatever we need.

We are not interested in the RubyGems events themselves, but rather two "Bundler" events: when it started running and when it finished running. If the lockfile ended up in a different state between these two points in time, then we can run Tapioca gem to ensure that the RBIs are up to date.

The approach we took here is to gather the contents of the lockfile when the plugin gets required (before any installations happen or the lockfile is committed) and then we register an `at_exit` hook to run Tapioca if necessary at the end of running bundle update. The plugin file is commented with more design information.

## Consensus

If we agree with this direction, we can get rid of all of the code related to gem RBI generation in the Ruby LSP add-on and simply rely on the RubyGems plugin to keep those up to date.

That will not only reduce the amount of code we have to maintain, but it will better adhere to Tapioca's own logic and mechanisms.

## Experience difference

If we run `bundle update` on a codebase that has gem RBIs that are out of sync, gem RBIs will be generated for dependencies that are not related to the updated gems.