### PR TITLE
Make ActiveRecord delete/destroy_by argument a rest parameters

### DIFF
--- a/lib/tapioca/dsl/compilers/active_record_relations.rb
+++ b/lib/tapioca/dsl/compilers/active_record_relations.rb
@@ -945,7 +945,7 @@ module Tapioca
               common_relation_methods_module.create_method(
                 method_name.to_s,
                 parameters: [
-                  create_param("args", type: "T.untyped"),
+                  create_rest_param("args", type: "T.untyped"),
                 ],
                 return_type: method_name == :delete_by ? "Integer" : "T::Array[#{constant_name}]",
               )

--- a/spec/tapioca/dsl/compilers/active_record_relations_spec.rb
+++ b/spec/tapioca/dsl/compilers/active_record_relations_spec.rb
@@ -139,7 +139,7 @@ module Tapioca
                     def delete_all; end
 
                     sig { params(args: T.untyped).returns(Integer) }
-                    def delete_by(args); end
+                    def delete_by(*args); end
 
                     sig { params(records: T.any(::Post, Integer, String, T::Enumerable[T.any(::Post, Integer, String, T::Enumerable[::Post])])).returns(T::Array[::Post]) }
                     def destroy(*records); end
@@ -151,7 +151,7 @@ module Tapioca
                     def destroy_all; end
 
                     sig { params(args: T.untyped).returns(T::Array[::Post]) }
-                    def destroy_by(args); end
+                    def destroy_by(*args); end
 
                     sig { params(conditions: T.untyped).returns(T::Boolean) }
                     def exists?(conditions = :none); end
@@ -846,7 +846,7 @@ module Tapioca
                     def delete_all; end
 
                     sig { params(args: T.untyped).returns(Integer) }
-                    def delete_by(args); end
+                    def delete_by(*args); end
 
                     sig { params(records: T.any(::Post, Integer, String, T::Enumerable[T.any(::Post, Integer, String, T::Enumerable[::Post])])).returns(T::Array[::Post]) }
                     def destroy(*records); end
@@ -858,7 +858,7 @@ module Tapioca
                     def destroy_all; end
 
                     sig { params(args: T.untyped).returns(T::Array[::Post]) }
-                    def destroy_by(args); end
+                    def destroy_by(*args); end
 
                     sig { params(conditions: T.untyped).returns(T::Boolean) }
                     def exists?(conditions = :none); end


### PR DESCRIPTION
### Motivation
The `delete_by` and `destroy_by` ActiveRecord methods take multiple arguments (like `where`) instead of a single argument.

### Implementation
I just replaced `create_param` with `create_rest_param` and updated the tests

### Tests
I updated the tests to expect the rest argument instead of a single argument

