### PR TITLE
Migrate release workflow to use trusted publisher

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,27 +1,52 @@
-name: Release
+name: Release gem on RubyGems.org and create GitHub release
 
 on:
   push:
     tags:
-      - v*
+      - 'v[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
-  publish:
+  release_gem:
+    name: Release gem on RubyGems.org
+    if: github.repository == 'Shopify/tapioca'
     runs-on: ubuntu-latest
 
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        name: Checkout
+    permissions:
+      contents: write
+      id-token: write
 
-      - name: Create release
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+    environment: release
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
-          script: |
-            await github.rest.repos.createRelease({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              tag_name: "${{ github.ref }}",
-              name: "${{ github.ref_name }}",
-              generate_release_notes: true
-            })
+          persist-credentials: false
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@dffb23f65a78bba8db45d387d5ea1bbd6be3ef18 # v1.293.0
+        with:
+          bundler-cache: true
+
+      - name: Release gem on RubyGems.org
+        uses: rubygems/release-gem@e9a6361a0b14562539327c2a02373edc56dd3169 # v1.1.4
+
+  release_github:
+    name: Create GitHub release
+    if: github.repository == 'Shopify/tapioca'
+    needs: release_gem
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Create GitHub release
+        run: |
+          tag_name="$(git describe --tags --abbrev=0)"
+          gh release create "${tag_name}" --verify-tag --generate-notes
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Motivation

Replace the current release workflow with the trusted publisher pattern used by other repos like `Shopify/spoom` and `Shopify/rbi`. The new workflow publishes the gem to RubyGems.org via OIDC (no API key needed) and then creates a GitHub release.

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->

