### PR TITLE
Start using Minitest 6 all the time

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,15 +7,7 @@ gemspec
 CURRENT_RAILS_VERSION = "8.1"
 rails_version = ENV.fetch("RAILS_VERSION", CURRENT_RAILS_VERSION)
 
-# Rails main and 8.1.2 onward support Minitest 6.
-# Rails 8.0.x lacks support for Minitest 6 in released versions.
-# TODO: Remove conditional once a Rails 8.0.x release with Minitest 6 support is cut.
-# See: https://github.com/rails/rails/commit/ec62932ee7d31e0ef870e61c2d7de2c3efe3faa6
-if rails_version == "8.0"
-  gem "minitest", "< 6"
-else
-  gem "minitest"
-end
+gem "minitest"
 gem "minitest-hooks"
 gem "minitest-reporters"
 gem "minitest-mock"


### PR DESCRIPTION
Now that Rails 8.0.5 is released, with support for Minitest 6, we can start using Minitest 6 for all versions of Rails.
