### PR TITLE
Simplify test to look for output in stderr and ignore warnings

### DIFF
--- a/spec/tapioca/cli/check_shims_spec.rb
+++ b/spec/tapioca/cli/check_shims_spec.rb
@@ -426,20 +426,17 @@ module Tapioca
           Looking for duplicates...  Done
         OUT
 
-        sections = T.must(result.err).split("\n\n").map(&:strip)
-        duplicates_for_object = sections[-4]&.split("\n")
-        assert_includes(duplicates_for_object, "Duplicated RBI for ::Object:")
-        assert_includes(duplicates_for_object, " * sorbet/rbi/shims/core/object.rbi:1:0-1:17")
+        stderr = T.must(result.err)
+        assert_includes(stderr, "Duplicated RBI for ::Object:")
+        assert_includes(stderr, " * sorbet/rbi/shims/core/object.rbi:1:0-1:17")
 
-        duplicates_for_string_capitalize = sections[-3]&.split("\n")
-        assert_includes(duplicates_for_string_capitalize, "Duplicated RBI for ::String#capitalize:")
-        assert_includes(duplicates_for_string_capitalize, " * sorbet/rbi/shims/core/string.rbi:3:2-3:23")
+        assert_includes(stderr, "Duplicated RBI for ::String#capitalize:")
+        assert_includes(stderr, " * sorbet/rbi/shims/core/string.rbi:3:2-3:23")
 
-        duplicates_for_base64_decode64 = sections[-2]&.split("\n")
-        assert_includes(duplicates_for_base64_decode64, "Duplicated RBI for ::Base64::decode64:")
-        assert_includes(duplicates_for_base64_decode64, " * sorbet/rbi/shims/stdlib/base64.rbi:3:2-3:29")
+        assert_includes(stderr, "Duplicated RBI for ::Base64::decode64:")
+        assert_includes(stderr, " * sorbet/rbi/shims/stdlib/base64.rbi:3:2-3:29")
 
-        assert_includes(sections[-1], "Please remove the duplicated definitions from sorbet/rbi/shims and sorbet/rbi/todo.rbi")
+        assert_includes(stderr, "Please remove the duplicated definitions from sorbet/rbi/shims and sorbet/rbi/todo.rbi")
 
         refute_success_status(result)
       end


### PR DESCRIPTION
Resolves https://github.com/Shopify/tapioca/issues/2414

Upgrading sorbet (which happens in CI when the Gemfile.lock is removed) currently results in a Warning.

Rather than trying to work around whether the warning is missing or present in a section by itself, or present in a section we are looking at, just look for what we want in the whole output without breaking into sections.

This addresses CI failures like https://github.com/Shopify/tapioca/actions/runs/18478106067/job/52647124759?pr=2402#step:6:1546