### PR TITLE
At fix docs

### DIFF
--- a/manual/compiler_aasm.md
+++ b/manual/compiler_aasm.md
@@ -25,5 +25,3 @@ and the following methods being defined:
 
   sleeping?, running?, cleaning?
   run, run!, run_without_validation!, may_run?
-
-: [ConstantType = (Class[::AASM] & ::AASM::ClassMethods)]

--- a/manual/compiler_actioncontrollerhelpers.md
+++ b/manual/compiler_actioncontrollerhelpers.md
@@ -55,4 +55,3 @@ class UserController
   def helpers; end
 end
 ~~~
-: [ConstantType = singleton(::ActionController::Base)]

--- a/manual/compiler_actionmailer.md
+++ b/manual/compiler_actionmailer.md
@@ -23,4 +23,3 @@ class NotifierMailer
   def self.notify_customer(customer_id); end
 end
 ~~~
-: [ConstantType = singleton(::ActionMailer::Base)]

--- a/manual/compiler_actiontext.md
+++ b/manual/compiler_actiontext.md
@@ -37,4 +37,3 @@ class Post
  def title?; end
 end
 ~~~
-: [ConstantType = singleton(::ActiveRecord::Base)]

--- a/manual/compiler_activejob.md
+++ b/manual/compiler_activejob.md
@@ -32,4 +32,3 @@ class NotifyUserJob
   def self.perform_now(user); end
 end
 ~~~
-: [ConstantType = singleton(::ActiveJob::Base)]

--- a/manual/compiler_activemodelattributes.md
+++ b/manual/compiler_activemodelattributes.md
@@ -30,4 +30,3 @@ class Shop
 
 end
 ~~~
-: [ConstantType = (Class[::ActiveModel::Attributes] & ::ActiveModel::Attributes::ClassMethods)]

--- a/manual/compiler_activemodelsecurepassword.md
+++ b/manual/compiler_activemodelsecurepassword.md
@@ -47,4 +47,3 @@ class User
   def token_confirmation=(unencrypted_password); end
 end
 ~~~
-: [ConstantType = (Class[::ActiveModel::SecurePassword] & ::ActiveModel::SecurePassword::ClassMethods)]

--- a/manual/compiler_activemodelvalidationsconfirmation.md
+++ b/manual/compiler_activemodelvalidationsconfirmation.md
@@ -34,4 +34,3 @@ class User
   def password_confirmation=(password_confirmation); end
 end
 ~~~
-: [ConstantType = (Class[ActiveModel::Validations] & ActiveModel::Validations::HelperMethods & ActiveModel::Validations::ClassMethods)]

--- a/manual/compiler_activerecordassociations.md
+++ b/manual/compiler_activerecordassociations.md
@@ -93,4 +93,3 @@ class Post
   end
 end
 ~~~
-: [ConstantType = singleton(ActiveRecord::Base)]

--- a/manual/compiler_activerecordcolumns.md
+++ b/manual/compiler_activerecordcolumns.md
@@ -111,4 +111,3 @@ and if the option is set to `untyped`, the `title` method will be generated as:
     sig { returns(T.untyped) }
     def title; end
 ~~~
-: [ConstantType = singleton(ActiveRecord::Base)]

--- a/manual/compiler_activerecorddelegatedtypes.md
+++ b/manual/compiler_activerecorddelegatedtypes.md
@@ -54,4 +54,3 @@ class Entry
 end
 
 ~~~
-: [ConstantType = (singleton(ActiveRecord::Base) & Extensions::ActiveRecord)]

--- a/manual/compiler_activerecordenum.md
+++ b/manual/compiler_activerecordenum.md
@@ -43,4 +43,3 @@ class Post
   end
 end
 ~~~
-: [ConstantType = singleton(::ActiveRecord::Base)]

--- a/manual/compiler_activerecordfixtures.md
+++ b/manual/compiler_activerecordfixtures.md
@@ -25,4 +25,3 @@ class ActiveSupport::TestCase
   def posts(fixture_name = nil, *other_fixtures); end
 end
 ~~~
-: [ConstantType = singleton(ActiveSupport::TestCase)]

