### PR TITLE
feat: Show list of ignored gems

### DIFF
--- a/lib/tapioca/commands/abstract_gem.rb
+++ b/lib/tapioca/commands/abstract_gem.rb
@@ -71,6 +71,7 @@ module Tapioca
         @include_doc = include_doc #: bool
         @include_loc = include_loc #: bool
         @include_exported_rbis = include_exported_rbis
+        @skipped_gems = [] #: Array[String]
         @halt_upon_load_error = halt_upon_load_error
       end
 

--- a/lib/tapioca/commands/gem_generate.rb
+++ b/lib/tapioca/commands/gem_generate.rb
@@ -65,7 +65,7 @@ module Tapioca
       def gems_to_generate(gem_names)
         return @bundle.dependencies if gem_names.empty?
 
-        gem_names.each_with_object([]) do |gem_name, gems|
+        (gem_names - @exclude).each_with_object([]) do |gem_name, gems|
           gem = @bundle.gem(gem_name)
 
           if gem.nil?

--- a/lib/tapioca/commands/gem_generate.rb
+++ b/lib/tapioca/commands/gem_generate.rb
@@ -17,7 +17,8 @@ module Tapioca
           halt_upon_load_error: @halt_upon_load_error,
         )
 
-        gem_queue = gems_to_generate(@gem_names).reject { |gem| @exclude.include?(gem.name) }
+        gem_queue = gems_to_generate(@gem_names)
+        gem_queue.reject! { |gem| @exclude.include?(gem.name) }
         anything_done = [
           perform_removals,
           gem_queue.any?,
@@ -28,6 +29,18 @@ module Tapioca
             compile_gem_rbi(gem)
             puts
           end
+        end
+
+        unless @skipped_gems.empty?
+          say("\nNote: Tapioca skipped RBI generation for the following gems because they are ignored by default:", [:yellow, :bold])
+          say(@skipped_gems.join(", "), [:yellow, :bold])
+        end
+
+        user_excluded_gems = @gem_names & @exclude
+
+        unless user_excluded_gems.empty?
+          say("\nNote: Tapioca skipped RBI generation for the following gems because they were excluded:", [:yellow, :bold])
+          say(user_excluded_gems.join(", "), [:yellow, :bold])
         end
 
         if anything_done
@@ -52,15 +65,19 @@ module Tapioca
       def gems_to_generate(gem_names)
         return @bundle.dependencies if gem_names.empty?
 
-        (gem_names - @exclude).each_with_object([]) do |gem_name, gems|
+        gem_names.each_with_object([]) do |gem_name, gems|
           gem = @bundle.gem(gem_name)
 
           if gem.nil?
-            next if @lsp_addon
-
-            raise Tapioca::Error, set_color("Error: Cannot find gem '#{gem_name}'", :red)
+            if @lsp_addon
+              next
+            elsif Gemfile::GemSpec::IGNORED_GEMS.include?(gem_name)
+              @skipped_gems << gem_name
+              next
+            else
+              raise Tapioca::Error, set_color("Error: Cannot find gem '#{gem_name}'", :red)
+            end
           end
-
           gems.concat(gem_dependencies(gem)) if @include_dependencies
           gems << gem
         end

--- a/lib/tapioca/commands/gem_generate.rb
+++ b/lib/tapioca/commands/gem_generate.rb
@@ -17,8 +17,7 @@ module Tapioca
           halt_upon_load_error: @halt_upon_load_error,
         )
 
