### PR TITLE
Avoid duplicating definition of ActiveRecord::Relation.destroy_all

### DIFF
--- a/lib/tapioca/dsl/compilers/active_record_relations.rb
+++ b/lib/tapioca/dsl/compilers/active_record_relations.rb
@@ -612,7 +612,7 @@ module Tapioca
           create_common_method(
             "destroy_all",
             return_type: "T::Array[#{constant_name}]",
-          )
+          ) unless RELATION_METHODS.include? :destroy_all
 
           FINDER_METHODS.each do |method_name|
             case method_name

--- a/spec/tapioca/dsl/compilers/active_record_relations_spec.rb
+++ b/spec/tapioca/dsl/compilers/active_record_relations_spec.rb
@@ -147,9 +147,6 @@ module Tapioca
                     sig { returns(T::Array[::Post]) }
                     def destroy_all; end
 
-                    sig { returns(T::Array[::Post]) }
-                    def destroy_all; end
-
                     sig { params(args: T.untyped).returns(T::Array[::Post]) }
                     def destroy_by(*args); end
 
@@ -850,9 +847,6 @@ module Tapioca
 
                     sig { params(records: T.any(::Post, Integer, String, T::Enumerable[T.any(::Post, Integer, String, T::Enumerable[::Post])])).returns(T::Array[::Post]) }
                     def destroy(*records); end
-
-                    sig { returns(T::Array[::Post]) }
-                    def destroy_all; end
 
                     sig { returns(T::Array[::Post]) }
                     def destroy_all; end


### PR DESCRIPTION
### Motivation

`destroy_all` is defined both as a hardcoded common method (line 612) and dynamically via the `RELATION_METHODS` loop (line 862), since `ActiveRecord::Relation` includes `destroy_all` as an instance method. This results in a duplicated `def destroy_all; end` signature in the generated RBI files.

### Implementation

Added a guard (`unless RELATION_METHODS.include? :destroy_all`) to the hardcoded `destroy_all` definition so it is only generated when `destroy_all` is not already part of `RELATION_METHODS`. When ActiveRecord includes it in `Relation.instance_methods(false)`, the dynamic loop handles it and the hardcoded one is skipped, avoiding the duplicate.

Updated the expected output in the spec to remove the duplicated `destroy_all` entries.

### Tests

Updated existing specs to reflect the corrected (non-duplicated) output.