### PR TITLE
Fix ActiveRecordRelations compiler insert/upsert methods signatures

### DIFF
--- a/lib/tapioca/dsl/compilers/active_record_relations.rb
+++ b/lib/tapioca/dsl/compilers/active_record_relations.rb
@@ -608,6 +608,7 @@ module Tapioca
           unique_by_type = "T.nilable(T.any(T::Array[T.any(Symbol, String)], Symbol, String))"
           record_timestamps_type = "T.nilable(T::Boolean)"
           update_only_type = "T.nilable(T::Array[T.any(Symbol, String)])"
+          on_duplicate_type = "T.any(Symbol, Arel::Nodes::SqlLiteral)"
 
           ASSOCIATION_METHODS.each do |method_name|
             case method_name
@@ -618,9 +619,10 @@ module Tapioca
                 create_kw_opt_param("record_timestamps", type: record_timestamps_type, default: "nil"),
               ]
 
-              # Only upsert_all has the `update_only` parameter
+              # Only upsert_all has the `update_only` and `on_duplicate` parameters
               if method_name == :upsert_all
                 parameters << create_kw_opt_param("update_only", type: update_only_type, default: "nil")
+                parameters << create_kw_opt_param("on_duplicate", type: on_duplicate_type, default: ":update")
               end
 
               # Bang methods don't have the `unique_by` parameter
@@ -640,9 +642,10 @@ module Tapioca
                 create_kw_opt_param("record_timestamps", type: record_timestamps_type, default: "nil"),
               ]
 
-              # Only upsert has the `update_only` parameter
+              # Only upsert has the `update_only` and `on_duplicate` parameters
               if method_name == :upsert
                 parameters << create_kw_opt_param("update_only", type: update_only_type, default: "nil")
+                parameters << create_kw_opt_param("on_duplicate", type: on_duplicate_type, default: ":update")
               end
 
               # Bang methods don't have the `unique_by` parameter
@@ -972,6 +975,7 @@ module Tapioca
               unique_by_type = "T.nilable(T.any(T::Array[T.any(Symbol, String)], Symbol, String))"
               record_timestamps_type = "T.nilable(T::Boolean)"
               update_only_type = "T.nilable(T::Array[T.any(Symbol, String)])"
+              on_duplicate_type = "T.any(Symbol, Arel::Nodes::SqlLiteral)"
 
               parameters = [
                 create_param("attributes", type: "T::Array[Hash]"),
@@ -979,9 +983,10 @@ module Tapioca
                 create_kw_opt_param("record_timestamps", type: record_timestamps_type, default: "nil"),
               ]
 
-              # Only upsert_all has the `update_only` parameter
+              # Only upsert_all has the `update_only` and `on_duplicate` parameters
               if method_name == :upsert_all
                 parameters << create_kw_opt_param("update_only", type: update_only_type, default: "nil")
+                parameters << create_kw_opt_param("on_duplicate", type: on_duplicate_type, default: ":update")
               end
 
               # Bang methods don't have the `unique_by` parameter
@@ -999,6 +1004,7 @@ module Tapioca
               unique_by_type = "T.nilable(T.any(T::Array[T.any(Symbol, String)], Symbol, String))"
               record_timestamps_type = "T.nilable(T::Boolean)"
               update_only_type = "T.nilable(T::Array[T.any(Symbol, String)])"
+              on_duplicate_type = "T.any(Symbol, Arel::Nodes::SqlLiteral)"
 
               parameters = [
                 create_param("attributes", type: "Hash"),
@@ -1006,9 +1012,10 @@ module Tapioca
                 create_kw_opt_param("record_timestamps", type: record_timestamps_type, default: "nil"),
               ]
 
-              # Only upsert has the `update_only` parameter
+              # Only upsert has the `update_only` and `on_duplicate` parameters
               if method_name == :upsert
                 parameters << create_kw_opt_param("update_only", type: update_only_type, default: "nil")
+                parameters << create_kw_opt_param("on_duplicate", type: on_duplicate_type, default: ":update")
               end
 
               # Bang methods don't have the `unique_by` parameter

--- a/spec/tapioca/dsl/compilers/active_record_relations_spec.rb
+++ b/spec/tapioca/dsl/compilers/active_record_relations_spec.rb
@@ -335,11 +335,11 @@ module Tapioca
                     sig { returns(::Post) }
                     def third_to_last!; end
 
-                    sig { params(attributes: Hash, returning: T.nilable(T.any(T::Array[T.any(Symbol, String)], String, FalseClass)), record_timestamps: T.nilable(T::Boolean), update_only: T.nilable(T::Array[T.any(Symbol, String)]), unique_by: T.nilable(T.any(T::Array[T.any(Symbol, String)], Symbol, String))).returns(ActiveRecord::Result) }
-                    def upsert(attributes, returning: nil, record_timestamps: nil, update_only: nil, unique_by: nil); end
+                    sig { params(attributes: Hash, returning: T.nilable(T.any(T::Array[T.any(Symbol, String)], String, FalseClass)), record_timestamps: T.nilable(T::Boolean), update_only: T.nilable(T::Array[T.any(Symbol, String)]), on_duplicate: T.any(Symbol, Arel::Nodes::SqlLiteral), unique_by: T.nilable(T.any(T::Array[T.any(Symbol, String)], Symbol, String))).returns(ActiveRecord::Result) }
+                    def upsert(attributes, returning: nil, record_timestamps: nil, update_only: nil, on_duplicate: :update, unique_by: nil); end
 
