### PR TITLE
Drop `T::` prefixes from RBS comments

### DIFF
--- a/lib/tapioca/dsl/compiler.rb
+++ b/lib/tapioca/dsl/compiler.rb
@@ -32,7 +32,7 @@ module Tapioca
         end
 
         # @abstract
-        #: -> T::Enumerable[T::Module[top]]
+        #: -> Enumerable[T::Module[top]]
         def gather_constants = raise NotImplementedError, "Abstract method called"
 
         #: -> Set[T::Module[top]]
@@ -68,18 +68,18 @@ module Tapioca
           end
         end
 
-        #: -> T::Enumerable[Class[top]]
+        #: -> Enumerable[Class[top]]
         def all_classes
-          @all_classes ||= all_modules.grep(Class).freeze #: T::Enumerable[Class[top]]?
+          @all_classes ||= all_modules.grep(Class).freeze #: Enumerable[Class[top]]?
         end
 
-        #: -> T::Enumerable[T::Module[top]]
+        #: -> Enumerable[T::Module[top]]
         def all_modules
           @all_modules ||= if @@requested_constants.any?
             @@requested_constants.grep(Module)
           else
             ObjectSpace.each_object(Module).to_a
-          end.freeze #: T::Enumerable[T::Module[top]]?
+          end.freeze #: Enumerable[T::Module[top]]?
         end
       end
 

--- a/lib/tapioca/dsl/compilers/aasm.rb
+++ b/lib/tapioca/dsl/compilers/aasm.rb
@@ -203,7 +203,7 @@ module Tapioca
           extend T::Sig
 
           # @override
-          #: -> T::Enumerable[T::Module[top]]
+          #: -> Enumerable[T::Module[top]]
           def gather_constants
             T.cast(ObjectSpace.each_object(::AASM::ClassMethods), T::Enumerable[T::Module[T.anything]])
           end

--- a/lib/tapioca/dsl/compilers/action_controller_helpers.rb
+++ b/lib/tapioca/dsl/compilers/action_controller_helpers.rb
@@ -121,7 +121,7 @@ module Tapioca
           extend T::Sig
 
           # @override
-          #: -> T::Enumerable[T::Module[top]]
+          #: -> Enumerable[T::Module[top]]
           def gather_constants
             descendants_of(::ActionController::Base).select(&:name).select do |klass|
               klass.const_defined?(:HelperMethods, false)

--- a/lib/tapioca/dsl/compilers/action_mailer.rb
+++ b/lib/tapioca/dsl/compilers/action_mailer.rb
@@ -54,7 +54,7 @@ module Tapioca
           extend T::Sig
 
           # @override
-          #: -> T::Enumerable[T::Module[top]]
+          #: -> Enumerable[T::Module[top]]
           def gather_constants
             descendants_of(::ActionMailer::Base).reject(&:abstract?)
           end

--- a/lib/tapioca/dsl/compilers/action_text.rb
+++ b/lib/tapioca/dsl/compilers/action_text.rb
@@ -84,7 +84,7 @@ module Tapioca
           end
 
           # @override
-          #: -> T::Enumerable[T::Module[top]]
+          #: -> Enumerable[T::Module[top]]
           def gather_constants
             descendants_of(::ActiveRecord::Base)
               .reject(&:abstract_class?)

--- a/lib/tapioca/dsl/compilers/active_job.rb
+++ b/lib/tapioca/dsl/compilers/active_job.rb
@@ -88,7 +88,7 @@ module Tapioca
           extend T::Sig
 
           # @override
-          #: -> T::Enumerable[T::Module[top]]
+          #: -> Enumerable[T::Module[top]]
           def gather_constants
             descendants_of(::ActiveJob::Base)
           end

--- a/lib/tapioca/dsl/compilers/active_model_attributes.rb
+++ b/lib/tapioca/dsl/compilers/active_model_attributes.rb
@@ -63,7 +63,7 @@ module Tapioca
           extend T::Sig
 
           # @override
-          #: -> T::Enumerable[T::Module[top]]
+          #: -> Enumerable[T::Module[top]]
           def gather_constants
             all_classes.grep(::ActiveModel::Attributes::ClassMethods)
           end

--- a/lib/tapioca/dsl/compilers/active_model_secure_password.rb
+++ b/lib/tapioca/dsl/compilers/active_model_secure_password.rb
@@ -93,7 +93,7 @@ module Tapioca
           extend T::Sig
 
           # @override
