### PR TITLE
Use explicit type annotations for CurrentAttributes methods

### DIFF
--- a/lib/tapioca/dsl/compilers/active_support_current_attributes.rb
+++ b/lib/tapioca/dsl/compilers/active_support_current_attributes.rb
@@ -72,11 +72,11 @@ module Tapioca
             current_attributes_methods_name = "GeneratedAttributeMethods"
             current_attributes.create_module(current_attributes_methods_name) do |generated_attribute_methods|
               dynamic_methods.each do |method|
-                method = method.to_s
+                method = constant.instance_method(method)
                 # We want to generate each method both on the class
-                generate_method(current_attributes, method, class_method: true)
+                create_method_from_def(current_attributes, method, class_method: true)
                 # and on the instance
-                generate_method(generated_attribute_methods, method, class_method: false)
+                create_method_from_def(generated_attribute_methods, method, class_method: false)
               end
 
               instance_methods.each do |method|
@@ -109,17 +109,6 @@ module Tapioca
         #: -> Array[Symbol]
         def instance_methods_of_constant
           constant.instance_methods(false)
-        end
-
-        #: (RBI::Scope klass, String method, class_method: bool) -> void
-        def generate_method(klass, method, class_method:)
-          method_def = if class_method
-            constant.method(method)
-          else
-            constant.instance_method(method)
-          end
-
-          create_method_from_def(klass, method_def, class_method: class_method)
         end
       end
     end

--- a/spec/tapioca/dsl/compilers/active_support_current_attributes_spec.rb
+++ b/spec/tapioca/dsl/compilers/active_support_current_attributes_spec.rb
@@ -142,6 +142,52 @@ module Tapioca
 
               assert_equal(expected, rbi_for(:Current))
             end
+
+            it "copies types from instance methods to class methods" do
+              add_ruby_file("current.rb", <<~RUBY)
+                class Current < ActiveSupport::CurrentAttributes
+                  extend T::Sig
+
+                  attribute :user_id
+
+                  sig { returns(T.nilable(Integer)) }
+                  def user_id
+                    super
+                  end
+
+                  sig { params(value: T.nilable(Integer)).void }
+                  def user_id=(value)
+                    super
+                  end
+                end
+              RUBY
+
+              expected = <<~RBI
+                # typed: strong
+
+                class Current
+                  include GeneratedAttributeMethods
+
+                  class << self
+                    sig { returns(T.nilable(::Integer)) }
+                    def user_id; end
+
+                    sig { params(value: T.nilable(::Integer)).void }
+                    def user_id=(value); end
+                  end
+
+                  module GeneratedAttributeMethods
+                    sig { returns(T.nilable(::Integer)) }
+                    def user_id; end
+
+                    sig { params(value: T.nilable(::Integer)).void }
+                    def user_id=(value); end
+                  end
+                end
+              RBI
+
+              assert_equal(expected, rbi_for(:Current))
+            end
           end
         end
       end


### PR DESCRIPTION
### Motivation

When an explicit type is given for an attributes, e.g. by

```ruby
attribute :user_id

#: -> Integer?
def user_id = super
```

we should use that type in the class methods rather than untyped.

### Implementation

Rather than grab the method from the class, use `instance_method()` for
both the class and the GeneratedAttributesMethod signatures.

### Tests

Yes.
