### PR TITLE
Faster `Reflection#singleton_class_of`

### DIFF
--- a/lib/tapioca/runtime/reflection.rb
+++ b/lib/tapioca/runtime/reflection.rb
@@ -21,7 +21,6 @@ module Tapioca
       CLASS_METHOD = Kernel.instance_method(:class) #: UnboundMethod
       CONSTANTS_METHOD = Module.instance_method(:constants) #: UnboundMethod
       NAME_METHOD = Module.instance_method(:name) #: UnboundMethod
-      SINGLETON_CLASS_METHOD = Object.instance_method(:singleton_class) #: UnboundMethod
       ANCESTORS_METHOD = Module.instance_method(:ancestors) #: UnboundMethod
       SUPERCLASS_METHOD = Class.instance_method(:superclass) #: UnboundMethod
       OBJECT_ID_METHOD = BasicObject.instance_method(:__id__) #: UnboundMethod
@@ -66,7 +65,9 @@ module Tapioca
 
       #: (T::Module[top] constant) -> Class[top]
       def singleton_class_of(constant)
-        SINGLETON_CLASS_METHOD.bind_call(constant)
+        class << constant
+          self
+        end
       end
 
       #: (T::Module[top] constant) -> Array[T::Module[top]]


### PR DESCRIPTION
### Motivation

Saved 44 ns per call lol

```
ruby 3.4.3 (2025-04-14 revision d0b7e5b6a0) +PRISM [arm64-darwin23]
Warming up --------------------------------------
   x.singleton_class     5.513M i/100ms
           bind_call     1.207M i/100ms
            class <<     2.879M i/100ms
Calculating -------------------------------------
   x.singleton_class     54.893M (± 3.2%) i/s   (18.22 ns/i) -    275.626M in   5.026668s
           bind_call     12.055M (± 2.2%) i/s   (82.95 ns/i) -     60.349M in   5.008511s
            class <<     26.106M (±18.0%) i/s   (38.30 ns/i) -    123.807M in   5.006527s

Comparison:
   x.singleton_class: 54892654.6 i/s
            class <<: 26106370.4 i/s - 2.10x  slower
           bind_call: 12055410.2 i/s - 4.55x  slower
```

<details><summary><code>benchmark.rb</code></summary>

```rb
#!/usr/bin/env ruby
# frozen_string_literal: true

require 'benchmark/ips'

x = Object.new
x.singleton_class # pre-allocate the singleton class before the benchmark

SINGLETON_CLASS_METHOD = Kernel.instance_method(:singleton_class)
  
Benchmark.ips do |x|
  x.config(warmup: 2, time: 5)

  x.report("x.singleton_class".rjust(17)) do |times|
    i = 0
    while (i += 1) <= times
      x.singleton_class
    end
  end

  x.report("bind_call".rjust(17)) do |times|
    i = 0
    while (i += 1) <= times
      SINGLETON_CLASS_METHOD.bind_call(x)
    end
  end

  x.report("class <<".rjust(17)) do |times|
    i = 0
    while (i += 1) <= times
      class << x; self; end
    end
  end

  x.compare!
end
```

</details>

Makes `lib/tapioca/runtime/attached_class_of_legacy.rb` ever-so-slightly faster, because it calls this once for every single object in your process.
