### PR TITLE
Sort YARD comments that have the same tag name

### DIFF
--- a/lib/tapioca/gem/listeners/yard_doc.rb
+++ b/lib/tapioca/gem/listeners/yard_doc.rb
@@ -74,7 +74,7 @@ module Tapioca
 
           comments << RBI::Comment.new("") if comments.any? && tags.any?
 
-          tags.sort_by(&:tag_name).each do |tag|
+          tags.sort_by { |tag| [tag.tag_name, tag.name.to_s] }.each do |tag|
             line = +"@#{tag.tag_name}"
 
             tag_name = tag.name

--- a/spec/tapioca/gem/pipeline_spec.rb
+++ b/spec/tapioca/gem/pipeline_spec.rb
@@ -4806,5 +4806,34 @@ class Tapioca::Gem::PipelineSpec < Minitest::HooksSpec
 
       assert_equal(output, compile)
     end
+
+    it "sorts YARD tags stably by tag_name and name" do
+      add_ruby_file("foo.rb", <<~RUBY)
+        class Foo
+          # Method with multiple parameters
+          # @return [String] the result
+          # @param zebra [String] last parameter alphabetically
+          # @raise [ArgumentError] when params are invalid
+          # @param alpha [Integer] first parameter alphabetically
+          # @param beta [Boolean] middle parameter alphabetically
+          def multi_param_method(zebra, alpha, beta); end
+        end
+      RUBY
+
+      output = template(<<~RBI)
+        class Foo
+          # Method with multiple parameters
+          #
+          # @param alpha [Integer] first parameter alphabetically
+          # @param beta [Boolean] middle parameter alphabetically
+          # @param zebra [String] last parameter alphabetically
+          # @raise [ArgumentError] when params are invalid
+          # @return [String] the result
+          def multi_param_method(zebra, alpha, beta); end
+        end
+      RBI
+
+      assert_equal(output, compile(include_doc: true))
+    end
   end
 end


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
YARD comments ordering was not idempotent for the same tags which creates larger diffs than necessary.

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
First we sort by tag kind (`@param`, `@return` ...) if those are equal we sort by the name associated with the tag.

Docs: https://github.com/lsegal/yard/blob/main/lib/yard/tags/tag.rb#L15-L27
### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->
Added