-                    sig { params(attributes: T::Array[Hash], returning: T.nilable(T.any(T::Array[T.any(Symbol, String)], String, FalseClass)), record_timestamps: T.nilable(T::Boolean), update_only: T.nilable(T::Array[T.any(Symbol, String)]), unique_by: T.nilable(T.any(T::Array[T.any(Symbol, String)], Symbol, String))).returns(ActiveRecord::Result) }
-                    def upsert_all(attributes, returning: nil, record_timestamps: nil, update_only: nil, unique_by: nil); end
+                    sig { params(attributes: T::Array[Hash], returning: T.nilable(T.any(T::Array[T.any(Symbol, String)], String, FalseClass)), record_timestamps: T.nilable(T::Boolean), update_only: T.nilable(T::Array[T.any(Symbol, String)]), on_duplicate: T.any(Symbol, Arel::Nodes::SqlLiteral), unique_by: T.nilable(T.any(T::Array[T.any(Symbol, String)], Symbol, String))).returns(ActiveRecord::Result) }
+                    def upsert_all(attributes, returning: nil, record_timestamps: nil, update_only: nil, on_duplicate: :update, unique_by: nil); end
                   end
 
                   module GeneratedAssociationRelationMethods
@@ -1052,11 +1052,11 @@ module Tapioca
                     sig { returns(::Post) }
                     def third_to_last!; end
 
-                    sig { params(attributes: Hash, returning: T.nilable(T.any(T::Array[T.any(Symbol, String)], String, FalseClass)), record_timestamps: T.nilable(T::Boolean), update_only: T.nilable(T::Array[T.any(Symbol, String)]), unique_by: T.nilable(T.any(T::Array[T.any(Symbol, String)], Symbol, String))).returns(ActiveRecord::Result) }
-                    def upsert(attributes, returning: nil, record_timestamps: nil, update_only: nil, unique_by: nil); end
+                    sig { params(attributes: Hash, returning: T.nilable(T.any(T::Array[T.any(Symbol, String)], String, FalseClass)), record_timestamps: T.nilable(T::Boolean), update_only: T.nilable(T::Array[T.any(Symbol, String)]), on_duplicate: T.any(Symbol, Arel::Nodes::SqlLiteral), unique_by: T.nilable(T.any(T::Array[T.any(Symbol, String)], Symbol, String))).returns(ActiveRecord::Result) }
+                    def upsert(attributes, returning: nil, record_timestamps: nil, update_only: nil, on_duplicate: :update, unique_by: nil); end
 
-                    sig { params(attributes: T::Array[Hash], returning: T.nilable(T.any(T::Array[T.any(Symbol, String)], String, FalseClass)), record_timestamps: T.nilable(T::Boolean), update_only: T.nilable(T::Array[T.any(Symbol, String)]), unique_by: T.nilable(T.any(T::Array[T.any(Symbol, String)], Symbol, String))).returns(ActiveRecord::Result) }
-                    def upsert_all(attributes, returning: nil, record_timestamps: nil, update_only: nil, unique_by: nil); end
+                    sig { params(attributes: T::Array[Hash], returning: T.nilable(T.any(T::Array[T.any(Symbol, String)], String, FalseClass)), record_timestamps: T.nilable(T::Boolean), update_only: T.nilable(T::Array[T.any(Symbol, String)]), on_duplicate: T.any(Symbol, Arel::Nodes::SqlLiteral), unique_by: T.nilable(T.any(T::Array[T.any(Symbol, String)], Symbol, String))).returns(ActiveRecord::Result) }
+                    def upsert_all(attributes, returning: nil, record_timestamps: nil, update_only: nil, on_duplicate: :update, unique_by: nil); end
                   end
 
                   module GeneratedAssociationRelationMethods


### PR DESCRIPTION
### Motivation

Fixes the generated RBI signatures for `ActiveRecord::Relation`'s [insert](https://github.com/rails/rails/blob/main/activerecord/lib/active_record/relation.rb#L664), [insert!](https://github.com/rails/rails/blob/main/activerecord/lib/active_record/relation.rb#L753), [insert_all](https://github.com/rails/rails/blob/main/activerecord/lib/active_record/relation.rb#L743), [insert_all!](https://github.com/rails/rails/blob/main/activerecord/lib/active_record/relation.rb#L810), [upsert](https://github.com/rails/rails/blob/main/activerecord/lib/active_record/relation.rb#L820), and [upsert_all](https://github.com/rails/rails/blob/main/activerecord/lib/active_record/relation.rb#L932) methods.


### Implementation

- Fix `returning` and `unique_by` parameter types
- Add missing `record_timestamps` parameter to all insert/upsert methods
- Add `update_only` and `on_duplicate` parameters to `upsert` and `upsert_all` methods