-          #: -> T::Enumerable[T::Module[top]]
+          #: -> Enumerable[T::Module[top]]
           def gather_constants
             # In some versions of Rails 8.1, `ActiveModel::SecurePassword` uses `Numeric#minutes`
             # which isn't explicitly required in the gem, and it might not be loaded already.

--- a/lib/tapioca/dsl/compilers/active_model_validations_confirmation.rb
+++ b/lib/tapioca/dsl/compilers/active_model_validations_confirmation.rb
@@ -46,7 +46,7 @@ module Tapioca
 
         class << self
           # @override
-          #: -> T::Enumerable[T::Module[top]]
+          #: -> Enumerable[T::Module[top]]
           def gather_constants
             # Collect all the classes that include ActiveModel::Validations
             all_classes.select { |c| ActiveModel::Validations > c }

--- a/lib/tapioca/dsl/compilers/active_record_associations.rb
+++ b/lib/tapioca/dsl/compilers/active_record_associations.rb
@@ -141,7 +141,7 @@ module Tapioca
           extend T::Sig
 
           # @override
-          #: -> T::Enumerable[T::Module[top]]
+          #: -> Enumerable[T::Module[top]]
           def gather_constants
             descendants_of(::ActiveRecord::Base).reject(&:abstract_class?)
           end

--- a/lib/tapioca/dsl/compilers/active_record_columns.rb
+++ b/lib/tapioca/dsl/compilers/active_record_columns.rb
@@ -166,7 +166,7 @@ module Tapioca
           extend T::Sig
 
           # @override
-          #: -> T::Enumerable[T::Module[top]]
+          #: -> Enumerable[T::Module[top]]
           def gather_constants
             descendants_of(::ActiveRecord::Base).reject(&:abstract_class?)
           end

--- a/lib/tapioca/dsl/compilers/active_record_delegated_types.rb
+++ b/lib/tapioca/dsl/compilers/active_record_delegated_types.rb
@@ -91,7 +91,7 @@ module Tapioca
           extend T::Sig
 
           # @override
-          #: -> T::Enumerable[T::Module[top]]
+          #: -> Enumerable[T::Module[top]]
           def gather_constants
             descendants_of(::ActiveRecord::Base).reject(&:abstract_class?)
           end

--- a/lib/tapioca/dsl/compilers/active_record_enum.rb
+++ b/lib/tapioca/dsl/compilers/active_record_enum.rb
@@ -78,7 +78,7 @@ module Tapioca
           extend T::Sig
 
           # @override
-          #: -> T::Enumerable[T::Module[top]]
+          #: -> Enumerable[T::Module[top]]
           def gather_constants
             descendants_of(::ActiveRecord::Base)
           end

--- a/lib/tapioca/dsl/compilers/active_record_fixtures.rb
+++ b/lib/tapioca/dsl/compilers/active_record_fixtures.rb
@@ -62,7 +62,7 @@ module Tapioca
           extend T::Sig
 
           # @override
-          #: -> T::Enumerable[T::Module[top]]
+          #: -> Enumerable[T::Module[top]]
           def gather_constants
             return [] unless defined?(Rails.application) && Rails.application
 

--- a/lib/tapioca/dsl/compilers/active_record_relations.rb
+++ b/lib/tapioca/dsl/compilers/active_record_relations.rb
@@ -184,7 +184,7 @@ module Tapioca
           extend T::Sig
 
           # @override
-          #: -> T::Enumerable[T::Module[top]]
+          #: -> Enumerable[T::Module[top]]
           def gather_constants
             ActiveRecord::Base.descendants.reject(&:abstract_class?)
           end

--- a/lib/tapioca/dsl/compilers/active_record_scope.rb
+++ b/lib/tapioca/dsl/compilers/active_record_scope.rb
@@ -78,7 +78,7 @@ module Tapioca
 
         class << self
           # @override
-          #: -> T::Enumerable[T::Module[top]]
+          #: -> Enumerable[T::Module[top]]
           def gather_constants
             descendants_of(::ActiveRecord::Base).reject(&:abstract_class?)
           end

--- a/lib/tapioca/dsl/compilers/active_record_secure_token.rb
+++ b/lib/tapioca/dsl/compilers/active_record_secure_token.rb
@@ -60,7 +60,7 @@ module Tapioca
           extend T::Sig
 
           # @override
