### PR TITLE
Constants defined in C extensions might be attributed other the gems

### DIFF
--- a/lib/tapioca/runtime/reflection.rb
+++ b/lib/tapioca/runtime/reflection.rb
@@ -213,9 +213,16 @@ module Tapioca
 
       #: (T::Module[top] constant) -> Set[String]
       def file_candidates_for(constant)
-        relevant_methods_for(constant).filter_map do |method|
+        # Grab all source files for (relevant) methods defined on the constant
+        candidates = relevant_methods_for(constant).filter_map do |method|
           method.source_location&.first
         end.to_set
+
+        # Add the source file for the constant definition itself, if available.
+        source_location_candidate = const_source_location(name_of(constant).to_s)&.file
+        candidates.add(source_location_candidate) if source_location_candidate
+
+        candidates
       end
 
       #: (T::Module[top] constant) -> untyped


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
Some constants like `ERB::Escape` that are defind in C extension components of gems are currently failing the `defined_in_gem?` look up.

This happens for `ERB::Escape` because, instead of `erb/lib/erb/utils.rb` loading the shared-object for `escape`, we have `erubi` loading it. Thus, when we do the backtrace scan to find the file that is loading the constant we attribute it to the `erubi` gem. This is because there are no frames in the backtrace for the class definition coming from a C extension, thus we miss the actual file that does the `ERB::Escape` definition.

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
Since we can look up the source location of constants now, it makes more sense to include that in the list of file candidate locations. Which makes it resilient against these kinds of mistakes.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->
No added tests
