### PR TITLE
Include type_parameters declarations in signatures

### DIFF
--- a/lib/tapioca/dsl/compiler.rb
+++ b/lib/tapioca/dsl/compiler.rb
@@ -139,11 +139,16 @@ module Tapioca
 
       #: (RBI::Scope scope, (Method | UnboundMethod) method_def, ?class_method: bool) -> void
       def create_method_from_def(scope, method_def, class_method: false)
+        parameters = compile_method_parameters_to_rbi(method_def)
+        return_type = compile_method_return_type_to_rbi(method_def)
+        type_params = extract_type_parameters(parameters.map(&:type).push(return_type))
+
         scope.create_method(
           method_def.name.to_s,
-          parameters: compile_method_parameters_to_rbi(method_def),
-          return_type: compile_method_return_type_to_rbi(method_def),
+          parameters: parameters,
+          return_type: return_type,
           class_method: class_method,
+          type_params: type_params,
         )
       end
 

--- a/lib/tapioca/gem/listeners/sorbet_signatures.rb
+++ b/lib/tapioca/gem/listeners/sorbet_signatures.rb
@@ -8,8 +8,6 @@ module Tapioca
         include Runtime::Reflection
         include RBIHelper
 
-        TYPE_PARAMETER_MATCHER = /T\.type_parameter\(:?([[:word:]]+)\)/
-
         private
 
         # @override
@@ -42,9 +40,7 @@ module Tapioca
           sig.return_type = return_type
           @pipeline.push_symbol(return_type)
 
-          parameter_types.values.join(", ").scan(TYPE_PARAMETER_MATCHER).flatten.uniq.each do |k, _|
-            sig.type_params << k
-          end
+          sig.type_params.concat(extract_type_parameters(parameter_types.values.map(&:to_s).push(return_type)))
 
           case signature.mode
           when "abstract"

--- a/lib/tapioca/helpers/rbi_helper.rb
+++ b/lib/tapioca/helpers/rbi_helper.rb
@@ -94,6 +94,13 @@ module Tapioca
       end
     end
 
+    TYPE_PARAMETER_MATCHER = /T\.type_parameter\(:?([[:word:]]+)\)/
+
+    #: (Array[String] type_strings) -> Array[String]
+    def extract_type_parameters(type_strings)
+      type_strings.join(", ").scan(TYPE_PARAMETER_MATCHER).flatten.uniq
+    end
+
     #: (String name) -> bool
     def valid_method_name?(name)
       Prism.parse_success?("def self.#{name}(a); end")

--- a/lib/tapioca/rbi_ext/model.rb
+++ b/lib/tapioca/rbi_ext/model.rb
@@ -65,10 +65,11 @@ module RBI
     #|   ?return_type: String?,
     #|   ?class_method: bool,
     #|   ?visibility: RBI::Visibility,
-    #|   ?comments: Array[RBI::Comment]
+    #|   ?comments: Array[RBI::Comment],
+    #|   ?type_params: Array[String]
     #| ) ?{ (RBI::Method node) -> void } -> void
     def create_method(name, parameters: [], return_type: nil, class_method: false, visibility: RBI::Public.new,
-      comments: [], &block)
+      comments: [], type_params: [], &block)
       return unless Tapioca::RBIHelper.valid_method_name?(name)
 
       sigs = []
@@ -77,7 +78,7 @@ module RBI
         # If there is no block, and the params and return type have not been supplied, then
         # we create a single signature with the given parameters and return type
         params = parameters.map { |param| RBI::SigParam.new(param.param.name.to_s, param.type) }