-          #: -> T::Enumerable[T::Module[top]]
+          #: -> Enumerable[T::Module[top]]
           def gather_constants
             descendants_of(::ActiveRecord::Base).reject(&:abstract_class?)
           end

--- a/lib/tapioca/dsl/compilers/active_record_store.rb
+++ b/lib/tapioca/dsl/compilers/active_record_store.rb
@@ -135,7 +135,7 @@ module Tapioca
           extend T::Sig
 
           # @override
-          #: -> T::Enumerable[T::Module[top]]
+          #: -> Enumerable[T::Module[top]]
           def gather_constants
             descendants_of(::ActiveRecord::Base).reject(&:abstract_class?)
           end

--- a/lib/tapioca/dsl/compilers/active_record_typed_store.rb
+++ b/lib/tapioca/dsl/compilers/active_record_typed_store.rb
@@ -111,7 +111,7 @@ module Tapioca
           extend T::Sig
 
           # @override
-          #: -> T::Enumerable[T::Module[top]]
+          #: -> Enumerable[T::Module[top]]
           def gather_constants
             descendants_of(::ActiveRecord::Base).select do |klass|
               klass.include?(ActiveRecord::TypedStore::Behavior)

--- a/lib/tapioca/dsl/compilers/active_resource.rb
+++ b/lib/tapioca/dsl/compilers/active_resource.rb
@@ -74,7 +74,7 @@ module Tapioca
           extend T::Sig
 
           # @override
-          #: -> T::Enumerable[T::Module[top]]
+          #: -> Enumerable[T::Module[top]]
           def gather_constants
             descendants_of(::ActiveResource::Base)
           end

--- a/lib/tapioca/dsl/compilers/active_storage.rb
+++ b/lib/tapioca/dsl/compilers/active_storage.rb
@@ -68,7 +68,7 @@ module Tapioca
           extend T::Sig
 
           # @override
-          #: -> T::Enumerable[T::Module[top]]
+          #: -> Enumerable[T::Module[top]]
           def gather_constants
             descendants_of(::ActiveRecord::Base)
               .reject(&:abstract_class?)

--- a/lib/tapioca/dsl/compilers/active_support_concern.rb
+++ b/lib/tapioca/dsl/compilers/active_support_concern.rb
@@ -65,7 +65,7 @@ module Tapioca
           extend T::Sig
 
           # @override
-          #: -> T::Enumerable[T::Module[top]]
+          #: -> Enumerable[T::Module[top]]
           def gather_constants
             all_modules.select do |mod|
               name_of(mod) && # i.e. not anonymous

--- a/lib/tapioca/dsl/compilers/active_support_current_attributes.rb
+++ b/lib/tapioca/dsl/compilers/active_support_current_attributes.rb
@@ -97,7 +97,7 @@ module Tapioca
           extend T::Sig
 
           # @override
-          #: -> T::Enumerable[T::Module[top]]
+          #: -> Enumerable[T::Module[top]]
           def gather_constants
             descendants_of(::ActiveSupport::CurrentAttributes)
           end

--- a/lib/tapioca/dsl/compilers/active_support_time_ext.rb
+++ b/lib/tapioca/dsl/compilers/active_support_time_ext.rb
@@ -58,7 +58,7 @@ module Tapioca
           extend T::Sig
 
           # @override
-          #: -> T::Enumerable[T::Module[top]]
+          #: -> Enumerable[T::Module[top]]
           def gather_constants
             [::Time]
           end

--- a/lib/tapioca/dsl/compilers/config.rb
+++ b/lib/tapioca/dsl/compilers/config.rb
@@ -96,7 +96,7 @@ module Tapioca
           extend T::Sig
 
           # @override
-          #: -> T::Enumerable[T::Module[top]]
+          #: -> Enumerable[T::Module[top]]
           def gather_constants
             name = ::Config.const_name
             return [] unless Object.const_defined?(name)

--- a/lib/tapioca/dsl/compilers/frozen_record.rb
+++ b/lib/tapioca/dsl/compilers/frozen_record.rb
@@ -88,7 +88,7 @@ module Tapioca
           extend T::Sig
 
           # @override
-          #: -> T::Enumerable[T::Module[top]]
+          #: -> Enumerable[T::Module[top]]
           def gather_constants
             descendants_of(::FrozenRecord::Base).reject(&:abstract_class?)
           end

--- a/lib/tapioca/dsl/compilers/graphql_input_object.rb
+++ b/lib/tapioca/dsl/compilers/graphql_input_object.rb
@@ -77,7 +77,7 @@ module Tapioca
           extend T::Sig
 
           # @override
