### PR TITLE
Make sure the RBS error is actually an error

### DIFF
--- a/spec/tapioca/gem/pipeline_spec.rb
+++ b/spec/tapioca/gem/pipeline_spec.rb
@@ -4780,7 +4780,7 @@ class Tapioca::Gem::PipelineSpec < Minitest::HooksSpec
         # typed: true
 
         class Foo
-          #: \o/
+          #: $o$
           attr_reader :bar
 
           #: foo
@@ -4793,9 +4793,7 @@ class Tapioca::Gem::PipelineSpec < Minitest::HooksSpec
 
       output = template(<<~RBI)
         class Foo
-          sig { returns(T.untyped) }
           def bar; end
-
           def foo; end
 
           sig { void }


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
Fix #2413 

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
The current `\o/` was being translated to `o/` which was being parsed as `o` by RBS and interpreted as a type alias, thus the type was being converted to `O`, and causing `NameError: Foo::O`

Changing it to `$o$` should ensure that the type can't get parsed.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->
Update existing test