--- a/manual/compiler_activerecordrelations.md
+++ b/manual/compiler_activerecordrelations.md
@@ -139,4 +139,3 @@ class Post
   end
 end
 ~~~
-: [ConstantType = singleton(::ActiveRecord::Base)]

--- a/manual/compiler_activerecordscope.md
+++ b/manual/compiler_activerecordscope.md
@@ -30,4 +30,3 @@ class Post
   end
 end
 ~~~
-: [ConstantType = singleton(::ActiveRecord::Base)]

--- a/manual/compiler_activerecordsecuretoken.md
+++ b/manual/compiler_activerecordsecuretoken.md
@@ -24,4 +24,3 @@ class User
   def regenerate_auth_token; end
 end
 ~~~
-: [ConstantType = (singleton(ActiveRecord::Base) & Extensions::ActiveRecord)]

--- a/manual/compiler_activerecordstore.md
+++ b/manual/compiler_activerecordstore.md
@@ -70,4 +70,3 @@ class User
   end
 end
 ~~~
-: [ConstantType = (singleton(ActiveRecord::Base) & Extensions::ActiveRecord)]

--- a/manual/compiler_activerecordtypedstore.md
+++ b/manual/compiler_activerecordtypedstore.md
@@ -75,4 +75,3 @@ class Post
   end
 end
 ~~~
-: [ConstantType = singleton(::ActiveRecord::Base)]

--- a/manual/compiler_activeresource.md
+++ b/manual/compiler_activeresource.md
@@ -48,4 +48,3 @@ class Post
   def year?; end
 end
 ~~~
-: [ConstantType = singleton(::ActiveResource::Base)]

--- a/manual/compiler_activestorage.md
+++ b/manual/compiler_activestorage.md
@@ -32,4 +32,3 @@ class Post
   def photo=(attachable); end
 end
 ~~~
-: [ConstantType = (Module & ::ActiveStorage::Reflection::ActiveRecordExtensions::ClassMethods)]

--- a/manual/compiler_activesupportconcern.md
+++ b/manual/compiler_activesupportconcern.md
@@ -31,4 +31,3 @@ module Bar
   mixes_in_class_methods(::Foo::ClassMethods)
 end
 ~~~
-: [ConstantType = Module]

--- a/manual/compiler_activesupportcurrentattributes.md
+++ b/manual/compiler_activesupportcurrentattributes.md
@@ -53,4 +53,3 @@ class Current
   end
 end
 ~~~
-: [ConstantType = singleton(::ActiveSupport::CurrentAttributes)]

--- a/manual/compiler_activesupporttimeext.md
+++ b/manual/compiler_activesupporttimeext.md
@@ -28,4 +28,3 @@ class Time
   end
 end
 ```
-: [ConstantType = singleton(::Time)]

--- a/manual/compiler_config.md
+++ b/manual/compiler_config.md
@@ -34,4 +34,3 @@ class AppSettingsConfigOptions < ::Config::Options
   def github=(value); end
 end
 ```
-: [ConstantType = Module]

--- a/manual/compiler_frozenrecord.md
+++ b/manual/compiler_frozenrecord.md
@@ -52,4 +52,3 @@ class Student
   end
 end
 ~~~
-: [ConstantType = (singleton(::FrozenRecord::Base) & Extensions::FrozenRecord)]

--- a/manual/compiler_graphqlinputobject.md
+++ b/manual/compiler_graphqlinputobject.md
@@ -25,4 +25,3 @@ class CreateCommentInput
   def post_id; end
 end
 ~~~
-: [ConstantType = singleton(GraphQL::Schema::InputObject)]

--- a/manual/compiler_graphqlmutation.md
+++ b/manual/compiler_graphqlmutation.md
@@ -26,4 +26,3 @@ class CreateComment
   def resolve(body:, post_id:); end
 end
 ~~~
-: [ConstantType = singleton(GraphQL::Schema::Mutation)]

--- a/manual/compiler_identitycache.md
+++ b/manual/compiler_identitycache.md
@@ -47,4 +47,3 @@ class Post
   def fetch_by_title_and_review_date(title, review_date, includes: nil); end
 end
 ~~~
-: [ConstantType = singleton(::ActiveRecord::Base)]