-          #: -> T::Enumerable[T::Module[top]]
+          #: -> Enumerable[T::Module[top]]
           def gather_constants
             all_classes.select { |c| GraphQL::Schema::InputObject > c }
           end

--- a/lib/tapioca/dsl/compilers/graphql_mutation.rb
+++ b/lib/tapioca/dsl/compilers/graphql_mutation.rb
@@ -74,7 +74,7 @@ module Tapioca
           extend T::Sig
 
           # @override
-          #: -> T::Enumerable[T::Module[top]]
+          #: -> Enumerable[T::Module[top]]
           def gather_constants
             all_classes.select { |c| GraphQL::Schema::Mutation > c && GraphQL::Schema::RelayClassicMutation != c }
           end

--- a/lib/tapioca/dsl/compilers/identity_cache.rb
+++ b/lib/tapioca/dsl/compilers/identity_cache.rb
@@ -95,7 +95,7 @@ module Tapioca
           extend T::Sig
 
           # @override
-          #: -> T::Enumerable[T::Module[top]]
+          #: -> Enumerable[T::Module[top]]
           def gather_constants
             descendants_of(::ActiveRecord::Base).select do |klass|
               ::IdentityCache::WithoutPrimaryIndex > klass

--- a/lib/tapioca/dsl/compilers/json_api_client_resource.rb
+++ b/lib/tapioca/dsl/compilers/json_api_client_resource.rb
@@ -109,7 +109,7 @@ module Tapioca
           extend T::Sig
 
           # @override
-          #: -> T::Enumerable[T::Module[top]]
+          #: -> Enumerable[T::Module[top]]
           def gather_constants
             all_modules.select do |c|
               name_of(c) && ::JsonApiClient::Resource > c

--- a/lib/tapioca/dsl/compilers/kredis.rb
+++ b/lib/tapioca/dsl/compilers/kredis.rb
@@ -88,7 +88,7 @@ module Tapioca
           extend T::Sig
 
           # @override
-          #: -> T::Enumerable[T::Module[top]]
+          #: -> Enumerable[T::Module[top]]
           def gather_constants
             all_classes
               .grep(::Kredis::Attributes::ClassMethods)

--- a/lib/tapioca/dsl/compilers/mixed_in_class_attributes.rb
+++ b/lib/tapioca/dsl/compilers/mixed_in_class_attributes.rb
@@ -63,7 +63,7 @@ module Tapioca
           extend T::Sig
 
           # @override
-          #: -> T::Enumerable[T::Module[top]]
+          #: -> Enumerable[T::Module[top]]
           def gather_constants
             # Select all non-anonymous modules that have overridden Module.included
             all_modules.select do |mod|

--- a/lib/tapioca/dsl/compilers/protobuf.rb
+++ b/lib/tapioca/dsl/compilers/protobuf.rb
@@ -156,7 +156,7 @@ module Tapioca
           extend T::Sig
 
           # @override
-          #: -> T::Enumerable[T::Module[top]]
+          #: -> Enumerable[T::Module[top]]
           def gather_constants
             marker = Google::Protobuf::MessageExts::ClassMethods
 

--- a/lib/tapioca/dsl/compilers/rails_generators.rb
+++ b/lib/tapioca/dsl/compilers/rails_generators.rb
@@ -60,7 +60,7 @@ module Tapioca
           extend T::Sig
 
           # @override
-          #: -> T::Enumerable[T::Module[top]]
+          #: -> Enumerable[T::Module[top]]
           def gather_constants
             all_classes.select do |const|
               name = qualified_name_of(const)

--- a/lib/tapioca/dsl/compilers/sidekiq_worker.rb
+++ b/lib/tapioca/dsl/compilers/sidekiq_worker.rb
@@ -87,7 +87,7 @@ module Tapioca
           extend T::Sig
 
           # @override
-          #: -> T::Enumerable[T::Module[top]]
+          #: -> Enumerable[T::Module[top]]
           def gather_constants
             all_classes.select { |c| Sidekiq::Worker > c }
           end

--- a/lib/tapioca/dsl/compilers/smart_properties.rb
+++ b/lib/tapioca/dsl/compilers/smart_properties.rb
@@ -84,7 +84,7 @@ module Tapioca
           extend T::Sig
 
           # @override
