### PR TITLE
Use `Bundler.load.specs` instead of reading `Gemfile.lock`

### DIFF
--- a/lib/tapioca/commands/annotations.rb
+++ b/lib/tapioca/commands/annotations.rb
@@ -41,10 +41,11 @@ module Tapioca
 
       #: -> Array[GemInfo]
       def list_gemfile_gems
-        say("Listing gems from Gemfile.lock... ", [:blue, :bold])
-        gemfile = Bundler.read_file("Gemfile.lock")
-        parser = Bundler::LockfileParser.new(gemfile)
-        gem_info = parser.specs.map { |spec| GemInfo.from_spec(spec) }
+        lockfile_path = Bundler.definition.lockfile.basename
+        say("Listing gems from #{lockfile_path}... ", [:blue, :bold])
+
+        specs = Bundler.definition.specs
+        gem_info = specs.map { |spec| GemInfo.from_spec(spec) }
         say("Done", :green)
         gem_info
       end

--- a/lib/tapioca/gem_info.rb
+++ b/lib/tapioca/gem_info.rb
@@ -9,7 +9,7 @@ module Tapioca
     class << self
       extend(T::Sig)
 
-      #: (Bundler::LazySpecification spec) -> GemInfo
+      #: (::Bundler::StubSpecification | ::Gem::Specification spec) -> GemInfo
       def from_spec(spec)
         new(name: spec.name, version: spec.version)
       end

--- a/spec/tapioca/cli/annotations_spec.rb
+++ b/spec/tapioca/cli/annotations_spec.rb
@@ -22,7 +22,7 @@ module Tapioca
 
         assert_stdout_equals(<<~OUT, result)
           Retrieving index from central repository... Done
-          Listing gems from Gemfile.lock... Done
+          Listing gems from bundle... Done
           Removing annotations for gems that have been removed...  Nothing to do
           Fetching gem annotations from central repository...  Nothing to do
         OUT

--- a/spec/tapioca/cli/annotations_spec.rb
+++ b/spec/tapioca/cli/annotations_spec.rb
@@ -22,7 +22,7 @@ module Tapioca
 
         assert_stdout_equals(<<~OUT, result)
           Retrieving index from central repository... Done
-          Listing gems from bundle... Done
+          Listing gems from Gemfile.lock... Done
           Removing annotations for gems that have been removed...  Nothing to do
           Fetching gem annotations from central repository...  Nothing to do
         OUT
@@ -397,6 +397,51 @@ module Tapioca
         assert_success_status(result)
 
         repo.destroy!
+      end
+
+      it "gets annotations if application uses a gems.rb" do
+        gemfile_content = @project.read("Gemfile")
+        gemfile_lock = @project.read("Gemfile.lock")
+        repo = nil
+
+        @project.remove!("Gemfile")
+        @project.remove!("Gemfile.lock")
+
+        @project.write!("gems.rb", <<~RBI)
+          source("https://rubygems.org")
+
+          gemspec name: "tapioca", path: "#{MockProject::TAPIOCA_PATH}"
+        RBI
+        @project.bundle_install!
+
+        repo = create_repo({
+          rbi: <<~RBI,
+            # typed: true
+
+            class AnnotationForRBI; end
+          RBI
+        })
+
+        result = @project.tapioca("annotations --sources #{repo.absolute_path}")
+        assert_stdout_includes(result, "create  sorbet/rbi/annotations/rbi.rbi")
+        assert_project_annotation_equal("sorbet/rbi/annotations/rbi.rbi", <<~RBI)
+          # typed: true
+
+          # DO NOT EDIT MANUALLY
+          # This file was pulled from a central RBI files repository.
+          # Please run `bin/tapioca annotations` to update it.
+
+          class AnnotationForRBI; end
+        RBI
+
+        assert_success_status(result)
+      ensure
+        repo&.destroy!
+        @project.remove!("gems.rb")
+        @project.remove!("gems.lock")
+        @project.write!("Gemfile", T.must(gemfile_content))
+        @project.write!("Gemfile.lock", T.must(gemfile_lock))
+        @project.bundle_install!
       end
     end
 


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
Resolves https://github.com/Shopify/tapioca/issues/2355
### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
`annotations` command parses the lockfile to get a list of gem names, we can get it from `Bundler.definition` instead.
### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->

