### PR TITLE
Do not mixin Kernel for modules

### DIFF
--- a/lib/tapioca/gem/listeners/mixins.rb
+++ b/lib/tapioca/gem/listeners/mixins.rb
@@ -98,7 +98,13 @@ module Tapioca
           # inherited ancestors, past the location of the constant itself.
           ancestors = Set.new.compare_by_identity.merge(ancestors_of(constant))
 
-          (ancestors - inherited_ancestors).to_a
+          result = (ancestors - inherited_ancestors).to_a
+
+          # Filter out Kernel for modules (but not classes) since modules shouldn't
+          # need to explicitly include Kernel in RBIs
+          result.delete(Kernel) unless Class === constant
+
+          result
         end
       end
     end

--- a/spec/tapioca/gem/pipeline_spec.rb
+++ b/spec/tapioca/gem/pipeline_spec.rb
@@ -1639,7 +1639,6 @@ class Tapioca::Gem::PipelineSpec < Minitest::HooksSpec
         module Baz
           include ::Quux
           include ::Foo
-          include ::Kernel
           extend ::Bar
         end
 


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
Part of https://github.com/Shopify/tapioca/issues/2393.

Fixes `Kernel` is already included errors by not generating `include ::Kernel` calls in RBIs.
### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
If a module includes Kernel it's to have access to Kernel methods in it's implementation. But in RBIs we don't generate the method bodies so we shouldn't run into isssues.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->