-          #: -> T::Enumerable[T::Module[top]]
+          #: -> Enumerable[T::Module[top]]
           def gather_constants
             all_modules.select do |c|
               name_of(c) &&

--- a/lib/tapioca/dsl/compilers/state_machines.rb
+++ b/lib/tapioca/dsl/compilers/state_machines.rb
@@ -158,7 +158,7 @@ module Tapioca
           extend T::Sig
 
           # @override
-          #: -> T::Enumerable[T::Module[top]]
+          #: -> Enumerable[T::Module[top]]
           def gather_constants
             all_classes.select { |mod| ::StateMachines::InstanceMethods > mod }
           end

--- a/lib/tapioca/dsl/compilers/url_helpers.rb
+++ b/lib/tapioca/dsl/compilers/url_helpers.rb
@@ -99,7 +99,7 @@ module Tapioca
         class << self
           extend T::Sig
           # @override
-          #: -> T::Enumerable[T::Module[top]]
+          #: -> Enumerable[T::Module[top]]
           def gather_constants
             return [] unless defined?(Rails.application) && Rails.application
 

--- a/lib/tapioca/dsl/pipeline.rb
+++ b/lib/tapioca/dsl/pipeline.rb
@@ -6,7 +6,7 @@ module Tapioca
     class Pipeline
       extend T::Sig
 
-      #: T::Enumerable[singleton(Compiler)]
+      #: Enumerable[singleton(Compiler)]
       attr_reader :active_compilers
 
       #: Array[T::Module[top]]
@@ -121,7 +121,7 @@ module Tapioca
 
       private
 
-      #: (Array[singleton(Compiler)] requested_compilers, Array[singleton(Compiler)] excluded_compilers) -> T::Enumerable[singleton(Compiler)]
+      #: (Array[singleton(Compiler)] requested_compilers, Array[singleton(Compiler)] excluded_compilers) -> Enumerable[singleton(Compiler)]
       def gather_active_compilers(requested_compilers, excluded_compilers)
         active_compilers = compilers
         active_compilers -= excluded_compilers

--- a/lib/tapioca/gemfile.rb
+++ b/lib/tapioca/gemfile.rb
@@ -64,7 +64,7 @@ module Tapioca
       [dependencies, missing_specs]
     end
 
-    #: -> [T::Enumerable[Spec], Array[String]]
+    #: -> [Enumerable[Spec], Array[String]]
     def materialize_deps
       deps = definition.locked_gems.dependencies.except(*@excluded_gems).values
       resolve = definition.resolve

--- a/lib/tapioca/helpers/rbi_files_helper.rb
+++ b/lib/tapioca/helpers/rbi_files_helper.rb
@@ -70,7 +70,7 @@ module Tapioca
     #|   dsl_dir: String,
     #|   auto_strictness: bool,
     #|   ?gems: Array[Gemfile::GemSpec],
-    #|   ?compilers: T::Enumerable[singleton(Dsl::Compiler)]
+    #|   ?compilers: Enumerable[singleton(Dsl::Compiler)]
     #| ) -> void
     def validate_rbi_files(command:, gem_dir:, dsl_dir:, auto_strictness:, gems: [], compilers: [])
       error_url_base = Spoom::Sorbet::Errors::DEFAULT_ERROR_URL_BASE

--- a/lib/tapioca/repo_index.rb
+++ b/lib/tapioca/repo_index.rb
@@ -30,7 +30,7 @@ module Tapioca
       @entries.add(gem_name)
     end
 
-    #: -> T::Enumerable[String]
+    #: -> Enumerable[String]
     def gems
       @entries.sort
     end

--- a/lib/tapioca/static/requires_compiler.rb
+++ b/lib/tapioca/static/requires_compiler.rb
@@ -40,7 +40,7 @@ module Tapioca
         end.sort.uniq
       end
 
-      #: (String file_path) -> T::Enumerable[String]
+      #: (String file_path) -> Enumerable[String]
       def collect_requires(file_path)
         File.binread(file_path).lines.filter_map do |line|
           /^\s*require\s*(\(\s*)?['"](?<name>[^'"]+)['"](\s*\))?/.match(line) { |m| m["name"] }


### PR DESCRIPTION
### Motivation

This is the same as #2434, but because dependabot closed the base branch, I couldn't re-open the same pull request after rebasing.

I dropped the stripping of the `T::` prefix for `Module` because it looks like the rewriter wasn't adding it back in yet (as the tests start failing with `undefined [] method for Module`).