-        sigs << RBI::Sig.new(params: params, return_type: return_type || "T.untyped")
+        sigs << RBI::Sig.new(params: params, return_type: return_type || "T.untyped", type_params: type_params)
       end
 
       method = RBI::Method.new(

--- a/spec/tapioca/dsl/compiler_spec.rb
+++ b/spec/tapioca/dsl/compiler_spec.rb
@@ -92,6 +92,15 @@ module Tapioca
               def baz(d:, e: 42, **f, &blk)
               end
 
+              sig do
+                type_parameters(:U, :V)
+                  .params(a: T.type_parameter(:U), blk: T.proc.params(arg: T.type_parameter(:U)).returns(T.type_parameter(:V)))
+                  .returns(T.type_parameter(:V))
+              end
+              def complex_type_params(a, &blk)
+                blk.call(a)
+              end
+
               sig { type_parameters(:U).params(a: T.type_parameter(:U)).returns(T.type_parameter(:U)) }
               def foo(a)
                 a
@@ -120,7 +129,10 @@ module Tapioca
               sig { params(d: ::String, e: ::Integer, f: ::Integer, blk: T.proc.params(a: ::String).returns(::String)).returns(::Integer) }
               def baz(d:, e: T.unsafe(nil), **f, &blk); end
 
-              sig { params(a: T.type_parameter(:U)).returns(T.type_parameter(:U)) }
+              sig { type_parameters(:U, :V).params(a: T.type_parameter(:U), blk: T.proc.params(arg: T.type_parameter(:U)).returns(T.type_parameter(:V))).returns(T.type_parameter(:V)) }
+              def complex_type_params(a, &blk); end
+
+              sig { type_parameters(:U).params(a: T.type_parameter(:U)).returns(T.type_parameter(:U)) }
               def foo(a); end
 
               sig { params(a: ::Integer, b: ::Integer, c: ::Integer, d: ::Integer, e: ::Integer, f: ::Integer, blk: T.proc.void).void }

--- a/spec/tapioca/dsl/compilers/active_support_current_attributes_spec.rb
+++ b/spec/tapioca/dsl/compilers/active_support_current_attributes_spec.rb
@@ -159,6 +159,11 @@ module Tapioca
                   def user_id=(value)
                     super
                   end
+
+                  sig { type_parameters(:T).params(t: T.untyped, blk: T.proc.returns(T.type_parameter(:T))).returns(T.type_parameter(:T)) }
+                  def with_type(t, &blk)
+                    blk.call
+                  end
                 end
               RUBY
 
@@ -174,6 +179,9 @@ module Tapioca
 
                     sig { params(value: T.nilable(::Integer)).void }
                     def user_id=(value); end
+
+                    sig { type_parameters(:T).params(t: T.untyped, blk: T.proc.returns(T.type_parameter(:T))).returns(T.type_parameter(:T)) }
+                    def with_type(t, &blk); end
                   end
 
                   module GeneratedAttributeMethods


### PR DESCRIPTION
- closes https://github.com/Shopify/tapioca/issues/2542

### Motivation

Previously, when a compiler used [create_method_from_def](https://github.com/Shopify/tapioca/blob/daa4f71223e267dda073233cbb37647934409710/lib/tapioca/dsl/compiler.rb#L141) (ex. [ActiveSupportCurrentAttributes](https://github.com/Shopify/tapioca/blob/d27f9cb4395d7d79a5b0dd657a5a44ec7d1cb7a3/lib/tapioca/dsl/compilers/active_support_current_attributes.rb#L86)) any method signatures would be generated without `type_parameters` declarations. This created [invalid](https://sorbet.run/#%23%20typed%3A%20true%0Aextend%20T%3A%3ASig%0A%0A%0A%23%20This%20is%20invalid%20%0Asig%20%7B%20params%28t%3A%20T.untyped%2C%20blk%3A%20T.proc.returns%28T.type_parameter%28%3AT%29%29%29.returns%28T.type_parameter%28%3AT%29%29%20%7D%0Adef%20with_type_bad%28t%2C%20%26blk%29%0A%20%20blk.call%0Aend%0A%0A%23%20This%20is%20valid%20%E2%80%94%20declares%20with%20type_parameters%0Asig%20%7B%20type_parameters%28%3AT%29.params%28t%3A%20T.untyped%2C%20blk%3A%20T.proc.returns%28T.type_parameter%28%3AT%29%29%29.returns%28T.type_parameter%28%3AT%29%29%20%7D%0Adef%20with_type_good%28t%2C%20%26blk%29%0A%20%20blk.call%0Aend) signatures when type params were used in the method sig


```diff
- sig { params(a: T.type_parameter(:U)).returns(T.type_parameter(:U)) }
+ sig { type_parameters(:U).params(a: T.type_parameter(:U)).returns(T.type_parameter(:U)) }
```

### Implementation

This PR moves out `TYPE_PARAMETER_MATCHER` and the type param extraction logic from gem `sorbet_signatures.rb` file to `rbi_helper.rb` so that they can also be used by dsl. This way `create_method_from_def` can pass any type params to `create_method` so that `RBI::Sig.new` will be able to include them in the generated signature

### Tests

- in `compiler_spec.rb` `compiles a class with methods that have signatures`:
   - updated a case to add `type_parameters` declaration
   - added new case to test more complex type param use
- added a method with type params to `active_support_current_attributes_spec.rb` `copies types from instance methods to class methods`
