### PR TITLE
Rescue ActiveSupport::DeprecationException to prevent crashes

### DIFF
--- a/lib/tapioca/dsl/compilers/active_support_concern.rb
+++ b/lib/tapioca/dsl/compilers/active_support_concern.rb
@@ -68,10 +68,14 @@ module Tapioca
           #: -> T::Enumerable[Module]
           def gather_constants
             all_modules.select do |mod|
-              name_of(mod) && # i.e. not anonymous
-                !mod.singleton_class? &&
-                ActiveSupport::Concern > mod.singleton_class &&
-                has_dependencies?(mod)
+              begin
+                name_of(mod) && # i.e. not anonymous
+                  !mod.singleton_class? &&
+                  ActiveSupport::Concern > mod.singleton_class &&
+                  has_dependencies?(mod)
+              rescue ActiveSupport::DeprecationException
+                false
+              end
             end
           end
 

--- a/lib/tapioca/dsl/compilers/mixed_in_class_attributes.rb
+++ b/lib/tapioca/dsl/compilers/mixed_in_class_attributes.rb
@@ -67,7 +67,13 @@ module Tapioca
           def gather_constants
             # Select all non-anonymous modules that have overridden Module.included
             all_modules.select do |mod|
-              !mod.is_a?(Class) && name_of(mod) && Runtime::Reflection.method_of(mod, :included).owner != Module
+              begin
+                !mod.is_a?(Class) &&
+                  name_of(mod) &&
+                  Runtime::Reflection.method_of(mod, :included).owner != Module
+              rescue ActiveSupport::DeprecationException
+                false
+              end
             end
           end
         end

--- a/lib/tapioca/dsl/compilers/url_helpers.rb
+++ b/lib/tapioca/dsl/compilers/url_helpers.rb
@@ -114,18 +114,22 @@ module Tapioca
             Object.const_set(:GeneratedPathHelpersModule, path_helpers_module)
 
             constants = all_modules.select do |mod|
-              next unless name_of(mod)
+              begin
+                next unless name_of(mod)
 
-              # Fast-path to quickly disqualify most cases
-              next false unless url_helpers_module > mod || # rubocop:disable Style/InvertibleUnlessCondition
-                path_helpers_module > mod ||
-                url_helpers_module > mod.singleton_class ||
-                path_helpers_module > mod.singleton_class
+                # Fast-path to quickly disqualify most cases
+                next false unless url_helpers_module > mod || # rubocop:disable Style/InvertibleUnlessCondition
+                  path_helpers_module > mod ||
+                  url_helpers_module > mod.singleton_class ||
+                  path_helpers_module > mod.singleton_class
 
-              includes_helper?(mod, url_helpers_module) ||
-                includes_helper?(mod, path_helpers_module) ||
-                includes_helper?(mod.singleton_class, url_helpers_module) ||
-                includes_helper?(mod.singleton_class, path_helpers_module)
+                includes_helper?(mod, url_helpers_module) ||
+                  includes_helper?(mod, path_helpers_module) ||
+                  includes_helper?(mod.singleton_class, url_helpers_module) ||
+                  includes_helper?(mod.singleton_class, path_helpers_module)
+              rescue ActiveSupport::DeprecationException
+                next false
+              end
             end
 
             constants.concat(NON_DISCOVERABLE_INCLUDERS).push(GeneratedUrlHelpersModule, GeneratedPathHelpersModule)


### PR DESCRIPTION
### Motivation

