### PR TITLE
Don't delete RBI files for missing constants in LSP addon mode

### DIFF
--- a/lib/tapioca/commands/abstract_dsl.rb
+++ b/lib/tapioca/commands/abstract_dsl.rb
@@ -175,11 +175,16 @@ module Tapioca
         unless unprocessable_constants.empty? || ignore_missing
           unprocessable_constants.each do |name, _|
             say("Error: Cannot find constant '#{name}'", :red)
-            filename = dsl_rbi_filename(name)
-            remove_file(filename) if File.file?(filename)
+
+            unless @lsp_addon
+              filename = dsl_rbi_filename(name)
+              remove_file(filename) if File.file?(filename)
+            end
           end
 
-          raise Tapioca::Error, ""
+          unless @lsp_addon
+            raise Tapioca::Error, ""
+          end
         end
 
         processable_constants

--- a/lib/tapioca/commands/dsl_generate.rb
+++ b/lib/tapioca/commands/dsl_generate.rb
@@ -17,7 +17,7 @@ module Tapioca
         rbi_files_to_purge = generate_dsl_rbi_files(@outpath, quiet: @quiet && !@verbose)
         say("")
 
-        purge_stale_dsl_rbi_files(rbi_files_to_purge)
+        purge_stale_dsl_rbi_files(rbi_files_to_purge) unless @lsp_addon
         say("Done", :green)
 
         if @auto_strictness && !@lsp_addon


### PR DESCRIPTION
## Summary

When the LSP addon requests DSL generation for a constant that can't be found (e.g., due to a failed reload or a mid-edit syntax error), the existing code:
1. **Deletes the RBI file** for the missing constant
2. **Raises an error** that aborts DSL generation for all remaining constants
3. **Purges "stale" files** — any RBI that existed before but wasn't regenerated gets deleted

This is wrong in addon mode. The constant may be temporarily unavailable (user is mid-edit, reload failed, server has stale state). Deleting the RBI means Sorbet loses type information until the next successful generation.

### Changes

Two deletion paths are fixed:
- **`abstract_dsl.rb` (`constantize`):** Skip deleting RBI and skip raising error when `@lsp_addon` is true
- **`dsl_generate.rb` (`execute`):** Skip `purge_stale_dsl_rbi_files` when `@lsp_addon` is true

### Testing

End-to-end test with a real Rails runner client:
1. Generate valid RBI for `NotifyUserJob`
2. Hide the job file to simulate it becoming unloadable (e.g., syntax error after save)
3. Trigger reload + request DSL for the now-missing constant
4. **RED (main):** RBI deleted
5. **GREEN (this branch):** RBI preserved

All 4 existing addon tests pass.

## Related

- Fixes https://github.com/Shopify/team-ruby-dx/issues/1711
- Part of https://github.com/Shopify/team-ruby-dx/issues/1762