### PR TITLE
Skip DSL generation on branch switch by detecting git HEAD changes

### DIFF
--- a/lib/ruby_lsp/tapioca/addon.rb
+++ b/lib/ruby_lsp/tapioca/addon.rb
@@ -28,6 +28,7 @@ module RubyLsp
         @file_checksums = {} #: Hash[String, String]
         @lockfile_diff = nil #: String?
         @outgoing_queue = nil #: Thread::Queue?
+        @last_known_git_head = read_git_head #: String?
       end
 
       # @override
@@ -126,6 +127,19 @@ module RubyLsp
 
         @rails_runner_client.trigger_reload
 
+        # If git HEAD changed, this is a branch switch (or rebase/pull). Skip DSL generation
+        # since the server state may be stale. Only reload was needed.
+        if git_head_changed?
+          queue = @outgoing_queue
+          if queue
+            queue << Notification.window_log_message(
+              "Tapioca add-on: detected branch switch, skipping DSL generation",
+              type: Constant::MessageType::INFO,
+            )
+          end
+          return
+        end
+
         if needs_compiler_reload
           @rails_runner_client.delegate_notification(
             server_addon_name: "Tapioca",
@@ -173,6 +187,24 @@ module RubyLsp
             },
           },
         })
+      end
+
+      #: -> bool
+      def git_head_changed?
+        current_head = read_git_head
+        changed = @last_known_git_head && current_head && @last_known_git_head != current_head
+        @last_known_git_head = current_head
+        !!changed
+      end
+
+      #: -> String?
+      def read_git_head
+        git_head_path = File.join(Dir.pwd, ".git", "HEAD")
+        return unless File.exist?(git_head_path)
+
+        File.read(git_head_path).strip
+      rescue SystemCallError
+        nil
       end
 
       #: (Hash[Symbol, untyped] change, String path) -> bool


### PR DESCRIPTION
## Summary

When switching branches (especially in large repos like world), VS Code sends hundreds of `didChangeWatchedFiles` notifications. Previously, each notification triggered `trigger_reload` + DSL generation, causing:
- Hundreds of parallel reload + DSL generation requests
- Incorrect RBIs generated against stale server state
- Valid RBI files deleted for constants that are temporarily unavailable

This PR detects branch switches by reading `.git/HEAD` on each file change event. If HEAD changed since the last check, we skip DSL generation entirely (only reload). Normal user edits don't change HEAD, so they continue to trigger DSL generation as before.

### How it works

- `read_git_head` reads `.git/HEAD` directly (no shelling out to git — just a file read)
- `git_head_changed?` compares current HEAD to the last known value
- On branch switch: reload fires but DSL generation is skipped
- On normal file edit: HEAD unchanged, DSL generation proceeds as before

### Testing

- **RED:** Original code fires DSL generation during branch switch (1 DSL call)
- **GREEN:** With fix, 0 DSL calls during branch switch
- Simulated world branch switch (14,672 Ruby files, 147 batches): **318 server requests → 4** (reload only)
- All 4 existing addon tests pass (normal edits still trigger DSL)

## Related

- Fixes https://github.com/Shopify/team-ruby-dx/issues/1429
- Part of https://github.com/Shopify/team-ruby-dx/issues/1762