### PR TITLE
Simplify Minitest 6 integration

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,24 +14,23 @@ require "dsl_spec_helper"
 require "spec_with_project"
 require "rails_spec_helper"
 
-# Minitest::Reporters currently lacks support for Minitest 6
-# https://github.com/minitest-reporters/minitest-reporters/issues/368
-if Gem::Version.new(Minitest::VERSION) < Gem::Version.new("6.0")
-  require "minitest/reporters"
-  require "spec_reporter"
+require "minitest/reporters"
+require "spec_reporter"
 
-  backtrace_filter = Minitest::ExtensibleBacktraceFilter.default_filter
-  backtrace_filter.add_filter(%r{gems/sorbet-runtime})
-  backtrace_filter.add_filter(%r{gems/railties})
-  backtrace_filter.add_filter(%r{tapioca/helpers/test/})
+# Minitest::Reporters currently lacks support for Minitest 6 out of the box
+# but we can register the plugin to use it.
+# Ref: https://github.com/minitest-reporters/minitest-reporters/pull/366#issuecomment-3731951673
+require "minitest/minitest_reporter_plugin"
+Minitest.register_plugin(:minitest_reporter)
 
-  Minitest::Reporters.use!(SpecReporter.new(color: true), ENV, backtrace_filter)
-end
+backtrace_filter = Minitest::ExtensibleBacktraceFilter.default_filter
+backtrace_filter.add_filter(%r{gems/sorbet-runtime})
+backtrace_filter.add_filter(%r{gems/railties})
+backtrace_filter.add_filter(%r{tapioca/helpers/test/})
 
-# Minitest 6 split Minitest::Mock out into its own gem
-if Gem::Version.new(Minitest::VERSION) >= Gem::Version.new("6.0")
-  require "minitest/mock"
-end
+Minitest::Reporters.use!(SpecReporter.new(color: true), ENV, backtrace_filter)
+
+require "minitest/mock"
 
 module Minitest
   class Test

--- a/spec/spec_reporter.rb
+++ b/spec/spec_reporter.rb
@@ -2,21 +2,10 @@
 # frozen_string_literal: true
 
 class SpecReporter < Minitest::Reporters::SpecReporter
-  def before_suite(suite)
-    suite.name.split("::").reduce(0) do |padding, name|
-      puts pad(name, padding)
-      padding + TEST_PADDING
-    end
-  end
-
   def record(test)
     # Trim leading "test_dddd_" and replace it with "it "
     test.name = test.name.gsub(/^test_\d{4}_/, "it ")
     @test_padding = test.class_name.split("::").size * TEST_PADDING
     super
-  end
-
-  def pad_test(str)
-    pad(format("%-#{TEST_SIZE}s", str), @test_padding)
   end
 end


### PR DESCRIPTION
We don't need many of the version checks and conditionals for Minitest 6, we can use the reporters on Minitest 6 just fine and load `minitest-mock` on all versions.

While I am at it, I also simplified our custom `SpecHelper` implementation so that it stops doing the nesting printout for the suite name.