### PR TITLE
Stop testing against rubygems 3.5.* and bundler 2.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,9 +49,6 @@ jobs:
             experimental: true
           - ruby: "head"
             experimental: true
-          - rails: "current"
-            ruby: "3.3"
-            rubygems: "3.5.23"
     name: Ruby ${{ matrix.ruby }} - Rails ${{ matrix.rails }} - RubyGems ${{ matrix.rubygems }}
     env:
       RAILS_VERSION: ${{ matrix.rails }}


### PR DESCRIPTION
### Motivation
Resolves https://github.com/Shopify/tapioca/issues/2199
1. We test against bundler 2.5 on CI by pointing to rubygems 3.5.23.
   This was introduced in https://github.com/Shopify/tapioca/pull/2129
2. There are compatibility issues between rubygems and RDoc 6.9+, which's fixes
   were not backported to rubygems 3.5.

While I can't pin down the exact interaction this is causing the random
CI failure, it's also not worth the effort to keep running it AND having
the failure blocking PRs.

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->

