### PR TITLE
Stop generating RBI for insert/upsert related methods

### DIFF
--- a/lib/tapioca/dsl/compilers/active_record_relations.rb
+++ b/lib/tapioca/dsl/compilers/active_record_relations.rb
@@ -604,47 +604,9 @@ module Tapioca
 
         #: -> void
         def create_association_relation_methods
-          returning_type = "T.nilable(T.any(T::Array[Symbol], FalseClass))"
-          unique_by_type = "T.nilable(T.any(T::Array[Symbol], Symbol))"
-
-          ASSOCIATION_METHODS.each do |method_name|
-            case method_name
-            when :insert_all, :insert_all!, :upsert_all
-              parameters = [
-                create_param("attributes", type: "T::Array[Hash]"),
-                create_kw_opt_param("returning", type: returning_type, default: "nil"),
-              ]
-
-              # Bang methods don't have the `unique_by` parameter
-              unless bang_method?(method_name)
-                parameters << create_kw_opt_param("unique_by", type: unique_by_type, default: "nil")
-              end
-
-              association_relation_methods_module.create_method(
-                method_name.to_s,
-                parameters: parameters,
-                return_type: "ActiveRecord::Result",
-              )
-            when :insert, :insert!, :upsert
-              parameters = [
-                create_param("attributes", type: "Hash"),
-                create_kw_opt_param("returning", type: returning_type, default: "nil"),
-              ]
-
-              # Bang methods don't have the `unique_by` parameter
-              unless bang_method?(method_name)
-                parameters << create_kw_opt_param("unique_by", type: unique_by_type, default: "nil")
-              end
-
-              association_relation_methods_module.create_method(
-                method_name.to_s,
-                parameters: parameters,
-                return_type: "ActiveRecord::Result",
-              )
-            when :proxy_association
-              # skip - private method
-            end
-          end
+          # skips insert/upsert methods - these methods' signatures aren't model-specific and don't need to be generated dynamically
+          # also skips proxy_association method - it's a private method
+          # but there could be other association methods that we need to generate
         end
 
         #: -> void
@@ -953,44 +915,8 @@ module Tapioca
                   sig.return_type = constant_name
                 end
               end
-            when :insert_all, :insert_all!, :upsert_all # insert all methods
-              returning_type = "T.nilable(T.any(T::Array[Symbol], FalseClass))"
-              unique_by_type = "T.nilable(T.any(T::Array[Symbol], Symbol))"
-
-              parameters = [
-                create_param("attributes", type: "T::Array[Hash]"),
-                create_kw_opt_param("returning", type: returning_type, default: "nil"),
-              ]
-
-              # Bang methods don't have the `unique_by` parameter
-              unless bang_method?(method_name)
-                parameters << create_kw_opt_param("unique_by", type: unique_by_type, default: "nil")
-              end
-
-              common_relation_methods_module.create_method(
-                method_name.to_s,
-                parameters: parameters,
-                return_type: "ActiveRecord::Result",
-              )
-            when :insert, :insert!, :upsert # insert methods
-              returning_type = "T.nilable(T.any(T::Array[Symbol], FalseClass))"
-              unique_by_type = "T.nilable(T.any(T::Array[Symbol], Symbol))"
-
-              parameters = [
-                create_param("attributes", type: "Hash"),
-                create_kw_opt_param("returning", type: returning_type, default: "nil"),
-              ]
-
-              # Bang methods don't have the `unique_by` parameter
-              unless bang_method?(method_name)
-                parameters << create_kw_opt_param("unique_by", type: unique_by_type, default: "nil")
-              end
-
-              common_relation_methods_module.create_method(
-                method_name.to_s,
-                parameters: parameters,
-                return_type: "ActiveRecord::Result",
-              )
+            when :insert_all, :insert_all!, :upsert_all, :insert, :insert!, :upsert # insert methods
+              # skip - these methods' signatures aren't model-specific and don't need to be generated dynamically
             when :delete, :destroy
               # For these cases, it is valid to pass the above kind of things, but also:
               # - a model identifier, which can be:

--- a/spec/tapioca/dsl/compilers/active_record_relations_spec.rb
+++ b/spec/tapioca/dsl/compilers/active_record_relations_spec.rb
@@ -249,18 +249,6 @@ module Tapioca
                     sig { params(record: T.untyped).returns(T::Boolean) }
                     def include?(record); end
 
