### PR TITLE
Add VSCode task for debugging `tapioca gem` failures

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -23,6 +23,15 @@
             "script": "${relativeFile}:${lineNumber}",
             "args": [],
             "askParameters": true
-        }
+        },
+        {
+            "type": "rdbg",
+            "useBundler": true,
+            "name": "bundle exec tapioca gem",
+            "request": "launch",
+            "command": "bundle exec ruby",
+            "script": "${workspaceFolder}/exe/tapioca",
+            "args": ["gem"],
+        },
     ]
 }


### PR DESCRIPTION
### Motivation

Add a task for debugging load failures during `tapioca gem`, such as in #2351