### PR TITLE
Update to latest version of bundler and rubygems everywhere

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         uses: ruby/setup-ruby@09a7688d3b55cf0e976497ff046b70949eeaccfd # v1.288.0
         with:
           bundler-cache: true
-          rubygems: 4.0.4
+          rubygems: 4.0.7
       - name: Run type check
         run: bin/typecheck
       - name: Run type check with Prism parser
@@ -43,7 +43,7 @@ jobs:
       matrix:
         ruby: ["3.2", "3.3", "3.4", "4.0","head"]
         rails: ["8.0", "current", "main"]
-        rubygems: ["3.6.2"]
+        rubygems: ["4.0.7"]
         exclude:
           - ruby: "3.2"
             rails: "main"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -478,4 +478,4 @@ DEPENDENCIES
   xpath
 
 BUNDLED WITH
-  4.0.3
+  4.0.7


### PR DESCRIPTION
### Motivation

I noticed we're still using an older version of rubygems, which I suppose I missed in https://github.com/Shopify/tapioca/pull/2490, and thus I'm proposing we update that _and_ all the previously updated bundler versions to the latest 4.0.7.

- https://github.com/ruby/rubygems/releases/tag/v4.0.7
- https://github.com/ruby/rubygems/releases/tag/bundler-v4.0.7

### Implementation

`bundler update --bundler` + manually updating `ci.yml`.

### Tests

CI passing should be sufficient. Already tested in [my fork](https://github.com/larouxn/tapioca/actions/runs/22494350762).
