### PR TITLE
use ActiveRecordColumnTypeHelper for primary key types

### DIFF
--- a/lib/tapioca/dsl/compilers/active_record_relations.rb
+++ b/lib/tapioca/dsl/compilers/active_record_relations.rb
@@ -4,6 +4,7 @@
 return unless defined?(ActiveRecord::Base)
 
 require "tapioca/dsl/helpers/active_model_type_helper"
+require "tapioca/dsl/helpers/active_record_column_type_helper"
 require "tapioca/dsl/helpers/active_record_constants_helper"
 
 module Tapioca
@@ -837,9 +838,13 @@ module Tapioca
               end
             when :ids
               if constant.table_exists?
-                primary_key_type = constant.type_for_attribute(constant.primary_key)
-                type = Tapioca::Dsl::Helpers::ActiveModelTypeHelper.type_for(primary_key_type)
-                type = RBIHelper.as_non_nilable_type(type)
+                column_type_helper = Tapioca::Dsl::Helpers::ActiveRecordColumnTypeHelper.new(
+                  constant,
+                  column_type_option: Tapioca::Dsl::Helpers::ActiveRecordColumnTypeHelper::ColumnTypeOption::Persisted,
+                )
+                primary_key = constant.primary_key
+                getter_type, _setter_type = column_type_helper.type_for(primary_key)
+                type = getter_type
                 create_common_method("ids", return_type: "T::Array[#{type}]")
               else
                 create_common_method("ids", return_type: "Array")


### PR DESCRIPTION
### Motivation
I couldn't find an existing issue for this, but I noticed while upgrading from 16 to 17, the ids method was generating as `Array[T.untyped]` for our UUID primary keys, while other similar UUID returning methods were generating as `String`

### Implementation
I don't know intention behind `ActiveModelTypeHelper` vs `ActiveRecordColumnHelper`, but since these are primary keys and tables exist, it seemed fine to use `ActiveRecordColumnHelper`? That seemed preferable compared to changing `ActiveModelTypeHelper` at all. Also, there is some other code using the Model Helper for `:find` and also seems to care about primary keys, but I don't know if that should also use `ActiveRecordColumnHelper` too.

### Tests
I wasn't sure the best way to test this, given it seems pretty postgres specific, but happy to add some! Seems like existing tests are passing fwiw.

Thanks for looking! 
