### PR TITLE
Add workaround to Ubuntu RubyGems permission issue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,12 @@ jobs:
         # Remove Gemfile.lock for Ruby head builds and non-Rails current builds
         if: ${{ matrix.ruby == 'head' || matrix.rails != 'current' }}
         run: "rm -f Gemfile.lock"
+
+      # Workaround for https://github.com/ruby/rubygems/issues/9284.
+      - name: Remove pre-installed Ruby 4.0
+        if: ${{ matrix.ruby == '4.0' }}
+        run: rm -rf /opt/hostedtoolcache/Ruby/4.0*
+
       - name: Set up Ruby
         uses: ruby/setup-ruby@90be1154f987f4dc0fe0dd0feedac9e473aa4ba8 # v1.286.0
         with:


### PR DESCRIPTION
### Motivation

See https://github.com/ruby/rubygems/issues/9284

There's an issue with the latest Ubuntu runners and RubyGems on Ruby 4 that makes bundle install fail. The issue was already reported here https://github.com/actions/runner-images/issues/13647, but until it is fixed we can get CI passing with this workaround.