### PR TITLE
Support RBS signatures in check-shims command

### DIFF
--- a/lib/tapioca/helpers/rbi_files_helper.rb
+++ b/lib/tapioca/helpers/rbi_files_helper.rb
@@ -239,6 +239,7 @@ module Tapioca
             return true if shim_or_todo_prop.sigs.any? { |sig| node.sigs.include?(sig) }
 
             # Another prop has the same RBS comment, we have a duplicate
+            # Note: can't use `intersect?` here because RBI::RBSComment doesn't implement `eql?`/`hash`
             other_rbs_comments = extract_rbs_comments(node)
             return true if shim_rbs_comments.any? { |rbs| other_rbs_comments.include?(rbs) }
           end


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->

The `check-shims` command detects duplicate definitions between shim files and generated RBIs. It correctly ignores duplicates when the shim adds a `sig` block (since the shim is adding type information, not just duplicating). However, it doesn't recognize RBS comment syntax (`#:`) as a signature, so shims using RBS syntax are incorrectly flagged as duplicates.

With Sorbet's [RBS support](https://sorbet.org/docs/rbs-support), users can now write type signatures using RBS comments instead of `sig` blocks. The `check-shims` command should treat these equivalently.

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->

Modified `has_duplicated_methods_and_attrs?` in `RBIFilesHelper` to check for `RBI::RBSComment` instances in a node's `comments` array, in addition to checking the `sigs` array. The logic mirrors the existing signature handling:

- A shim with an RBS comment is not considered a duplicate of an untyped method (it's adding type info)
- A shim with a different RBS signature is not a duplicate (it's refining the type)
- A shim with an identical RBS signature is flagged as a duplicate

Added a small helper method `extract_rbs_comments` to extract RBS comments from a node.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->

Added 3 new tests mirroring the existing `sig` block tests:
- `ignores duplicates that have an RBS signature`
- `ignores duplicates that have a different RBS signature`
- `detects duplicates that have the same RBS signature`