### PR TITLE
Fix missing gem specs test

### DIFF
--- a/spec/tapioca/cli/gem_spec.rb
+++ b/spec/tapioca/cli/gem_spec.rb
@@ -767,10 +767,14 @@ module Tapioca
 
         it "must not generate RBIs for missing gem specs" do
           @project.write_gemfile!(<<~GEMFILE, append: true)
-            platform :rbx do
+            platform :jruby do
               gem "sidekiq", "=7.1.2"
             end
           GEMFILE
+
+          # We need to add the platform to the lock file so that bundler includes the gem
+          # but it won't be materializable on the current platform (since we are not on JRuby)
+          @project.exec("bundle lock --add-platform jruby")
 
           @project.bundle_install!
 


### PR DESCRIPTION
Apparently missing gem specs are only populated if the platform for the declared gem is one of the platforms Bundler is installing for. Since `:rbx` wasn't one of the added platforms, the gem was completely being ignored.

However, we can't just add `:rbx` as a platform to the lockfile since (a) it is not a platform supported by RubyGems anymore, and (b) it isn't a platform that Sorbet has any support for.

Of the platforms supported by RubyGems, the one that we can also resolve Sorbet against seems only to be the `:jruby` platform. So, adding the gem that we expect to be missing as a `:jruby` platform gem and then adding `:jruby` as a platform to the lockfile resurfaces the missing gem spec again.
