### PR TITLE
Fix DSL test failure caused by ActiveModel::SecurePassword change

### DIFF
--- a/spec/tapioca/cli/dsl_spec.rb
+++ b/spec/tapioca/cli/dsl_spec.rb
@@ -1845,7 +1845,9 @@ module Tapioca
         end
 
         it "generates RBIs for ActiveResource containing arbitrary constants, and referenced by file path" do
-          @project.require_real_gem("activeresource")
+          # locking to 6.1.4 to avoid breaking changes in later versions
+          @project.require_real_gem("activeresource", "6.1.4")
+          @project.require_real_gem("activemodel", "8.0.0")
           @project.bundle_install!
           @project.write!("lib/post.rb", <<~RUBY)
             require "active_resource"


### PR DESCRIPTION
### Motivation

In Rails 8.1, `ActiveModel::SecurePassword` starts to use ActiveSupport's `Numeric#minutes` method (https://github.com/rails/rails/pull/55574) without explicitly requiring that core extension, and that's causing the related test to fail.

Since the behaviour of `ActiveModel::SecurePassword` isn't what that test is for, we can lock related dependencies versions to avoid failures for now.

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->

