### PR TITLE
Print currently compiling gems. Add verbose attribute to gem command.

### DIFF
--- a/lib/tapioca/cli.rb
+++ b/lib/tapioca/cli.rb
@@ -301,6 +301,7 @@ module Tapioca
         rbi_formatter: rbi_formatter(options),
         halt_upon_load_error: options[:halt_upon_load_error],
         lsp_addon: options[:lsp_addon],
+        verbose: options[:verbose],
       }
 
       command = if verify

--- a/lib/tapioca/commands/abstract_gem.rb
+++ b/lib/tapioca/commands/abstract_gem.rb
@@ -8,7 +8,7 @@ module Tapioca
       include SorbetHelper
       include RBIFilesHelper
 
-      #: (gem_names: Array[String], exclude: Array[String], include_dependencies: bool, prerequire: String?, postrequire: String, typed_overrides: Hash[String, String], outpath: Pathname, file_header: bool, include_doc: bool, include_loc: bool, include_exported_rbis: bool, ?number_of_workers: Integer?, ?auto_strictness: bool, ?dsl_dir: String, ?rbi_formatter: RBIFormatter, ?halt_upon_load_error: bool, ?lsp_addon: bool?) -> void
+      #: (gem_names: Array[String], exclude: Array[String], include_dependencies: bool, prerequire: String?, postrequire: String, typed_overrides: Hash[String, String], outpath: Pathname, file_header: bool, include_doc: bool, include_loc: bool, include_exported_rbis: bool, ?number_of_workers: Integer?, ?auto_strictness: bool, ?dsl_dir: String, ?rbi_formatter: RBIFormatter, ?halt_upon_load_error: bool, ?lsp_addon: bool?, ?verbose: bool?) -> void
       def initialize(
         gem_names:,
         exclude:,
@@ -26,7 +26,8 @@ module Tapioca
         dsl_dir: DEFAULT_DSL_DIR,
         rbi_formatter: DEFAULT_RBI_FORMATTER,
         halt_upon_load_error: true,
-        lsp_addon: false
+        lsp_addon: false,
+        verbose: false
       )
         @gem_names = gem_names
         @exclude = exclude
@@ -41,6 +42,7 @@ module Tapioca
         @dsl_dir = dsl_dir
         @rbi_formatter = rbi_formatter
         @lsp_addon = lsp_addon
+        @verbose = verbose
 
         super()
 
@@ -58,6 +60,7 @@ module Tapioca
       #: (Gemfile::GemSpec gem) -> void
       def compile_gem_rbi(gem)
         gem_name = set_color(gem.name, :yellow, :bold)
+        say("Currently compiling #{gem_name}", :cyan) if @verbose
 
         rbi = RBI::File.new(strictness: @typed_overrides[gem.name] || "true")
 

--- a/spec/tapioca/cli/gem_spec.rb
+++ b/spec/tapioca/cli/gem_spec.rb
@@ -381,6 +381,44 @@ module Tapioca
           assert_success_status(result)
         end
 
+        it "must output currently compiling status with verbose flag" do
+          foo = mock_gem("foo", "0.0.1") do
+            write!("lib/foo.rb", FOO_RB)
+          end
+
+          @project.require_mock_gem(foo)
+          @project.bundle_install!
+
+          result = @project.tapioca("gem foo --verbose")
+
+          assert_stdout_includes(result, "Currently compiling foo")
+          assert_stdout_includes(result, "Compiled foo")
+          assert_stdout_includes(result, "create  sorbet/rbi/gems/foo@0.0.1.rbi")
+
+          assert_project_file_equal("sorbet/rbi/gems/foo@0.0.1.rbi", FOO_RBI)
+          assert_empty_stderr(result)
+          assert_success_status(result)
+        end
+
+        it "must output currently compiling with -V flag" do
+          foo = mock_gem("foo", "0.0.1") do
+            write!("lib/foo.rb", FOO_RB)
+          end
+
+          @project.require_mock_gem(foo)
+          @project.bundle_install!
+
+          result = @project.tapioca("gem foo -V")
+
+          assert_stdout_includes(result, "Currently compiling foo")
+          assert_stdout_includes(result, "Compiled foo")
+          assert_stdout_includes(result, "create  sorbet/rbi/gems/foo@0.0.1.rbi")
+
+          assert_project_file_equal("sorbet/rbi/gems/foo@0.0.1.rbi", FOO_RBI)
+          assert_empty_stderr(result)
+          assert_success_status(result)
+        end
+
         it "must generate a gem RBI without the ones exported from the gem when called with `--no-exported-gem-rbis`" do
           foo = mock_gem("foo", "0.0.1") do
             write!("lib/foo.rb", FOO_RB)


### PR DESCRIPTION
### Motivation
Recently in one project I was working on I encountered the following problem when initializing tapioca:
- while compiling gems, the process just halted at some point - I guess it encountered some issues with compiling specific gems
- I had problems with pinpointing exactly WHICH gems Tapioca had problem with - because the pipeline outputs only compiled gems, not ongoing compilations
- This made debugging very hard - finding those problematic gems required me to put debuggers inside library and I don't think that's how it's supposed to work
- Also, it baffled me that `--verbose` flag didn't change anything in output when running `bundle exec tapioca init` or `bundle exec tapioca gems` - I thought it's gonna tell me what's happening in the background or what gems are currently compiled but it looks like this parameter isn't passed to gems command at all
- Eventually, I found those gems that halted tapioca gems compilation process and just excluded them from compilation 

### Implementation
- I've added `@verbose` attribute to `AbstractGem` class which is passed there from cli options
- When `@verbose` is true, it outputs `Currently compiling <gem_name>` before compiling gem
- This make it easier to find in the pipeline output which gems are _being compiled_, but which _weren't compiled_

### Tests
- Two tests for running `bundle exec tapioca gems --verbose` and `bundle exec tapioca gems -V`

### Example
<img width="376" height="487" alt="image" src="https://github.com/user-attachments/assets/b6ebf563-2fdf-4f7c-9443-9fc298ab0cff" />