### PR TITLE
Fix dsl compiler for Google::Protobuf::RepeatedField

### DIFF
--- a/lib/tapioca/dsl/compilers/protobuf.rb
+++ b/lib/tapioca/dsl/compilers/protobuf.rb
@@ -269,7 +269,11 @@ module Tapioca
               Field.new(
                 name: descriptor.name,
                 type: type,
-                init_type: "T.nilable(T.any(#{type}, T::Array[#{elem_type}]))",
+                # The FFI implementation accepts Enumerables:
+                # https://github.com/protocolbuffers/protobuf/blob/fc0eda1fd4eff075f1fb2e9249fa4209f0227e33/ruby/lib/google/protobuf/ffi/repeated_field.rb#L361-L366
+                # However the C implementation of the initializer specifically checks for Arrays:
+                # https://github.com/protocolbuffers/protobuf/blob/fc0eda1fd4eff075f1fb2e9249fa4209f0227e33/ruby/ext/google/protobuf_c/message.c#L568-L573
+                init_type: "T.nilable(T::Array[#{elem_type}])",
                 default: "T.unsafe(nil)",
               )
             end

--- a/spec/tapioca/dsl/compilers/protobuf_spec.rb
+++ b/spec/tapioca/dsl/compilers/protobuf_spec.rb
@@ -242,7 +242,7 @@ module Tapioca
                 # typed: strong
 
                 class Cart < Google::Protobuf::AbstractMessage
-                  sig { params(customer_ids: T.nilable(T.any(Google::Protobuf::RepeatedField[Integer], T::Array[Integer])), indices: T.nilable(T.any(Google::Protobuf::RepeatedField[Google::Protobuf::UInt64Value], T::Array[Google::Protobuf::UInt64Value]))).void }
+                  sig { params(customer_ids: T.nilable(T::Array[Integer]), indices: T.nilable(T::Array[Google::Protobuf::UInt64Value])).void }
                   def initialize(customer_ids: T.unsafe(nil), indices: T.unsafe(nil)); end
 
                   sig { void }


### PR DESCRIPTION
See the code comments:
The attribute accessors require `RepeatedField`s but the initializer requires an `Array`.

```
$ bin/console
tapioca(main):001> require "google/protobuf/well_known_types"
=> true

# initialize takes an Array
tapioca(main):003> fm = Google::Protobuf::FieldMask.new(paths: ["a", "b"])
=> <Google::Protobuf::FieldMask: paths: ["a", "b"]>
tapioca(main):004> fm.paths
=> ["a", "b"]
tapioca(main):005> fm.paths.class
=> Google::Protobuf::RepeatedField

# initialize with RepeatedField fails
tapioca(main):006> Google::Protobuf::FieldMask.new(paths: fm.paths)
(tapioca):6:in 'Google::Protobuf::AbstractMessage#initialize': Expected array as initializer value for repeated field 'paths' (given Google::Protobuf::RepeatedField). (ArgumentError)
        from (tapioca):6:in 'Class#new'
        from (tapioca):6:in '<top (required)>'
        from <internal:kernel>:168:in 'Kernel#loop'
        from bin/console:13:in '<main>'

# attr writer with Array fails
tapioca(main):010> fm.paths = ["a", "b"]
(tapioca):10:in 'Google::Protobuf::AbstractMessage#method_missing': Expected repeated field array (Google::Protobuf::TypeError)
        from (tapioca):10:in '<top (required)>'
        from <internal:kernel>:168:in 'Kernel#loop'
        from bin/console:13:in '<main>'

# attr writer takes RepeatedField
tapioca(main):014> fm.paths = Google::Protobuf::RepeatedField.new(:string, ["b", "c"])
=> ["b", "c"]
tapioca(main):015> fm.paths.class
=> Google::Protobuf::RepeatedField
tapioca(main):016> fm.paths
=> ["b", "c"]
```

We intend to report the inconsistency to Google, but even if they fix it it won't work for older versions.

Do we want the output of tapioca to match what protobuf does now?
Or would we want to leave this as is _if_ Google were to fix protobuf?