-        gem_queue = gems_to_generate(@gem_names)
-        gem_queue.reject! { |gem| @exclude.include?(gem.name) }
+        gem_queue = gems_to_generate(@gem_names).reject { |gem| @exclude.include?(gem.name) }
         anything_done = [
           perform_removals,
           gem_queue.any?,

--- a/spec/tapioca/cli/gem_spec.rb
+++ b/spec/tapioca/cli/gem_spec.rb
@@ -920,6 +920,26 @@ module Tapioca
           assert_success_status(result)
         end
 
+        it "does not generate dependencies of explicitly excluded gems" do
+          @project.require_mock_gem(mock_gem("foo", "0.0.1", dependencies: ["bar"]))
+          @project.require_mock_gem(mock_gem("bar", "0.0.1"))
+          # Keep foo materialized after Bundler excludes it as a direct dependency.
+          @project.require_mock_gem(mock_gem("baz", "0.0.1", dependencies: ["foo"]))
+          @project.bundle_install!
+
+          result = @project.tapioca("gem foo --include-dependencies --exclude foo")
+
+          assert_stdout_includes(result, <<~OUT)
+            Note: Tapioca skipped RBI generation for the following gems because they were excluded:
+            foo
+          OUT
+          refute_includes(result.out, "Compiled foo")
+          refute_includes(result.out, "Compiled bar")
+
+          assert_empty_stderr(result)
+          assert_success_status(result)
+        end
+
         it "does not report exclusions when no gems are explicitly requested" do
           result = @project.tapioca("gem --exclude rbi")
 

--- a/spec/tapioca/cli/gem_spec.rb
+++ b/spec/tapioca/cli/gem_spec.rb
@@ -877,6 +877,67 @@ module Tapioca
           assert_success_status(result)
         end
 
+        it "reports explicitly requested ignored gems" do
+          result = @project.tapioca("gem sorbet", exclude: [])
+
+          assert_stdout_includes(result, <<~OUT)
+            Note: Tapioca skipped RBI generation for the following gems because they are ignored by default:
+            sorbet
+          OUT
+          refute_includes(result.out, "Compiled sorbet")
+
+          assert_empty_stderr(result)
+          assert_success_status(result)
+        end
+
+        it "reports gems excluded by built-in and user configuration" do
+          result = @project.tapioca("gem sorbet rbi --exclude rbi")
+
+          assert_stdout_includes(result, <<~OUT)
+            Note: Tapioca skipped RBI generation for the following gems because they are ignored by default:
+            sorbet
+          OUT
+          assert_stdout_includes(result, <<~OUT)
+            Note: Tapioca skipped RBI generation for the following gems because they were excluded:
+            rbi
+          OUT
+          refute_includes(result.out, "Compiled rbi")
+
+          assert_empty_stderr(result)
+          assert_success_status(result)
+        end
+
+        it "reports gems excluded by user configuration" do
+          result = @project.tapioca("gem rbi --exclude rbi")
+
+          assert_stdout_includes(result, <<~OUT)
+            Note: Tapioca skipped RBI generation for the following gems because they were excluded:
+            rbi
+          OUT
+          refute_includes(result.out, "Compiled rbi")
+
+          assert_empty_stderr(result)
+          assert_success_status(result)
+        end
+
+        it "does not report exclusions when no gems are explicitly requested" do
+          result = @project.tapioca("gem --exclude rbi")
+
+          refute_includes(result.out, "because they were excluded")
+
+          assert_empty_stderr(result)
+          assert_success_status(result)
+        end
+
+        it "does not report exclusions when all gems are requested" do
+          result = @project.tapioca("gem --all --exclude rbi")
+
+          refute_includes(result.out, "because they were excluded")
+
+          assert_empty_stderr(result)
+          assert_success_status(result)
+        end
+
         it "fails with error when gem cannot be found" do
           result = @project.tapioca("gem non_existent_gem")
 


### PR DESCRIPTION
### Motivation

This PR addresses #1347 which aims to show a message when trying to run `tapioca gem` on a ignored gem.

### Implementation

I have added a skipped gems property to the cli. 


### Tests

I have now written a test just to confirm something like `gem sorbet` outputs the warning that it was skipped. More than happy to add more if needed.

#### No warning

<img width="599" height="288" alt="Showing no warning" src="https://github.com/user-attachments/assets/80a6500a-7f23-453b-8238-c3087309909d" />

#### Warning

<img width="602" height="236" alt="image" src="https://github.com/user-attachments/assets/7ed35c4a-94c9-4d3e-9030-e1280e521d3c" />
