### PR TITLE
Silence expected warning about `__id__` definition

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -29,3 +29,46 @@ module Minitest
     extend Rails::LineFiltering
   end
 end
+
+module WarnMonkeyPatch
+  # extend T::Sig
+
+  # Detects the file, line number and "warning: " prefix at the
+  # start of every warning message, for us to chop off.
+  # Users can get the file/line from the backtrace.
+  WARNING_PREFIX_PATTERN = /^.+?:\d+: warning: /
+
+  #: (String message, ?category: Symbol?, **top) -> void
+  def warn(message, category: nil, **kwargs)
+    if Thread.current[:__raise_warnings_as_exceptions]
+      message.sub!(WARNING_PREFIX_PATTERN, "")
+      message.chomp!
+      Kernel.raise Warning::Exception, message
+    else
+      super
+    end
+  end
+
+  # sig do
+  #   type_parameters(:R)
+  #     .params(block: T.proc.returns(T.type_parameter(:R)))
+  #     .returns(T.type_parameter(:R))
+  # end
+  #: [R] { -> R } -> R
+  def raise_warnings_as_exceptions(&block)
+    previous_state = Thread.current[:__raise_warnings_as_exceptions]
+    Thread.current[:__raise_warnings_as_exceptions] = true
+    block.call
+  ensure
+    Thread.current[:__raise_warnings_as_exceptions] = previous_state
+  end
+end
+
+module ::Warning
+  extend T::Helpers
+
+  Exception = Class.new(StandardError)
+  
+  singleton_class.prepend(WarnMonkeyPatch)
+  mixes_in_class_methods(WarnMonkeyPatch)
+end

--- a/spec/tapioca/runtime/reflection_spec.rb
+++ b/spec/tapioca/runtime/reflection_spec.rb
@@ -52,8 +52,18 @@ module Tapioca
         ::String
       end
 
-      def __id__ # rubocop:disable Naming/MethodName
-        1
+      begin
+        ::Warning.raise_warnings_as_exceptions do
+          def __id__ # rubocop:disable Naming/MethodName
+            1
+          end
+        end
+      rescue ::Warning::Exception => e
+        if e.message == "redefining '__id__' may cause serious problems"
+          # We know, that's why we're testing this :)
+        else
+          raise
+        end
       end
 
       def equal?(other)


### PR DESCRIPTION
### Motivation

Removes this line noise from CI logs:

```
/home/runner/work/tapioca/tapioca/spec/tapioca/runtime/reflection_spec.rb:55: warning: redefining '__id__' may cause serious problems
```

### Implementation

Hooks in the `Warning` callback chain, raises and exception, and ignores it if it's the one we expected.