--- a/manual/compiler_jsonapiclientresource.md
+++ b/manual/compiler_jsonapiclientresource.md
@@ -73,4 +73,3 @@ class Post
   end
 end
 ~~~
-: [ConstantType = singleton(::JsonApiClient::Resource)]

--- a/manual/compiler_kredis.md
+++ b/manual/compiler_kredis.md
@@ -57,4 +57,3 @@ class Person
   end
 end
 ~~~
-: [ConstantType = (Class[::Kredis::Attributes] & ::Kredis::Attributes::ClassMethods & Extensions::Kredis)]

--- a/manual/compiler_mixedinclassattributes.md
+++ b/manual/compiler_mixedinclassattributes.md
@@ -38,4 +38,3 @@ module Taggeable
   end
 end
 ~~~
-: [ConstantType = Module]

--- a/manual/compiler_protobuf.md
+++ b/manual/compiler_protobuf.md
@@ -58,4 +58,3 @@ Do this by extending your Sorbet config file:
 ~~~
 --ignore=/path/to/proto/cart_pb.rb
 ~~~
-: [ConstantType = Class[top]]

--- a/manual/compiler_railsgenerators.md
+++ b/manual/compiler_railsgenerators.md
@@ -27,4 +27,3 @@ class ServiceGenerator
   def skip_comments; end
 end
 ~~~
-: [ConstantType = singleton(::Rails::Generators::Base)]

--- a/manual/compiler_sidekiqworker.md
+++ b/manual/compiler_sidekiqworker.md
@@ -35,4 +35,3 @@ If your project uses `ActiveSupport` as well, then the compiler will automatical
 as accepted values for the `interval` parameter:
 * `self.perform_at` will also accept a `ActiveSupport::TimeWithZone` value
 * `self.perform_in` will also accept a `ActiveSupport::Duration` value
-: [ConstantType = singleton(::Sidekiq::Worker)]

--- a/manual/compiler_smartproperties.md
+++ b/manual/compiler_smartproperties.md
@@ -52,4 +52,3 @@ class Post
   end
 end
 ~~~
-: [ConstantType = singleton(::SmartProperties)]

--- a/manual/compiler_statemachines.md
+++ b/manual/compiler_statemachines.md
@@ -103,4 +103,3 @@ class Vehicle
   end
 end
 ~~~
-: [ConstantType = (Module & ::StateMachines::ClassMethods)]

--- a/manual/compiler_urlhelpers.md
+++ b/manual/compiler_urlhelpers.md
@@ -72,4 +72,3 @@ class Post
   include GeneratedUrlHelpersModule
 end
 ~~~
-: [ConstantType = Module]

--- a/tasks/generator_documentation.rake
+++ b/tasks/generator_documentation.rake
@@ -7,6 +7,20 @@ require "tapioca/runtime/reflection"
 
 YARD::Tags::Library.define_tag("@override", :override)
 
+# A custom docstring parser that ignores RBS signature comments
+class IgnoreRBSDocstringParser < YARD::DocstringParser
+  def parse_content(content)
+    # Remove RBS signature comments (lines starting with `#:` or `#|`)
+    #
+    # At this point, `content` represents each line of the docstring where
+    # the `#` has already been stripped.
+    super(content.sub(/^[:|].*$/, ""))
+  end
+end
+
+# Use our custom docstring parser for all docstrings
+YARD::Docstring.default_parser = IgnoreRBSDocstringParser
+
 YARD::Rake::YardocTask.new(:yard_for_generate_documentation) do |task|
   task.files = ["lib/tapioca/dsl/compilers/**/*.rb"]
   task.options = ["--no-output"]


### PR DESCRIPTION
### Motivation

I noticed that our documentation pages were picking up the RBS generic signature comment for compiler classes like here: https://github.com/Shopify/tapioca/blob/main/manual/compiler_activerecordcolumns.md

<img width="891" height="168" alt="image" src="https://github.com/user-attachments/assets/07db60d6-dd22-48d8-9275-2178a4af8b16" />

We should ignore these lines when generating the documentation.

### Implementation

Added a custom Yard::DocstringParser that ignores all the lines starting with `#:` or `#|`.

### Tests

See regenerated documentation pages.

