### PR TITLE
Add optional CI step to run Sorbet with Prism

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,9 @@ jobs:
           rubygems: 3.6.2
       - name: Run type check
         run: bin/typecheck
+      - name: Run type check with Prism parser
+        run: bin/typecheck --parser=prism
+        continue-on-error: true
       - name: Lint Ruby files
         run: bin/style
       - name: Verify documentation


### PR DESCRIPTION
This will give us some insight into how feature complete the Prism parser mode for Sorbet is. If this step fails, we should not block the PR from being merged, however it's currently passing.
