### PR TITLE
Remove unused ASSOCIATION_METHODS constant

### DIFF
--- a/lib/tapioca/dsl/compilers/active_record_relations.rb
+++ b/lib/tapioca/dsl/compilers/active_record_relations.rb
@@ -187,8 +187,6 @@ module Tapioca
           end
         end
 
-        ASSOCIATION_METHODS = ::ActiveRecord::AssociationRelation.instance_methods -
-          ::ActiveRecord::Relation.instance_methods #: Array[Symbol]
         COLLECTION_PROXY_METHODS = ::ActiveRecord::Associations::CollectionProxy.instance_methods -
           ::ActiveRecord::AssociationRelation.instance_methods #: Array[Symbol]
 


### PR DESCRIPTION
## Summary
- Remove dead `ASSOCIATION_METHODS` constant from `ActiveRecordRelations` compiler — defined but never referenced anywhere in the codebase.