### PR TITLE
Pre-load AR schemas and disconnect before forking DSL workers

### DIFF
--- a/lib/tapioca/dsl/pipeline.rb
+++ b/lib/tapioca/dsl/pipeline.rb
@@ -73,6 +73,21 @@ module Tapioca
 
         if defined?(::ActiveRecord::Base) && constants_to_process.any? { |c| ::ActiveRecord::Base > c }
           abort_if_pending_migrations!
+
+          # Pre-load the schema for all AR models we're about to process. This populates the schema cache in the
+          # parent process so that forked workers inherit it via copy-on-write and don't each need to establish their
+          # own database connection just to load schema information.
+          constants_to_process.each do |c|
+            next unless ::ActiveRecord::Base > c
+
+            ar_model = c #: as singleton(::ActiveRecord::Base)
+            ar_model.load_schema
+          end
+
+          # Disconnect all database connections before forking workers. The migration check and schema pre-loading
+          # above may have established connections; clearing them ensures forked children don't inherit stale
+          # connections from the parent, avoiding exceeding connection limits (e.g. Semian ticket counts).
+          ::ActiveRecord::Base.connection_handler.clear_all_connections!
         end
 
         result = Executor.new(


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
With multiple workers, we've been hitting connection limits on CI when verifying DSL RBI files. This PR attempts to fix that problem.

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
Pre-load the schema for all ActiveRecord models in the parent process before forking parallel workers, so the schema cache is inherited via copy-on-write. Then clear all database connections so forked children don't inherit stale connections from the parent. Together, this should ensure that child processes do not make any database connections, since most of our introspection should just be hitting the schema.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->
No new tests.