This fixes a crash I was seeing with the Dotenv gem. They use [ActiveSupport::Deprecation::DeprecatedConstantProxy](https://api.rubyonrails.org/classes/ActiveSupport/Deprecation/DeprecatedConstantProxy.html) for their old Railtie module so it blows up if anything touches it (since we raise on deprecation warnings in our app).

### Implementation

I added some `begin...rescue` blocks to catch any deprecation exceptions and suppress them.

### Tests

I've added some tests to ensure that tapioca ignores `DeprecationException` for these cases. These are the only locations where it was crashing, and now `tapioca dsl` runs without errors.


### Crash Backtrace

```
/Users/ndbroadbent/.local/share/mise/installs/ruby/3.4.4/lib/ruby/gems/3.4.0/gems/tapioca-0.17.7/lib/tapioca/dsl/compilers/active_support_concern.rb:76:in 'block in Tapioca::Dsl::Compilers::ActiveSupportConcern.gather_constants': DEPRECATION WARNING: Dotenv::Railtie is deprecated! Use Dotenv::Rails instead. (called from Kernel#load at ./bin/tapioca:27) (ActiveSupport::DeprecationException)
	from /Users/ndbroadbent/.local/share/mise/installs/ruby/3.4.4/lib/ruby/gems/3.4.0/gems/tapioca-0.17.7/lib/tapioca/dsl/compilers/active_support_concern.rb:73:in 'Array#select'
	from /Users/ndbroadbent/.local/share/mise/installs/ruby/3.4.4/lib/ruby/gems/3.4.0/gems/tapioca-0.17.7/lib/tapioca/dsl/compilers/active_support_concern.rb:73:in 'Tapioca::Dsl::Compilers::ActiveSupportConcern.gather_constants'
	from /Users/ndbroadbent/.local/share/mise/installs/ruby/3.4.4/lib/ruby/gems/3.4.0/gems/sorbet-runtime-0.6.12466/lib/types/private/methods/_methods.rb:279:in 'UnboundMethod#bind_call'
	from /Users/ndbroadbent/.local/share/mise/installs/ruby/3.4.4/lib/ruby/gems/3.4.0/gems/sorbet-runtime-0.6.12466/lib/types/private/methods/_methods.rb:279:in 'block in Tapioca::Dsl::Compilers::ActiveSupportConcern._on_method_added'
	from /Users/ndbroadbent/.local/share/mise/installs/ruby/3.4.4/lib/ruby/gems/3.4.0/gems/tapioca-0.17.7/lib/tapioca/dsl/compiler.rb:46:in 'Tapioca::Dsl::Compiler.processable_constants'
	from /Users/ndbroadbent/.local/share/mise/installs/ruby/3.4.4/lib/ruby/gems/3.4.0/gems/tapioca-0.17.7/lib/tapioca/dsl/pipeline.rb:127:in 'block in Tapioca::Dsl::Pipeline#gather_constants'
	from /Users/ndbroadbent/.local/share/mise/installs/ruby/3.4.4/lib/ruby/gems/3.4.0/gems/tapioca-0.17.7/lib/tapioca/dsl/pipeline.rb:126:in 'Array#each'
	from /Users/ndbroadbent/.local/share/mise/installs/ruby/3.4.4/lib/ruby/gems/3.4.0/gems/tapioca-0.17.7/lib/tapioca/dsl/pipeline.rb:126:in 'Tapioca::Dsl::Pipeline#gather_constants'
	from /Users/ndbroadbent/.local/share/mise/installs/ruby/3.4.4/lib/ruby/gems/3.4.0/gems/sorbet-runtime-0.6.12466/lib/types/private/methods/_methods.rb:279:in 'UnboundMethod#bind_call'
	from /Users/ndbroadbent/.local/share/mise/installs/ruby/3.4.4/lib/ruby/gems/3.4.0/gems/sorbet-runtime-0.6.12466/lib/types/private/methods/_methods.rb:279:in 'block in Tapioca::Dsl::Pipeline#_on_method_added'
	from /Users/ndbroadbent/.local/share/mise/installs/ruby/3.4.4/lib/ruby/gems/3.4.0/gems/tapioca-0.17.7/lib/tapioca/dsl/pipeline.rb:53:in 'Tapioca::Dsl::Pipeline#run'
	from /Users/ndbroadbent/.local/share/mise/installs/ruby/3.4.4/lib/ruby/gems/3.4.0/gems/sorbet-runtime-0.6.12466/lib/types/private/methods/_methods.rb:279:in 'UnboundMethod#bind_call'
	from /Users/ndbroadbent/.local/share/mise/installs/ruby/3.4.4/lib/ruby/gems/3.4.0/gems/sorbet-runtime-0.6.12466/lib/types/private/methods/_methods.rb:279:in 'block in Tapioca::Dsl::Pipeline#_on_method_added'
	from /Users/ndbroadbent/.local/share/mise/installs/ruby/3.4.4/lib/ruby/gems/3.4.0/gems/tapioca-0.17.7/lib/tapioca/commands/abstract_dsl.rb:65:in 'Tapioca::Commands::AbstractDsl#generate_dsl_rbi_files'
	from /Users/ndbroadbent/.local/share/mise/installs/ruby/3.4.4/lib/ruby/gems/3.4.0/gems/tapioca-0.17.7/lib/tapioca/commands/dsl_generate.rb:17:in 'Tapioca::Commands::DslGenerate#execute'
	from /Users/ndbroadbent/.local/share/mise/installs/ruby/3.4.4/lib/ruby/gems/3.4.0/gems/sorbet-runtime-0.6.12466/lib/types/private/methods/_methods.rb:279:in 'UnboundMethod#bind_call'
	from /Users/ndbroadbent/.local/share/mise/installs/ruby/3.4.4/lib/ruby/gems/3.4.0/gems/sorbet-runtime-0.6.12466/lib/types/private/methods/_methods.rb:279:in 'block in Tapioca::Commands::DslGenerate#_on_method_added'
	from /Users/ndbroadbent/.local/share/mise/installs/ruby/3.4.4/lib/ruby/gems/3.4.0/gems/tapioca-0.17.7/lib/tapioca/commands/command.rb:28:in 'block in Tapioca::Commands::Command#run'
	from /Users/ndbroadbent/.local/share/mise/installs/ruby/3.4.4/lib/ruby/gems/3.4.0/gems/tapioca-0.17.7/lib/tapioca.rb:20:in 'block in Tapioca.silence_warnings'
	from /Users/ndbroadbent/.local/share/mise/installs/ruby/3.4.4/lib/ruby/site_ruby/3.4.0/rubygems/user_interaction.rb:46:in 'Gem::DefaultUserInteraction.use_ui'
	from /Users/ndbroadbent/.local/share/mise/installs/ruby/3.4.4/lib/ruby/gems/3.4.0/gems/tapioca-0.17.7/lib/tapioca.rb:19:in 'Tapioca.silence_warnings'
	from /Users/ndbroadbent/.local/share/mise/installs/ruby/3.4.4/lib/ruby/gems/3.4.0/gems/tapioca-0.17.7/lib/tapioca/commands/command.rb:27:in 'Tapioca::Commands::Command#run'
	from /Users/ndbroadbent/.local/share/mise/installs/ruby/3.4.4/lib/ruby/gems/3.4.0/gems/sorbet-runtime-0.6.12466/lib/types/private/methods/_methods.rb:279:in 'UnboundMethod#bind_call'
	from /Users/ndbroadbent/.local/share/mise/installs/ruby/3.4.4/lib/ruby/gems/3.4.0/gems/sorbet-runtime-0.6.12466/lib/types/private/methods/_methods.rb:279:in 'block in Tapioca::Commands::Command#_on_method_added'
	from /Users/ndbroadbent/.local/share/mise/installs/ruby/3.4.4/lib/ruby/gems/3.4.0/gems/tapioca-0.17.7/lib/tapioca/cli.rb:179:in 'Tapioca::Cli#dsl'
	from /Users/ndbroadbent/.local/share/mise/installs/ruby/3.4.4/lib/ruby/gems/3.4.0/gems/thor-1.4.0/lib/thor/command.rb:28:in 'Thor::Command#run'
	from /Users/ndbroadbent/.local/share/mise/installs/ruby/3.4.4/lib/ruby/gems/3.4.0/gems/thor-1.4.0/lib/thor/invocation.rb:127:in 'Thor::Invocation#invoke_command'
	from /Users/ndbroadbent/.local/share/mise/installs/ruby/3.4.4/lib/ruby/gems/3.4.0/gems/thor-1.4.0/lib/thor.rb:538:in 'Thor.dispatch'
	from /Users/ndbroadbent/.local/share/mise/installs/ruby/3.4.4/lib/ruby/gems/3.4.0/gems/thor-1.4.0/lib/thor/base.rb:584:in 'Thor::Base::ClassMethods#start'
	from /Users/ndbroadbent/.local/share/mise/installs/ruby/3.4.4/lib/ruby/gems/3.4.0/gems/tapioca-0.17.7/exe/tapioca:31:in '<top (required)>'
	from ./bin/tapioca:27:in 'Kernel#load'
	from ./bin/tapioca:27:in '<main>'
```
