### PR TITLE
Generate Active Model attributes in an included `GeneratedAttributeMethods` module

### DIFF
--- a/lib/tapioca/dsl/compilers/active_model_attributes.rb
+++ b/lib/tapioca/dsl/compilers/active_model_attributes.rb
@@ -26,12 +26,16 @@ module Tapioca
       # # typed: true
       #
       # class Shop
+      #   include GeneratedAttributeMethods
       #
-      #   sig { returns(T.nilable(::String)) }
-      #   def name; end
+      #   module GeneratedAttributeMethods
+      #     sig { returns(T.nilable(::String)) }
+      #     def name; end
       #
-      #   sig { params(name: T.nilable(::String)).returns(T.nilable(::String)) }
-      #   def name=(name); end
+      #     sig { params(name: T.nilable(::String)).returns(T.nilable(::String)) }
+      #     def name=(name); end
+      #   end
+      #
       # end
       # ~~~
       #: [ConstantType = (Class[::ActiveModel::Attributes] & ::ActiveModel::Attributes::ClassMethods)]
@@ -45,9 +49,13 @@ module Tapioca
           return if attribute_methods.empty?
 
           root.create_path(constant) do |klass|
-            attribute_methods.each do |method, attribute_type|
-              generate_method(klass, method, attribute_type)
+            klass.create_module("GeneratedAttributeMethods") do |mod|
+              attribute_methods.each do |method, attribute_type|
+                generate_method(mod, method, attribute_type)
+              end
             end
+
+            klass.create_include("GeneratedAttributeMethods")
           end
         end
 

--- a/manual/compiler_activemodelattributes.md
+++ b/manual/compiler_activemodelattributes.md
@@ -18,12 +18,16 @@ this compiler will produce an RBI file with the following content:
 # typed: true
 
 class Shop
+  include GeneratedAttributeMethods
 
-  sig { returns(T.nilable(::String)) }
-  def name; end
+  module GeneratedAttributeMethods
+    sig { returns(T.nilable(::String)) }
+    def name; end
 
-  sig { params(name: T.nilable(::String)).returns(T.nilable(::String)) }
-  def name=(name); end
+    sig { params(name: T.nilable(::String)).returns(T.nilable(::String)) }
+    def name=(name); end
+  end
+
 end
 ~~~
 : [ConstantType = (Class[::ActiveModel::Attributes] & ::ActiveModel::Attributes::ClassMethods)]

--- a/spec/tapioca/dsl/compilers/active_model_attributes_spec.rb
+++ b/spec/tapioca/dsl/compilers/active_model_attributes_spec.rb
@@ -70,11 +70,15 @@ module Tapioca
                 # typed: strong
 
                 class Shop
-                  sig { returns(T.untyped) }
-                  def name; end
+                  include GeneratedAttributeMethods
 
-                  sig { params(value: T.untyped).returns(T.untyped) }
-                  def name=(value); end
+                  module GeneratedAttributeMethods
+                    sig { returns(T.untyped) }
+                    def name; end
+
+                    sig { params(value: T.untyped).returns(T.untyped) }
+                    def name=(value); end
+                  end
                 end
               RBI
 
@@ -95,11 +99,15 @@ module Tapioca
                 # typed: strong
 
                 class Shop
-                  sig { returns(T.untyped) }
-                  def name; end
+                  include GeneratedAttributeMethods
 
-                  sig { params(value: T.untyped).returns(T.untyped) }
-                  def name=(value); end
+                  module GeneratedAttributeMethods
+                    sig { returns(T.untyped) }
+                    def name; end
+
+                    sig { params(value: T.untyped).returns(T.untyped) }
+                    def name=(value); end
+                  end
                 end
               RBI
 
@@ -123,35 +131,39 @@ module Tapioca
                 # typed: strong
 
                 class Shop
-                  sig { returns(T.nilable(::Time)) }
-                  def created_at; end
+                  include GeneratedAttributeMethods
 
