### PR TITLE
Use `Kernel.caller_locations` in `Runtime::Trackers::MethodDefinition`

### DIFF
--- a/lib/tapioca/runtime/trackers/method_definition.rb
+++ b/lib/tapioca/runtime/trackers/method_definition.rb
@@ -53,12 +53,12 @@ end
 class Module
   prepend(Module.new do
     def singleton_method_added(method_name)
-      Tapioca::Runtime::Trackers::MethodDefinition.register(method_name, singleton_class, caller_locations)
+      Tapioca::Runtime::Trackers::MethodDefinition.register(method_name, singleton_class, Kernel.caller_locations)
       super
     end
 
     def method_added(method_name)
-      Tapioca::Runtime::Trackers::MethodDefinition.register(method_name, self, caller_locations)
+      Tapioca::Runtime::Trackers::MethodDefinition.register(method_name, self, Kernel.caller_locations)
       super
     end
   end)

--- a/spec/tapioca/dsl/compiler_spec.rb
+++ b/spec/tapioca/dsl/compiler_spec.rb
@@ -136,6 +136,30 @@ module Tapioca
 
           assert_equal(expected, rbi_for(:Post))
         end
+
+        it "compiles a class that overrides caller_locations" do
+          add_ruby_file("post.rb", <<~RUBY)
+            class Post
+              class << self
+                def self.caller_locations(...)
+                  wrapper_caller_locations(...)
+                end
+
+                def self.wrapper_caller_locations(...)
+                  Kernel.caller_locations(...)
+                end
+              end
+            end
+          RUBY
+
+          expected = <<~RBI
+            # typed: strong
+
+            class Post; end
+          RBI
+
+          assert_equal(expected, rbi_for(:Post))
+        end
       end
 
       describe "Tapioca::Dsl::Compiler with invalid syntax" do


### PR DESCRIPTION
### Motivation
Encountered a crash running `tapioca dsl` after updating to v0.17.6 (explained in #2346)

### Implementation
Update the `singleton_method_added` and `method_added` prepends to always use `Kernel.caller_location` instead of `caller_location` which may be overriden

### Tests
Added a test case to `compiler_spec.rb`. Without the change to `method_defintion.rb`, this test fails with:

```
NameError: undefined local variable or method 'wrapper_caller_locations' for class #<Class:Post>
```

