### PR TITLE
feat: Add support for app Sinatra app with ActiveRecord

### DIFF
--- a/lib/tapioca/dsl/pipeline.rb
+++ b/lib/tapioca/dsl/pipeline.rb
@@ -202,8 +202,13 @@ module Tapioca
         # warns the user, so that they are aware they need to migrate their database
         return if @lsp_addon
         return unless defined?(::Rake)
+        return unless defined?(::Rails) || defined?(::Sinatra)
 
-        Rails.application.load_tasks
+        if defined?(::Rails)
+          Rails.application.load_tasks
+        elsif defined?(::Sinatra) # support Sinatra app with ActiveRecord
+          require "sinatra/activerecord/rake"
+        end
 
         if Rake::Task.task_defined?("db:abort_if_pending_migrations")
           Rake::Task["db:abort_if_pending_migrations"].invoke


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
I'm getting an error when trying to generate DSL with `bundle exec tapioca dsl` on Sinatra-based app with ActiveRecord
It complains about `Rails` constant missing
```shell
uninitialized constant Tapioca::Dsl::Pipeline::Rails
```
This PR adds support for a Sinatra app with ActiveRecord.
Task `db:abort_if_pending_migrations` will be loaded from `sinatra/activerecord/rake` instead of `Rails.application.load_tasks`.

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->