-                  sig { params(value: T.nilable(::Time)).returns(T.nilable(::Time)) }
-                  def created_at=(value); end
+                  module GeneratedAttributeMethods
+                    sig { returns(T.nilable(::Time)) }
+                    def created_at; end
 
-                  sig { returns(T.nilable(::Integer)) }
-                  def id; end
+                    sig { params(value: T.nilable(::Time)).returns(T.nilable(::Time)) }
+                    def created_at=(value); end
 
-                  sig { params(value: T.nilable(::Integer)).returns(T.nilable(::Integer)) }
-                  def id=(value); end
+                    sig { returns(T.nilable(::Integer)) }
+                    def id; end
 
-                  sig { returns(T.nilable(::Float)) }
-                  def latitude; end
+                    sig { params(value: T.nilable(::Integer)).returns(T.nilable(::Integer)) }
+                    def id=(value); end
 
-                  sig { params(value: T.nilable(::Float)).returns(T.nilable(::Float)) }
-                  def latitude=(value); end
+                    sig { returns(T.nilable(::Float)) }
+                    def latitude; end
 
-                  sig { returns(T.nilable(::String)) }
-                  def name; end
+                    sig { params(value: T.nilable(::Float)).returns(T.nilable(::Float)) }
+                    def latitude=(value); end
 
-                  sig { params(value: T.nilable(::String)).returns(T.nilable(::String)) }
-                  def name=(value); end
+                    sig { returns(T.nilable(::String)) }
+                    def name; end
 
-                  sig { returns(T.nilable(T::Boolean)) }
-                  def test_shop; end
+                    sig { params(value: T.nilable(::String)).returns(T.nilable(::String)) }
+                    def name=(value); end
 
-                  sig { params(value: T.nilable(T::Boolean)).returns(T.nilable(T::Boolean)) }
-                  def test_shop=(value); end
+                    sig { returns(T.nilable(T::Boolean)) }
+                    def test_shop; end
+
+                    sig { params(value: T.nilable(T::Boolean)).returns(T.nilable(T::Boolean)) }
+                    def test_shop=(value); end
+                  end
                 end
               RBI
 
@@ -179,11 +191,15 @@ module Tapioca
                 # typed: strong
 
                 class Shop
-                  sig { returns(T.nilable(::String)) }
-                  def custom_with_cast_sig_attr; end
+                  include GeneratedAttributeMethods
 
-                  sig { params(value: T.nilable(::String)).returns(T.nilable(::String)) }
-                  def custom_with_cast_sig_attr=(value); end
+                  module GeneratedAttributeMethods
+                    sig { returns(T.nilable(::String)) }
+                    def custom_with_cast_sig_attr; end
+
+                    sig { params(value: T.nilable(::String)).returns(T.nilable(::String)) }
+                    def custom_with_cast_sig_attr=(value); end
+                  end
                 end
               RBI
 
@@ -221,17 +237,21 @@ module Tapioca
                 # typed: strong
 
                 class Shop
-                  sig { returns(T.nilable(::Post)) }
-                  def post; end
+                  include GeneratedAttributeMethods
 
-                  sig { params(value: T.nilable(::Post)).returns(T.nilable(::Post)) }
-                  def post=(value); end
+                  module GeneratedAttributeMethods
+                    sig { returns(T.nilable(::Post)) }
+                    def post; end
 
-                  sig { returns(::User) }
-                  def user; end
+                    sig { params(value: T.nilable(::Post)).returns(T.nilable(::Post)) }
+                    def post=(value); end
 
-                  sig { params(value: ::User).returns(::User) }
-                  def user=(value); end
+                    sig { returns(::User) }
+                    def user; end
+
+                    sig { params(value: ::User).returns(::User) }
+                    def user=(value); end
+                  end
                 end
               RBI
 


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->

Consumers that define Active Model classes which override any of the attribute models cannot override the signature of the generated attribute methods since we are making it look like the methods are defined on the model class, and not on an included module.

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
Start generating all attribute methods on a `GeneratedAttributeMethods` module that gets included into the model class.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->
Update the existing tests to match
