### PR TITLE
Update bundler to fix issues in some tests

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -453,4 +453,4 @@ DEPENDENCIES
   xpath
 
 BUNDLED WITH
-   2.6.2
+   2.7.2


### PR DESCRIPTION
This locally resolved an error in the tests when using ruby 3.3.

> Error loading RubyGems plugin "/Users/rwstauner/.rubies/3.3.6/lib/ruby/gems/3.3.0/plugins/rubygems-generate_index_plugin.rb": cannot load such file -- compact_index (LoadError)
