### PR TITLE
Add `unscoped` to Active Record relations compiler

### DIFF
--- a/lib/tapioca/dsl/compilers/active_record_relations.rb
+++ b/lib/tapioca/dsl/compilers/active_record_relations.rb
@@ -541,6 +541,7 @@ module Tapioca
         #: -> void
         def create_relation_methods
           create_relation_method("all")
+          create_unscoped_relation_method
 
           QUERY_METHODS.each do |method_name|
             case method_name
@@ -1055,6 +1056,35 @@ module Tapioca
             parameters: parameters,
             return_type: association_return_type,
           )
+        end
+
+        #: -> void
+        def create_unscoped_relation_method
+          relation_methods_module.create_method("unscoped") do |method|
+            method.add_block_param("block")
+
+            method.add_sig do |sig|
+              sig.return_type = RelationClassName
+            end
+
+            method.add_sig(type_params: ["U"]) do |sig|
+              sig.add_param("block", "T.proc.returns(T.type_parameter(:U))")
+              sig.return_type = "T.type_parameter(:U)"
+            end
+          end
+
+          association_relation_methods_module.create_method("unscoped") do |method|
+            method.add_block_param("block")
+
+            method.add_sig do |sig|
+              sig.return_type = AssociationRelationClassName
+            end
+
+            method.add_sig(type_params: ["U"]) do |sig|
+              sig.add_param("block", "T.proc.returns(T.type_parameter(:U))")
+              sig.return_type = "T.type_parameter(:U)"
+            end
+          end
         end
       end
     end

--- a/spec/tapioca/dsl/compilers/active_record_relations_spec.rb
+++ b/spec/tapioca/dsl/compilers/active_record_relations_spec.rb
@@ -455,6 +455,10 @@ module Tapioca
                     sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
                     def unscope(*args, &blk); end
 
+                    sig { returns(PrivateAssociationRelation) }
+                    sig { type_parameters(:U).params(block: T.proc.returns(T.type_parameter(:U))).returns(T.type_parameter(:U)) }
+                    def unscoped(&block); end
+
                     sig { returns(PrivateAssociationRelationWhereChain) }
                     sig { params(args: T.untyped).returns(PrivateAssociationRelation) }
                     def where(*args); end
@@ -599,6 +603,10 @@ module Tapioca
 
                     sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
                     def unscope(*args, &blk); end
+
+                    sig { returns(PrivateRelation) }
+                    sig { type_parameters(:U).params(block: T.proc.returns(T.type_parameter(:U))).returns(T.type_parameter(:U)) }
+                    def unscoped(&block); end
 
                     sig { returns(PrivateRelationWhereChain) }
                     sig { params(args: T.untyped).returns(PrivateRelation) }
@@ -1154,6 +1162,10 @@ module Tapioca
                     sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
                     def unscope(*args, &blk); end
 
+                    sig { returns(PrivateAssociationRelation) }
+                    sig { type_parameters(:U).params(block: T.proc.returns(T.type_parameter(:U))).returns(T.type_parameter(:U)) }
+                    def unscoped(&block); end
+
                     sig { returns(PrivateAssociationRelationWhereChain) }
                     sig { params(args: T.untyped).returns(PrivateAssociationRelation) }
                     def where(*args); end
@@ -1298,6 +1310,10 @@ module Tapioca
 
                     sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
                     def unscope(*args, &blk); end
+
+                    sig { returns(PrivateRelation) }
+                    sig { type_parameters(:U).params(block: T.proc.returns(T.type_parameter(:U))).returns(T.type_parameter(:U)) }
+                    def unscoped(&block); end
 
                     sig { returns(PrivateRelationWhereChain) }
                     sig { params(args: T.untyped).returns(PrivateRelation) }


### PR DESCRIPTION
### Motivation
Closes https://github.com/Shopify/tapioca/issues/2451

### Implementation
See https://api.rubyonrails.org/classes/ActiveRecord/Scoping/Default/ClassMethods.html#method-i-unscoped for reference.