-                    sig { params(attributes: Hash, returning: T.nilable(T.any(T::Array[Symbol], FalseClass)), unique_by: T.nilable(T.any(T::Array[Symbol], Symbol))).returns(ActiveRecord::Result) }
-                    def insert(attributes, returning: nil, unique_by: nil); end
-
-                    sig { params(attributes: Hash, returning: T.nilable(T.any(T::Array[Symbol], FalseClass))).returns(ActiveRecord::Result) }
-                    def insert!(attributes, returning: nil); end
-
-                    sig { params(attributes: T::Array[Hash], returning: T.nilable(T.any(T::Array[Symbol], FalseClass)), unique_by: T.nilable(T.any(T::Array[Symbol], Symbol))).returns(ActiveRecord::Result) }
-                    def insert_all(attributes, returning: nil, unique_by: nil); end
-
-                    sig { params(attributes: T::Array[Hash], returning: T.nilable(T.any(T::Array[Symbol], FalseClass))).returns(ActiveRecord::Result) }
-                    def insert_all!(attributes, returning: nil); end
-
                     sig { returns(T.nilable(::Post)) }
                     sig { params(limit: Integer).returns(T::Array[::Post]) }
                     def last(limit = nil); end
@@ -334,12 +322,6 @@ module Tapioca
 
                     sig { returns(::Post) }
                     def third_to_last!; end
-
-                    sig { params(attributes: Hash, returning: T.nilable(T.any(T::Array[Symbol], FalseClass)), unique_by: T.nilable(T.any(T::Array[Symbol], Symbol))).returns(ActiveRecord::Result) }
-                    def upsert(attributes, returning: nil, unique_by: nil); end
-
-                    sig { params(attributes: T::Array[Hash], returning: T.nilable(T.any(T::Array[Symbol], FalseClass)), unique_by: T.nilable(T.any(T::Array[Symbol], Symbol))).returns(ActiveRecord::Result) }
-                    def upsert_all(attributes, returning: nil, unique_by: nil); end
                   end
 
                   module GeneratedAssociationRelationMethods
@@ -966,18 +948,6 @@ module Tapioca
                     sig { params(record: T.untyped).returns(T::Boolean) }
                     def include?(record); end
 
-                    sig { params(attributes: Hash, returning: T.nilable(T.any(T::Array[Symbol], FalseClass)), unique_by: T.nilable(T.any(T::Array[Symbol], Symbol))).returns(ActiveRecord::Result) }
-                    def insert(attributes, returning: nil, unique_by: nil); end
-
-                    sig { params(attributes: Hash, returning: T.nilable(T.any(T::Array[Symbol], FalseClass))).returns(ActiveRecord::Result) }
-                    def insert!(attributes, returning: nil); end
-
-                    sig { params(attributes: T::Array[Hash], returning: T.nilable(T.any(T::Array[Symbol], FalseClass)), unique_by: T.nilable(T.any(T::Array[Symbol], Symbol))).returns(ActiveRecord::Result) }
-                    def insert_all(attributes, returning: nil, unique_by: nil); end
-
-                    sig { params(attributes: T::Array[Hash], returning: T.nilable(T.any(T::Array[Symbol], FalseClass))).returns(ActiveRecord::Result) }
-                    def insert_all!(attributes, returning: nil); end
-
                     sig { returns(T.nilable(::Post)) }
                     sig { params(limit: Integer).returns(T::Array[::Post]) }
                     def last(limit = nil); end
@@ -1051,12 +1021,6 @@ module Tapioca
 
                     sig { returns(::Post) }
                     def third_to_last!; end
-
-                    sig { params(attributes: Hash, returning: T.nilable(T.any(T::Array[Symbol], FalseClass)), unique_by: T.nilable(T.any(T::Array[Symbol], Symbol))).returns(ActiveRecord::Result) }
-                    def upsert(attributes, returning: nil, unique_by: nil); end
-
-                    sig { params(attributes: T::Array[Hash], returning: T.nilable(T.any(T::Array[Symbol], FalseClass)), unique_by: T.nilable(T.any(T::Array[Symbol], Symbol))).returns(ActiveRecord::Result) }
-                    def upsert_all(attributes, returning: nil, unique_by: nil); end
                   end
 
                   module GeneratedAssociationRelationMethods


### PR DESCRIPTION
### Motivation

These methods' signatures aren't model-specific and don't need to be generated through runtime for every model. We can use rbi-central for them instead.

There are other methods that probably aren't model-specific and can be removed too. But I'd prefer dropping them later as these ones causes the most errors in Core.

Closes #2425 #2441

### Implementation

Just remove associated logic from AR compiler.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->

