### PR TITLE
Fix binpath in CI error messages

### DIFF
--- a/lib/tapioca.rb
+++ b/lib/tapioca.rb
@@ -17,7 +17,6 @@ module Tapioca
   TAPIOCA_DIR = "#{SORBET_DIR}/tapioca" #: String
   TAPIOCA_CONFIG_FILE = "#{TAPIOCA_DIR}/config.yml" #: String
 
-  BINARY_FILE = "bin/tapioca" #: String
   DEFAULT_POSTREQUIRE_FILE = "#{TAPIOCA_DIR}/require.rb" #: String
   DEFAULT_RBI_DIR = "#{SORBET_DIR}/rbi" #: String
   DEFAULT_DSL_DIR = "#{DEFAULT_RBI_DIR}/dsl" #: String
@@ -38,6 +37,21 @@ module Tapioca
   CENTRAL_REPO_ROOT_URI = "https://raw.githubusercontent.com/Shopify/rbi-central/main"
   CENTRAL_REPO_INDEX_PATH = "index.json"
   CENTRAL_REPO_ANNOTATIONS_DIR = "rbi/annotations"
+
+  #: -> bool
+  def self.__is_this_bundle_tapioca_itself?
+    (Bundler.root + "tapioca.gemspec").exist?
+  rescue Bundler::GemfileNotFound
+    false
+  end
+
+  BINARY_FILE = if __is_this_bundle_tapioca_itself?
+    # This code is running from the Tapioca repo itself, which doesn't have `bin/tapioca`
+    "exe/tapioca"
+  else
+    # This code is running from any other user of Tapioca, who should have a binstub.
+    "bin/tapioca"
+  end #: String
 end
 
 require "tapioca/version"


### PR DESCRIPTION
### Motivation

Fix the command suggested by this error message in Tapioca's CI:

```diff
bundle exec exe/tapioca gem --verify
Checking for out-of-date RBIs...

RBI files are out-of-date. In your development environment, please run:
-  `bin/tapioca gem`
+  `exe/tapioca gem`
Once it is complete, be sure to commit and push any changes

Reason:
  File(s) changed:
  - sorbet/rbi/gems/action_text-trix@2.1.16.rbi
  - sorbet/rbi/gems/bigdecimal@4.0.1.rbi
  - sorbet/rbi/gems/concurrent-ruby@1.3.6.rbi
  - sorbet/rbi/gems/i18n@1.14.8.rbi
  - sorbet/rbi/gems/loofah@2.25.0.rbi
  - sorbet/rbi/gems/rack-test@2.2.0.rbi
  - sorbet/rbi/gems/rackup@2.3.1.rbi
  - sorbet/rbi/gems/rails-dom-testing@2.3.0.rbi
  - sorbet/rbi/gems/rails-html-sanitizer@1.6.2.rbi
  - sorbet/rbi/gems/rdoc@7.0.3.rbi
  - sorbet/rbi/gems/uri@1.1.1.rbi
  - sorbet/rbi/gems/zeitwerk@2.7.4.rbi
```

### Implementation

I just conditionally change the value of `BINARY_FILE` on startup, but that involves an extra IO op to stat `Bundler.root + "tapioca.gemspec"`.

Another idea I had was to symlink from `bin/tapioca` to `exe/tapioca`

### Tests

Not tested :D