### PR TITLE
Ensure Dsl::Compiler extends T::Generic in server add-on

### DIFF
--- a/lib/ruby_lsp/tapioca/server_addon.rb
+++ b/lib/ruby_lsp/tapioca/server_addon.rb
@@ -20,6 +20,7 @@ module RubyLsp
           # Load DSL extensions and compilers ahead of time, so that we don't have to pay the price of invoking
           # `Gem.find_files` on every execution, which is quite expensive
           with_notification_wrapper("load_compilers_and_extensions", "Loading DSL compilers") do
+            ::Tapioca::Dsl::Compiler.extend(T::Generic)
             @loader = ::Tapioca::Loaders::Dsl.new(
               tapioca_path: ::Tapioca::TAPIOCA_DIR,
               eager_load: false,


### PR DESCRIPTION
### Motivation

More context in #2349

Currently, any custom DSL compiler that uses `type_member` without extending `T::Generic` crashes in the add-on because the base `Tapioca::Dsl::Compiler` class no longer extends it and so the method doesn't exist.

This doesn't happen when running Tapioca through the CLI thanks to the rewriting done by Spoom, which adds back those extends. I don't yet understand why the rewriting doesn't happen as expected in add-on mode. It seems like it might be an ordering issue because when trying to print from the rewriter logic, I can't see the prints before DSL compilers are loaded.

Let's add an extend for `T::Generic` temporarily to bring the add-on back to a working state while we dig deeper.

### Implementation

Started extending `T::Generic` before loading DSL compilers, which fixes the issue.