### PR TITLE
Fully qualify T and NilClass references in generated RBI output

### DIFF
--- a/lib/tapioca/dsl/compiler.rb
+++ b/lib/tapioca/dsl/compiler.rb
@@ -115,7 +115,7 @@ module Tapioca
       def parameters_types_from_signature(method_def, signature)
         params = [] #: Array[String]
 
-        return method_def.parameters.map { "T.untyped" } unless signature
+        return method_def.parameters.map { "::T.untyped" } unless signature
 
         # parameters types
         signature.arg_types.each { |arg_type| params << arg_type[1].to_s }
@@ -171,13 +171,13 @@ module Tapioca
           when :req
             create_param(name, type: method_type)
           when :opt
-            create_opt_param(name, type: method_type, default: "T.unsafe(nil)")
+            create_opt_param(name, type: method_type, default: "::T.unsafe(nil)")
           when :rest
             create_rest_param(name, type: method_type)
           when :keyreq
             create_kw_param(name, type: method_type)
           when :key
-            create_kw_opt_param(name, type: method_type, default: "T.unsafe(nil)")
+            create_kw_opt_param(name, type: method_type, default: "::T.unsafe(nil)")
           when :keyrest
             create_kw_rest_param(name, type: method_type)
           when :block
@@ -191,7 +191,7 @@ module Tapioca
       #: ((Method | UnboundMethod) method_def) -> String
       def compile_method_return_type_to_rbi(method_def)
         signature = signature_of(method_def)
-        return_type = signature.nil? ? "T.untyped" : name_of_type(signature.return_type)
+        return_type = signature.nil? ? "::T.untyped" : name_of_type(signature.return_type)
         sanitize_signature_types(return_type)
       end
     end

--- a/lib/tapioca/dsl/compilers/aasm.rb
+++ b/lib/tapioca/dsl/compilers/aasm.rb
@@ -85,17 +85,17 @@ module Tapioca
                 name = state.name
                 name = "#{namespace}_#{name}" if namespace
 
-                model.create_constant("STATE_#{name.upcase}", value: "T.let(T.unsafe(nil), Symbol)")
-                model.create_method("#{name}?", return_type: "T::Boolean")
+                model.create_constant("STATE_#{name.upcase}", value: "::T.let(::T.unsafe(nil), Symbol)")
+                model.create_method("#{name}?", return_type: "::T::Boolean")
               end
 
               # Create all of the methods for each event
-              parameters = [create_rest_param("opts", type: "T.untyped")]
+              parameters = [create_rest_param("opts", type: "::T.untyped")]
               state_machine.events.each do |event|
                 model.create_method(event.name.to_s, parameters: parameters)
                 model.create_method("#{event.name}!", parameters: parameters)
                 model.create_method("#{event.name}_without_validation!", parameters: parameters)
-                model.create_method("may_#{event.name}?", return_type: "T::Boolean")
+                model.create_method("may_#{event.name}?", return_type: "::T::Boolean")
 
                 # For events, if there's a namespace the default methods are created in addition to
                 # namespaced ones.
@@ -105,7 +105,7 @@ module Tapioca
 
                 model.create_method(name.to_s, parameters: parameters)
                 model.create_method("#{name}!", parameters: parameters)
-                model.create_method("may_#{name}?", return_type: "T::Boolean")
+                model.create_method("may_#{name}?", return_type: "::T::Boolean")
 
                 # There's no namespaced method created for `_without_validation`, so skip
                 # defining a method for:
@@ -118,8 +118,8 @@ module Tapioca
             model.create_method(
               "aasm",
               parameters: [
-                create_rest_param("args", type: "T.untyped"),
-                create_block_param("block", type: "T.nilable(T.proc.bind(PrivateAASMMachine).void)"),
+                create_rest_param("args", type: "::T.untyped"),
+                create_block_param("block", type: "::T.nilable(::T.proc.bind(PrivateAASMMachine).void)"),
               ],
               return_type: "PrivateAASMMachine",
               class_method: true,
@@ -132,9 +132,9 @@ module Tapioca
               machine.create_method(
                 "event",
                 parameters: [
-                  create_param("name", type: "T.untyped"),
-                  create_opt_param("options", default: "nil", type: "T.untyped"),
-                  create_block_param("block", type: "T.proc.bind(PrivateAASMEvent).void"),
+                  create_param("name", type: "::T.untyped"),
+                  create_opt_param("options", default: "nil", type: "::T.untyped"),
+                  create_block_param("block", type: "::T.proc.bind(PrivateAASMEvent).void"),
                 ],
               )
 
@@ -144,8 +144,8 @@ module Tapioca
                 machine.create_method(
                   method,
                   parameters: [
-                    create_rest_param("callbacks", type: "T.any(String, Symbol, T::Class[T.anything], Proc)"),
-                    create_block_param("block", type: "T.nilable(T.proc.bind(#{constant_name}).void)"),
+                    create_rest_param("callbacks", type: "::T.any(String, Symbol, ::T::Class[::T.anything], Proc)"),
+                    create_block_param("block", type: "::T.nilable(::T.proc.bind(#{constant_name}).void)"),
                   ],
                 )
               end
@@ -158,10 +158,10 @@ module Tapioca
                   event.create_method(
                     method,
                     parameters: [
-                      create_opt_param("symbol", type: "T.nilable(Symbol)", default: "nil"),
+                      create_opt_param("symbol", type: "::T.nilable(Symbol)", default: "nil"),
                       create_block_param(
                         "block",
-                        type: "T.nilable(T.proc.bind(#{constant_name}).params(opts: T.untyped).void)",
+                        type: "::T.nilable(::T.proc.bind(#{constant_name}).params(opts: ::T.untyped).void)",
                       ),
                     ],
                   )
@@ -170,23 +170,23 @@ module Tapioca
                 event.create_method(
                   "transitions",
                   parameters: [
-                    create_opt_param("definitions", default: "nil", type: "T.untyped"),
-                    create_block_param("block", type: "T.nilable(T.proc.bind(PrivateAASMTransition).void)"),
+                    create_opt_param("definitions", default: "nil", type: "::T.untyped"),
+                    create_block_param("block", type: "::T.nilable(::T.proc.bind(PrivateAASMTransition).void)"),
                   ],
                 )
               end
 
               machine.create_class("PrivateAASMTransition", superclass_name: "AASM::Core::Transition") do |transition|
                 TRANSITION_CALLBACKS.each do |method|
-                  return_type = "T.untyped"
-                  return_type = "T::Boolean" if method == "guard"
+                  return_type = "::T.untyped"
+                  return_type = "::T::Boolean" if method == "guard"
 
                   transition.create_method(
                     method,
                     parameters: [
                       create_block_param(
                         "block",
-                        type: "T.nilable(T.proc.bind(#{constant_name}).params(opts: T.untyped).void)",
+                        type: "::T.nilable(::T.proc.bind(#{constant_name}).params(opts: ::T.untyped).void)",
                       ),
                     ],
                     return_type: return_type,

--- a/lib/tapioca/dsl/compilers/action_controller_helpers.rb
+++ b/lib/tapioca/dsl/compilers/action_controller_helpers.rb
@@ -140,11 +140,11 @@ module Tapioca
           helper_methods.create_method(
             method_name.to_s,
             parameters: [
-              create_rest_param("args", type: "T.untyped"),
-              create_kw_rest_param("kwargs", type: "T.untyped"),
-              create_block_param("blk", type: "T.untyped"),
+              create_rest_param("args", type: "::T.untyped"),
+              create_kw_rest_param("kwargs", type: "::T.untyped"),
+              create_block_param("blk", type: "::T.untyped"),
             ],
-            return_type: "T.untyped",
+            return_type: "::T.untyped",
           )
         end
 

--- a/lib/tapioca/dsl/compilers/action_text.rb
+++ b/lib/tapioca/dsl/compilers/action_text.rb
@@ -59,12 +59,12 @@ module Tapioca
               )
               scope.create_method(
                 "#{name}?",
-                return_type: "T::Boolean",
+                return_type: "::T::Boolean",
               )
               scope.create_method(
                 "#{name}=",
-                parameters: [create_param("value", type: "T.nilable(T.any(#{type}, String))")],
-                return_type: "T.untyped",
+                parameters: [create_param("value", type: "::T.nilable(::T.any(#{type}, String))")],
+                return_type: "::T.untyped",
               )
             end
           end

--- a/lib/tapioca/dsl/compilers/active_job.rb
+++ b/lib/tapioca/dsl/compilers/active_job.rb
@@ -54,7 +54,7 @@ module Tapioca
             job.create_method(
               "perform_later",
               parameters: perform_later_parameters(parameters, constant_name),
-              return_type: "T.any(#{constant_name}, FalseClass)",
+              return_type: "::T.any(#{constant_name}, FalseClass)",
               class_method: true,
             )
 
@@ -75,7 +75,7 @@ module Tapioca
             parameters.reject! { |typed_param| RBI::BlockParam === typed_param.param }
             parameters + [create_block_param(
               "block",
-              type: "T.nilable(T.proc.params(job: #{constant_name}).void)",
+              type: "::T.nilable(::T.proc.params(job: #{constant_name}).void)",
             )]
           else
             parameters

--- a/lib/tapioca/dsl/compilers/active_model_attributes.rb
+++ b/lib/tapioca/dsl/compilers/active_model_attributes.rb
@@ -106,7 +106,7 @@ module Tapioca
         def type_for(attribute_type_value)
           case attribute_type_value
           when ActiveModel::Type::Boolean
-            as_nilable_type("T::Boolean")
+            as_nilable_type("::T::Boolean")
           when ActiveModel::Type::Date
             as_nilable_type("::Date")
           when ActiveModel::Type::DateTime, ActiveModel::Type::Time

--- a/lib/tapioca/dsl/compilers/active_model_secure_password.rb
+++ b/lib/tapioca/dsl/compilers/active_model_secure_password.rb
@@ -77,8 +77,8 @@ module Tapioca
               if method == :authenticate || method.start_with?("authenticate_")
                 klass.create_method(
                   method.to_s,
-                  parameters: [create_param("unencrypted_password", type: "T.untyped")],
-                  return_type: "T.any(#{constant}, FalseClass)",
+                  parameters: [create_param("unencrypted_password", type: "::T.untyped")],
+                  return_type: "::T.any(#{constant}, FalseClass)",
                 )
               else
                 create_method_from_def(klass, constant.instance_method(method))

--- a/lib/tapioca/dsl/compilers/active_model_validations_confirmation.rb
+++ b/lib/tapioca/dsl/compilers/active_model_validations_confirmation.rb
@@ -63,11 +63,11 @@ module Tapioca
             # Create RBI definitions for all the attributes that use confirmation validation
             confirmation_validators.each do |validator|
               validator.attributes.each do |attr_name|
-                klass.create_method("#{attr_name}_confirmation", return_type: "T.untyped")
+                klass.create_method("#{attr_name}_confirmation", return_type: "::T.untyped")
                 klass.create_method(
                   "#{attr_name}_confirmation=",
-                  parameters: [create_param("#{attr_name}_confirmation", type: "T.untyped")],
-                  return_type: "T.untyped",
+                  parameters: [create_param("#{attr_name}_confirmation", type: "::T.untyped")],
+                  return_type: "::T.untyped",
                 )
               end
             end

--- a/lib/tapioca/dsl/compilers/active_record_associations.rb
+++ b/lib/tapioca/dsl/compilers/active_record_associations.rb
@@ -149,8 +149,8 @@ module Tapioca
           constant.nested_attributes_options.keys.each do |association_name|
             mod.create_method(
               "#{association_name}_attributes=",
-              parameters: [create_param("attributes", type: "T.untyped")],
-              return_type: "T.untyped",
+              parameters: [create_param("attributes", type: "::T.untyped")],
+              return_type: "::T.untyped",
             )
           end
         end
@@ -200,37 +200,37 @@ module Tapioca
           if association_methods_module.method_defined?("#{association_name}_changed?")
             klass.create_method(
               "#{association_name}_changed?",
-              return_type: "T::Boolean",
+              return_type: "::T::Boolean",
             )
           end
           if association_methods_module.method_defined?("#{association_name}_previously_changed?")
             klass.create_method(
               "#{association_name}_previously_changed?",
-              return_type: "T::Boolean",
+              return_type: "::T::Boolean",
             )
           end
           unless reflection.polymorphic?
             klass.create_method(
               "build_#{association_name}",
               parameters: [
-                create_rest_param("args", type: "T.untyped"),
-                create_block_param("blk", type: "T.untyped"),
+                create_rest_param("args", type: "::T.untyped"),
+                create_block_param("blk", type: "::T.untyped"),
               ],
               return_type: association_class,
             )
             klass.create_method(
               "create_#{association_name}",
               parameters: [
-                create_rest_param("args", type: "T.untyped"),
-                create_block_param("blk", type: "T.untyped"),
+                create_rest_param("args", type: "::T.untyped"),
+                create_block_param("blk", type: "::T.untyped"),
               ],
               return_type: association_class,
             )
             klass.create_method(
               "create_#{association_name}!",
               parameters: [
-                create_rest_param("args", type: "T.untyped"),
-                create_block_param("blk", type: "T.untyped"),
+                create_rest_param("args", type: "::T.untyped"),
+                create_block_param("blk", type: "::T.untyped"),
               ],
               return_type: association_class,
             )
@@ -249,17 +249,17 @@ module Tapioca
           )
           klass.create_method(
             "#{association_name}=",
-            parameters: [create_param("value", type: "T::Enumerable[#{association_class}]")],
+            parameters: [create_param("value", type: "::T::Enumerable[#{association_class}]")],
             return_type: "void",
           )
           klass.create_method(
             "#{association_name.to_s.singularize}_ids",
-            return_type: "T::Array[T.untyped]",
+            return_type: "::T::Array[::T.untyped]",
           )
           klass.create_method(
             "#{association_name.to_s.singularize}_ids=",
-            parameters: [create_param("ids", type: "T::Array[T.untyped]")],
-            return_type: "T::Array[T.untyped]",
+            parameters: [create_param("ids", type: "::T::Array[::T.untyped]")],
+            return_type: "::T::Array[::T.untyped]",
           )
         end
 
@@ -267,7 +267,7 @@ module Tapioca
         def type_for(reflection)
           validate_reflection!(reflection)
 
-          return "T.untyped" if !constant.table_exists? || polymorphic_association?(reflection)
+          return "::T.untyped" if !constant.table_exists? || polymorphic_association?(reflection)
 
           T.must(qualified_name_of(reflection.klass))
         end
@@ -364,7 +364,7 @@ module Tapioca
               "#{qualified_name_of(reflection.klass)}::#{AssociationsCollectionProxyClassName}"
             end
           elsif polymorphic_association
-            "ActiveRecord::Associations::CollectionProxy[T.untyped]"
+            "ActiveRecord::Associations::CollectionProxy[::T.untyped]"
           else
             "::ActiveRecord::Associations::CollectionProxy[#{qualified_name_of(reflection.klass)}]"
           end

--- a/lib/tapioca/dsl/compilers/active_record_columns.rb
+++ b/lib/tapioca/dsl/compilers/active_record_columns.rb
@@ -232,7 +232,7 @@ module Tapioca
             klass,
             "#{attribute_name}?",
             methods_to_add,
-            return_type: "T::Boolean",
+            return_type: "::T::Boolean",
           )
 
           # Added by ActiveRecord::AttributeMethods::Dirty
@@ -247,7 +247,7 @@ module Tapioca
             klass,
             "#{attribute_name}_change_to_be_saved",
             methods_to_add,
-            return_type: "T.nilable([#{getter_type}, #{getter_type}])",
+            return_type: "::T.nilable([#{getter_type}, #{getter_type}])",
           )
           add_method(
             klass,
@@ -259,26 +259,26 @@ module Tapioca
             klass,
             "saved_change_to_#{attribute_name}",
             methods_to_add,
-            return_type: "T.nilable([#{getter_type}, #{getter_type}])",
+            return_type: "::T.nilable([#{getter_type}, #{getter_type}])",
           )
           add_method(
             klass,
             "saved_change_to_#{attribute_name}?",
             methods_to_add,
-            return_type: "T::Boolean",
+            return_type: "::T::Boolean",
             parameters: [
-              create_kw_opt_param("from", type: "T.untyped", default: "T.unsafe(nil)"),
-              create_kw_opt_param("to", type: "T.untyped", default: "T.unsafe(nil)"),
+              create_kw_opt_param("from", type: "::T.untyped", default: "::T.unsafe(nil)"),
+              create_kw_opt_param("to", type: "::T.untyped", default: "::T.unsafe(nil)"),
             ],
           )
           add_method(
             klass,
             "will_save_change_to_#{attribute_name}?",
             methods_to_add,
-            return_type: "T::Boolean",
+            return_type: "::T::Boolean",
             parameters: [
-              create_kw_opt_param("from", type: "T.untyped", default: "T.unsafe(nil)"),
-              create_kw_opt_param("to", type: "T.untyped", default: "T.unsafe(nil)"),
+              create_kw_opt_param("from", type: "::T.untyped", default: "::T.unsafe(nil)"),
+              create_kw_opt_param("to", type: "::T.untyped", default: "::T.unsafe(nil)"),
             ],
           )
 
@@ -288,16 +288,16 @@ module Tapioca
             klass,
             "#{attribute_name}_change",
             methods_to_add,
-            return_type: "T.nilable([#{getter_type}, #{getter_type}])",
+            return_type: "::T.nilable([#{getter_type}, #{getter_type}])",
           )
           add_method(
             klass,
             "#{attribute_name}_changed?",
             methods_to_add,
-            return_type: "T::Boolean",
+            return_type: "::T::Boolean",
             parameters: [
-              create_kw_opt_param("from", type: "T.untyped", default: "T.unsafe(nil)"),
-              create_kw_opt_param("to", type: "T.untyped", default: "T.unsafe(nil)"),
+              create_kw_opt_param("from", type: "::T.untyped", default: "::T.unsafe(nil)"),
+              create_kw_opt_param("to", type: "::T.untyped", default: "::T.unsafe(nil)"),
             ],
           )
           add_method(
@@ -315,16 +315,16 @@ module Tapioca
             klass,
             "#{attribute_name}_previous_change",
             methods_to_add,
-            return_type: "T.nilable([#{getter_type}, #{getter_type}])",
+            return_type: "::T.nilable([#{getter_type}, #{getter_type}])",
           )
           add_method(
             klass,
             "#{attribute_name}_previously_changed?",
             methods_to_add,
-            return_type: "T::Boolean",
+            return_type: "::T::Boolean",
             parameters: [
-              create_kw_opt_param("from", type: "T.untyped", default: "T.unsafe(nil)"),
-              create_kw_opt_param("to", type: "T.untyped", default: "T.unsafe(nil)"),
+              create_kw_opt_param("from", type: "::T.untyped", default: "::T.unsafe(nil)"),
+              create_kw_opt_param("to", type: "::T.untyped", default: "::T.unsafe(nil)"),
             ],
           )
           add_method(
@@ -345,13 +345,13 @@ module Tapioca
             klass,
             "#{attribute_name}_before_type_cast",
             methods_to_add,
-            return_type: "T.untyped",
+            return_type: "::T.untyped",
           )
           add_method(
             klass,
             "#{attribute_name}_came_from_user?",
             methods_to_add,
-            return_type: "T::Boolean",
+            return_type: "::T::Boolean",
           )
         end
       end

--- a/lib/tapioca/dsl/compilers/active_record_delegated_types.rb
+++ b/lib/tapioca/dsl/compilers/active_record_delegated_types.rb
@@ -107,13 +107,13 @@ module Tapioca
           mod.create_method(
             "#{role}_class",
             parameters: [],
-            return_type: "T::Class[T.anything]",
+            return_type: "::T::Class[::T.anything]",
           )
 
           mod.create_method(
             "build_#{role}",
-            parameters: [create_rest_param("args", type: "T.untyped")],
-            return_type: types.size == 1 ? types.first : "T.any(#{types.join(", ")})",
+            parameters: [create_rest_param("args", type: "::T.untyped")],
+            return_type: types.size == 1 ? types.first : "::T.any(#{types.join(", ")})",
           )
         end
 
@@ -136,13 +136,13 @@ module Tapioca
           mod.create_method(
             query,
             parameters: [],
-            return_type: "T::Boolean",
+            return_type: "::T::Boolean",
           )
 
           mod.create_method(
             singular,
             parameters: [],
-            return_type: "T.nilable(#{type})",
+            return_type: "::T.nilable(#{type})",
           )
 
           mod.create_method(

--- a/lib/tapioca/dsl/compilers/active_record_enum.rb
+++ b/lib/tapioca/dsl/compilers/active_record_enum.rb
@@ -88,10 +88,10 @@ module Tapioca
           value_type = if value_type.length == 1
             value_type.first
           else
-            "T.any(#{value_type.join(", ")})"
+            "::T.any(#{value_type.join(", ")})"
           end
 
-          "T::Hash[T.any(String, Symbol), #{value_type}]"
+          "::T::Hash[::T.any(String, Symbol), #{value_type}]"
         end
 
         #: (RBI::Scope klass) -> void
@@ -100,7 +100,7 @@ module Tapioca
 
           methods.each do |method|
             method = method.to_s
-            return_type = method.end_with?("?") ? "T::Boolean" : "void"
+            return_type = method.end_with?("?") ? "::T::Boolean" : "void"
 
             klass.create_method(method, return_type: return_type)
           end

--- a/lib/tapioca/dsl/compilers/active_record_fixtures.rb
+++ b/lib/tapioca/dsl/compilers/active_record_fixtures.rb
@@ -111,21 +111,21 @@ module Tapioca
             node.add_rest_param("other_fixtures")
 
             node.add_sig do |sig|
-              sig.add_param("fixture_name", "NilClass")
-              sig.add_param("other_fixtures", "NilClass")
-              sig.return_type = "T::Array[#{return_type}]"
+              sig.add_param("fixture_name", "::NilClass")
+              sig.add_param("other_fixtures", "::NilClass")
+              sig.return_type = "::T::Array[#{return_type}]"
             end
 
             node.add_sig do |sig|
-              sig.add_param("fixture_name", "T.any(String, Symbol)")
-              sig.add_param("other_fixtures", "NilClass")
+              sig.add_param("fixture_name", "::T.any(String, Symbol)")
+              sig.add_param("other_fixtures", "::NilClass")
               sig.return_type = return_type
             end
 
             node.add_sig do |sig|
-              sig.add_param("fixture_name", "T.any(String, Symbol)")
-              sig.add_param("other_fixtures", "T.any(String, Symbol)")
-              sig.return_type = "T::Array[#{return_type}]"
+              sig.add_param("fixture_name", "::T.any(String, Symbol)")
+              sig.add_param("other_fixtures", "::T.any(String, Symbol)")
+              sig.return_type = "::T::Array[#{return_type}]"
             end
           end
         end
@@ -135,7 +135,7 @@ module Tapioca
           fixture_class_mapping_from_fixture_files[fixture_name] ||
             fixture_class_from_fixture_set(fixture_name) ||
             fixture_class_from_active_record_base_class_mapping[fixture_name] ||
-            "T.untyped"
+            "::T.untyped"
         end
 
         #: (String fixture_name) -> String?

--- a/lib/tapioca/dsl/compilers/active_record_relations.rb
+++ b/lib/tapioca/dsl/compilers/active_record_relations.rb
@@ -159,7 +159,7 @@ module Tapioca
           "String",
           "Symbol",
           "::ActiveSupport::Multibyte::Chars",
-          "T::Boolean",
+          "::T::Boolean",
           "BigDecimal",
           "Numeric",
           "::ActiveRecord::Type::Binary::Data",
@@ -167,7 +167,7 @@ module Tapioca
           "Date",
           "Time",
           "::ActiveSupport::Duration",
-          "T::Class[T.anything]",
+          "::T::Class[::T.anything]",
         ].to_set.freeze #: Set[String]
 
         # @override
@@ -215,15 +215,15 @@ module Tapioca
         end #: Array[Symbol]
         BATCHES_METHODS = ActiveRecord::Batches.instance_methods(false) #: Array[Symbol]
         BATCHES_METHODS_PARAMETERS = {
-          start: ["T.untyped", "nil"],
-          finish: ["T.untyped", "nil"],
-          load: ["T.untyped", "false"],
+          start: ["::T.untyped", "nil"],
+          finish: ["::T.untyped", "nil"],
+          load: ["::T.untyped", "false"],
           batch_size: ["Integer", "1000"],
           of: ["Integer", "1000"],
-          error_on_ignore: ["T.untyped", "nil"],
-          order: ["T.any(Symbol, T::Array[Symbol])", ":asc"],
-          cursor: ["T.untyped", "primary_key"],
-          use_ranges: ["T.untyped", "nil"],
+          error_on_ignore: ["::T.untyped", "nil"],
+          order: ["::T.any(Symbol, ::T::Array[Symbol])", ":asc"],
+          cursor: ["::T.untyped", "primary_key"],
+          use_ranges: ["::T.untyped", "nil"],
         } #: Hash[Symbol, [String, String]]
         CALCULATION_METHODS = ActiveRecord::Calculations.instance_methods(false) #: Array[Symbol]
         RELATION_METHODS = ActiveRecord::Relation.instance_methods(false) #: Array[Symbol]
@@ -270,7 +270,7 @@ module Tapioca
 
           # Type the `to_ary` method as returning `NilClass` so that flatten stops recursing
           # See https://github.com/sorbet/sorbet/pull/4706 for details
-          model.create_method("to_ary", return_type: "NilClass", visibility: RBI::Private.new)
+          model.create_method("to_ary", return_type: "::NilClass", visibility: RBI::Private.new)
 
           create_relation_class
           create_association_relation_class
@@ -288,7 +288,7 @@ module Tapioca
             klass.create_type_variable("Elem", type: "type_member", fixed: constant_name)
 
             TO_ARRAY_METHODS.each do |method_name|
-              klass.create_method(method_name.to_s, return_type: "T::Array[#{constant_name}]")
+              klass.create_method(method_name.to_s, return_type: "::T::Array[#{constant_name}]")
             end
           end
 
@@ -307,7 +307,7 @@ module Tapioca
             klass.create_type_variable("Elem", type: "type_member", fixed: constant_name)
 
             TO_ARRAY_METHODS.each do |method_name|
-              klass.create_method(method_name.to_s, return_type: "T::Array[#{constant_name}]")
+              klass.create_method(method_name.to_s, return_type: "::T::Array[#{constant_name}]")
             end
           end
 
@@ -346,15 +346,15 @@ module Tapioca
           klass.create_method(
             "having",
             parameters: [
-              create_rest_param("args", type: "T.untyped"),
-              create_block_param("blk", type: "T.untyped"),
+              create_rest_param("args", type: "::T.untyped"),
+              create_block_param("blk", type: "::T.untyped"),
             ],
-            return_type: "T.self_type",
+            return_type: "::T.self_type",
           )
 
           klass.create_method(
             "size",
-            return_type: "T::Hash[T.untyped, Integer]",
+            return_type: "::T::Hash[::T.untyped, Integer]",
           )
 
           CALCULATION_METHODS.each do |method_name|
@@ -363,36 +363,36 @@ module Tapioca
               klass.create_method(
                 method_name.to_s,
                 parameters: [
-                  create_param("column_name", type: "T.any(String, Symbol)"),
+                  create_param("column_name", type: "::T.any(String, Symbol)"),
                 ],
-                return_type: "T::Hash[T.untyped, " \
-                  "#{method_name == :average ? "T.any(Integer, Float, BigDecimal)" : "T.untyped"}]",
+                return_type: "::T::Hash[::T.untyped, " \
+                  "#{method_name == :average ? "::T.any(Integer, Float, BigDecimal)" : "::T.untyped"}]",
               )
             when :calculate
               klass.create_method(
                 "calculate",
                 parameters: [
                   create_param("operation", type: "Symbol"),
-                  create_param("column_name", type: "T.any(String, Symbol)"),
+                  create_param("column_name", type: "::T.any(String, Symbol)"),
                 ],
-                return_type: "T::Hash[T.untyped, T.any(Integer, Float, BigDecimal)]",
+                return_type: "::T::Hash[::T.untyped, ::T.any(Integer, Float, BigDecimal)]",
               )
             when :count
               klass.create_method(
                 "count",
                 parameters: [
-                  create_opt_param("column_name", type: "T.untyped", default: "nil"),
+                  create_opt_param("column_name", type: "::T.untyped", default: "nil"),
                 ],
-                return_type: "T::Hash[T.untyped, Integer]",
+                return_type: "::T::Hash[::T.untyped, Integer]",
               )
             when :sum
               klass.create_method(
                 "sum",
                 parameters: [
-                  create_opt_param("column_name", type: "T.nilable(T.any(String, Symbol))", default: "nil"),
-                  create_block_param("block", type: "T.nilable(T.proc.params(record: T.untyped).returns(T.untyped))"),
+                  create_opt_param("column_name", type: "::T.nilable(::T.any(String, Symbol))", default: "nil"),
+                  create_block_param("block", type: "::T.nilable(::T.proc.params(record: ::T.untyped).returns(::T.untyped))"),
                 ],
-                return_type: "T::Hash[T.untyped, T.any(Integer, Float, BigDecimal)]",
+                return_type: "::T::Hash[::T.untyped, ::T.any(Integer, Float, BigDecimal)]",
               )
             end
           end
@@ -422,8 +422,8 @@ module Tapioca
               klass.create_method(
                 method_name.to_s,
                 parameters: [
-                  create_param("opts", type: "T.untyped"),
-                  create_rest_param("rest", type: "T.untyped"),
+                  create_param("opts", type: "::T.untyped"),
+                  create_rest_param("rest", type: "::T.untyped"),
                 ],
                 return_type: return_type,
               )
@@ -431,7 +431,7 @@ module Tapioca
               klass.create_method(
                 method_name.to_s,
                 parameters: [
-                  create_rest_param("args", type: "T.untyped"),
+                  create_rest_param("args", type: "::T.untyped"),
                 ],
                 return_type: return_type,
               )
@@ -450,7 +450,7 @@ module Tapioca
             klass.create_type_variable("Elem", type: "type_member", fixed: constant_name)
 
             TO_ARRAY_METHODS.each do |method_name|
-              klass.create_method(method_name.to_s, return_type: "T::Array[#{constant_name}]")
+              klass.create_method(method_name.to_s, return_type: "::T::Array[#{constant_name}]")
             end
             create_collection_proxy_methods(klass)
           end
@@ -469,7 +469,7 @@ module Tapioca
           # which altogether gives us:
           #   `T.any(Model, T::Enumerable[T.any(Model, T::Enumerable[Model])])`
           model_collection =
-            "T.any(#{constant_name}, T::Enumerable[T.any(#{constant_name}, T::Enumerable[#{constant_name}])])"
+            "::T.any(#{constant_name}, ::T::Enumerable[::T.any(#{constant_name}, ::T::Enumerable[#{constant_name}])])"
 
           # For these cases, it is valid to pass the above kind of things, but also:
           # - a model identifier, which can be:
@@ -480,8 +480,8 @@ module Tapioca
           # which, coupled with the above case, gives us:
           #   `T.any(Model, Integer, String, T::Enumerable[T.any(Model, Integer, String, T::Enumerable[Model])])`
           model_or_id_collection =
-            "T.any(#{constant_name}, Integer, String" \
-              ", T::Enumerable[T.any(#{constant_name}, Integer, String, T::Enumerable[#{constant_name}])])"
+            "::T.any(#{constant_name}, Integer, String" \
+              ", ::T::Enumerable[::T.any(#{constant_name}, Integer, String, ::T::Enumerable[#{constant_name}])])"
 
           COLLECTION_PROXY_METHODS.each do |method_name|
             case method_name
@@ -504,12 +504,12 @@ module Tapioca
                 parameters: [
                   create_rest_param("records", type: model_or_id_collection),
                 ],
-                return_type: "T::Array[#{constant_name}]",
+                return_type: "::T::Array[#{constant_name}]",
               )
             when :load_target
               klass.create_method(
                 method_name.to_s,
-                return_type: "T::Array[#{constant_name}]",
+                return_type: "::T::Array[#{constant_name}]",
               )
             when :replace
               klass.create_method(
@@ -517,7 +517,7 @@ module Tapioca
                 parameters: [
                   create_param("other_array", type: model_collection),
                 ],
-                return_type: "T::Array[#{constant_name}]",
+                return_type: "::T::Array[#{constant_name}]",
               )
             when :reset_scope
               # skip
@@ -529,7 +529,7 @@ module Tapioca
             when :target
               klass.create_method(
                 method_name.to_s,
-                return_type: "T::Array[#{constant_name}]",
+                return_type: "::T::Array[#{constant_name}]",
               )
             end
           end
@@ -548,8 +548,8 @@ module Tapioca
               create_relation_method(
                 "group",
                 parameters: [
-                  create_rest_param("args", type: "T.untyped"),
-                  create_block_param("blk", type: "T.untyped"),
+                  create_rest_param("args", type: "::T.untyped"),
+                  create_block_param("blk", type: "::T.untyped"),
                 ],
                 relation_return_type: RelationGroupChainClassName,
                 association_return_type: AssociationRelationGroupChainClassName,
@@ -557,11 +557,11 @@ module Tapioca
             when :distinct
               create_relation_method(
                 method_name.to_s,
-                parameters: [create_opt_param("value", type: "T::Boolean", default: "true")],
+                parameters: [create_opt_param("value", type: "::T::Boolean", default: "true")],
               )
             when :extract_associated
               parameters = [create_param("association", type: "Symbol")]
-              return_type = "T::Array[T.untyped]"
+              return_type = "::T::Array[::T.untyped]"
               relation_methods_module.create_method(
                 method_name.to_s,
                 parameters: parameters,
@@ -579,12 +579,12 @@ module Tapioca
                   method.add_block_param("blk")
 
                   method.add_sig do |sig|
-                    sig.add_param("args", "T.untyped")
+                    sig.add_param("args", "::T.untyped")
                     sig.return_type = mod == relation_methods_module ? RelationClassName : AssociationRelationClassName
                   end
                   method.add_sig do |sig|
-                    sig.add_param("blk", "T.proc.params(record: #{constant_name}).returns(BasicObject)")
-                    sig.return_type = "T::Array[#{constant_name}]"
+                    sig.add_param("blk", "::T.proc.params(record: #{constant_name}).returns(BasicObject)")
+                    sig.return_type = "::T::Array[#{constant_name}]"
                   end
                 end
               end
@@ -592,8 +592,8 @@ module Tapioca
               create_relation_method(
                 method_name,
                 parameters: [
-                  create_rest_param("args", type: "T.untyped"),
-                  create_block_param("blk", type: "T.untyped"),
+                  create_rest_param("args", type: "::T.untyped"),
+                  create_block_param("blk", type: "::T.untyped"),
                 ],
               )
             end
@@ -611,7 +611,7 @@ module Tapioca
         def create_common_methods
           create_common_method(
             "destroy_all",
-            return_type: "T::Array[#{constant_name}]",
+            return_type: "::T::Array[#{constant_name}]",
           )
 
           FINDER_METHODS.each do |method_name|
@@ -620,17 +620,17 @@ module Tapioca
               create_common_method(
                 "exists?",
                 parameters: [
-                  create_opt_param("conditions", type: "T.untyped", default: ":none"),
+                  create_opt_param("conditions", type: "::T.untyped", default: ":none"),
                 ],
-                return_type: "T::Boolean",
+                return_type: "::T::Boolean",
               )
             when :include?, :member?
               create_common_method(
                 method_name,
                 parameters: [
-                  create_param("record", type: "T.untyped"),
+                  create_param("record", type: "::T.untyped"),
                 ],
-                return_type: "T::Boolean",
+                return_type: "::T::Boolean",
               )
             when :find
               id_types = ID_TYPES
@@ -640,15 +640,15 @@ module Tapioca
                 type = Tapioca::Dsl::Helpers::ActiveModelTypeHelper.type_for(primary_key_type)
                 type = RBIHelper.as_non_nilable_type(type)
 
-                id_types = ID_TYPES.union([type]) if type != "T.untyped"
+                id_types = ID_TYPES.union([type]) if type != "::T.untyped"
               end
 
-              id_types = "T.any(#{id_types.to_a.join(", ")})"
+              id_types = "::T.any(#{id_types.to_a.join(", ")})"
               if constant.try(:composite_primary_key?)
-                id_types = "T::Array[#{id_types}]"
+                id_types = "::T::Array[#{id_types}]"
               end
 
-              array_type = "T::Array[#{id_types}]"
+              array_type = "::T::Array[#{id_types}]"
 
               common_relation_methods_module.create_method("find") do |method|
                 method.add_opt_param("args", "nil")
@@ -661,12 +661,12 @@ module Tapioca
 
                 method.add_sig do |sig|
                   sig.add_param("args", array_type)
-                  sig.return_type = "T::Enumerable[#{constant_name}]"
+                  sig.return_type = "::T::Enumerable[#{constant_name}]"
                 end
 
                 method.add_sig do |sig|
-                  sig.add_param("args", "NilClass")
-                  sig.add_param("block", "T.proc.params(object: #{constant_name}).void")
+                  sig.add_param("args", "::NilClass")
+                  sig.add_param("block", "::T.proc.params(object: #{constant_name}).void")
                   sig.return_type = as_nilable_type(constant_name)
                 end
               end
@@ -674,7 +674,7 @@ module Tapioca
               create_common_method(
                 "find_by",
                 parameters: [
-                  create_rest_param("args", type: "T.untyped"),
+                  create_rest_param("args", type: "::T.untyped"),
                 ],
                 return_type: as_nilable_type(constant_name),
               )
@@ -682,7 +682,7 @@ module Tapioca
               create_common_method(
                 "find_by!",
                 parameters: [
-                  create_rest_param("args", type: "T.untyped"),
+                  create_rest_param("args", type: "::T.untyped"),
                 ],
                 return_type: constant_name,
               )
@@ -690,8 +690,8 @@ module Tapioca
               create_common_method(
                 "find_sole_by",
                 parameters: [
-                  create_param("arg", type: "T.untyped"),
-                  create_rest_param("args", type: "T.untyped"),
+                  create_param("arg", type: "::T.untyped"),
+                  create_rest_param("args", type: "::T.untyped"),
                 ],
                 return_type: constant_name,
               )
@@ -711,7 +711,7 @@ module Tapioca
 
                 method.add_sig do |sig|
                   sig.add_param("limit", "Integer")
-                  sig.return_type = "T::Array[#{constant_name}]"
+                  sig.return_type = "::T::Array[#{constant_name}]"
                 end
               end
             when :raise_record_not_found_exception!
@@ -736,8 +736,8 @@ module Tapioca
               create_common_method(
                 "find_signed",
                 parameters: [
-                  create_param("signed_id", type: "T.untyped"),
-                  create_kw_opt_param("purpose", type: "T.untyped", default: "nil"),
+                  create_param("signed_id", type: "::T.untyped"),
+                  create_kw_opt_param("purpose", type: "::T.untyped", default: "nil"),
                 ],
                 return_type: as_nilable_type(constant_name),
               )
@@ -745,8 +745,8 @@ module Tapioca
               create_common_method(
                 "find_signed!",
                 parameters: [
-                  create_param("signed_id", type: "T.untyped"),
-                  create_kw_opt_param("purpose", type: "T.untyped", default: "nil"),
+                  create_param("signed_id", type: "::T.untyped"),
+                  create_kw_opt_param("purpose", type: "::T.untyped", default: "nil"),
                 ],
                 return_type: constant_name,
               )
@@ -759,18 +759,18 @@ module Tapioca
               create_common_method(
                 method_name,
                 parameters: [
-                  create_param("column_name", type: "T.any(String, Symbol)"),
+                  create_param("column_name", type: "::T.any(String, Symbol)"),
                 ],
-                return_type: method_name == :average ? "T.any(Integer, Float, BigDecimal)" : "T.untyped",
+                return_type: method_name == :average ? "::T.any(Integer, Float, BigDecimal)" : "::T.untyped",
               )
             when :calculate
               create_common_method(
                 "calculate",
                 parameters: [
                   create_param("operation", type: "Symbol"),
-                  create_param("column_name", type: "T.any(String, Symbol)"),
+                  create_param("column_name", type: "::T.any(String, Symbol)"),
                 ],
-                return_type: "T.any(Integer, Float, BigDecimal)",
+                return_type: "::T.any(Integer, Float, BigDecimal)",
               )
             when :count
               common_relation_methods_module.create_method(method_name.to_s) do |method|
@@ -778,13 +778,13 @@ module Tapioca
                 method.add_block_param("block")
 
                 method.add_sig do |sig|
-                  sig.add_param("column_name", "T.nilable(T.any(String, Symbol))")
+                  sig.add_param("column_name", "::T.nilable(::T.any(String, Symbol))")
                   sig.return_type = "Integer"
                 end
 
                 method.add_sig do |sig|
-                  sig.add_param("column_name", "NilClass")
-                  sig.add_param("block", "T.proc.params(object: #{constant_name}).void")
+                  sig.add_param("column_name", "::NilClass")
+                  sig.add_param("block", "::T.proc.params(object: #{constant_name}).void")
                   sig.return_type = "Integer"
                 end
               end
@@ -797,7 +797,7 @@ module Tapioca
                 primary_key = constant.primary_key
                 getter_type, _setter_type = column_type_helper.type_for(primary_key)
                 type = getter_type
-                create_common_method("ids", return_type: "T::Array[#{type}]")
+                create_common_method("ids", return_type: "::T::Array[#{type}]")
               else
                 create_common_method("ids", return_type: "Array")
               end
@@ -806,9 +806,9 @@ module Tapioca
               create_common_method(
                 method_name,
                 parameters: [
-                  create_rest_param("column_names", type: "T.untyped"),
+                  create_rest_param("column_names", type: "::T.untyped"),
                 ],
-                return_type: "T.untyped",
+                return_type: "::T.untyped",
               )
             when :sum
               common_relation_methods_module.create_method(method_name.to_s) do |method|
@@ -816,14 +816,14 @@ module Tapioca
                 method.add_block_param("block")
 
                 method.add_sig do |sig|
-                  sig.add_param("initial_value_or_column", "T.untyped")
-                  sig.return_type = "T.any(Integer, Float, BigDecimal)"
+                  sig.add_param("initial_value_or_column", "::T.untyped")
+                  sig.return_type = "::T.any(Integer, Float, BigDecimal)"
                 end
 
                 method.add_sig(type_params: ["U"]) do |sig|
-                  sig.add_param("initial_value_or_column", "T.nilable(T.type_parameter(:U))")
-                  sig.add_param("block", "T.proc.params(object: #{constant_name}).returns(T.type_parameter(:U))")
-                  sig.return_type = "T.type_parameter(:U)"
+                  sig.add_param("initial_value_or_column", "::T.nilable(::T.type_parameter(:U))")
+                  sig.add_param("block", "::T.proc.params(object: #{constant_name}).returns(::T.type_parameter(:U))")
+                  sig.return_type = "::T.type_parameter(:U)"
                 end
               end
             end
@@ -846,7 +846,7 @@ module Tapioca
                 parameters.each do |name, (_style, type, _default)|
                   sig.add_param(name, type)
                 end
-                sig.add_param("block", "T.proc.params(object: #{block_param}).void")
+                sig.add_param("block", "::T.proc.params(object: #{block_param}).void")
                 sig.return_type = "void"
               end
 
@@ -862,13 +862,13 @@ module Tapioca
           RELATION_METHODS.each do |method_name|
             case method_name
             when :any?, :many?, :none?, :one? # enumerable query methods
-              block_type = "T.nilable(T.proc.params(record: #{constant_name}).returns(T.untyped))"
+              block_type = "::T.nilable(::T.proc.params(record: #{constant_name}).returns(::T.untyped))"
               create_common_method(
                 method_name,
                 parameters: [
                   create_block_param("block", type: block_type),
                 ],
-                return_type: "T::Boolean",
+                return_type: "::T::Boolean",
               )
             when :find_or_create_by, :find_or_create_by!, :find_or_initialize_by, :create_or_find_by, :create_or_find_by! # find or create methods
               common_relation_methods_module.create_method(method_name.to_s) do |method|
@@ -878,14 +878,14 @@ module Tapioca
                 # `T.untyped` matches `T::Array[T.untyped]` so the array signature
                 # must be defined first for Sorbet to pick it, if valid.
                 method.add_sig do |sig|
-                  sig.add_param("attributes", "T::Array[T.untyped]")
-                  sig.add_param("block", "T.nilable(T.proc.params(object: #{constant_name}).void)")
-                  sig.return_type = "T::Array[#{constant_name}]"
+                  sig.add_param("attributes", "::T::Array[::T.untyped]")
+                  sig.add_param("block", "::T.nilable(::T.proc.params(object: #{constant_name}).void)")
+                  sig.return_type = "::T::Array[#{constant_name}]"
                 end
 
                 method.add_sig do |sig|
-                  sig.add_param("attributes", "T.untyped")
-                  sig.add_param("block", "T.nilable(T.proc.params(object: #{constant_name}).void)")
+                  sig.add_param("attributes", "::T.untyped")
+                  sig.add_param("block", "::T.nilable(::T.proc.params(object: #{constant_name}).void)")
                   sig.return_type = constant_name
                 end
               end
@@ -895,21 +895,21 @@ module Tapioca
                 method.add_block_param("block")
 
                 method.add_sig do |sig|
-                  sig.add_param("block", "T.nilable(T.proc.params(object: #{constant_name}).void)")
+                  sig.add_param("block", "::T.nilable(::T.proc.params(object: #{constant_name}).void)")
                   sig.return_type = constant_name
                 end
 
                 # `T.untyped` matches `T::Array[T.untyped]` so the array signature
                 # must be defined first for Sorbet to pick it, if valid.
                 method.add_sig do |sig|
-                  sig.add_param("attributes", "T::Array[T.untyped]")
-                  sig.add_param("block", "T.nilable(T.proc.params(object: #{constant_name}).void)")
-                  sig.return_type = "T::Array[#{constant_name}]"
+                  sig.add_param("attributes", "::T::Array[::T.untyped]")
+                  sig.add_param("block", "::T.nilable(::T.proc.params(object: #{constant_name}).void)")
+                  sig.return_type = "::T::Array[#{constant_name}]"
                 end
 
                 method.add_sig do |sig|
-                  sig.add_param("attributes", "T.untyped")
-                  sig.add_param("block", "T.nilable(T.proc.params(object: #{constant_name}).void)")
+                  sig.add_param("attributes", "::T.untyped")
+                  sig.add_param("block", "::T.nilable(::T.proc.params(object: #{constant_name}).void)")
                   sig.return_type = constant_name
                 end
               end
@@ -930,24 +930,24 @@ module Tapioca
                 parameters: [
                   create_rest_param(
                     "records",
-                    type: "T.any(#{constant_name}, Integer, String" \
-                      ", T::Enumerable[T.any(#{constant_name}, Integer, String, T::Enumerable[#{constant_name}])])",
+                    type: "::T.any(#{constant_name}, Integer, String" \
+                      ", ::T::Enumerable[::T.any(#{constant_name}, Integer, String, ::T::Enumerable[#{constant_name}])])",
                   ),
                 ],
-                return_type: method_name == :delete ? "Integer" : "T::Array[#{constant_name}]",
+                return_type: method_name == :delete ? "Integer" : "::T::Array[#{constant_name}]",
               )
             when :delete_all, :destroy_all
               common_relation_methods_module.create_method(
                 method_name.to_s,
-                return_type: method_name == :delete_all ? "Integer" : "T::Array[#{constant_name}]",
+                return_type: method_name == :delete_all ? "Integer" : "::T::Array[#{constant_name}]",
               )
             when :delete_by, :destroy_by
               common_relation_methods_module.create_method(
                 method_name.to_s,
                 parameters: [
-                  create_rest_param("args", type: "T.untyped"),
+                  create_rest_param("args", type: "::T.untyped"),
                 ],
-                return_type: method_name == :delete_by ? "Integer" : "T::Array[#{constant_name}]",
+                return_type: method_name == :delete_by ? "Integer" : "::T::Array[#{constant_name}]",
               )
             end
           end
@@ -961,8 +961,8 @@ module Tapioca
             method.add_block_param("block")
 
             method.add_sig do |sig|
-              sig.add_param("attributes", "T.untyped")
-              sig.add_param("block", "T.nilable(T.proc.params(object: #{constant_name}).void)")
+              sig.add_param("attributes", "::T.untyped")
+              sig.add_param("block", "::T.nilable(::T.proc.params(object: #{constant_name}).void)")
               sig.return_type = constant_name
             end
           end
@@ -972,9 +972,9 @@ module Tapioca
         def batch_method_configs(method_name)
           block_param, return_type = case method_name
           when :find_each
-            [constant_name, "T::Enumerator[#{constant_name}]"]
+            [constant_name, "::T::Enumerator[#{constant_name}]"]
           when :find_in_batches
-            ["T::Array[#{constant_name}]", "T::Enumerator[T::Array[#{constant_name}]]"]
+            ["::T::Array[#{constant_name}]", "::T::Enumerator[::T::Array[#{constant_name}]]"]
           when :in_batches
             [RelationClassName, "::ActiveRecord::Batches::BatchEnumerator"]
           else
@@ -1012,7 +1012,7 @@ module Tapioca
             end
 
             method.add_sig do |sig|
-              sig.add_param("args", "T.untyped")
+              sig.add_param("args", "::T.untyped")
               sig.return_type = RelationClassName
             end
           end
@@ -1025,7 +1025,7 @@ module Tapioca
             end
 
             method.add_sig do |sig|
-              sig.add_param("args", "T.untyped")
+              sig.add_param("args", "::T.untyped")
               sig.return_type = AssociationRelationClassName
             end
           end
@@ -1065,8 +1065,8 @@ module Tapioca
             end
 
             method.add_sig(type_params: ["U"]) do |sig|
-              sig.add_param("block", "T.proc.returns(T.type_parameter(:U))")
-              sig.return_type = "T.type_parameter(:U)"
+              sig.add_param("block", "::T.proc.returns(::T.type_parameter(:U))")
+              sig.return_type = "::T.type_parameter(:U)"
             end
           end
 
@@ -1078,8 +1078,8 @@ module Tapioca
             end
 
             method.add_sig(type_params: ["U"]) do |sig|
-              sig.add_param("block", "T.proc.returns(T.type_parameter(:U))")
-              sig.return_type = "T.type_parameter(:U)"
+              sig.add_param("block", "::T.proc.returns(::T.type_parameter(:U))")
+              sig.return_type = "::T.type_parameter(:U)"
             end
           end
         end

--- a/lib/tapioca/dsl/compilers/active_record_scope.rb
+++ b/lib/tapioca/dsl/compilers/active_record_scope.rb
@@ -59,7 +59,7 @@ module Tapioca
               generate_scope_method(
                 relation_methods_module,
                 scope_method.to_s,
-                relations_enabled ? RelationClassName : "T.untyped",
+                relations_enabled ? RelationClassName : "::T.untyped",
               )
 
               next unless relations_enabled
@@ -109,8 +109,8 @@ module Tapioca
           mod.create_method(
             scope_method,
             parameters: [
-              create_rest_param("args", type: "T.untyped"),
-              create_block_param("blk", type: "T.untyped"),
+              create_rest_param("args", type: "::T.untyped"),
+              create_block_param("blk", type: "::T.untyped"),
             ],
             return_type: return_type,
           )

--- a/lib/tapioca/dsl/compilers/active_record_secure_token.rb
+++ b/lib/tapioca/dsl/compilers/active_record_secure_token.rb
@@ -46,7 +46,7 @@ module Tapioca
               constant.__tapioca_secure_tokens.each do |attribute|
                 mod.create_method(
                   "regenerate_#{attribute}",
-                  return_type: "T::Boolean",
+                  return_type: "::T::Boolean",
                 )
               end
             end

--- a/lib/tapioca/dsl/compilers/active_record_store.rb
+++ b/lib/tapioca/dsl/compilers/active_record_store.rb
@@ -112,16 +112,16 @@ module Tapioca
                 keys.flatten.map { |key| "#{accessor_prefix}#{key}#{accessor_suffix}" }.each do |accessor_key|
                   mod.create_method(
                     "#{accessor_key}=",
-                    parameters: [create_param("value", type: "T.untyped")],
-                    return_type: "T.untyped",
+                    parameters: [create_param("value", type: "::T.untyped")],
+                    return_type: "::T.untyped",
                   )
-                  mod.create_method(accessor_key, return_type: "T.untyped")
-                  mod.create_method("#{accessor_key}_changed?", return_type: "T::Boolean")
-                  mod.create_method("#{accessor_key}_change", return_type: "T.untyped")
-                  mod.create_method("#{accessor_key}_was", return_type: "T.untyped")
-                  mod.create_method("saved_change_to_#{accessor_key}?", return_type: "T::Boolean")
-                  mod.create_method("saved_change_to_#{accessor_key}", return_type: "T.untyped")
-                  mod.create_method("#{accessor_key}_before_last_save", return_type: "T.untyped")
+                  mod.create_method(accessor_key, return_type: "::T.untyped")
+                  mod.create_method("#{accessor_key}_changed?", return_type: "::T::Boolean")
+                  mod.create_method("#{accessor_key}_change", return_type: "::T.untyped")
+                  mod.create_method("#{accessor_key}_was", return_type: "::T.untyped")
+                  mod.create_method("saved_change_to_#{accessor_key}?", return_type: "::T::Boolean")
+                  mod.create_method("saved_change_to_#{accessor_key}", return_type: "::T.untyped")
+                  mod.create_method("#{accessor_key}_before_last_save", return_type: "::T.untyped")
                 end
               end
             end

--- a/lib/tapioca/dsl/compilers/active_record_typed_store.rb
+++ b/lib/tapioca/dsl/compilers/active_record_typed_store.rb
@@ -118,7 +118,7 @@ module Tapioca
         private
 
         TYPES = {
-          boolean: "T::Boolean",
+          boolean: "::T::Boolean",
           integer: "Integer",
           string: "String",
           float: "Float",
@@ -126,19 +126,19 @@ module Tapioca
           time: "Time",
           datetime: "DateTime",
           decimal: "BigDecimal",
-          any: "T.untyped",
+          any: "::T.untyped",
         }.freeze #: Hash[Symbol, String]
 
         #: (ActiveRecord::TypedStore::Field field) -> String
         def type_for(field)
-          type = TYPES.fetch(field.type_sym, "T.untyped")
+          type = TYPES.fetch(field.type_sym, "::T.untyped")
 
           type = if field.array
             # `null: false` applies to the array itself, not the elements, which are always nilable.
             # https://github.com/byroot/activerecord-typedstore/blob/2f3fb98/spec/support/models.rb#L46C34-L46C45
             # https://github.com/byroot/activerecord-typedstore/blob/2f3fb98/spec/active_record/typed_store_spec.rb#L854-L857
             nilable_element_type = as_nilable_type(type)
-            "T::Array[#{nilable_element_type}]"
+            "::T::Array[#{nilable_element_type}]"
           else
             type
           end
@@ -156,13 +156,13 @@ module Tapioca
             return_type: type,
           )
           klass.create_method(name, return_type: type)
-          klass.create_method("#{name}?", return_type: "T::Boolean")
+          klass.create_method("#{name}?", return_type: "::T::Boolean")
           klass.create_method("#{name}_was", return_type: type)
-          klass.create_method("#{name}_changed?", return_type: "T::Boolean")
+          klass.create_method("#{name}_changed?", return_type: "::T::Boolean")
           klass.create_method("#{name}_before_last_save", return_type: type)
-          klass.create_method("saved_change_to_#{name}?", return_type: "T::Boolean")
-          klass.create_method("#{name}_change", return_type: "T.nilable([#{type}, #{type}])")
-          klass.create_method("saved_change_to_#{name}", return_type: "T.nilable([#{type}, #{type}])")
+          klass.create_method("saved_change_to_#{name}?", return_type: "::T::Boolean")
+          klass.create_method("#{name}_change", return_type: "::T.nilable([#{type}, #{type}])")
+          klass.create_method("saved_change_to_#{name}", return_type: "::T.nilable([#{type}, #{type}])")
         end
       end
     end

--- a/lib/tapioca/dsl/compilers/active_resource.rb
+++ b/lib/tapioca/dsl/compilers/active_resource.rb
@@ -79,7 +79,7 @@ module Tapioca
         private
 
         TYPES = {
-          boolean: "T::Boolean",
+          boolean: "::T::Boolean",
           integer: "Integer",
           string: "String",
           float: "Float",
@@ -93,7 +93,7 @@ module Tapioca
 
         #: (Symbol attr_type) -> String
         def type_for(attr_type)
-          TYPES.fetch(attr_type, "T.untyped")
+          TYPES.fetch(attr_type, "::T.untyped")
         end
 
         #: (RBI::Scope klass, String attribute, String type) -> void
@@ -101,7 +101,7 @@ module Tapioca
           return_type = type_for(type.to_sym)
 
           klass.create_method(attribute, return_type: return_type)
-          klass.create_method("#{attribute}?", return_type: "T::Boolean")
+          klass.create_method("#{attribute}?", return_type: "::T::Boolean")
           klass.create_method(
             "#{attribute}=",
             parameters: [

--- a/lib/tapioca/dsl/compilers/active_storage.rb
+++ b/lib/tapioca/dsl/compilers/active_storage.rb
@@ -55,8 +55,8 @@ module Tapioca
               )
               scope.create_method(
                 "#{name}=",
-                parameters: [create_param("attachable", type: "T.untyped")],
-                return_type: "T.untyped",
+                parameters: [create_param("attachable", type: "::T.untyped")],
+                return_type: "::T.untyped",
               )
             end
           end
@@ -82,7 +82,7 @@ module Tapioca
           when ::ActiveStorage::Reflection::HasManyAttachedReflection
             "ActiveStorage::Attached::Many"
           else
-            "T.untyped"
+            "::T.untyped"
           end
         end
       end

--- a/lib/tapioca/dsl/compilers/active_support_environment_inquirer.rb
+++ b/lib/tapioca/dsl/compilers/active_support_environment_inquirer.rb
@@ -40,7 +40,7 @@ module Tapioca
 
           root.create_path(::ActiveSupport::EnvironmentInquirer) do |mod|
             envs.each do |env|
-              mod.create_method("#{env}?", return_type: "T::Boolean")
+              mod.create_method("#{env}?", return_type: "::T::Boolean")
             end
           end
         end

--- a/lib/tapioca/dsl/compilers/config.rb
+++ b/lib/tapioca/dsl/compilers/config.rb
@@ -61,7 +61,7 @@ module Tapioca
 
           return if method_names.empty?
 
-          root.create_constant(config_constant_name, value: "T.let(T.unsafe(nil), #{option_class_name})")
+          root.create_constant(config_constant_name, value: "::T.let(::T.unsafe(nil), #{option_class_name})")
 
           root.create_class(option_class_name, superclass_name: "::Config::Options") do |mod|
             # We need this to be generic only because `Config::Options` is an
@@ -70,21 +70,21 @@ module Tapioca
             # We declare it as a fixed member of `T.untyped` so that if anyone
             # enumerates the entries, we don't make any assumptions about their
             # types.
-            mod.create_extend("T::Generic")
-            mod.create_type_variable("Elem", type: "type_member", fixed: "T.untyped")
+            mod.create_extend("::T::Generic")
+            mod.create_type_variable("Elem", type: "type_member", fixed: "::T.untyped")
 
             method_names.each do |method_name|
               # Create getter method
               mod.create_method(
                 method_name.to_s,
-                return_type: "T.untyped",
+                return_type: "::T.untyped",
               )
 
               # Create setter method
               mod.create_method(
                 "#{method_name}=",
-                parameters: [create_param("value", type: "T.untyped")],
-                return_type: "T.untyped",
+                parameters: [create_param("value", type: "::T.untyped")],
+                return_type: "::T.untyped",
               )
             end
           end

--- a/lib/tapioca/dsl/compilers/frozen_record.rb
+++ b/lib/tapioca/dsl/compilers/frozen_record.rb
@@ -71,8 +71,8 @@ module Tapioca
 
             record.create_module(module_name) do |mod|
               attributes.each do |attribute|
-                mod.create_method("#{attribute}?", return_type: "T::Boolean")
-                mod.create_method(attribute.to_s, return_type: "T.untyped")
+                mod.create_method("#{attribute}?", return_type: "::T::Boolean")
+                mod.create_method(attribute.to_s, return_type: "::T.untyped")
               end
             end
 
@@ -113,10 +113,10 @@ module Tapioca
           mod.create_method(
             scope_method,
             parameters: [
-              create_rest_param("args", type: "T.untyped"),
-              create_block_param("blk", type: "T.untyped"),
+              create_rest_param("args", type: "::T.untyped"),
+              create_block_param("blk", type: "::T.untyped"),
             ],
-            return_type: "T.untyped",
+            return_type: "::T.untyped",
           )
         end
       end

--- a/lib/tapioca/dsl/compilers/graphql_mutation.rb
+++ b/lib/tapioca/dsl/compilers/graphql_mutation.rb
@@ -57,13 +57,13 @@ module Tapioca
           end
 
           root.create_path(constant) do |mutation|
-            mutation.create_method("resolve", parameters: params, return_type: "T.untyped")
+            mutation.create_method("resolve", parameters: params, return_type: "::T.untyped")
           end
         end
 
         #: (GraphQL::Schema::Argument? argument, singleton(GraphQL::Schema::Mutation) constant) -> String
         def argument_type(argument, constant)
-          return "T.untyped" unless argument
+          return "::T.untyped" unless argument
 
           Helpers::GraphqlTypeHelper.type_for_argument(argument, constant)
         end

--- a/lib/tapioca/dsl/compilers/identity_cache.rb
+++ b/lib/tapioca/dsl/compilers/identity_cache.rb
@@ -57,7 +57,11 @@ module Tapioca
       # ~~~
       #: [ConstantType = singleton(::ActiveRecord::Base)]
       class IdentityCache < Compiler
-        COLLECTION_TYPE = ->(type) { "T::Array[::#{type}]" } #: ^((T::Module[top] | String) type) -> String
+        COLLECTION_TYPE = ->(type) do #: ^((T::Module[top] | String) type) -> String
+          qualified = type.to_s
+          qualified = "::#{qualified}" unless qualified.start_with?("::")
+          "::T::Array[#{qualified}]"
+        end
 
         # @override
         #: -> void
@@ -110,7 +114,7 @@ module Tapioca
             as_nilable_type(T.must(qualified_name_of(cache_type)))
           end
         rescue ArgumentError
-          "T.untyped"
+          "::T.untyped"
         end
 
         #: (untyped field, RBI::Scope klass, returns_collection: bool) -> void
@@ -120,9 +124,9 @@ module Tapioca
           klass.create_method(name, return_type: type)
 
           if field.respond_to?(:cached_ids_name)
-            klass.create_method(field.cached_ids_name, return_type: "T::Array[T.untyped]")
+            klass.create_method(field.cached_ids_name, return_type: "::T::Array[::T.untyped]")
           elsif field.respond_to?(:cached_id_name)
-            klass.create_method(field.cached_id_name, return_type: "T.untyped")
+            klass.create_method(field.cached_id_name, return_type: "::T.untyped")
           end
         end
 
@@ -142,9 +146,9 @@ module Tapioca
           fields_name = field.key_fields.join("_and_")
           name = "fetch_by_#{fields_name}"
           parameters = field.key_fields.map do |arg|
-            create_param(arg.to_s, type: "T.untyped")
+            create_param(arg.to_s, type: "::T.untyped")
           end
-          parameters << create_kw_opt_param("includes", default: "nil", type: "T.untyped")
+          parameters << create_kw_opt_param("includes", default: "nil", type: "::T.untyped")
 
           if field.unique
             type = T.must(qualified_name_of(constant))
@@ -175,8 +179,8 @@ module Tapioca
             "fetch_multi_by_#{fields_name}",
             class_method: true,
             parameters: [
-              create_param("index_values", type: "T::Enumerable[T.untyped]"),
-              create_kw_opt_param("includes", default: "nil", type: "T.untyped"),
+              create_param("index_values", type: "::T::Enumerable[::T.untyped]"),
+              create_kw_opt_param("includes", default: "nil", type: "::T.untyped"),
             ],
             return_type: COLLECTION_TYPE.call(constant),
           )
@@ -188,11 +192,11 @@ module Tapioca
             constant,
             column_type_option: Helpers::ActiveRecordColumnTypeHelper::ColumnTypeOption::Nilable,
           ).type_for(field.alias_name.to_s)
-          multi_type = type.delete_prefix("T.nilable(").delete_suffix(")").delete_prefix("::")
+          multi_type = type.delete_prefix("::T.nilable(").delete_suffix(")").delete_prefix("::")
           suffix = field.send(:fetch_method_suffix)
 
           parameters = field.key_fields.map do |arg|
-            create_param(arg.to_s, type: "T.untyped")
+            create_param(arg.to_s, type: "::T.untyped")
           end
 
           klass.create_method(
@@ -205,7 +209,7 @@ module Tapioca
           klass.create_method(
             "fetch_multi_#{suffix}",
             class_method: true,
-            parameters: [create_param("keys", type: "T::Enumerable[T.untyped]")],
+            parameters: [create_param("keys", type: "::T::Enumerable[::T.untyped]")],
             return_type: COLLECTION_TYPE.call(multi_type),
           )
         end

--- a/lib/tapioca/dsl/compilers/json_api_client_resource.rb
+++ b/lib/tapioca/dsl/compilers/json_api_client_resource.rb
@@ -136,7 +136,7 @@ module Tapioca
         #: (::JsonApiClient::Schema::Property property) -> String
         def type_for(property)
           type = ::JsonApiClient::Schema::TypeFactory.type_for(property.type)
-          return "T.untyped" if type.nil?
+          return "::T.untyped" if type.nil?
 
           tapioca_type = if type.respond_to?(:__tapioca_type)
             type.__tapioca_type
@@ -151,9 +151,9 @@ module Tapioca
           elsif type == ::JsonApiClient::Schema::Types::Decimal
             "::BigDecimal"
           elsif type == ::JsonApiClient::Schema::Types::Boolean
-            "T::Boolean"
+            "::T::Boolean"
           else
-            "T.untyped"
+            "::T.untyped"
           end
 
           if property.default.nil?
@@ -171,11 +171,11 @@ module Tapioca
           name, type = case association
           when ::JsonApiClient::Associations::BelongsTo::Association
             # id must be a string: # https://jsonapi.org/format/#document-resource-object-identification
-            [association.param.to_s, "T.nilable(::String)"]
+            [association.param.to_s, "::T.nilable(::String)"]
           when ::JsonApiClient::Associations::HasOne::Association
-            [association.attr_name.to_s, "T.nilable(#{klass})"]
+            [association.attr_name.to_s, "::T.nilable(#{klass})"]
           when ::JsonApiClient::Associations::HasMany::Association
-            [association.attr_name.to_s, "T.nilable(T::Array[#{klass}])"]
+            [association.attr_name.to_s, "::T.nilable(::T::Array[#{klass}])"]
           else
             return # Unsupported association type
           end

--- a/lib/tapioca/dsl/compilers/kredis.rb
+++ b/lib/tapioca/dsl/compilers/kredis.rb
@@ -103,7 +103,7 @@ module Tapioca
             create_enum_class(mod, klass_name, data.fetch(:values))
             return_type = klass_name
           when "Kredis::Types::Flag"
-            mod.create_method("#{method}?", return_type: "T::Boolean")
+            mod.create_method("#{method}?", return_type: "::T::Boolean")
           end
 
           mod.create_method(method, return_type: return_type)
@@ -114,7 +114,7 @@ module Tapioca
           klass = mod.create_class(klass_name, superclass_name: "Kredis::Types::Enum")
           values.each do |value|
             klass.create_method("#{value}!", return_type: "void")
-            klass.create_method("#{value}?", return_type: "T::Boolean")
+            klass.create_method("#{value}?", return_type: "::T::Boolean")
           end
         end
       end

--- a/lib/tapioca/dsl/compilers/protobuf.rb
+++ b/lib/tapioca/dsl/compilers/protobuf.rb
@@ -106,13 +106,13 @@ module Tapioca
                 klass.create_method(
                   "lookup",
                   parameters: [create_param("number", type: "Integer")],
-                  return_type: "T.nilable(Symbol)",
+                  return_type: "::T.nilable(Symbol)",
                   class_method: true,
                 )
                 klass.create_method(
                   "resolve",
                   parameters: [create_param("symbol", type: "Symbol")],
-                  return_type: "T.nilable(Integer)",
+                  return_type: "::T.nilable(Integer)",
                   class_method: true,
                 )
                 klass.create_method(
@@ -138,7 +138,7 @@ module Tapioca
                   # One of the fields has an incorrect name for a named parameter so creating the default initialize for
                   # it would create a RBI with a syntax error.
                   # The workaround is to create an initialize that takes a **kwargs instead.
-                  kwargs_parameter = create_kw_rest_param("fields", type: "T.untyped")
+                  kwargs_parameter = create_kw_rest_param("fields", type: "::T.untyped")
                   klass.create_method("initialize", parameters: [kwargs_parameter], return_type: "void")
                 end
               else
@@ -189,7 +189,7 @@ module Tapioca
 
         #: (RBI::Scope klass, *String names) -> void
         def create_type_members(klass, *names)
-          klass.create_extend("T::Generic")
+          klass.create_extend("::T::Generic")
 
           names.each do |name|
             klass.create_type_variable(name, type: "type_member")
@@ -206,19 +206,19 @@ module Tapioca
             # > value is known, or a number if it is unknown. Since proto3 uses
             # > open enum semantics, any number may be assigned to an enum
             # > field, even if it was not defined in the enum.
-            "T.any(Symbol, Integer)"
+            "::T.any(Symbol, Integer)"
           when :message
-            descriptor.subtype.msgclass.name || "T.untyped"
+            descriptor.subtype.msgclass.name || "::T.untyped"
           when :int32, :int64, :uint32, :uint64
             "Integer"
           when :double, :float
             "Float"
           when :bool
-            "T::Boolean"
+            "::T::Boolean"
           when :string, :bytes
             "String"
           else
-            "T.untyped"
+            "::T.untyped"
           end
         end
 
@@ -255,8 +255,8 @@ module Tapioca
               Field.new(
                 name: descriptor.name,
                 type: type,
-                init_type: "T.nilable(T.any(#{type}, T::Hash[#{key_type}, #{value_type}]))",
-                default: "T.unsafe(nil)",
+                init_type: "::T.nilable(::T.any(#{type}, ::T::Hash[#{key_type}, #{value_type}]))",
+                default: "::T.unsafe(nil)",
               )
             else
               elem_type = type_of(descriptor)
@@ -269,8 +269,8 @@ module Tapioca
                 # https://github.com/protocolbuffers/protobuf/blob/fc0eda1fd4eff075f1fb2e9249fa4209f0227e33/ruby/lib/google/protobuf/ffi/repeated_field.rb#L361-L366
                 # However the C implementation of the initializer specifically checks for Arrays:
                 # https://github.com/protocolbuffers/protobuf/blob/fc0eda1fd4eff075f1fb2e9249fa4209f0227e33/ruby/ext/google/protobuf_c/message.c#L568-L573
-                init_type: "T.nilable(T::Array[#{elem_type}])",
-                default: "T.unsafe(nil)",
+                init_type: "::T.nilable(::T::Array[#{elem_type}])",
+                default: "::T.unsafe(nil)",
               )
             end
           else
@@ -321,7 +321,7 @@ module Tapioca
         def create_oneof_method(klass, desc)
           klass.create_method(
             desc.name,
-            return_type: "T.nilable(Symbol)",
+            return_type: "::T.nilable(Symbol)",
           )
         end
       end

--- a/lib/tapioca/dsl/compilers/rails_generators.rb
+++ b/lib/tapioca/dsl/compilers/rails_generators.rb
@@ -92,12 +92,12 @@ module Tapioca
         def type_for(arg)
           type =
             case arg.type
-            when :array then "T::Array[::String]"
-            when :boolean then "T::Boolean"
-            when :hash then "T::Hash[::String, ::String]"
+            when :array then "::T::Array[::String]"
+            when :boolean then "::T::Boolean"
+            when :hash then "::T::Hash[::String, ::String]"
             when :numeric then "::Numeric"
             when :string then "::String"
-            else "T.untyped"
+            else "::T.untyped"
             end
 
           if arg.required || arg.default

--- a/lib/tapioca/dsl/compilers/sidekiq_worker.rb
+++ b/lib/tapioca/dsl/compilers/sidekiq_worker.rb
@@ -57,16 +57,16 @@ module Tapioca
             # accept a datetime, time, or numeric but we're typing them differently so they
             # semantically make sense.
             at_return_type = if defined?(ActiveSupport::TimeWithZone)
-              "T.any(DateTime, Time, ActiveSupport::TimeWithZone)"
+              "::T.any(DateTime, Time, ActiveSupport::TimeWithZone)"
             else
-              "T.any(DateTime, Time)"
+              "::T.any(DateTime, Time)"
             end
             at_params = [
               create_param("interval", type: at_return_type),
               *async_params,
             ]
             in_return_type = if defined?(ActiveSupport::Duration)
-              "T.any(Numeric, ActiveSupport::Duration)"
+              "::T.any(Numeric, ActiveSupport::Duration)"
             else
               "Numeric"
             end

--- a/lib/tapioca/dsl/compilers/smart_properties.rb
+++ b/lib/tapioca/dsl/compilers/smart_properties.rb
@@ -120,21 +120,21 @@ module Tapioca
             :required,
           )
 
-          return "T.untyped" if converter
+          return "::T.untyped" if converter
 
           type = if accepter.nil? || accepter.respond_to?(:to_proc)
-            "T.untyped"
+            "::T.untyped"
           elsif accepter == Array
-            "T::Array[T.untyped]"
+            "::T::Array[::T.untyped]"
           elsif BOOLEANS.include?(accepter)
-            "T::Boolean"
+            "::T::Boolean"
           elsif Array(accepter).all? { |a| a.is_a?(Module) }
             accepters = Array(accepter)
             types = accepters.map { |mod| T.must(qualified_name_of(mod)) }.join(", ")
-            types = "T.any(#{types})" if accepters.size > 1
+            types = "::T.any(#{types})" if accepters.size > 1
             types
           else
-            "T.untyped"
+            "::T.untyped"
           end
 
           might_be_optional = Proc === required || !required

--- a/lib/tapioca/dsl/compilers/state_machines.rb
+++ b/lib/tapioca/dsl/compilers/state_machines.rb
@@ -169,7 +169,7 @@ module Tapioca
           if value_types.size == 1
             value_types.first
           else
-            "T.any(#{value_types.join(", ")})"
+            "::T.any(#{value_types.join(", ")})"
           end
         end
 
@@ -177,7 +177,7 @@ module Tapioca
         def define_activerecord_methods(instance_module)
           instance_module.create_method(
             "changed_for_autosave?",
-            return_type: "T::Boolean",
+            return_type: "::T::Boolean",
           )
         end
 
@@ -186,7 +186,7 @@ module Tapioca
           machine.states.each do |state|
             instance_module.create_method(
               "#{state.qualified_name}?",
-              return_type: "T::Boolean",
+              return_type: "::T::Boolean",
             )
           end
         end
@@ -196,22 +196,22 @@ module Tapioca
           machine.events.each do |event|
             instance_module.create_method(
               "can_#{event.qualified_name}?",
-              return_type: "T::Boolean",
+              return_type: "::T::Boolean",
             )
             instance_module.create_method(
               "#{event.qualified_name}_transition",
-              parameters: [create_rest_param("args", type: "T.untyped")],
-              return_type: "T.nilable(::StateMachines::Transition)",
+              parameters: [create_rest_param("args", type: "::T.untyped")],
+              return_type: "::T.nilable(::StateMachines::Transition)",
             )
             instance_module.create_method(
               event.qualified_name.to_s,
-              parameters: [create_rest_param("args", type: "T.untyped")],
-              return_type: "T::Boolean",
+              parameters: [create_rest_param("args", type: "::T.untyped")],
+              return_type: "::T::Boolean",
             )
             instance_module.create_method(
               "#{event.qualified_name}!",
-              parameters: [create_rest_param("args", type: "T.untyped")],
-              return_type: "T::Boolean",
+              parameters: [create_rest_param("args", type: "::T.untyped")],
+              return_type: "::T::Boolean",
             )
           end
         end
@@ -234,8 +234,8 @@ module Tapioca
         def define_state_predicate(instance_module, machine)
           instance_module.create_method(
             "#{machine.name}?",
-            parameters: [create_param("state", type: "T.any(String, Symbol)")],
-            return_type: "T::Boolean",
+            parameters: [create_param("state", type: "::T.any(String, Symbol)")],
+            return_type: "::T::Boolean",
           )
         end
 
@@ -248,35 +248,35 @@ module Tapioca
 
           instance_module.create_method(
             events_attribute,
-            parameters: [create_rest_param("args", type: "T.untyped")],
-            return_type: "T::Array[T.any(String, Symbol)]",
+            parameters: [create_rest_param("args", type: "::T.untyped")],
+            return_type: "::T::Array[::T.any(String, Symbol)]",
           )
           instance_module.create_method(
             transitions_attribute,
-            parameters: [create_rest_param("args", type: "T.untyped")],
-            return_type: "T::Array[::StateMachines::Transition]",
+            parameters: [create_rest_param("args", type: "::T.untyped")],
+            return_type: "::T::Array[::StateMachines::Transition]",
           )
           instance_module.create_method(
             "fire_#{event_attribute}",
             parameters: [
-              create_param("event", type: "T.any(String, Symbol)"),
-              create_rest_param("args", type: "T.untyped"),
+              create_param("event", type: "::T.any(String, Symbol)"),
+              create_rest_param("args", type: "::T.untyped"),
             ],
-            return_type: "T::Boolean",
+            return_type: "::T::Boolean",
           )
           if machine.action
             instance_module.create_method(
               event_attribute,
-              return_type: "T.nilable(Symbol)",
+              return_type: "::T.nilable(Symbol)",
             )
             instance_module.create_method(
               "#{event_attribute}=",
-              parameters: [create_param("value", type: "T.any(String, Symbol)")],
-              return_type: "T.any(String, Symbol)",
+              parameters: [create_param("value", type: "::T.any(String, Symbol)")],
+              return_type: "::T.any(String, Symbol)",
             )
             instance_module.create_method(
               event_transition_attribute,
-              return_type: "T.nilable(::StateMachines::Transition)",
+              return_type: "::T.nilable(::StateMachines::Transition)",
             )
             instance_module.create_method(
               "#{event_transition_attribute}=",
@@ -292,8 +292,8 @@ module Tapioca
 
           instance_module.create_method(
             paths_attribute,
-            parameters: [create_rest_param("args", type: "T.untyped")],
-            return_type: "T::Array[::StateMachines::Transition]",
+            parameters: [create_rest_param("args", type: "::T.untyped")],
+            return_type: "::T::Array[::StateMachines::Transition]",
           )
         end
 
@@ -304,17 +304,17 @@ module Tapioca
 
           class_module.create_method(
             "human_#{name_attribute}",
-            parameters: [create_param("state", type: "T.any(String, Symbol)")],
+            parameters: [create_param("state", type: "::T.any(String, Symbol)")],
             return_type: "String",
           )
           class_module.create_method(
             "human_#{event_name_attribute}",
-            parameters: [create_param("event", type: "T.any(String, Symbol)")],
+            parameters: [create_param("event", type: "::T.any(String, Symbol)")],
             return_type: "String",
           )
           instance_module.create_method(
             name_attribute,
-            return_type: "T.any(String, Symbol)",
+            return_type: "::T.any(String, Symbol)",
           )
           instance_module.create_method(
             "human_#{name_attribute}",
@@ -332,8 +332,8 @@ module Tapioca
             .each do |method|
               class_module.create_method(
                 method.to_s,
-                parameters: [create_rest_param("states", type: "T.any(String, Symbol)")],
-                return_type: "T.untyped",
+                parameters: [create_rest_param("states", type: "::T.any(String, Symbol)")],
+                return_type: "::T.untyped",
               )
             end
         end

--- a/lib/tapioca/dsl/compilers/url_helpers.rb
+++ b/lib/tapioca/dsl/compilers/url_helpers.rb
@@ -171,7 +171,7 @@ module Tapioca
             constant.instance_methods(false).each do |method|
               mod.create_method(
                 method.to_s,
-                parameters: [create_rest_param("args", type: "T.untyped")],
+                parameters: [create_rest_param("args", type: "::T.untyped")],
                 return_type: "String",
               )
             end

--- a/lib/tapioca/dsl/helpers/active_model_type_helper.rb
+++ b/lib/tapioca/dsl/helpers/active_model_type_helper.rb
@@ -10,7 +10,7 @@ module Tapioca
           # Accepts subclasses of ActiveModel::Type::Value as well as classes that implement similar methods.
           #: (untyped type_value) -> String
           def type_for(type_value)
-            return "T.untyped" if Runtime::GenericTypeRegistry.generic_type_instance?(type_value)
+            return "::T.untyped" if Runtime::GenericTypeRegistry.generic_type_instance?(type_value)
 
             type = lookup_tapioca_type(type_value) ||
               lookup_return_type_of_method(type_value, :deserialize) ||
@@ -18,7 +18,7 @@ module Tapioca
               lookup_return_type_of_method(type_value, :cast_value) ||
               lookup_arg_type_of_method(type_value, :serialize) ||
               T.untyped
-            type.to_s
+            type.to_s.gsub(/(?<!:)\bT(::|\.)/, '::T\1')
           end
 
           #: (untyped type_value) -> bool

--- a/lib/tapioca/dsl/helpers/active_record_column_type_helper.rb
+++ b/lib/tapioca/dsl/helpers/active_record_column_type_helper.rb
@@ -89,7 +89,7 @@ module Tapioca
 
         #: (String? column_name) -> [String, String]
         def column_type_for(column_name)
-          return ["T.untyped", "T.untyped"] if @column_type_option.untyped?
+          return ["::T.untyped", "::T.untyped"] if @column_type_option.untyped?
 
           column = @constant.columns_hash[column_name]
           column_type = @constant.attribute_types[column_name]
@@ -125,7 +125,7 @@ module Tapioca
 
             # Fallback to String as `ActiveRecord::Encryption::EncryptedAttributeType` inherits from
             # `ActiveRecord::Type::Text` which inherits from `ActiveModel::Type::String`.
-            return "::String" if getter_type == "T.untyped"
+            return "::String" if getter_type == "::T.untyped"
 
             as_non_nilable_if_persisted_and_not_nullable(getter_type, column_nullability:)
           when ActiveRecord::Type::String
@@ -137,7 +137,7 @@ module Tapioca
           when ActiveRecord::Type::Float
             "::Float"
           when ActiveRecord::Type::Boolean
-            "T::Boolean"
+            "::T::Boolean"
           when ActiveRecord::Type::DateTime, ActiveRecord::Type::Time
             "::Time"
           when ActiveRecord::AttributeMethods::TimeZoneConversion::TimeZoneConverter
@@ -169,7 +169,7 @@ module Tapioca
                  defined?(ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Hstore) &&
                    ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Hstore === type
                }
-            "T::Hash[::String, ::String]"
+            "::T::Hash[::String, ::String]"
           when ->(type) {
                  defined?(ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Interval) &&
                    ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Interval === type
@@ -179,7 +179,7 @@ module Tapioca
                  defined?(ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Array) &&
                    ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Array === type
                }
-            "T::Array[#{type_for_activerecord_value(column_type.subtype, column_nullability:)}]"
+            "::T::Array[#{type_for_activerecord_value(column_type.subtype, column_nullability:)}]"
           when ->(type) {
                  defined?(ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Bit) &&
                    ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Bit === type
@@ -194,7 +194,7 @@ module Tapioca
                  defined?(ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Range) &&
                    ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Range === type
                }
-            "T::Range[#{type_for_activerecord_value(column_type.subtype, column_nullability:)}]"
+            "::T::Range[#{type_for_activerecord_value(column_type.subtype, column_nullability:)}]"
           when ->(type) {
                  defined?(ActiveRecord::Locking::LockingType) &&
                    ActiveRecord::Locking::LockingType === type
@@ -228,9 +228,9 @@ module Tapioca
           # In Rails < 7 this method is private. When support for that is dropped we can call the method directly
           case column_type.send(:subtype)
           when ActiveRecord::Type::Integer
-            "T.any(::String, ::Symbol, ::Integer)"
+            "::T.any(::String, ::Symbol, ::Integer)"
           else
-            "T.any(::String, ::Symbol)"
+            "::T.any(::String, ::Symbol)"
           end
         end
 
@@ -240,14 +240,14 @@ module Tapioca
           when ActiveRecord::Coders::YAMLColumn
             case column_type.coder.object_class
             when Array.singleton_class
-              "T::Array[T.untyped]"
+              "::T::Array[::T.untyped]"
             when Hash.singleton_class
-              "T::Hash[T.untyped, T.untyped]"
+              "::T::Hash[::T.untyped, ::T.untyped]"
             else
-              "T.untyped"
+              "::T.untyped"
             end
           else
-            "T.untyped"
+            "::T.untyped"
           end
         end
 

--- a/lib/tapioca/dsl/helpers/graphql_type_helper.rb
+++ b/lib/tapioca/dsl/helpers/graphql_type_helper.rb
@@ -5,6 +5,7 @@ module Tapioca
   module Dsl
     module Helpers
       module GraphqlTypeHelper
+        include RBIHelper
         extend self
 
         #: (
@@ -53,7 +54,7 @@ module Tapioca
 
           parsed_type = case unwrapped_type
           when GraphQL::Types::Boolean.singleton_class
-            "T::Boolean"
+            "::T::Boolean"
           when GraphQL::Types::Float.singleton_class
             type_for_constant(Float)
           when GraphQL::Types::ID.singleton_class, GraphQL::Types::String.singleton_class
@@ -65,7 +66,7 @@ module Tapioca
           when GraphQL::Types::ISO8601DateTime.singleton_class
             type_for_constant(Time)
           when GraphQL::Types::JSON.singleton_class
-            "T::Hash[::String, T.untyped]"
+            "::T::Hash[::String, ::T.untyped]"
           when GraphQL::Schema::Enum.singleton_class
             enum_values = T.cast(unwrapped_type.enum_values, T::Array[GraphQL::Schema::EnumValue])
             value_types = enum_values.map { |v| type_for_constant(v.value.class) }.uniq
@@ -73,32 +74,32 @@ module Tapioca
             if value_types.size == 1
               T.must(value_types.first)
             else
-              "T.any(#{value_types.join(", ")})"
+              "::T.any(#{value_types.join(", ")})"
             end
           when GraphQL::Schema::Scalar.singleton_class
             method = Runtime::Reflection.method_of(unwrapped_type, :coerce_input)
             signature = Runtime::Reflection.signature_of(method)
             return_type = signature&.return_type
 
-            valid_return_type?(return_type) ? return_type.to_s : "T.untyped"
+            valid_return_type?(return_type) ? sanitize_signature_types(return_type.to_s) : "::T.untyped"
           when GraphQL::Schema::InputObject.singleton_class
             type_for_constant(unwrapped_type)
           when Module
-            Runtime::Reflection.qualified_name_of(unwrapped_type) || "T.untyped"
+            Runtime::Reflection.qualified_name_of(unwrapped_type) || "::T.untyped"
           else
-            "T.untyped"
+            "::T.untyped"
           end
 
           if prepare_method
             prepare_signature = Runtime::Reflection.signature_of(prepare_method)
             prepare_return_type = prepare_signature&.return_type
             if valid_return_type?(prepare_return_type)
-              parsed_type = prepare_return_type&.to_s
+              parsed_type = sanitize_signature_types(prepare_return_type.to_s)
             end
           end
 
           if type.list?
-            parsed_type = "T::Array[#{parsed_type}]"
+            parsed_type = "::T::Array[#{parsed_type}]"
           end
 
           unless type.non_null? || ignore_nilable_wrapper
@@ -117,10 +118,10 @@ module Tapioca
 
             prepare_signature = Runtime::Reflection.signature_of(prepare_method)
 
-            return prepare_signature.return_type&.to_s if valid_return_type?(prepare_signature&.return_type)
+            return sanitize_signature_types(prepare_signature.return_type.to_s) if valid_return_type?(prepare_signature&.return_type)
           end
 
-          Runtime::Reflection.qualified_name_of(constant) || "T.untyped"
+          Runtime::Reflection.qualified_name_of(constant) || "::T.untyped"
         end
 
         #: (GraphQL::Schema::Argument argument) -> bool

--- a/lib/tapioca/gem/listeners/methods.rb
+++ b/lib/tapioca/gem/listeners/methods.rb
@@ -142,13 +142,13 @@ module Tapioca
             when :req
               rbi_method << RBI::ReqParam.new(name)
             when :opt
-              rbi_method << RBI::OptParam.new(name, "T.unsafe(nil)")
+              rbi_method << RBI::OptParam.new(name, "::T.unsafe(nil)")
             when :rest
               rbi_method << RBI::RestParam.new(name)
             when :keyreq
               rbi_method << RBI::KwParam.new(name)
             when :key
-              rbi_method << RBI::KwOptParam.new(name, "T.unsafe(nil)")
+              rbi_method << RBI::KwOptParam.new(name, "::T.unsafe(nil)")
             when :keyrest
               rbi_method << RBI::KwRestParam.new(name)
             when :block

--- a/lib/tapioca/gem/listeners/sorbet_props.rb
+++ b/lib/tapioca/gem/listeners/sorbet_props.rb
@@ -18,9 +18,9 @@ module Tapioca
           return unless T::Props::ClassMethods === constant
 
           constant.props.map do |name, prop|
-            type = sanitize_signature_types(prop.fetch(:type_object, "T.untyped").to_s)
+            type = sanitize_signature_types(prop.fetch(:type_object, "::T.untyped").to_s)
 
-            default = prop.key?(:default) || prop.key?(:factory) ? "T.unsafe(nil)" : nil
+            default = prop.key?(:default) || prop.key?(:factory) ? "::T.unsafe(nil)" : nil
             node << if prop.fetch(:immutable, false)
               RBI::TStructConst.new(name.to_s, type, default: default)
             else

--- a/lib/tapioca/gem/listeners/sorbet_required_ancestors.rb
+++ b/lib/tapioca/gem/listeners/sorbet_required_ancestors.rb
@@ -5,6 +5,8 @@ module Tapioca
   module Gem
     module Listeners
       class SorbetRequiredAncestors < Base
+        include RBIHelper
+
         private
 
         # @override
@@ -14,7 +16,7 @@ module Tapioca
           ancestors.each do |ancestor|
             next unless ancestor # TODO: We should have a way to warn from here
 
-            event.node << RBI::RequiresAncestor.new(ancestor.to_s)
+            event.node << RBI::RequiresAncestor.new(sanitize_signature_types(ancestor.to_s))
           end
         end
 

--- a/lib/tapioca/gem/listeners/sorbet_type_variables.rb
+++ b/lib/tapioca/gem/listeners/sorbet_type_variables.rb
@@ -42,7 +42,7 @@ module Tapioca
 
           return if type_variable_declarations.empty?
 
-          tree << RBI::Extend.new("T::Generic")
+          tree << RBI::Extend.new("::T::Generic")
         end
 
         #: (Tapioca::TypeVariableModule type_variable) -> RBI::Node?

--- a/lib/tapioca/gem/pipeline.rb
+++ b/lib/tapioca/gem/pipeline.rb
@@ -314,7 +314,7 @@ module Tapioca
 
         if klass_name == "T::Private::Types::TypeAlias"
           type_alias = sanitize_signature_types(T.unsafe(value).aliased_type.to_s)
-          node = RBI::Const.new(name, "T.type_alias { #{type_alias} }")
+          node = RBI::Const.new(name, "::T.type_alias { #{type_alias} }")
           push_const(name, klass, node)
           @root << node
           return
@@ -322,9 +322,9 @@ module Tapioca
 
         return if klass_name&.start_with?("T::Types::", "T::Private::")
 
-        type_name = klass_name || "T.untyped"
-        type_name = "T.untyped" if type_name == "NilClass"
-        node = RBI::Const.new(name, "T.let(T.unsafe(nil), #{type_name})")
+        type_name = klass_name || "::T.untyped"
+        type_name = "::T.untyped" if type_name == "NilClass"
+        node = RBI::Const.new(name, "::T.let(::T.unsafe(nil), #{type_name})")
         push_const(name, klass, node)
         @root << node
       end
@@ -508,7 +508,7 @@ module Tapioca
         type_variables = type_variables.reject(&:fixed?)
         return type_name if type_variables.empty?
 
-        type_variable_names = type_variables.map { "T.untyped" }.join(", ")
+        type_variable_names = type_variables.map { "::T.untyped" }.join(", ")
 
         "#{type_name}[#{type_variable_names}]"
       end

--- a/lib/tapioca/helpers/rbi_helper.rb
+++ b/lib/tapioca/helpers/rbi_helper.rb
@@ -72,8 +72,10 @@ module Tapioca
       sig_string
         .gsub(".returns(<VOID>)", ".void")
         .gsub("<VOID>", "void")
-        .gsub("<NOT-TYPED>", "T.untyped")
+        .gsub("<NOT-TYPED>", "::T.untyped")
         .gsub(".params()", "")
+        .gsub(/(?<!:)\bT(::|\.)/, '::T\1')
+        .gsub(/(?<!:)\bNilClass\b/, '::NilClass')
     end
 
     #: (String type) -> String
@@ -81,7 +83,7 @@ module Tapioca
       if type.start_with?("T.nilable(", "::T.nilable(") || type == "T.untyped" || type == "::T.untyped"
         type
       else
-        "T.nilable(#{type})"
+        "::T.nilable(#{type})"
       end
     end
 

--- a/lib/tapioca/rbi_ext/model.rb
+++ b/lib/tapioca/rbi_ext/model.rb
@@ -78,7 +78,7 @@ module RBI
         # If there is no block, and the params and return type have not been supplied, then
         # we create a single signature with the given parameters and return type
         params = parameters.map { |param| RBI::SigParam.new(param.param.name.to_s, param.type) }
-        sigs << RBI::Sig.new(params: params, return_type: return_type || "T.untyped", type_params: type_params)
+        sigs << RBI::Sig.new(params: params, return_type: return_type || "::T.untyped", type_params: type_params)
       end
 
       method = RBI::Method.new(

--- a/lib/tapioca/sorbet_ext/generic_name_patch.rb
+++ b/lib/tapioca/sorbet_ext/generic_name_patch.rb
@@ -156,9 +156,9 @@ module Tapioca
 
     #: -> String
     def serialize
-      fixed = bounds[:fixed].to_s if fixed?
-      lower = bounds[:lower].to_s if bounds.key?(:lower)
-      upper = bounds[:upper].to_s if bounds.key?(:upper)
+      fixed = RBIHelper.sanitize_signature_types(bounds[:fixed].to_s) if fixed?
+      lower = RBIHelper.sanitize_signature_types(bounds[:lower].to_s) if bounds.key?(:lower)
+      upper = RBIHelper.sanitize_signature_types(bounds[:upper].to_s) if bounds.key?(:upper)
 
       RBIHelper.serialize_type_variable(
         @type.serialize,

--- a/spec/tapioca/addon_spec.rb
+++ b/spec/tapioca/addon_spec.rb
@@ -119,7 +119,7 @@ module RubyLsp
                 job.create_method(
                   "hello_from_spec",
                   parameters: [],
-                  return_type: "T.untyped",
+                  return_type: "::T.untyped",
                   class_method: true,
                 )
               end

--- a/spec/tapioca/cli/dsl_spec.rb
+++ b/spec/tapioca/cli/dsl_spec.rb
@@ -206,10 +206,10 @@ module Tapioca
               include SmartPropertiesGeneratedMethods
 
               module SmartPropertiesGeneratedMethods
-                sig { returns(T.nilable(::String)) }
+                sig { returns(::T.nilable(::String)) }
                 def title; end
 
-                sig { params(title: T.nilable(::String)).returns(T.nilable(::String)) }
+                sig { params(title: ::T.nilable(::String)).returns(::T.nilable(::String)) }
                 def title=(title); end
               end
             end
@@ -323,10 +323,10 @@ module Tapioca
               include SmartPropertiesGeneratedMethods
 
               module SmartPropertiesGeneratedMethods
-                sig { returns(T.nilable(::String)) }
+                sig { returns(::T.nilable(::String)) }
                 def title; end
 
-                sig { params(title: T.nilable(::String)).returns(T.nilable(::String)) }
+                sig { params(title: ::T.nilable(::String)).returns(::T.nilable(::String)) }
                 def title=(title); end
               end
             end
@@ -410,10 +410,10 @@ module Tapioca
               include SmartPropertiesGeneratedMethods
 
               module SmartPropertiesGeneratedMethods
-                sig { returns(T.nilable(::String)) }
+                sig { returns(::T.nilable(::String)) }
                 def title; end
 
-                sig { params(title: T.nilable(::String)).returns(T.nilable(::String)) }
+                sig { params(title: ::T.nilable(::String)).returns(::T.nilable(::String)) }
                 def title=(title); end
               end
             end
@@ -465,10 +465,10 @@ module Tapioca
                 include SmartPropertiesGeneratedMethods
 
                 module SmartPropertiesGeneratedMethods
-                  sig { returns(T.nilable(::String)) }
+                  sig { returns(::T.nilable(::String)) }
                   def title; end
 
-                  sig { params(title: T.nilable(::String)).returns(T.nilable(::String)) }
+                  sig { params(title: ::T.nilable(::String)).returns(::T.nilable(::String)) }
                   def title=(title); end
                 end
               end
@@ -677,10 +677,10 @@ module Tapioca
               include SmartPropertiesGeneratedMethods
 
               module SmartPropertiesGeneratedMethods
-                sig { returns(T.nilable(::String)) }
+                sig { returns(::T.nilable(::String)) }
                 def title; end
 
-                sig { params(title: T.nilable(::String)).returns(T.nilable(::String)) }
+                sig { params(title: ::T.nilable(::String)).returns(::T.nilable(::String)) }
                 def title=(title); end
               end
             end
@@ -1067,10 +1067,10 @@ module Tapioca
               module GeneratedFoo; end
 
               module SmartPropertiesGeneratedMethods
-                sig { returns(T.nilable(::String)) }
+                sig { returns(::T.nilable(::String)) }
                 def title; end
 
-                sig { params(title: T.nilable(::String)).returns(T.nilable(::String)) }
+                sig { params(title: ::T.nilable(::String)).returns(::T.nilable(::String)) }
                 def title=(title); end
               end
             end
@@ -1155,13 +1155,13 @@ module Tapioca
 
             class Job
               class << self
-                sig { params(foo: T.untyped, bar: T.untyped).returns(String) }
+                sig { params(foo: ::T.untyped, bar: ::T.untyped).returns(String) }
                 def perform_async(foo, bar); end
 
-                sig { params(interval: T.any(DateTime, Time), foo: T.untyped, bar: T.untyped).returns(String) }
+                sig { params(interval: ::T.any(DateTime, Time), foo: ::T.untyped, bar: ::T.untyped).returns(String) }
                 def perform_at(interval, foo, bar); end
 
-                sig { params(interval: Numeric, foo: T.untyped, bar: T.untyped).returns(String) }
+                sig { params(interval: Numeric, foo: ::T.untyped, bar: ::T.untyped).returns(String) }
                 def perform_in(interval, foo, bar); end
               end
 
@@ -1374,10 +1374,10 @@ module Tapioca
               include SmartPropertiesGeneratedMethods
 
               module SmartPropertiesGeneratedMethods
-                sig { returns(T.nilable(::String)) }
+                sig { returns(::T.nilable(::String)) }
                 def body; end
 
-                sig { params(body: T.nilable(::String)).returns(T.nilable(::String)) }
+                sig { params(body: ::T.nilable(::String)).returns(::T.nilable(::String)) }
                 def body=(body); end
               end
             end
@@ -1811,31 +1811,31 @@ module Tapioca
               include StoreAccessors
 
               module StoreAccessors
-                sig { returns(T.nilable(String)) }
+                sig { returns(::T.nilable(String)) }
                 def reviewer; end
 
-                sig { params(reviewer: T.nilable(String)).returns(T.nilable(String)) }
+                sig { params(reviewer: ::T.nilable(String)).returns(::T.nilable(String)) }
                 def reviewer=(reviewer); end
 
-                sig { returns(T::Boolean) }
+                sig { returns(::T::Boolean) }
                 def reviewer?; end
 
-                sig { returns(T.nilable(String)) }
+                sig { returns(::T.nilable(String)) }
                 def reviewer_before_last_save; end
 
-                sig { returns(T.nilable([T.nilable(String), T.nilable(String)])) }
+                sig { returns(::T.nilable([::T.nilable(String), ::T.nilable(String)])) }
                 def reviewer_change; end
 
-                sig { returns(T::Boolean) }
+                sig { returns(::T::Boolean) }
                 def reviewer_changed?; end
 
-                sig { returns(T.nilable(String)) }
+                sig { returns(::T.nilable(String)) }
                 def reviewer_was; end
 
-                sig { returns(T.nilable([T.nilable(String), T.nilable(String)])) }
+                sig { returns(::T.nilable([::T.nilable(String), ::T.nilable(String)])) }
                 def saved_change_to_reviewer; end
 
-                sig { returns(T::Boolean) }
+                sig { returns(::T::Boolean) }
                 def saved_change_to_reviewer?; end
               end
             end
@@ -1897,7 +1897,7 @@ module Tapioca
               sig { params(value: Integer).returns(Integer) }
               def id=(value); end
 
-              sig { returns(T::Boolean) }
+              sig { returns(::T::Boolean) }
               def id?; end
             end
           RUBY
@@ -2083,7 +2083,7 @@ module Tapioca
             # typed: true
 
             module Post::SmartPropertiesGeneratedMethods
-              sig { params(title: T.nilable(::String), subtitle: T.nilable(::String)).returns(T.nilable(::String)) }
+              sig { params(title: ::T.nilable(::String), subtitle: ::T.nilable(::String)).returns(::T.nilable(::String)) }
               def title=(title, subtitle); end
             end
           RBI
@@ -2297,15 +2297,15 @@ module Tapioca
           assert_project_file_includes("sorbet/rbi/dsl/post.rbi", indented(<<~RBI, 4))
             sig do
               params(
-                args: T.any(String, Symbol, ::ActiveSupport::Multibyte::Chars, T::Boolean, BigDecimal, Numeric, ::ActiveRecord::Type::Binary::Data, ::ActiveRecord::Type::Time::Value, Date, Time, ::ActiveSupport::Duration, T::Class[T.anything], Foo)
+                args: ::T.any(String, Symbol, ::ActiveSupport::Multibyte::Chars, ::T::Boolean, BigDecimal, Numeric, ::ActiveRecord::Type::Binary::Data, ::ActiveRecord::Type::Time::Value, Date, Time, ::ActiveSupport::Duration, ::T::Class[::T.anything], Foo)
               ).returns(::Post)
             end
             sig do
               params(
-                args: T::Array[T.any(String, Symbol, ::ActiveSupport::Multibyte::Chars, T::Boolean, BigDecimal, Numeric, ::ActiveRecord::Type::Binary::Data, ::ActiveRecord::Type::Time::Value, Date, Time, ::ActiveSupport::Duration, T::Class[T.anything], Foo)]
-              ).returns(T::Enumerable[::Post])
+                args: ::T::Array[::T.any(String, Symbol, ::ActiveSupport::Multibyte::Chars, ::T::Boolean, BigDecimal, Numeric, ::ActiveRecord::Type::Binary::Data, ::ActiveRecord::Type::Time::Value, Date, Time, ::ActiveSupport::Duration, ::T::Class[::T.anything], Foo)]
+              ).returns(::T::Enumerable[::Post])
             end
-            sig { params(args: NilClass, block: T.proc.params(object: ::Post).void).returns(T.nilable(::Post)) }
+            sig { params(args: ::NilClass, block: ::T.proc.params(object: ::Post).void).returns(::T.nilable(::Post)) }
             def find(args = nil, &block); end
           RBI
 
@@ -2684,7 +2684,7 @@ module Tapioca
 
             module Bar
               # This method is missing a `)`
-              sig { params(block: T.proc.params(x: T.any(String, Integer).void).void }
+              sig { params(block: ::T.proc.params(x: ::T.any(String, Integer).void).void }
               def bar(&block); end
             end
           RBI
@@ -2768,10 +2768,10 @@ module Tapioca
               include SmartPropertiesGeneratedMethods
 
               module SmartPropertiesGeneratedMethods
-                sig { returns(T.nilable(::String)) }
+                sig { returns(::T.nilable(::String)) }
                 def title; end
 
-                sig { params(title: T.nilable(::String)).returns(T.nilable(::String)) }
+                sig { params(title: ::T.nilable(::String)).returns(::T.nilable(::String)) }
                 def title=(title); end
               end
             end
@@ -2789,10 +2789,10 @@ module Tapioca
               include SmartPropertiesGeneratedMethods
 
               module SmartPropertiesGeneratedMethods
-                sig { returns(T.nilable(::String)) }
+                sig { returns(::T.nilable(::String)) }
                 def title; end
 
-                sig { params(title: T.nilable(::String)).returns(T.nilable(::String)) }
+                sig { params(title: ::T.nilable(::String)).returns(::T.nilable(::String)) }
                 def title=(title); end
               end
             end
@@ -3142,13 +3142,13 @@ module Tapioca
               include GeneratedAttributeMethods
 
               module GeneratedAttributeMethods
-                sig { returns(T.untyped) }
+                sig { returns(::T.untyped) }
                 def id; end
 
-                sig { params(value: T.untyped).returns(T.untyped) }
+                sig { params(value: ::T.untyped).returns(::T.untyped) }
                 def id=(value); end
 
-                sig { returns(T::Boolean) }
+                sig { returns(::T::Boolean) }
                 def id?; end
           RBI
 

--- a/spec/tapioca/cli/gem_spec.rb
+++ b/spec/tapioca/cli/gem_spec.rb
@@ -33,13 +33,13 @@ module Tapioca
 
       module Foo
         class << self
-          def foo(a = T.unsafe(nil), b: T.unsafe(nil), **opts); end
+          def foo(a = ::T.unsafe(nil), b: ::T.unsafe(nil), **opts); end
         end
       end
 
-      Foo::PI = T.let(T.unsafe(nil), Float)
+      Foo::PI = ::T.let(::T.unsafe(nil), Float)
       module Reopened; end
-      Reopened::E = T.let(T.unsafe(nil), Float)
+      Reopened::E = ::T.let(::T.unsafe(nil), Float)
     RBI
 
     BAR_RB = <<~RB
@@ -68,14 +68,14 @@ module Tapioca
 
       module Bar
         class << self
-          def bar(a = T.unsafe(nil), b: T.unsafe(nil), **opts); end
+          def bar(a = ::T.unsafe(nil), b: ::T.unsafe(nil), **opts); end
         end
       end
 
-      Bar::PI = T.let(T.unsafe(nil), Float)
+      Bar::PI = ::T.let(::T.unsafe(nil), Float)
       module Reopened; end
-      Reopened::PI = T.let(T.unsafe(nil), Float)
-      Reopened::TAU = T.let(T.unsafe(nil), Float)
+      Reopened::PI = ::T.let(::T.unsafe(nil), Float)
+      Reopened::TAU = ::T.let(::T.unsafe(nil), Float)
     RBI
 
     BAZ_RB = <<~RB
@@ -326,8 +326,8 @@ module Tapioca
 
             write!("rbi/foo.rbi", <<~RBI)
               module Foo
-                sig { params(a: String, b: Integer, opts: T.untyped).void }
-                def self.foo(a = T.unsafe(nil), b: T.unsafe(nil), **opts); end
+                sig { params(a: String, b: Integer, opts: ::T.untyped).void }
+                def self.foo(a = ::T.unsafe(nil), b: ::T.unsafe(nil), **opts); end
               end
             RBI
 
@@ -363,8 +363,8 @@ module Tapioca
               def foo; end
 
               class << self
-                sig { params(a: String, b: Integer, opts: T.untyped).void }
-                def foo(a = T.unsafe(nil), b: T.unsafe(nil), **opts); end
+                sig { params(a: String, b: Integer, opts: ::T.untyped).void }
+                def foo(a = ::T.unsafe(nil), b: ::T.unsafe(nil), **opts); end
               end
             end
 
@@ -372,9 +372,9 @@ module Tapioca
               def bar; end
             end
 
-            Foo::PI = T.let(T.unsafe(nil), Float)
+            Foo::PI = ::T.let(::T.unsafe(nil), Float)
             module Reopened; end
-            Reopened::E = T.let(T.unsafe(nil), Float)
+            Reopened::E = ::T.let(::T.unsafe(nil), Float)
           RBI
 
           assert_empty_stderr(result)
@@ -1161,12 +1161,12 @@ module Tapioca
           foo = mock_gem("foo", "0.0.1") do
             write!("lib/foo.rb", <<~RBI)
               module Foo
-                extend T::Sig
+                extend ::T::Sig
 
-                sig { params(a: T.untyped, b: T.untyped, c: T.untyped, d: T.untyped, e: T.untyped, f: T.untyped, g: T.untyped).void }
+                sig { params(a: ::T.untyped, b: ::T.untyped, c: ::T.untyped, d: ::T.untyped, e: ::T.untyped, f: ::T.untyped, g: ::T.untyped).void }
                 def bar(a, b, c, d, e, f, g); end
 
-                sig { params(a: T.untyped, b: T.untyped, c: T.untyped, d: T.untyped, e: T.untyped, f: T.untyped, g: T.untyped, h: T.untyped).void }
+                sig { params(a: ::T.untyped, b: ::T.untyped, c: ::T.untyped, d: ::T.untyped, e: ::T.untyped, f: ::T.untyped, g: ::T.untyped, h: ::T.untyped).void }
                 def foo(a, b, c, d, e, f, g, h); end
               end
             RBI
@@ -1186,19 +1186,29 @@ module Tapioca
 
 
             module Foo
-              sig { params(a: T.untyped, b: T.untyped, c: T.untyped, d: T.untyped, e: T.untyped, f: T.untyped, g: T.untyped).void }
+              sig do
+                params(
+                  a: ::T.untyped,
+                  b: ::T.untyped,
+                  c: ::T.untyped,
+                  d: ::T.untyped,
+                  e: ::T.untyped,
+                  f: ::T.untyped,
+                  g: ::T.untyped
+                ).void
+              end
               def bar(a, b, c, d, e, f, g); end
 
               sig do
                 params(
-                  a: T.untyped,
-                  b: T.untyped,
-                  c: T.untyped,
-                  d: T.untyped,
-                  e: T.untyped,
-                  f: T.untyped,
-                  g: T.untyped,
-                  h: T.untyped
+                  a: ::T.untyped,
+                  b: ::T.untyped,
+                  c: ::T.untyped,
+                  d: ::T.untyped,
+                  e: ::T.untyped,
+                  f: ::T.untyped,
+                  g: ::T.untyped,
+                  h: ::T.untyped
                 ).void
               end
               def foo(a, b, c, d, e, f, g, h); end
@@ -1213,12 +1223,12 @@ module Tapioca
           foo = mock_gem("foo", "0.0.1") do
             write!("lib/foo.rb", <<~RBI)
               module Foo
-                extend T::Sig
+                extend ::T::Sig
 
-                sig { params(a: T.untyped, b: T.untyped, c: T.untyped, d: T.untyped, e: T.untyped, f: T.untyped, g: T.untyped).void }
+                sig { params(a: ::T.untyped, b: ::T.untyped, c: ::T.untyped, d: ::T.untyped, e: ::T.untyped, f: ::T.untyped, g: ::T.untyped).void }
                 def bar(a, b, c, d, e, f, g); end
 
-                sig { params(a: T.untyped, b: T.untyped, c: T.untyped, d: T.untyped, e: T.untyped, f: T.untyped, g: T.untyped, h: T.untyped).void }
+                sig { params(a: ::T.untyped, b: ::T.untyped, c: ::T.untyped, d: ::T.untyped, e: ::T.untyped, f: ::T.untyped, g: ::T.untyped, h: ::T.untyped).void }
                 def foo(a, b, c, d, e, f, g, h); end
               end
             RBI
@@ -1240,27 +1250,27 @@ module Tapioca
             module Foo
               sig do
                 params(
-                  a: T.untyped,
-                  b: T.untyped,
-                  c: T.untyped,
-                  d: T.untyped,
-                  e: T.untyped,
-                  f: T.untyped,
-                  g: T.untyped
+                  a: ::T.untyped,
+                  b: ::T.untyped,
+                  c: ::T.untyped,
+                  d: ::T.untyped,
+                  e: ::T.untyped,
+                  f: ::T.untyped,
+                  g: ::T.untyped
                 ).void
               end
               def bar(a, b, c, d, e, f, g); end
 
               sig do
                 params(
-                  a: T.untyped,
-                  b: T.untyped,
-                  c: T.untyped,
-                  d: T.untyped,
-                  e: T.untyped,
-                  f: T.untyped,
-                  g: T.untyped,
-                  h: T.untyped
+                  a: ::T.untyped,
+                  b: ::T.untyped,
+                  c: ::T.untyped,
+                  d: ::T.untyped,
+                  e: ::T.untyped,
+                  f: ::T.untyped,
+                  g: ::T.untyped,
+                  h: ::T.untyped
                 ).void
               end
               def foo(a, b, c, d, e, f, g, h); end
@@ -1904,7 +1914,7 @@ module Tapioca
 
             module Bar
               # This method is missing a `)`
-              sig { params(block: T.proc.params(x: T.any(String, Integer).void).void }
+              sig { params(block: ::T.proc.params(x: ::T.any(String, Integer).void).void }
               def bar(&block); end
             end
           RBI
@@ -1996,7 +2006,7 @@ module Tapioca
 
 
           class ComplexGenericType
-            extend T::Generic
+            extend ::T::Generic
 
             A = type_template(:in)
             B = type_template(:out)
@@ -2009,7 +2019,7 @@ module Tapioca
             I = type_member(:in) { { fixed: Integer, lower: Complex, upper: Numeric } }
 
             class << self
-              extend T::Generic
+              extend ::T::Generic
 
               A = type_template(:in)
               B = type_template(:out)

--- a/spec/tapioca/dsl/compiler_spec.rb
+++ b/spec/tapioca/dsl/compiler_spec.rb
@@ -68,11 +68,11 @@ module Tapioca
             # typed: strong
 
             class Post
-              sig { params(a: T.untyped, b: T.untyped, c: T.untyped).returns(T.untyped) }
-              def bar(a, b = T.unsafe(nil), *c); end
+              sig { params(a: ::T.untyped, b: ::T.untyped, c: ::T.untyped).returns(::T.untyped) }
+              def bar(a, b = ::T.unsafe(nil), *c); end
 
-              sig { params(d: T.untyped, e: T.untyped, f: T.untyped, blk: T.untyped).returns(T.untyped) }
-              def foo(d:, e: T.unsafe(nil), **f, &blk); end
+              sig { params(d: ::T.untyped, e: ::T.untyped, f: ::T.untyped, blk: ::T.untyped).returns(::T.untyped) }
+              def foo(d:, e: ::T.unsafe(nil), **f, &blk); end
             end
           RBI
 
@@ -124,24 +124,24 @@ module Tapioca
 
             class Post
               sig { params(a: ::String, b: ::Integer, c: ::Integer).void }
-              def bar(a, b = T.unsafe(nil), *c); end
+              def bar(a, b = ::T.unsafe(nil), *c); end
 
-              sig { params(d: ::String, e: ::Integer, f: ::Integer, blk: T.proc.params(a: ::String).returns(::String)).returns(::Integer) }
-              def baz(d:, e: T.unsafe(nil), **f, &blk); end
+              sig { params(d: ::String, e: ::Integer, f: ::Integer, blk: ::T.proc.params(a: ::String).returns(::String)).returns(::Integer) }
+              def baz(d:, e: ::T.unsafe(nil), **f, &blk); end
 
-              sig { type_parameters(:U, :V).params(a: T.type_parameter(:U), blk: T.proc.params(arg: T.type_parameter(:U)).returns(T.type_parameter(:V))).returns(T.type_parameter(:V)) }
+              sig { type_parameters(:U, :V).params(a: ::T.type_parameter(:U), blk: ::T.proc.params(arg: ::T.type_parameter(:U)).returns(::T.type_parameter(:V))).returns(::T.type_parameter(:V)) }
               def complex_type_params(a, &blk); end
 
-              sig { type_parameters(:U).params(a: T.type_parameter(:U)).returns(T.type_parameter(:U)) }
+              sig { type_parameters(:U).params(a: ::T.type_parameter(:U)).returns(::T.type_parameter(:U)) }
               def foo(a); end
 
-              sig { params(a: ::Integer, b: ::Integer, c: ::Integer, d: ::Integer, e: ::Integer, f: ::Integer, blk: T.proc.void).void }
-              def many_kinds_of_args(*a, b, c, d:, e: T.unsafe(nil), **f, &blk); end
+              sig { params(a: ::Integer, b: ::Integer, c: ::Integer, d: ::Integer, e: ::Integer, f: ::Integer, blk: ::T.proc.void).void }
+              def many_kinds_of_args(*a, b, c, d:, e: ::T.unsafe(nil), **f, &blk); end
 
-              sig { params(proc: T.proc.void, blk: T.proc.returns(T.noreturn)).void }
+              sig { params(proc: ::T.proc.void, blk: ::T.proc.returns(::T.noreturn)).void }
               def method_with_procs(proc, &blk); end
 
-              sig { returns(T.proc.params(x: ::String).void) }
+              sig { returns(::T.proc.params(x: ::String).void) }
               def some_attribute; end
             end
           RBI

--- a/spec/tapioca/dsl/compilers/aasm_spec.rb
+++ b/spec/tapioca/dsl/compilers/aasm_spec.rb
@@ -73,107 +73,107 @@ module Tapioca
                 # typed: strong
 
                 class StateMachine
-                  sig { returns(T::Boolean) }
+                  sig { returns(::T::Boolean) }
                   def cleaning?; end
 
-                  sig { returns(T::Boolean) }
+                  sig { returns(::T::Boolean) }
                   def may_run?; end
 
-                  sig { params(opts: T.untyped).returns(T.untyped) }
+                  sig { params(opts: ::T.untyped).returns(::T.untyped) }
                   def run(*opts); end
 
-                  sig { params(opts: T.untyped).returns(T.untyped) }
+                  sig { params(opts: ::T.untyped).returns(::T.untyped) }
                   def run!(*opts); end
 
-                  sig { params(opts: T.untyped).returns(T.untyped) }
+                  sig { params(opts: ::T.untyped).returns(::T.untyped) }
                   def run_without_validation!(*opts); end
 
-                  sig { returns(T::Boolean) }
+                  sig { returns(::T::Boolean) }
                   def running?; end
 
-                  sig { returns(T::Boolean) }
+                  sig { returns(::T::Boolean) }
                   def sleeping?; end
 
                   class << self
-                    sig { params(args: T.untyped, block: T.nilable(T.proc.bind(PrivateAASMMachine).void)).returns(PrivateAASMMachine) }
+                    sig { params(args: ::T.untyped, block: ::T.nilable(::T.proc.bind(PrivateAASMMachine).void)).returns(PrivateAASMMachine) }
                     def aasm(*args, &block); end
                   end
 
                   class PrivateAASMMachine < AASM::Base
-                    sig { params(callbacks: T.any(String, Symbol, T::Class[T.anything], Proc), block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
+                    sig { params(callbacks: ::T.any(String, Symbol, ::T::Class[::T.anything], Proc), block: ::T.nilable(::T.proc.bind(StateMachine).void)).returns(::T.untyped) }
                     def after_all_events(*callbacks, &block); end
 
-                    sig { params(callbacks: T.any(String, Symbol, T::Class[T.anything], Proc), block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
+                    sig { params(callbacks: ::T.any(String, Symbol, ::T::Class[::T.anything], Proc), block: ::T.nilable(::T.proc.bind(StateMachine).void)).returns(::T.untyped) }
                     def after_all_transactions(*callbacks, &block); end
 
-                    sig { params(callbacks: T.any(String, Symbol, T::Class[T.anything], Proc), block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
+                    sig { params(callbacks: ::T.any(String, Symbol, ::T::Class[::T.anything], Proc), block: ::T.nilable(::T.proc.bind(StateMachine).void)).returns(::T.untyped) }
                     def after_all_transitions(*callbacks, &block); end
 
-                    sig { params(callbacks: T.any(String, Symbol, T::Class[T.anything], Proc), block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
+                    sig { params(callbacks: ::T.any(String, Symbol, ::T::Class[::T.anything], Proc), block: ::T.nilable(::T.proc.bind(StateMachine).void)).returns(::T.untyped) }
                     def before_all_events(*callbacks, &block); end
 
-                    sig { params(callbacks: T.any(String, Symbol, T::Class[T.anything], Proc), block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
+                    sig { params(callbacks: ::T.any(String, Symbol, ::T::Class[::T.anything], Proc), block: ::T.nilable(::T.proc.bind(StateMachine).void)).returns(::T.untyped) }
                     def before_all_transactions(*callbacks, &block); end
 
-                    sig { params(callbacks: T.any(String, Symbol, T::Class[T.anything], Proc), block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
+                    sig { params(callbacks: ::T.any(String, Symbol, ::T::Class[::T.anything], Proc), block: ::T.nilable(::T.proc.bind(StateMachine).void)).returns(::T.untyped) }
                     def ensure_on_all_events(*callbacks, &block); end
 
-                    sig { params(callbacks: T.any(String, Symbol, T::Class[T.anything], Proc), block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
+                    sig { params(callbacks: ::T.any(String, Symbol, ::T::Class[::T.anything], Proc), block: ::T.nilable(::T.proc.bind(StateMachine).void)).returns(::T.untyped) }
                     def error_on_all_events(*callbacks, &block); end
 
-                    sig { params(name: T.untyped, options: T.untyped, block: T.proc.bind(PrivateAASMEvent).void).returns(T.untyped) }
+                    sig { params(name: ::T.untyped, options: ::T.untyped, block: ::T.proc.bind(PrivateAASMEvent).void).returns(::T.untyped) }
                     def event(name, options = nil, &block); end
 
                     class PrivateAASMEvent < AASM::Core::Event
-                      sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).params(opts: T.untyped).void)).returns(T.untyped) }
+                      sig { params(symbol: ::T.nilable(Symbol), block: ::T.nilable(::T.proc.bind(StateMachine).params(opts: ::T.untyped).void)).returns(::T.untyped) }
                       def after(symbol = nil, &block); end
 
-                      sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).params(opts: T.untyped).void)).returns(T.untyped) }
+                      sig { params(symbol: ::T.nilable(Symbol), block: ::T.nilable(::T.proc.bind(StateMachine).params(opts: ::T.untyped).void)).returns(::T.untyped) }
                       def after_commit(symbol = nil, &block); end
 
-                      sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).params(opts: T.untyped).void)).returns(T.untyped) }
+                      sig { params(symbol: ::T.nilable(Symbol), block: ::T.nilable(::T.proc.bind(StateMachine).params(opts: ::T.untyped).void)).returns(::T.untyped) }
                       def after_transaction(symbol = nil, &block); end
 
-                      sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).params(opts: T.untyped).void)).returns(T.untyped) }
+                      sig { params(symbol: ::T.nilable(Symbol), block: ::T.nilable(::T.proc.bind(StateMachine).params(opts: ::T.untyped).void)).returns(::T.untyped) }
                       def before(symbol = nil, &block); end
 
-                      sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).params(opts: T.untyped).void)).returns(T.untyped) }
+                      sig { params(symbol: ::T.nilable(Symbol), block: ::T.nilable(::T.proc.bind(StateMachine).params(opts: ::T.untyped).void)).returns(::T.untyped) }
                       def before_success(symbol = nil, &block); end
 
-                      sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).params(opts: T.untyped).void)).returns(T.untyped) }
+                      sig { params(symbol: ::T.nilable(Symbol), block: ::T.nilable(::T.proc.bind(StateMachine).params(opts: ::T.untyped).void)).returns(::T.untyped) }
                       def before_transaction(symbol = nil, &block); end
 
-                      sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).params(opts: T.untyped).void)).returns(T.untyped) }
+                      sig { params(symbol: ::T.nilable(Symbol), block: ::T.nilable(::T.proc.bind(StateMachine).params(opts: ::T.untyped).void)).returns(::T.untyped) }
                       def ensure(symbol = nil, &block); end
 
-                      sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).params(opts: T.untyped).void)).returns(T.untyped) }
+                      sig { params(symbol: ::T.nilable(Symbol), block: ::T.nilable(::T.proc.bind(StateMachine).params(opts: ::T.untyped).void)).returns(::T.untyped) }
                       def error(symbol = nil, &block); end
 
-                      sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).params(opts: T.untyped).void)).returns(T.untyped) }
+                      sig { params(symbol: ::T.nilable(Symbol), block: ::T.nilable(::T.proc.bind(StateMachine).params(opts: ::T.untyped).void)).returns(::T.untyped) }
                       def success(symbol = nil, &block); end
 
-                      sig { params(definitions: T.untyped, block: T.nilable(T.proc.bind(PrivateAASMTransition).void)).returns(T.untyped) }
+                      sig { params(definitions: ::T.untyped, block: ::T.nilable(::T.proc.bind(PrivateAASMTransition).void)).returns(::T.untyped) }
                       def transitions(definitions = nil, &block); end
                     end
 
                     class PrivateAASMTransition < AASM::Core::Transition
-                      sig { params(block: T.nilable(T.proc.bind(StateMachine).params(opts: T.untyped).void)).returns(T.untyped) }
+                      sig { params(block: ::T.nilable(::T.proc.bind(StateMachine).params(opts: ::T.untyped).void)).returns(::T.untyped) }
                       def after(&block); end
 
-                      sig { params(block: T.nilable(T.proc.bind(StateMachine).params(opts: T.untyped).void)).returns(T::Boolean) }
+                      sig { params(block: ::T.nilable(::T.proc.bind(StateMachine).params(opts: ::T.untyped).void)).returns(::T::Boolean) }
                       def guard(&block); end
 
-                      sig { params(block: T.nilable(T.proc.bind(StateMachine).params(opts: T.untyped).void)).returns(T.untyped) }
+                      sig { params(block: ::T.nilable(::T.proc.bind(StateMachine).params(opts: ::T.untyped).void)).returns(::T.untyped) }
                       def on_transition(&block); end
 
-                      sig { params(block: T.nilable(T.proc.bind(StateMachine).params(opts: T.untyped).void)).returns(T.untyped) }
+                      sig { params(block: ::T.nilable(::T.proc.bind(StateMachine).params(opts: ::T.untyped).void)).returns(::T.untyped) }
                       def success(&block); end
                     end
                   end
 
-                  STATE_CLEANING = T.let(T.unsafe(nil), Symbol)
-                  STATE_RUNNING = T.let(T.unsafe(nil), Symbol)
-                  STATE_SLEEPING = T.let(T.unsafe(nil), Symbol)
+                  STATE_CLEANING = ::T.let(::T.unsafe(nil), Symbol)
+                  STATE_RUNNING = ::T.let(::T.unsafe(nil), Symbol)
+                  STATE_SLEEPING = ::T.let(::T.unsafe(nil), Symbol)
                 end
               RBI
 
@@ -211,111 +211,111 @@ module Tapioca
                 # typed: strong
 
                 class StateMachine
-                  sig { returns(T::Boolean) }
+                  sig { returns(::T::Boolean) }
                   def cleaning?; end
 
-                  sig { returns(T::Boolean) }
+                  sig { returns(::T::Boolean) }
                   def existing?; end
 
-                  sig { returns(T::Boolean) }
+                  sig { returns(::T::Boolean) }
                   def may_run?; end
 
-                  sig { params(opts: T.untyped).returns(T.untyped) }
+                  sig { params(opts: ::T.untyped).returns(::T.untyped) }
                   def run(*opts); end
 
-                  sig { params(opts: T.untyped).returns(T.untyped) }
+                  sig { params(opts: ::T.untyped).returns(::T.untyped) }
                   def run!(*opts); end
 
-                  sig { params(opts: T.untyped).returns(T.untyped) }
+                  sig { params(opts: ::T.untyped).returns(::T.untyped) }
                   def run_without_validation!(*opts); end
 
-                  sig { returns(T::Boolean) }
+                  sig { returns(::T::Boolean) }
                   def running?; end
 
-                  sig { returns(T::Boolean) }
+                  sig { returns(::T::Boolean) }
                   def sleeping?; end
 
                   class << self
-                    sig { params(args: T.untyped, block: T.nilable(T.proc.bind(PrivateAASMMachine).void)).returns(PrivateAASMMachine) }
+                    sig { params(args: ::T.untyped, block: ::T.nilable(::T.proc.bind(PrivateAASMMachine).void)).returns(PrivateAASMMachine) }
                     def aasm(*args, &block); end
                   end
 
                   class PrivateAASMMachine < AASM::Base
-                    sig { params(callbacks: T.any(String, Symbol, T::Class[T.anything], Proc), block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
+                    sig { params(callbacks: ::T.any(String, Symbol, ::T::Class[::T.anything], Proc), block: ::T.nilable(::T.proc.bind(StateMachine).void)).returns(::T.untyped) }
                     def after_all_events(*callbacks, &block); end
 
-                    sig { params(callbacks: T.any(String, Symbol, T::Class[T.anything], Proc), block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
+                    sig { params(callbacks: ::T.any(String, Symbol, ::T::Class[::T.anything], Proc), block: ::T.nilable(::T.proc.bind(StateMachine).void)).returns(::T.untyped) }
                     def after_all_transactions(*callbacks, &block); end
 
-                    sig { params(callbacks: T.any(String, Symbol, T::Class[T.anything], Proc), block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
+                    sig { params(callbacks: ::T.any(String, Symbol, ::T::Class[::T.anything], Proc), block: ::T.nilable(::T.proc.bind(StateMachine).void)).returns(::T.untyped) }
                     def after_all_transitions(*callbacks, &block); end
 
-                    sig { params(callbacks: T.any(String, Symbol, T::Class[T.anything], Proc), block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
+                    sig { params(callbacks: ::T.any(String, Symbol, ::T::Class[::T.anything], Proc), block: ::T.nilable(::T.proc.bind(StateMachine).void)).returns(::T.untyped) }
                     def before_all_events(*callbacks, &block); end
 
-                    sig { params(callbacks: T.any(String, Symbol, T::Class[T.anything], Proc), block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
+                    sig { params(callbacks: ::T.any(String, Symbol, ::T::Class[::T.anything], Proc), block: ::T.nilable(::T.proc.bind(StateMachine).void)).returns(::T.untyped) }
                     def before_all_transactions(*callbacks, &block); end
 
-                    sig { params(callbacks: T.any(String, Symbol, T::Class[T.anything], Proc), block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
+                    sig { params(callbacks: ::T.any(String, Symbol, ::T::Class[::T.anything], Proc), block: ::T.nilable(::T.proc.bind(StateMachine).void)).returns(::T.untyped) }
                     def ensure_on_all_events(*callbacks, &block); end
 
-                    sig { params(callbacks: T.any(String, Symbol, T::Class[T.anything], Proc), block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
+                    sig { params(callbacks: ::T.any(String, Symbol, ::T::Class[::T.anything], Proc), block: ::T.nilable(::T.proc.bind(StateMachine).void)).returns(::T.untyped) }
                     def error_on_all_events(*callbacks, &block); end
 
-                    sig { params(name: T.untyped, options: T.untyped, block: T.proc.bind(PrivateAASMEvent).void).returns(T.untyped) }
+                    sig { params(name: ::T.untyped, options: ::T.untyped, block: ::T.proc.bind(PrivateAASMEvent).void).returns(::T.untyped) }
                     def event(name, options = nil, &block); end
 
                     class PrivateAASMEvent < AASM::Core::Event
-                      sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).params(opts: T.untyped).void)).returns(T.untyped) }
+                      sig { params(symbol: ::T.nilable(Symbol), block: ::T.nilable(::T.proc.bind(StateMachine).params(opts: ::T.untyped).void)).returns(::T.untyped) }
                       def after(symbol = nil, &block); end
 
-                      sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).params(opts: T.untyped).void)).returns(T.untyped) }
+                      sig { params(symbol: ::T.nilable(Symbol), block: ::T.nilable(::T.proc.bind(StateMachine).params(opts: ::T.untyped).void)).returns(::T.untyped) }
                       def after_commit(symbol = nil, &block); end
 
-                      sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).params(opts: T.untyped).void)).returns(T.untyped) }
+                      sig { params(symbol: ::T.nilable(Symbol), block: ::T.nilable(::T.proc.bind(StateMachine).params(opts: ::T.untyped).void)).returns(::T.untyped) }
                       def after_transaction(symbol = nil, &block); end
 
-                      sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).params(opts: T.untyped).void)).returns(T.untyped) }
+                      sig { params(symbol: ::T.nilable(Symbol), block: ::T.nilable(::T.proc.bind(StateMachine).params(opts: ::T.untyped).void)).returns(::T.untyped) }
                       def before(symbol = nil, &block); end
 
-                      sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).params(opts: T.untyped).void)).returns(T.untyped) }
+                      sig { params(symbol: ::T.nilable(Symbol), block: ::T.nilable(::T.proc.bind(StateMachine).params(opts: ::T.untyped).void)).returns(::T.untyped) }
                       def before_success(symbol = nil, &block); end
 
-                      sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).params(opts: T.untyped).void)).returns(T.untyped) }
+                      sig { params(symbol: ::T.nilable(Symbol), block: ::T.nilable(::T.proc.bind(StateMachine).params(opts: ::T.untyped).void)).returns(::T.untyped) }
                       def before_transaction(symbol = nil, &block); end
 
-                      sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).params(opts: T.untyped).void)).returns(T.untyped) }
+                      sig { params(symbol: ::T.nilable(Symbol), block: ::T.nilable(::T.proc.bind(StateMachine).params(opts: ::T.untyped).void)).returns(::T.untyped) }
                       def ensure(symbol = nil, &block); end
 
-                      sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).params(opts: T.untyped).void)).returns(T.untyped) }
+                      sig { params(symbol: ::T.nilable(Symbol), block: ::T.nilable(::T.proc.bind(StateMachine).params(opts: ::T.untyped).void)).returns(::T.untyped) }
                       def error(symbol = nil, &block); end
 
-                      sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).params(opts: T.untyped).void)).returns(T.untyped) }
+                      sig { params(symbol: ::T.nilable(Symbol), block: ::T.nilable(::T.proc.bind(StateMachine).params(opts: ::T.untyped).void)).returns(::T.untyped) }
                       def success(symbol = nil, &block); end
 
-                      sig { params(definitions: T.untyped, block: T.nilable(T.proc.bind(PrivateAASMTransition).void)).returns(T.untyped) }
+                      sig { params(definitions: ::T.untyped, block: ::T.nilable(::T.proc.bind(PrivateAASMTransition).void)).returns(::T.untyped) }
                       def transitions(definitions = nil, &block); end
                     end
 
                     class PrivateAASMTransition < AASM::Core::Transition
-                      sig { params(block: T.nilable(T.proc.bind(StateMachine).params(opts: T.untyped).void)).returns(T.untyped) }
+                      sig { params(block: ::T.nilable(::T.proc.bind(StateMachine).params(opts: ::T.untyped).void)).returns(::T.untyped) }
                       def after(&block); end
 
-                      sig { params(block: T.nilable(T.proc.bind(StateMachine).params(opts: T.untyped).void)).returns(T::Boolean) }
+                      sig { params(block: ::T.nilable(::T.proc.bind(StateMachine).params(opts: ::T.untyped).void)).returns(::T::Boolean) }
                       def guard(&block); end
 
-                      sig { params(block: T.nilable(T.proc.bind(StateMachine).params(opts: T.untyped).void)).returns(T.untyped) }
+                      sig { params(block: ::T.nilable(::T.proc.bind(StateMachine).params(opts: ::T.untyped).void)).returns(::T.untyped) }
                       def on_transition(&block); end
 
-                      sig { params(block: T.nilable(T.proc.bind(StateMachine).params(opts: T.untyped).void)).returns(T.untyped) }
+                      sig { params(block: ::T.nilable(::T.proc.bind(StateMachine).params(opts: ::T.untyped).void)).returns(::T.untyped) }
                       def success(&block); end
                     end
                   end
 
-                  STATE_CLEANING = T.let(T.unsafe(nil), Symbol)
-                  STATE_EXISTING = T.let(T.unsafe(nil), Symbol)
-                  STATE_RUNNING = T.let(T.unsafe(nil), Symbol)
-                  STATE_SLEEPING = T.let(T.unsafe(nil), Symbol)
+                  STATE_CLEANING = ::T.let(::T.unsafe(nil), Symbol)
+                  STATE_EXISTING = ::T.let(::T.unsafe(nil), Symbol)
+                  STATE_RUNNING = ::T.let(::T.unsafe(nil), Symbol)
+                  STATE_SLEEPING = ::T.let(::T.unsafe(nil), Symbol)
                 end
               RBI
 
@@ -349,116 +349,116 @@ module Tapioca
                 # typed: strong
 
                 class StateMachine
-                  sig { returns(T::Boolean) }
+                  sig { returns(::T::Boolean) }
                   def foo_cleaning?; end
 
-                  sig { returns(T::Boolean) }
+                  sig { returns(::T::Boolean) }
                   def foo_running?; end
 
-                  sig { returns(T::Boolean) }
+                  sig { returns(::T::Boolean) }
                   def foo_sleeping?; end
 
-                  sig { returns(T::Boolean) }
+                  sig { returns(::T::Boolean) }
                   def may_run?; end
 
-                  sig { returns(T::Boolean) }
+                  sig { returns(::T::Boolean) }
                   def may_run_foo?; end
 
-                  sig { params(opts: T.untyped).returns(T.untyped) }
+                  sig { params(opts: ::T.untyped).returns(::T.untyped) }
                   def run(*opts); end
 
-                  sig { params(opts: T.untyped).returns(T.untyped) }
+                  sig { params(opts: ::T.untyped).returns(::T.untyped) }
                   def run!(*opts); end
 
-                  sig { params(opts: T.untyped).returns(T.untyped) }
+                  sig { params(opts: ::T.untyped).returns(::T.untyped) }
                   def run_foo(*opts); end
 
-                  sig { params(opts: T.untyped).returns(T.untyped) }
+                  sig { params(opts: ::T.untyped).returns(::T.untyped) }
                   def run_foo!(*opts); end
 
-                  sig { params(opts: T.untyped).returns(T.untyped) }
+                  sig { params(opts: ::T.untyped).returns(::T.untyped) }
                   def run_without_validation!(*opts); end
 
                   class << self
-                    sig { params(args: T.untyped, block: T.nilable(T.proc.bind(PrivateAASMMachine).void)).returns(PrivateAASMMachine) }
+                    sig { params(args: ::T.untyped, block: ::T.nilable(::T.proc.bind(PrivateAASMMachine).void)).returns(PrivateAASMMachine) }
                     def aasm(*args, &block); end
                   end
 
                   class PrivateAASMMachine < AASM::Base
-                    sig { params(callbacks: T.any(String, Symbol, T::Class[T.anything], Proc), block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
+                    sig { params(callbacks: ::T.any(String, Symbol, ::T::Class[::T.anything], Proc), block: ::T.nilable(::T.proc.bind(StateMachine).void)).returns(::T.untyped) }
                     def after_all_events(*callbacks, &block); end
 
-                    sig { params(callbacks: T.any(String, Symbol, T::Class[T.anything], Proc), block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
+                    sig { params(callbacks: ::T.any(String, Symbol, ::T::Class[::T.anything], Proc), block: ::T.nilable(::T.proc.bind(StateMachine).void)).returns(::T.untyped) }
                     def after_all_transactions(*callbacks, &block); end
 
-                    sig { params(callbacks: T.any(String, Symbol, T::Class[T.anything], Proc), block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
+                    sig { params(callbacks: ::T.any(String, Symbol, ::T::Class[::T.anything], Proc), block: ::T.nilable(::T.proc.bind(StateMachine).void)).returns(::T.untyped) }
                     def after_all_transitions(*callbacks, &block); end
 
-                    sig { params(callbacks: T.any(String, Symbol, T::Class[T.anything], Proc), block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
+                    sig { params(callbacks: ::T.any(String, Symbol, ::T::Class[::T.anything], Proc), block: ::T.nilable(::T.proc.bind(StateMachine).void)).returns(::T.untyped) }
                     def before_all_events(*callbacks, &block); end
 
-                    sig { params(callbacks: T.any(String, Symbol, T::Class[T.anything], Proc), block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
+                    sig { params(callbacks: ::T.any(String, Symbol, ::T::Class[::T.anything], Proc), block: ::T.nilable(::T.proc.bind(StateMachine).void)).returns(::T.untyped) }
                     def before_all_transactions(*callbacks, &block); end
 
-                    sig { params(callbacks: T.any(String, Symbol, T::Class[T.anything], Proc), block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
+                    sig { params(callbacks: ::T.any(String, Symbol, ::T::Class[::T.anything], Proc), block: ::T.nilable(::T.proc.bind(StateMachine).void)).returns(::T.untyped) }
                     def ensure_on_all_events(*callbacks, &block); end
 
-                    sig { params(callbacks: T.any(String, Symbol, T::Class[T.anything], Proc), block: T.nilable(T.proc.bind(StateMachine).void)).returns(T.untyped) }
+                    sig { params(callbacks: ::T.any(String, Symbol, ::T::Class[::T.anything], Proc), block: ::T.nilable(::T.proc.bind(StateMachine).void)).returns(::T.untyped) }
                     def error_on_all_events(*callbacks, &block); end
 
-                    sig { params(name: T.untyped, options: T.untyped, block: T.proc.bind(PrivateAASMEvent).void).returns(T.untyped) }
+                    sig { params(name: ::T.untyped, options: ::T.untyped, block: ::T.proc.bind(PrivateAASMEvent).void).returns(::T.untyped) }
                     def event(name, options = nil, &block); end
 
                     class PrivateAASMEvent < AASM::Core::Event
-                      sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).params(opts: T.untyped).void)).returns(T.untyped) }
+                      sig { params(symbol: ::T.nilable(Symbol), block: ::T.nilable(::T.proc.bind(StateMachine).params(opts: ::T.untyped).void)).returns(::T.untyped) }
                       def after(symbol = nil, &block); end
 
-                      sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).params(opts: T.untyped).void)).returns(T.untyped) }
+                      sig { params(symbol: ::T.nilable(Symbol), block: ::T.nilable(::T.proc.bind(StateMachine).params(opts: ::T.untyped).void)).returns(::T.untyped) }
                       def after_commit(symbol = nil, &block); end
 
-                      sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).params(opts: T.untyped).void)).returns(T.untyped) }
+                      sig { params(symbol: ::T.nilable(Symbol), block: ::T.nilable(::T.proc.bind(StateMachine).params(opts: ::T.untyped).void)).returns(::T.untyped) }
                       def after_transaction(symbol = nil, &block); end
 
-                      sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).params(opts: T.untyped).void)).returns(T.untyped) }
+                      sig { params(symbol: ::T.nilable(Symbol), block: ::T.nilable(::T.proc.bind(StateMachine).params(opts: ::T.untyped).void)).returns(::T.untyped) }
                       def before(symbol = nil, &block); end
 
-                      sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).params(opts: T.untyped).void)).returns(T.untyped) }
+                      sig { params(symbol: ::T.nilable(Symbol), block: ::T.nilable(::T.proc.bind(StateMachine).params(opts: ::T.untyped).void)).returns(::T.untyped) }
                       def before_success(symbol = nil, &block); end
 
-                      sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).params(opts: T.untyped).void)).returns(T.untyped) }
+                      sig { params(symbol: ::T.nilable(Symbol), block: ::T.nilable(::T.proc.bind(StateMachine).params(opts: ::T.untyped).void)).returns(::T.untyped) }
                       def before_transaction(symbol = nil, &block); end
 
-                      sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).params(opts: T.untyped).void)).returns(T.untyped) }
+                      sig { params(symbol: ::T.nilable(Symbol), block: ::T.nilable(::T.proc.bind(StateMachine).params(opts: ::T.untyped).void)).returns(::T.untyped) }
                       def ensure(symbol = nil, &block); end
 
-                      sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).params(opts: T.untyped).void)).returns(T.untyped) }
+                      sig { params(symbol: ::T.nilable(Symbol), block: ::T.nilable(::T.proc.bind(StateMachine).params(opts: ::T.untyped).void)).returns(::T.untyped) }
                       def error(symbol = nil, &block); end
 
-                      sig { params(symbol: T.nilable(Symbol), block: T.nilable(T.proc.bind(StateMachine).params(opts: T.untyped).void)).returns(T.untyped) }
+                      sig { params(symbol: ::T.nilable(Symbol), block: ::T.nilable(::T.proc.bind(StateMachine).params(opts: ::T.untyped).void)).returns(::T.untyped) }
                       def success(symbol = nil, &block); end
 
-                      sig { params(definitions: T.untyped, block: T.nilable(T.proc.bind(PrivateAASMTransition).void)).returns(T.untyped) }
+                      sig { params(definitions: ::T.untyped, block: ::T.nilable(::T.proc.bind(PrivateAASMTransition).void)).returns(::T.untyped) }
                       def transitions(definitions = nil, &block); end
                     end
 
                     class PrivateAASMTransition < AASM::Core::Transition
-                      sig { params(block: T.nilable(T.proc.bind(StateMachine).params(opts: T.untyped).void)).returns(T.untyped) }
+                      sig { params(block: ::T.nilable(::T.proc.bind(StateMachine).params(opts: ::T.untyped).void)).returns(::T.untyped) }
                       def after(&block); end
 
-                      sig { params(block: T.nilable(T.proc.bind(StateMachine).params(opts: T.untyped).void)).returns(T::Boolean) }
+                      sig { params(block: ::T.nilable(::T.proc.bind(StateMachine).params(opts: ::T.untyped).void)).returns(::T::Boolean) }
                       def guard(&block); end
 
-                      sig { params(block: T.nilable(T.proc.bind(StateMachine).params(opts: T.untyped).void)).returns(T.untyped) }
+                      sig { params(block: ::T.nilable(::T.proc.bind(StateMachine).params(opts: ::T.untyped).void)).returns(::T.untyped) }
                       def on_transition(&block); end
 
-                      sig { params(block: T.nilable(T.proc.bind(StateMachine).params(opts: T.untyped).void)).returns(T.untyped) }
+                      sig { params(block: ::T.nilable(::T.proc.bind(StateMachine).params(opts: ::T.untyped).void)).returns(::T.untyped) }
                       def success(&block); end
                     end
                   end
 
-                  STATE_FOO_CLEANING = T.let(T.unsafe(nil), Symbol)
-                  STATE_FOO_RUNNING = T.let(T.unsafe(nil), Symbol)
-                  STATE_FOO_SLEEPING = T.let(T.unsafe(nil), Symbol)
+                  STATE_FOO_CLEANING = ::T.let(::T.unsafe(nil), Symbol)
+                  STATE_FOO_RUNNING = ::T.let(::T.unsafe(nil), Symbol)
+                  STATE_FOO_SLEEPING = ::T.let(::T.unsafe(nil), Symbol)
                 end
               RBI
 

--- a/spec/tapioca/dsl/compilers/action_controller_helpers_spec.rb
+++ b/spec/tapioca/dsl/compilers/action_controller_helpers_spec.rb
@@ -124,10 +124,10 @@ module Tapioca
                   module HelperMethods
                     include ::ActionController::Base::HelperMethods
 
-                    sig { params(args: T.untyped, kwargs: T.untyped, blk: T.untyped).returns(T.untyped) }
+                    sig { params(args: ::T.untyped, kwargs: ::T.untyped, blk: ::T.untyped).returns(::T.untyped) }
                     def current_user_name(*args, **kwargs, &blk); end
 
-                    sig { params(args: T.untyped, kwargs: T.untyped, blk: T.untyped).returns(T.untyped) }
+                    sig { params(args: ::T.untyped, kwargs: ::T.untyped, blk: ::T.untyped).returns(::T.untyped) }
                     def notify_user(*args, **kwargs, &blk); end
                   end
 
@@ -169,7 +169,7 @@ module Tapioca
                   module HelperMethods
                     include ::ActionController::Base::HelperMethods
 
-                    sig { returns(T.untyped) }
+                    sig { returns(::T.untyped) }
                     def current_user_name; end
 
                     sig { params(user_id: ::Integer).void }
@@ -214,7 +214,7 @@ module Tapioca
                   module HelperMethods
                     include ::ActionController::Base::HelperMethods
 
-                    sig { params(user: T.untyped).returns(T.untyped) }
+                    sig { params(user: ::T.untyped).returns(::T.untyped) }
                     def greet(user); end
 
                     sig { params(user_id: ::Integer).void }
@@ -352,7 +352,7 @@ module Tapioca
                   module HelperMethods
                     include ::ActionController::Base::HelperMethods
 
-                    sig { returns(T.untyped) }
+                    sig { returns(::T.untyped) }
                     def foo; end
                   end
 

--- a/spec/tapioca/dsl/compilers/action_mailer_spec.rb
+++ b/spec/tapioca/dsl/compilers/action_mailer_spec.rb
@@ -86,7 +86,7 @@ module Tapioca
 
                 class NotifierMailer
                   class << self
-                    sig { params(customer_id: T.untyped).returns(::ActionMailer::MessageDelivery) }
+                    sig { params(customer_id: ::T.untyped).returns(::ActionMailer::MessageDelivery) }
                     def notify_customer(customer_id); end
                   end
                 end
@@ -134,10 +134,10 @@ module Tapioca
 
                 class NotifierMailer
                   class << self
-                    sig { params(_arg0: T.untyped, _arg1: T.untyped, _arg2: T.untyped).returns(::ActionMailer::MessageDelivery) }
+                    sig { params(_arg0: ::T.untyped, _arg1: ::T.untyped, _arg2: ::T.untyped).returns(::ActionMailer::MessageDelivery) }
                     def notify_admin(*_arg0, **_arg1, &_arg2); end
 
-                    sig { params(_arg0: T.untyped, _arg1: T.untyped, _arg2: T.untyped).returns(::ActionMailer::MessageDelivery) }
+                    sig { params(_arg0: ::T.untyped, _arg1: ::T.untyped, _arg2: ::T.untyped).returns(::ActionMailer::MessageDelivery) }
                     def notify_customer(*_arg0, **_arg1, &_arg2); end
                   end
                 end
@@ -168,7 +168,7 @@ module Tapioca
 
                 class NotifierMailer
                   class << self
-                    sig { params(customer_id: T.untyped).returns(::ActionMailer::MessageDelivery) }
+                    sig { params(customer_id: ::T.untyped).returns(::ActionMailer::MessageDelivery) }
                     def notify_customer(customer_id); end
                   end
                 end
@@ -194,7 +194,7 @@ module Tapioca
 
                 class SecondaryMailer
                   class << self
-                    sig { params(customer_id: T.untyped).returns(::ActionMailer::MessageDelivery) }
+                    sig { params(customer_id: ::T.untyped).returns(::ActionMailer::MessageDelivery) }
                     def notify_customer(customer_id); end
                   end
                 end
@@ -233,7 +233,7 @@ module Tapioca
                     sig { returns(::ActionMailer::MessageDelivery) }
                     def foo_helper_method; end
 
-                    sig { params(customer_id: T.untyped).returns(::ActionMailer::MessageDelivery) }
+                    sig { params(customer_id: ::T.untyped).returns(::ActionMailer::MessageDelivery) }
                     def notify_customer(customer_id); end
                   end
                 end

--- a/spec/tapioca/dsl/compilers/action_text_spec.rb
+++ b/spec/tapioca/dsl/compilers/action_text_spec.rb
@@ -61,19 +61,19 @@ module Tapioca
                   sig { returns(ActionText::RichText) }
                   def body; end
 
-                  sig { params(value: T.nilable(T.any(ActionText::RichText, String))).returns(T.untyped) }
+                  sig { params(value: ::T.nilable(::T.any(ActionText::RichText, String))).returns(::T.untyped) }
                   def body=(value); end
 
-                  sig { returns(T::Boolean) }
+                  sig { returns(::T::Boolean) }
                   def body?; end
 
                   sig { returns(ActionText::RichText) }
                   def title; end
 
-                  sig { params(value: T.nilable(T.any(ActionText::RichText, String))).returns(T.untyped) }
+                  sig { params(value: ::T.nilable(::T.any(ActionText::RichText, String))).returns(::T.untyped) }
                   def title=(value); end
 
-                  sig { returns(T::Boolean) }
+                  sig { returns(::T::Boolean) }
                   def title?; end
                 end
               RBI
@@ -97,10 +97,10 @@ module Tapioca
                   sig { returns(ActionText::EncryptedRichText) }
                   def body; end
 
-                  sig { params(value: T.nilable(T.any(ActionText::EncryptedRichText, String))).returns(T.untyped) }
+                  sig { params(value: ::T.nilable(::T.any(ActionText::EncryptedRichText, String))).returns(::T.untyped) }
                   def body=(value); end
 
-                  sig { returns(T::Boolean) }
+                  sig { returns(::T::Boolean) }
                   def body?; end
                 end
               RBI

--- a/spec/tapioca/dsl/compilers/active_job_spec.rb
+++ b/spec/tapioca/dsl/compilers/active_job_spec.rb
@@ -73,10 +73,10 @@ module Tapioca
 
                 class NotifyJob
                   class << self
-                    sig { params(user_id: T.untyped, block: T.nilable(T.proc.params(job: NotifyJob).void)).returns(T.any(NotifyJob, FalseClass)) }
+                    sig { params(user_id: ::T.untyped, block: ::T.nilable(::T.proc.params(job: NotifyJob).void)).returns(::T.any(NotifyJob, FalseClass)) }
                     def perform_later(user_id, &block); end
 
-                    sig { params(user_id: T.untyped).returns(T.untyped) }
+                    sig { params(user_id: ::T.untyped).returns(::T.untyped) }
                     def perform_now(user_id); end
                   end
                 end
@@ -100,7 +100,7 @@ module Tapioca
 
                 class NotifyJob
                   class << self
-                    sig { params(user_id: ::Integer, block: T.nilable(T.proc.params(job: NotifyJob).void)).returns(T.any(NotifyJob, FalseClass)) }
+                    sig { params(user_id: ::Integer, block: ::T.nilable(::T.proc.params(job: NotifyJob).void)).returns(::T.any(NotifyJob, FalseClass)) }
                     def perform_later(user_id, &block); end
 
                     sig { params(user_id: ::Integer).void }
@@ -125,10 +125,10 @@ module Tapioca
 
                 class NotifyJob
                   class << self
-                    sig { params(user_id: T.untyped, block: T.nilable(T.proc.params(job: NotifyJob).void)).returns(T.any(NotifyJob, FalseClass)) }
+                    sig { params(user_id: ::T.untyped, block: ::T.nilable(::T.proc.params(job: NotifyJob).void)).returns(::T.any(NotifyJob, FalseClass)) }
                     def perform_later(user_id, &block); end
 
-                    sig { params(user_id: T.untyped).returns(T.untyped) }
+                    sig { params(user_id: ::T.untyped).returns(::T.untyped) }
                     def perform_now(user_id); end
                   end
                 end
@@ -153,7 +153,7 @@ module Tapioca
 
                 class NotifyJob
                   class << self
-                    sig { params(user_id: ::Integer, block: T.nilable(T.proc.params(job: NotifyJob).void)).returns(T.any(NotifyJob, FalseClass)) }
+                    sig { params(user_id: ::Integer, block: ::T.nilable(::T.proc.params(job: NotifyJob).void)).returns(::T.any(NotifyJob, FalseClass)) }
                     def perform_later(user_id, &block); end
 
                     sig { params(user_id: ::Integer).void }

--- a/spec/tapioca/dsl/compilers/active_model_attributes_spec.rb
+++ b/spec/tapioca/dsl/compilers/active_model_attributes_spec.rb
@@ -73,10 +73,10 @@ module Tapioca
                   include GeneratedAttributeMethods
 
                   module GeneratedAttributeMethods
-                    sig { returns(T.untyped) }
+                    sig { returns(::T.untyped) }
                     def name; end
 
-                    sig { params(value: T.untyped).returns(T.untyped) }
+                    sig { params(value: ::T.untyped).returns(::T.untyped) }
                     def name=(value); end
                   end
                 end
@@ -102,10 +102,10 @@ module Tapioca
                   include GeneratedAttributeMethods
 
                   module GeneratedAttributeMethods
-                    sig { returns(T.untyped) }
+                    sig { returns(::T.untyped) }
                     def name; end
 
-                    sig { params(value: T.untyped).returns(T.untyped) }
+                    sig { params(value: ::T.untyped).returns(::T.untyped) }
                     def name=(value); end
                   end
                 end
@@ -134,34 +134,34 @@ module Tapioca
                   include GeneratedAttributeMethods
 
                   module GeneratedAttributeMethods
-                    sig { returns(T.nilable(::Time)) }
+                    sig { returns(::T.nilable(::Time)) }
                     def created_at; end
 
-                    sig { params(value: T.nilable(::Time)).returns(T.nilable(::Time)) }
+                    sig { params(value: ::T.nilable(::Time)).returns(::T.nilable(::Time)) }
                     def created_at=(value); end
 
-                    sig { returns(T.nilable(::Integer)) }
+                    sig { returns(::T.nilable(::Integer)) }
                     def id; end
 
-                    sig { params(value: T.nilable(::Integer)).returns(T.nilable(::Integer)) }
+                    sig { params(value: ::T.nilable(::Integer)).returns(::T.nilable(::Integer)) }
                     def id=(value); end
 
-                    sig { returns(T.nilable(::Float)) }
+                    sig { returns(::T.nilable(::Float)) }
                     def latitude; end
 
-                    sig { params(value: T.nilable(::Float)).returns(T.nilable(::Float)) }
+                    sig { params(value: ::T.nilable(::Float)).returns(::T.nilable(::Float)) }
                     def latitude=(value); end
 
-                    sig { returns(T.nilable(::String)) }
+                    sig { returns(::T.nilable(::String)) }
                     def name; end
 
-                    sig { params(value: T.nilable(::String)).returns(T.nilable(::String)) }
+                    sig { params(value: ::T.nilable(::String)).returns(::T.nilable(::String)) }
                     def name=(value); end
 
-                    sig { returns(T.nilable(T::Boolean)) }
+                    sig { returns(::T.nilable(::T::Boolean)) }
                     def test_shop; end
 
-                    sig { params(value: T.nilable(T::Boolean)).returns(T.nilable(T::Boolean)) }
+                    sig { params(value: ::T.nilable(::T::Boolean)).returns(::T.nilable(::T::Boolean)) }
                     def test_shop=(value); end
                   end
                 end
@@ -194,10 +194,10 @@ module Tapioca
                   include GeneratedAttributeMethods
 
                   module GeneratedAttributeMethods
-                    sig { returns(T.nilable(::String)) }
+                    sig { returns(::T.nilable(::String)) }
                     def custom_with_cast_sig_attr; end
 
-                    sig { params(value: T.nilable(::String)).returns(T.nilable(::String)) }
+                    sig { params(value: ::T.nilable(::String)).returns(::T.nilable(::String)) }
                     def custom_with_cast_sig_attr=(value); end
                   end
                 end
@@ -240,10 +240,10 @@ module Tapioca
                   include GeneratedAttributeMethods
 
                   module GeneratedAttributeMethods
-                    sig { returns(T.nilable(::Post)) }
+                    sig { returns(::T.nilable(::Post)) }
                     def post; end
 
-                    sig { params(value: T.nilable(::Post)).returns(T.nilable(::Post)) }
+                    sig { params(value: ::T.nilable(::Post)).returns(::T.nilable(::Post)) }
                     def post=(value); end
 
                     sig { returns(::User) }

--- a/spec/tapioca/dsl/compilers/active_model_secure_password_spec.rb
+++ b/spec/tapioca/dsl/compilers/active_model_secure_password_spec.rb
@@ -67,34 +67,34 @@ module Tapioca
                 # typed: strong
 
                 class User
-                  sig { params(unencrypted_password: T.untyped).returns(T.any(User, FalseClass)) }
+                  sig { params(unencrypted_password: ::T.untyped).returns(::T.any(User, FalseClass)) }
                   def authenticate(unencrypted_password); end
 
-                  sig { params(unencrypted_password: T.untyped).returns(T.any(User, FalseClass)) }
+                  sig { params(unencrypted_password: ::T.untyped).returns(::T.any(User, FalseClass)) }
                   def authenticate_password(unencrypted_password); end
 
-                  sig { returns(T.untyped) }
+                  sig { returns(::T.untyped) }
                   def password; end
 
-                  sig { params(unencrypted_password: T.untyped).returns(T.untyped) }
+                  sig { params(unencrypted_password: ::T.untyped).returns(::T.untyped) }
                   def password=(unencrypted_password); end
 
-                  sig { returns(T.untyped) }
+                  sig { returns(::T.untyped) }
                   def password_challenge; end
 
-                  sig { params(_arg0: T.untyped).returns(T.untyped) }
+                  sig { params(_arg0: ::T.untyped).returns(::T.untyped) }
                   def password_challenge=(_arg0); end
 
-                  sig { returns(T.untyped) }
+                  sig { returns(::T.untyped) }
                   def password_confirmation; end
 
-                  sig { params(_arg0: T.untyped).returns(T.untyped) }
+                  sig { params(_arg0: ::T.untyped).returns(::T.untyped) }
                   def password_confirmation=(_arg0); end
 
-                  sig { returns(T.untyped) }
+                  sig { returns(::T.untyped) }
                   def password_reset_token; end
 
-                  sig { returns(T.untyped) }
+                  sig { returns(::T.untyped) }
                   def password_salt; end
                 end
               RBI
@@ -115,31 +115,31 @@ module Tapioca
                 # typed: strong
 
                 class User
-                  sig { params(unencrypted_password: T.untyped).returns(T.any(User, FalseClass)) }
+                  sig { params(unencrypted_password: ::T.untyped).returns(::T.any(User, FalseClass)) }
                   def authenticate_token(unencrypted_password); end
 
-                  sig { returns(T.untyped) }
+                  sig { returns(::T.untyped) }
                   def token; end
 
-                  sig { params(unencrypted_password: T.untyped).returns(T.untyped) }
+                  sig { params(unencrypted_password: ::T.untyped).returns(::T.untyped) }
                   def token=(unencrypted_password); end
 
-                  sig { returns(T.untyped) }
+                  sig { returns(::T.untyped) }
                   def token_challenge; end
 
-                  sig { params(_arg0: T.untyped).returns(T.untyped) }
+                  sig { params(_arg0: ::T.untyped).returns(::T.untyped) }
                   def token_challenge=(_arg0); end
 
-                  sig { returns(T.untyped) }
+                  sig { returns(::T.untyped) }
                   def token_confirmation; end
 
-                  sig { params(_arg0: T.untyped).returns(T.untyped) }
+                  sig { params(_arg0: ::T.untyped).returns(::T.untyped) }
                   def token_confirmation=(_arg0); end
 
-                  sig { returns(T.untyped) }
+                  sig { returns(::T.untyped) }
                   def token_reset_token; end
 
-                  sig { returns(T.untyped) }
+                  sig { returns(::T.untyped) }
                   def token_salt; end
                 end
               RBI
@@ -161,61 +161,61 @@ module Tapioca
                 # typed: strong
 
                 class User
-                  sig { params(unencrypted_password: T.untyped).returns(T.any(User, FalseClass)) }
+                  sig { params(unencrypted_password: ::T.untyped).returns(::T.any(User, FalseClass)) }
                   def authenticate(unencrypted_password); end
 
-                  sig { params(unencrypted_password: T.untyped).returns(T.any(User, FalseClass)) }
+                  sig { params(unencrypted_password: ::T.untyped).returns(::T.any(User, FalseClass)) }
                   def authenticate_password(unencrypted_password); end
 
-                  sig { params(unencrypted_password: T.untyped).returns(T.any(User, FalseClass)) }
+                  sig { params(unencrypted_password: ::T.untyped).returns(::T.any(User, FalseClass)) }
                   def authenticate_token(unencrypted_password); end
 
-                  sig { returns(T.untyped) }
+                  sig { returns(::T.untyped) }
                   def password; end
 
-                  sig { params(unencrypted_password: T.untyped).returns(T.untyped) }
+                  sig { params(unencrypted_password: ::T.untyped).returns(::T.untyped) }
                   def password=(unencrypted_password); end
 
-                  sig { returns(T.untyped) }
+                  sig { returns(::T.untyped) }
                   def password_challenge; end
 
-                  sig { params(_arg0: T.untyped).returns(T.untyped) }
+                  sig { params(_arg0: ::T.untyped).returns(::T.untyped) }
                   def password_challenge=(_arg0); end
 
-                  sig { returns(T.untyped) }
+                  sig { returns(::T.untyped) }
                   def password_confirmation; end
 
-                  sig { params(_arg0: T.untyped).returns(T.untyped) }
+                  sig { params(_arg0: ::T.untyped).returns(::T.untyped) }
                   def password_confirmation=(_arg0); end
 
-                  sig { returns(T.untyped) }
+                  sig { returns(::T.untyped) }
                   def password_reset_token; end
 
-                  sig { returns(T.untyped) }
+                  sig { returns(::T.untyped) }
                   def password_salt; end
 
-                  sig { returns(T.untyped) }
+                  sig { returns(::T.untyped) }
                   def token; end
 
-                  sig { params(unencrypted_password: T.untyped).returns(T.untyped) }
+                  sig { params(unencrypted_password: ::T.untyped).returns(::T.untyped) }
                   def token=(unencrypted_password); end
 
-                  sig { returns(T.untyped) }
+                  sig { returns(::T.untyped) }
                   def token_challenge; end
 
-                  sig { params(_arg0: T.untyped).returns(T.untyped) }
+                  sig { params(_arg0: ::T.untyped).returns(::T.untyped) }
                   def token_challenge=(_arg0); end
 
-                  sig { returns(T.untyped) }
+                  sig { returns(::T.untyped) }
                   def token_confirmation; end
 
-                  sig { params(_arg0: T.untyped).returns(T.untyped) }
+                  sig { params(_arg0: ::T.untyped).returns(::T.untyped) }
                   def token_confirmation=(_arg0); end
 
-                  sig { returns(T.untyped) }
+                  sig { returns(::T.untyped) }
                   def token_reset_token; end
 
-                  sig { returns(T.untyped) }
+                  sig { returns(::T.untyped) }
                   def token_salt; end
                 end
               RBI

--- a/spec/tapioca/dsl/compilers/active_model_validations_confirmation_spec.rb
+++ b/spec/tapioca/dsl/compilers/active_model_validations_confirmation_spec.rb
@@ -68,16 +68,16 @@ module Tapioca
                 # typed: strong
 
                 class Shop
-                  sig { returns(T.untyped) }
+                  sig { returns(::T.untyped) }
                   def name_confirmation; end
 
-                  sig { params(name_confirmation: T.untyped).returns(T.untyped) }
+                  sig { params(name_confirmation: ::T.untyped).returns(::T.untyped) }
                   def name_confirmation=(name_confirmation); end
 
-                  sig { returns(T.untyped) }
+                  sig { returns(::T.untyped) }
                   def password_confirmation; end
 
-                  sig { params(password_confirmation: T.untyped).returns(T.untyped) }
+                  sig { params(password_confirmation: ::T.untyped).returns(::T.untyped) }
                   def password_confirmation=(password_confirmation); end
                 end
               RBI

--- a/spec/tapioca/dsl/compilers/active_record_associations_spec.rb
+++ b/spec/tapioca/dsl/compilers/active_record_associations_spec.rb
@@ -115,58 +115,58 @@ module Tapioca
                       include GeneratedAssociationMethods
 
                       module GeneratedAssociationMethods
-                        sig { returns(T.nilable(::User)) }
+                        sig { returns(::T.nilable(::User)) }
                         def author; end
 
-                        sig { params(value: T.nilable(::User)).void }
+                        sig { params(value: ::T.nilable(::User)).void }
                         def author=(value); end
 
-                        sig { params(attributes: T.untyped).returns(T.untyped) }
+                        sig { params(attributes: ::T.untyped).returns(::T.untyped) }
                         def author_attributes=(attributes); end
 
-                        sig { returns(T::Boolean) }
+                        sig { returns(::T::Boolean) }
                         def author_changed?; end
 
-                        sig { returns(T::Boolean) }
+                        sig { returns(::T::Boolean) }
                         def author_previously_changed?; end
 
-                        sig { params(args: T.untyped, blk: T.untyped).returns(::User) }
+                        sig { params(args: ::T.untyped, blk: ::T.untyped).returns(::User) }
                         def build_author(*args, &blk); end
 
-                        sig { params(args: T.untyped, blk: T.untyped).returns(::Category) }
+                        sig { params(args: ::T.untyped, blk: ::T.untyped).returns(::Category) }
                         def build_category(*args, &blk); end
 
-                        sig { returns(T.nilable(::Category)) }
+                        sig { returns(::T.nilable(::Category)) }
                         def category; end
 
-                        sig { params(value: T.nilable(::Category)).void }
+                        sig { params(value: ::T.nilable(::Category)).void }
                         def category=(value); end
 
-                        sig { params(attributes: T.untyped).returns(T.untyped) }
+                        sig { params(attributes: ::T.untyped).returns(::T.untyped) }
                         def category_attributes=(attributes); end
 
-                        sig { returns(T::Boolean) }
+                        sig { returns(::T::Boolean) }
                         def category_changed?; end
 
-                        sig { returns(T::Boolean) }
+                        sig { returns(::T::Boolean) }
                         def category_previously_changed?; end
 
-                        sig { params(args: T.untyped, blk: T.untyped).returns(::User) }
+                        sig { params(args: ::T.untyped, blk: ::T.untyped).returns(::User) }
                         def create_author(*args, &blk); end
 
-                        sig { params(args: T.untyped, blk: T.untyped).returns(::User) }
+                        sig { params(args: ::T.untyped, blk: ::T.untyped).returns(::User) }
                         def create_author!(*args, &blk); end
 
-                        sig { params(args: T.untyped, blk: T.untyped).returns(::Category) }
+                        sig { params(args: ::T.untyped, blk: ::T.untyped).returns(::Category) }
                         def create_category(*args, &blk); end
 
-                        sig { params(args: T.untyped, blk: T.untyped).returns(::Category) }
+                        sig { params(args: ::T.untyped, blk: ::T.untyped).returns(::Category) }
                         def create_category!(*args, &blk); end
 
-                        sig { returns(T.nilable(::User)) }
+                        sig { returns(::T.nilable(::User)) }
                         def reload_author; end
 
-                        sig { returns(T.nilable(::Category)) }
+                        sig { returns(::T.nilable(::Category)) }
                         def reload_category; end
 
                         sig { void }
@@ -202,22 +202,22 @@ module Tapioca
                       include GeneratedAssociationMethods
 
                       module GeneratedAssociationMethods
-                        sig { returns(T.untyped) }
+                        sig { returns(::T.untyped) }
                         def category; end
 
-                        sig { params(value: T.untyped).void }
+                        sig { params(value: ::T.untyped).void }
                         def category=(value); end
 
-                        sig { params(attributes: T.untyped).returns(T.untyped) }
+                        sig { params(attributes: ::T.untyped).returns(::T.untyped) }
                         def category_attributes=(attributes); end
 
-                        sig { returns(T::Boolean) }
+                        sig { returns(::T::Boolean) }
                         def category_changed?; end
 
-                        sig { returns(T::Boolean) }
+                        sig { returns(::T::Boolean) }
                         def category_previously_changed?; end
 
-                        sig { returns(T.untyped) }
+                        sig { returns(::T.untyped) }
                         def reload_category; end
 
                         sig { void }
@@ -251,10 +251,10 @@ module Tapioca
                       include GeneratedAssociationMethods
 
                       module GeneratedAssociationMethods
-                        sig { returns(T::Array[T.untyped]) }
+                        sig { returns(::T::Array[::T.untyped]) }
                         def picture_ids; end
 
-                        sig { params(ids: T::Array[T.untyped]).returns(T::Array[T.untyped]) }
+                        sig { params(ids: ::T::Array[::T.untyped]).returns(::T::Array[::T.untyped]) }
                         def picture_ids=(ids); end
 
                         # This method is created by ActiveRecord on the `Employee` class because it declared `has_many :pictures`.
@@ -262,7 +262,7 @@ module Tapioca
                         sig { returns(ActiveRecord::Associations::CollectionProxy) }
                         def pictures; end
 
-                        sig { params(value: T::Enumerable[T.untyped]).void }
+                        sig { params(value: ::T::Enumerable[::T.untyped]).void }
                         def pictures=(value); end
                       end
                     end
@@ -301,25 +301,25 @@ module Tapioca
                       include GeneratedAssociationMethods
 
                       module GeneratedAssociationMethods
-                        sig { returns(T.nilable(::User)) }
+                        sig { returns(::T.nilable(::User)) }
                         def author; end
 
-                        sig { params(value: T.nilable(::User)).void }
+                        sig { params(value: ::T.nilable(::User)).void }
                         def author=(value); end
 
-                        sig { params(attributes: T.untyped).returns(T.untyped) }
+                        sig { params(attributes: ::T.untyped).returns(::T.untyped) }
                         def author_attributes=(attributes); end
 
-                        sig { params(args: T.untyped, blk: T.untyped).returns(::User) }
+                        sig { params(args: ::T.untyped, blk: ::T.untyped).returns(::User) }
                         def build_author(*args, &blk); end
 
-                        sig { params(args: T.untyped, blk: T.untyped).returns(::User) }
+                        sig { params(args: ::T.untyped, blk: ::T.untyped).returns(::User) }
                         def create_author(*args, &blk); end
 
-                        sig { params(args: T.untyped, blk: T.untyped).returns(::User) }
+                        sig { params(args: ::T.untyped, blk: ::T.untyped).returns(::User) }
                         def create_author!(*args, &blk); end
 
-                        sig { returns(T.nilable(::User)) }
+                        sig { returns(::T.nilable(::User)) }
                         def reload_author; end
 
                         sig { void }
@@ -364,10 +364,10 @@ module Tapioca
                       include GeneratedAssociationMethods
 
                       module GeneratedAssociationMethods
-                        sig { returns(T::Array[T.untyped]) }
+                        sig { returns(::T::Array[::T.untyped]) }
                         def comment_ids; end
 
-                        sig { params(ids: T::Array[T.untyped]).returns(T::Array[T.untyped]) }
+                        sig { params(ids: ::T::Array[::T.untyped]).returns(::T::Array[::T.untyped]) }
                         def comment_ids=(ids); end
 
                         # This method is created by ActiveRecord on the `Post` class because it declared `has_many :comments`.
@@ -375,10 +375,10 @@ module Tapioca
                         sig { returns(::Comment::PrivateCollectionProxy) }
                         def comments; end
 
-                        sig { params(value: T::Enumerable[::Comment]).void }
+                        sig { params(value: ::T::Enumerable[::Comment]).void }
                         def comments=(value); end
 
-                        sig { params(attributes: T.untyped).returns(T.untyped) }
+                        sig { params(attributes: ::T.untyped).returns(::T.untyped) }
                         def comments_attributes=(attributes); end
                       end
                     end
@@ -427,16 +427,16 @@ module Tapioca
                       include GeneratedAssociationMethods
 
                       module GeneratedAssociationMethods
-                        sig { returns(T::Array[T.untyped]) }
+                        sig { returns(::T::Array[::T.untyped]) }
                         def comment_ids; end
 
-                        sig { params(ids: T::Array[T.untyped]).returns(T::Array[T.untyped]) }
+                        sig { params(ids: ::T::Array[::T.untyped]).returns(::T::Array[::T.untyped]) }
                         def comment_ids=(ids); end
 
-                        sig { returns(T::Array[T.untyped]) }
+                        sig { returns(::T::Array[::T.untyped]) }
                         def commenter_ids; end
 
-                        sig { params(ids: T::Array[T.untyped]).returns(T::Array[T.untyped]) }
+                        sig { params(ids: ::T::Array[::T.untyped]).returns(::T::Array[::T.untyped]) }
                         def commenter_ids=(ids); end
 
                         # This method is created by ActiveRecord on the `Post` class because it declared `has_many :commenters, through: :comments`.
@@ -444,10 +444,10 @@ module Tapioca
                         sig { returns(::Commenter::PrivateCollectionProxy) }
                         def commenters; end
 
-                        sig { params(value: T::Enumerable[::Commenter]).void }
+                        sig { params(value: ::T::Enumerable[::Commenter]).void }
                         def commenters=(value); end
 
-                        sig { params(attributes: T.untyped).returns(T.untyped) }
+                        sig { params(attributes: ::T.untyped).returns(::T.untyped) }
                         def commenters_attributes=(attributes); end
 
                         # This method is created by ActiveRecord on the `Post` class because it declared `has_many :comments`.
@@ -455,7 +455,7 @@ module Tapioca
                         sig { returns(::Comment::PrivateCollectionProxy) }
                         def comments; end
 
-                        sig { params(value: T::Enumerable[::Comment]).void }
+                        sig { params(value: ::T::Enumerable[::Comment]).void }
                         def comments=(value); end
                       end
                     end
@@ -498,10 +498,10 @@ module Tapioca
                       include GeneratedAssociationMethods
 
                       module GeneratedAssociationMethods
-                        sig { returns(T::Array[T.untyped]) }
+                        sig { returns(::T::Array[::T.untyped]) }
                         def commenter_ids; end
 
-                        sig { params(ids: T::Array[T.untyped]).returns(T::Array[T.untyped]) }
+                        sig { params(ids: ::T::Array[::T.untyped]).returns(::T::Array[::T.untyped]) }
                         def commenter_ids=(ids); end
 
                         # This method is created by ActiveRecord on the `Post` class because it declared `has_and_belongs_to_many :commenters`.
@@ -509,10 +509,10 @@ module Tapioca
                         sig { returns(::Commenter::PrivateCollectionProxy) }
                         def commenters; end
 
-                        sig { params(value: T::Enumerable[::Commenter]).void }
+                        sig { params(value: ::T::Enumerable[::Commenter]).void }
                         def commenters=(value); end
 
-                        sig { params(attributes: T.untyped).returns(T.untyped) }
+                        sig { params(attributes: ::T.untyped).returns(::T.untyped) }
                         def commenters_attributes=(attributes); end
                       end
                     end
@@ -570,28 +570,28 @@ module Tapioca
                       include GeneratedAssociationMethods
 
                       module GeneratedAssociationMethods
-                        sig { returns(T.nilable(::Blog::Author)) }
+                        sig { returns(::T.nilable(::Blog::Author)) }
                         def author; end
 
-                        sig { params(value: T.nilable(::Blog::Author)).void }
+                        sig { params(value: ::T.nilable(::Blog::Author)).void }
                         def author=(value); end
 
-                        sig { returns(T::Boolean) }
+                        sig { returns(::T::Boolean) }
                         def author_changed?; end
 
-                        sig { returns(T::Boolean) }
+                        sig { returns(::T::Boolean) }
                         def author_previously_changed?; end
 
-                        sig { params(args: T.untyped, blk: T.untyped).returns(::Blog::Author) }
+                        sig { params(args: ::T.untyped, blk: ::T.untyped).returns(::Blog::Author) }
                         def build_author(*args, &blk); end
 
-                        sig { params(args: T.untyped, blk: T.untyped).returns(::Blog::Author) }
+                        sig { params(args: ::T.untyped, blk: ::T.untyped).returns(::Blog::Author) }
                         def create_author(*args, &blk); end
 
-                        sig { params(args: T.untyped, blk: T.untyped).returns(::Blog::Author) }
+                        sig { params(args: ::T.untyped, blk: ::T.untyped).returns(::Blog::Author) }
                         def create_author!(*args, &blk); end
 
-                        sig { returns(T.nilable(::Blog::Author)) }
+                        sig { returns(::T.nilable(::Blog::Author)) }
                         def reload_author; end
 
                         sig { void }
@@ -609,10 +609,10 @@ module Tapioca
                       include GeneratedAssociationMethods
 
                       module GeneratedAssociationMethods
-                        sig { returns(T::Array[T.untyped]) }
+                        sig { returns(::T::Array[::T.untyped]) }
                         def comment_ids; end
 
-                        sig { params(ids: T::Array[T.untyped]).returns(T::Array[T.untyped]) }
+                        sig { params(ids: ::T::Array[::T.untyped]).returns(::T::Array[::T.untyped]) }
                         def comment_ids=(ids); end
 
                         # This method is created by ActiveRecord on the `Blog::Author` class because it declared `has_many :comments`.
@@ -620,13 +620,13 @@ module Tapioca
                         sig { returns(::Comment::PrivateCollectionProxy) }
                         def comments; end
 
-                        sig { params(value: T::Enumerable[::Comment]).void }
+                        sig { params(value: ::T::Enumerable[::Comment]).void }
                         def comments=(value); end
 
-                        sig { returns(T::Array[T.untyped]) }
+                        sig { returns(::T::Array[::T.untyped]) }
                         def draft_ids; end
 
-                        sig { params(ids: T::Array[T.untyped]).returns(T::Array[T.untyped]) }
+                        sig { params(ids: ::T::Array[::T.untyped]).returns(::T::Array[::T.untyped]) }
                         def draft_ids=(ids); end
 
                         # This method is created by ActiveRecord on the `Blog::Author` class because it declared `has_many :drafts`.
@@ -634,7 +634,7 @@ module Tapioca
                         sig { returns(::Blog::Draft::PrivateCollectionProxy) }
                         def drafts; end
 
-                        sig { params(value: T::Enumerable[::Blog::Draft]).void }
+                        sig { params(value: ::T::Enumerable[::Blog::Draft]).void }
                         def drafts=(value); end
                       end
                     end
@@ -649,28 +649,28 @@ module Tapioca
                       include GeneratedAssociationMethods
 
                       module GeneratedAssociationMethods
-                        sig { params(args: T.untyped, blk: T.untyped).returns(::Blog::Core::Post) }
+                        sig { params(args: ::T.untyped, blk: ::T.untyped).returns(::Blog::Core::Post) }
                         def build_post(*args, &blk); end
 
-                        sig { params(args: T.untyped, blk: T.untyped).returns(::Blog::Core::Post) }
+                        sig { params(args: ::T.untyped, blk: ::T.untyped).returns(::Blog::Core::Post) }
                         def create_post(*args, &blk); end
 
-                        sig { params(args: T.untyped, blk: T.untyped).returns(::Blog::Core::Post) }
+                        sig { params(args: ::T.untyped, blk: ::T.untyped).returns(::Blog::Core::Post) }
                         def create_post!(*args, &blk); end
 
-                        sig { returns(T.nilable(::Blog::Core::Post)) }
+                        sig { returns(::T.nilable(::Blog::Core::Post)) }
                         def post; end
 
-                        sig { params(value: T.nilable(::Blog::Core::Post)).void }
+                        sig { params(value: ::T.nilable(::Blog::Core::Post)).void }
                         def post=(value); end
 
-                        sig { returns(T::Boolean) }
+                        sig { returns(::T::Boolean) }
                         def post_changed?; end
 
-                        sig { returns(T::Boolean) }
+                        sig { returns(::T::Boolean) }
                         def post_previously_changed?; end
 
-                        sig { returns(T.nilable(::Blog::Core::Post)) }
+                        sig { returns(::T.nilable(::Blog::Core::Post)) }
                         def reload_post; end
 
                         sig { void }
@@ -779,31 +779,31 @@ module Tapioca
                       include GeneratedAssociationMethods
 
                       module GeneratedAssociationMethods
-                        sig { params(args: T.untyped, blk: T.untyped).returns(::Shop) }
+                        sig { params(args: ::T.untyped, blk: ::T.untyped).returns(::Shop) }
                         def build_shop(*args, &blk); end
 
-                        sig { params(args: T.untyped, blk: T.untyped).returns(::Shop) }
+                        sig { params(args: ::T.untyped, blk: ::T.untyped).returns(::Shop) }
                         def create_shop(*args, &blk); end
 
-                        sig { params(args: T.untyped, blk: T.untyped).returns(::Shop) }
+                        sig { params(args: ::T.untyped, blk: ::T.untyped).returns(::Shop) }
                         def create_shop!(*args, &blk); end
 
-                        sig { returns(T.nilable(::Shop)) }
+                        sig { returns(::T.nilable(::Shop)) }
                         def reload_shop; end
 
                         sig { void }
                         def reset_shop; end
 
-                        sig { returns(T.nilable(::Shop)) }
+                        sig { returns(::T.nilable(::Shop)) }
                         def shop; end
 
-                        sig { params(value: T.nilable(::Shop)).void }
+                        sig { params(value: ::T.nilable(::Shop)).void }
                         def shop=(value); end
 
-                        sig { returns(T::Boolean) }
+                        sig { returns(::T::Boolean) }
                         def shop_changed?; end
 
-                        sig { returns(T::Boolean) }
+                        sig { returns(::T::Boolean) }
                         def shop_previously_changed?; end
                       end
                     end
@@ -872,58 +872,58 @@ module Tapioca
                       include GeneratedAssociationMethods
 
                       module GeneratedAssociationMethods
-                        sig { returns(T.nilable(::User)) }
+                        sig { returns(::T.nilable(::User)) }
                         def author; end
 
-                        sig { params(value: T.nilable(::User)).void }
+                        sig { params(value: ::T.nilable(::User)).void }
                         def author=(value); end
 
-                        sig { params(attributes: T.untyped).returns(T.untyped) }
+                        sig { params(attributes: ::T.untyped).returns(::T.untyped) }
                         def author_attributes=(attributes); end
 
-                        sig { returns(T::Boolean) }
+                        sig { returns(::T::Boolean) }
                         def author_changed?; end
 
-                        sig { returns(T::Boolean) }
+                        sig { returns(::T::Boolean) }
                         def author_previously_changed?; end
 
-                        sig { params(args: T.untyped, blk: T.untyped).returns(::User) }
+                        sig { params(args: ::T.untyped, blk: ::T.untyped).returns(::User) }
                         def build_author(*args, &blk); end
 
-                        sig { params(args: T.untyped, blk: T.untyped).returns(::Category) }
+                        sig { params(args: ::T.untyped, blk: ::T.untyped).returns(::Category) }
                         def build_category(*args, &blk); end
 
-                        sig { returns(T.nilable(::Category)) }
+                        sig { returns(::T.nilable(::Category)) }
                         def category; end
 
-                        sig { params(value: T.nilable(::Category)).void }
+                        sig { params(value: ::T.nilable(::Category)).void }
                         def category=(value); end
 
-                        sig { params(attributes: T.untyped).returns(T.untyped) }
+                        sig { params(attributes: ::T.untyped).returns(::T.untyped) }
                         def category_attributes=(attributes); end
 
-                        sig { returns(T::Boolean) }
+                        sig { returns(::T::Boolean) }
                         def category_changed?; end
 
-                        sig { returns(T::Boolean) }
+                        sig { returns(::T::Boolean) }
                         def category_previously_changed?; end
 
-                        sig { params(args: T.untyped, blk: T.untyped).returns(::User) }
+                        sig { params(args: ::T.untyped, blk: ::T.untyped).returns(::User) }
                         def create_author(*args, &blk); end
 
-                        sig { params(args: T.untyped, blk: T.untyped).returns(::User) }
+                        sig { params(args: ::T.untyped, blk: ::T.untyped).returns(::User) }
                         def create_author!(*args, &blk); end
 
-                        sig { params(args: T.untyped, blk: T.untyped).returns(::Category) }
+                        sig { params(args: ::T.untyped, blk: ::T.untyped).returns(::Category) }
                         def create_category(*args, &blk); end
 
-                        sig { params(args: T.untyped, blk: T.untyped).returns(::Category) }
+                        sig { params(args: ::T.untyped, blk: ::T.untyped).returns(::Category) }
                         def create_category!(*args, &blk); end
 
-                        sig { returns(T.nilable(::User)) }
+                        sig { returns(::T.nilable(::User)) }
                         def reload_author; end
 
-                        sig { returns(T.nilable(::Category)) }
+                        sig { returns(::T.nilable(::Category)) }
                         def reload_category; end
 
                         sig { void }
@@ -959,22 +959,22 @@ module Tapioca
                       include GeneratedAssociationMethods
 
                       module GeneratedAssociationMethods
-                        sig { returns(T.untyped) }
+                        sig { returns(::T.untyped) }
                         def category; end
 
-                        sig { params(value: T.untyped).void }
+                        sig { params(value: ::T.untyped).void }
                         def category=(value); end
 
-                        sig { params(attributes: T.untyped).returns(T.untyped) }
+                        sig { params(attributes: ::T.untyped).returns(::T.untyped) }
                         def category_attributes=(attributes); end
 
-                        sig { returns(T::Boolean) }
+                        sig { returns(::T::Boolean) }
                         def category_changed?; end
 
-                        sig { returns(T::Boolean) }
+                        sig { returns(::T::Boolean) }
                         def category_previously_changed?; end
 
-                        sig { returns(T.untyped) }
+                        sig { returns(::T.untyped) }
                         def reload_category; end
 
                         sig { void }
@@ -1008,18 +1008,18 @@ module Tapioca
                       include GeneratedAssociationMethods
 
                       module GeneratedAssociationMethods
-                        sig { returns(T::Array[T.untyped]) }
+                        sig { returns(::T::Array[::T.untyped]) }
                         def picture_ids; end
 
-                        sig { params(ids: T::Array[T.untyped]).returns(T::Array[T.untyped]) }
+                        sig { params(ids: ::T::Array[::T.untyped]).returns(::T::Array[::T.untyped]) }
                         def picture_ids=(ids); end
 
                         # This method is created by ActiveRecord on the `Employee` class because it declared `has_many :pictures`.
                         # 🔗 [Rails guide for `has_many` association](https://guides.rubyonrails.org/association_basics.html#the-has-many-association)
-                        sig { returns(ActiveRecord::Associations::CollectionProxy[T.untyped]) }
+                        sig { returns(ActiveRecord::Associations::CollectionProxy[::T.untyped]) }
                         def pictures; end
 
-                        sig { params(value: T::Enumerable[T.untyped]).void }
+                        sig { params(value: ::T::Enumerable[::T.untyped]).void }
                         def pictures=(value); end
                       end
                     end
@@ -1058,25 +1058,25 @@ module Tapioca
                       include GeneratedAssociationMethods
 
                       module GeneratedAssociationMethods
-                        sig { returns(T.nilable(::User)) }
+                        sig { returns(::T.nilable(::User)) }
                         def author; end
 
-                        sig { params(value: T.nilable(::User)).void }
+                        sig { params(value: ::T.nilable(::User)).void }
                         def author=(value); end
 
-                        sig { params(attributes: T.untyped).returns(T.untyped) }
+                        sig { params(attributes: ::T.untyped).returns(::T.untyped) }
                         def author_attributes=(attributes); end
 
-                        sig { params(args: T.untyped, blk: T.untyped).returns(::User) }
+                        sig { params(args: ::T.untyped, blk: ::T.untyped).returns(::User) }
                         def build_author(*args, &blk); end
 
-                        sig { params(args: T.untyped, blk: T.untyped).returns(::User) }
+                        sig { params(args: ::T.untyped, blk: ::T.untyped).returns(::User) }
                         def create_author(*args, &blk); end
 
-                        sig { params(args: T.untyped, blk: T.untyped).returns(::User) }
+                        sig { params(args: ::T.untyped, blk: ::T.untyped).returns(::User) }
                         def create_author!(*args, &blk); end
 
-                        sig { returns(T.nilable(::User)) }
+                        sig { returns(::T.nilable(::User)) }
                         def reload_author; end
 
                         sig { void }
@@ -1121,10 +1121,10 @@ module Tapioca
                       include GeneratedAssociationMethods
 
                       module GeneratedAssociationMethods
-                        sig { returns(T::Array[T.untyped]) }
+                        sig { returns(::T::Array[::T.untyped]) }
                         def comment_ids; end
 
-                        sig { params(ids: T::Array[T.untyped]).returns(T::Array[T.untyped]) }
+                        sig { params(ids: ::T::Array[::T.untyped]).returns(::T::Array[::T.untyped]) }
                         def comment_ids=(ids); end
 
                         # This method is created by ActiveRecord on the `Post` class because it declared `has_many :comments`.
@@ -1132,10 +1132,10 @@ module Tapioca
                         sig { returns(::ActiveRecord::Associations::CollectionProxy[::Comment]) }
                         def comments; end
 
-                        sig { params(value: T::Enumerable[::Comment]).void }
+                        sig { params(value: ::T::Enumerable[::Comment]).void }
                         def comments=(value); end
 
-                        sig { params(attributes: T.untyped).returns(T.untyped) }
+                        sig { params(attributes: ::T.untyped).returns(::T.untyped) }
                         def comments_attributes=(attributes); end
                       end
                     end
@@ -1184,16 +1184,16 @@ module Tapioca
                       include GeneratedAssociationMethods
 
                       module GeneratedAssociationMethods
-                        sig { returns(T::Array[T.untyped]) }
+                        sig { returns(::T::Array[::T.untyped]) }
                         def comment_ids; end
 
-                        sig { params(ids: T::Array[T.untyped]).returns(T::Array[T.untyped]) }
+                        sig { params(ids: ::T::Array[::T.untyped]).returns(::T::Array[::T.untyped]) }
                         def comment_ids=(ids); end
 
-                        sig { returns(T::Array[T.untyped]) }
+                        sig { returns(::T::Array[::T.untyped]) }
                         def commenter_ids; end
 
-                        sig { params(ids: T::Array[T.untyped]).returns(T::Array[T.untyped]) }
+                        sig { params(ids: ::T::Array[::T.untyped]).returns(::T::Array[::T.untyped]) }
                         def commenter_ids=(ids); end
 
                         # This method is created by ActiveRecord on the `Post` class because it declared `has_many :commenters, through: :comments`.
@@ -1201,10 +1201,10 @@ module Tapioca
                         sig { returns(::ActiveRecord::Associations::CollectionProxy[::Commenter]) }
                         def commenters; end
 
-                        sig { params(value: T::Enumerable[::Commenter]).void }
+                        sig { params(value: ::T::Enumerable[::Commenter]).void }
                         def commenters=(value); end
 
-                        sig { params(attributes: T.untyped).returns(T.untyped) }
+                        sig { params(attributes: ::T.untyped).returns(::T.untyped) }
                         def commenters_attributes=(attributes); end
 
                         # This method is created by ActiveRecord on the `Post` class because it declared `has_many :comments`.
@@ -1212,7 +1212,7 @@ module Tapioca
                         sig { returns(::ActiveRecord::Associations::CollectionProxy[::Comment]) }
                         def comments; end
 
-                        sig { params(value: T::Enumerable[::Comment]).void }
+                        sig { params(value: ::T::Enumerable[::Comment]).void }
                         def comments=(value); end
                       end
                     end
@@ -1255,10 +1255,10 @@ module Tapioca
                       include GeneratedAssociationMethods
 
                       module GeneratedAssociationMethods
-                        sig { returns(T::Array[T.untyped]) }
+                        sig { returns(::T::Array[::T.untyped]) }
                         def commenter_ids; end
 
-                        sig { params(ids: T::Array[T.untyped]).returns(T::Array[T.untyped]) }
+                        sig { params(ids: ::T::Array[::T.untyped]).returns(::T::Array[::T.untyped]) }
                         def commenter_ids=(ids); end
 
                         # This method is created by ActiveRecord on the `Post` class because it declared `has_and_belongs_to_many :commenters`.
@@ -1266,10 +1266,10 @@ module Tapioca
                         sig { returns(::ActiveRecord::Associations::CollectionProxy[::Commenter]) }
                         def commenters; end
 
-                        sig { params(value: T::Enumerable[::Commenter]).void }
+                        sig { params(value: ::T::Enumerable[::Commenter]).void }
                         def commenters=(value); end
 
-                        sig { params(attributes: T.untyped).returns(T.untyped) }
+                        sig { params(attributes: ::T.untyped).returns(::T.untyped) }
                         def commenters_attributes=(attributes); end
                       end
                     end
@@ -1327,28 +1327,28 @@ module Tapioca
                       include GeneratedAssociationMethods
 
                       module GeneratedAssociationMethods
-                        sig { returns(T.nilable(::Blog::Author)) }
+                        sig { returns(::T.nilable(::Blog::Author)) }
                         def author; end
 
-                        sig { params(value: T.nilable(::Blog::Author)).void }
+                        sig { params(value: ::T.nilable(::Blog::Author)).void }
                         def author=(value); end
 
-                        sig { returns(T::Boolean) }
+                        sig { returns(::T::Boolean) }
                         def author_changed?; end
 
-                        sig { returns(T::Boolean) }
+                        sig { returns(::T::Boolean) }
                         def author_previously_changed?; end
 
-                        sig { params(args: T.untyped, blk: T.untyped).returns(::Blog::Author) }
+                        sig { params(args: ::T.untyped, blk: ::T.untyped).returns(::Blog::Author) }
                         def build_author(*args, &blk); end
 
-                        sig { params(args: T.untyped, blk: T.untyped).returns(::Blog::Author) }
+                        sig { params(args: ::T.untyped, blk: ::T.untyped).returns(::Blog::Author) }
                         def create_author(*args, &blk); end
 
-                        sig { params(args: T.untyped, blk: T.untyped).returns(::Blog::Author) }
+                        sig { params(args: ::T.untyped, blk: ::T.untyped).returns(::Blog::Author) }
                         def create_author!(*args, &blk); end
 
-                        sig { returns(T.nilable(::Blog::Author)) }
+                        sig { returns(::T.nilable(::Blog::Author)) }
                         def reload_author; end
 
                         sig { void }
@@ -1366,10 +1366,10 @@ module Tapioca
                       include GeneratedAssociationMethods
 
                       module GeneratedAssociationMethods
-                        sig { returns(T::Array[T.untyped]) }
+                        sig { returns(::T::Array[::T.untyped]) }
                         def comment_ids; end
 
-                        sig { params(ids: T::Array[T.untyped]).returns(T::Array[T.untyped]) }
+                        sig { params(ids: ::T::Array[::T.untyped]).returns(::T::Array[::T.untyped]) }
                         def comment_ids=(ids); end
 
                         # This method is created by ActiveRecord on the `Blog::Author` class because it declared `has_many :comments`.
@@ -1377,13 +1377,13 @@ module Tapioca
                         sig { returns(::ActiveRecord::Associations::CollectionProxy[::Comment]) }
                         def comments; end
 
-                        sig { params(value: T::Enumerable[::Comment]).void }
+                        sig { params(value: ::T::Enumerable[::Comment]).void }
                         def comments=(value); end
 
-                        sig { returns(T::Array[T.untyped]) }
+                        sig { returns(::T::Array[::T.untyped]) }
                         def draft_ids; end
 
-                        sig { params(ids: T::Array[T.untyped]).returns(T::Array[T.untyped]) }
+                        sig { params(ids: ::T::Array[::T.untyped]).returns(::T::Array[::T.untyped]) }
                         def draft_ids=(ids); end
 
                         # This method is created by ActiveRecord on the `Blog::Author` class because it declared `has_many :drafts`.
@@ -1391,7 +1391,7 @@ module Tapioca
                         sig { returns(::ActiveRecord::Associations::CollectionProxy[::Blog::Draft]) }
                         def drafts; end
 
-                        sig { params(value: T::Enumerable[::Blog::Draft]).void }
+                        sig { params(value: ::T::Enumerable[::Blog::Draft]).void }
                         def drafts=(value); end
                       end
                     end
@@ -1406,28 +1406,28 @@ module Tapioca
                       include GeneratedAssociationMethods
 
                       module GeneratedAssociationMethods
-                        sig { params(args: T.untyped, blk: T.untyped).returns(::Blog::Core::Post) }
+                        sig { params(args: ::T.untyped, blk: ::T.untyped).returns(::Blog::Core::Post) }
                         def build_post(*args, &blk); end
 
-                        sig { params(args: T.untyped, blk: T.untyped).returns(::Blog::Core::Post) }
+                        sig { params(args: ::T.untyped, blk: ::T.untyped).returns(::Blog::Core::Post) }
                         def create_post(*args, &blk); end
 
-                        sig { params(args: T.untyped, blk: T.untyped).returns(::Blog::Core::Post) }
+                        sig { params(args: ::T.untyped, blk: ::T.untyped).returns(::Blog::Core::Post) }
                         def create_post!(*args, &blk); end
 
-                        sig { returns(T.nilable(::Blog::Core::Post)) }
+                        sig { returns(::T.nilable(::Blog::Core::Post)) }
                         def post; end
 
-                        sig { params(value: T.nilable(::Blog::Core::Post)).void }
+                        sig { params(value: ::T.nilable(::Blog::Core::Post)).void }
                         def post=(value); end
 
-                        sig { returns(T::Boolean) }
+                        sig { returns(::T::Boolean) }
                         def post_changed?; end
 
-                        sig { returns(T::Boolean) }
+                        sig { returns(::T::Boolean) }
                         def post_previously_changed?; end
 
-                        sig { returns(T.nilable(::Blog::Core::Post)) }
+                        sig { returns(::T.nilable(::Blog::Core::Post)) }
                         def reload_post; end
 
                         sig { void }
@@ -1536,31 +1536,31 @@ module Tapioca
                       include GeneratedAssociationMethods
 
                       module GeneratedAssociationMethods
-                        sig { params(args: T.untyped, blk: T.untyped).returns(::Shop) }
+                        sig { params(args: ::T.untyped, blk: ::T.untyped).returns(::Shop) }
                         def build_shop(*args, &blk); end
 
-                        sig { params(args: T.untyped, blk: T.untyped).returns(::Shop) }
+                        sig { params(args: ::T.untyped, blk: ::T.untyped).returns(::Shop) }
                         def create_shop(*args, &blk); end
 
-                        sig { params(args: T.untyped, blk: T.untyped).returns(::Shop) }
+                        sig { params(args: ::T.untyped, blk: ::T.untyped).returns(::Shop) }
                         def create_shop!(*args, &blk); end
 
-                        sig { returns(T.nilable(::Shop)) }
+                        sig { returns(::T.nilable(::Shop)) }
                         def reload_shop; end
 
                         sig { void }
                         def reset_shop; end
 
-                        sig { returns(T.nilable(::Shop)) }
+                        sig { returns(::T.nilable(::Shop)) }
                         def shop; end
 
-                        sig { params(value: T.nilable(::Shop)).void }
+                        sig { params(value: ::T.nilable(::Shop)).void }
                         def shop=(value); end
 
-                        sig { returns(T::Boolean) }
+                        sig { returns(::T::Boolean) }
                         def shop_changed?; end
 
-                        sig { returns(T::Boolean) }
+                        sig { returns(::T::Boolean) }
                         def shop_previously_changed?; end
                       end
                     end
@@ -1599,40 +1599,40 @@ module Tapioca
                   include GeneratedAssociationMethods
 
                   module GeneratedAssociationMethods
-                    sig { params(args: T.untyped, blk: T.untyped).returns(T.untyped) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(::T.untyped) }
                     def build_photo_attachment(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(T.untyped) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(::T.untyped) }
                     def build_photo_blob(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(T.untyped) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(::T.untyped) }
                     def create_photo_attachment(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(T.untyped) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(::T.untyped) }
                     def create_photo_attachment!(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(T.untyped) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(::T.untyped) }
                     def create_photo_blob(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(T.untyped) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(::T.untyped) }
                     def create_photo_blob!(*args, &blk); end
 
-                    sig { returns(T.untyped) }
+                    sig { returns(::T.untyped) }
                     def photo_attachment; end
 
-                    sig { params(value: T.untyped).void }
+                    sig { params(value: ::T.untyped).void }
                     def photo_attachment=(value); end
 
-                    sig { returns(T.untyped) }
+                    sig { returns(::T.untyped) }
                     def photo_blob; end
 
-                    sig { params(value: T.untyped).void }
+                    sig { params(value: ::T.untyped).void }
                     def photo_blob=(value); end
 
-                    sig { returns(T.untyped) }
+                    sig { returns(::T.untyped) }
                     def reload_photo_attachment; end
 
-                    sig { returns(T.untyped) }
+                    sig { returns(::T.untyped) }
                     def reload_photo_blob; end
 
                     sig { void }
@@ -1670,10 +1670,10 @@ module Tapioca
                   include GeneratedAssociationMethods
 
                   module GeneratedAssociationMethods
-                    sig { returns(T::Array[T.untyped]) }
+                    sig { returns(::T::Array[::T.untyped]) }
                     def photos_attachment_ids; end
 
-                    sig { params(ids: T::Array[T.untyped]).returns(T::Array[T.untyped]) }
+                    sig { params(ids: ::T::Array[::T.untyped]).returns(::T::Array[::T.untyped]) }
                     def photos_attachment_ids=(ids); end
 
                     # This method is created by ActiveRecord on the `Post` class because it declared `has_many :photos_attachments`.
@@ -1681,13 +1681,13 @@ module Tapioca
                     sig { returns(::ActiveStorage::Attachment::PrivateCollectionProxy) }
                     def photos_attachments; end
 
-                    sig { params(value: T::Enumerable[::ActiveStorage::Attachment]).void }
+                    sig { params(value: ::T::Enumerable[::ActiveStorage::Attachment]).void }
                     def photos_attachments=(value); end
 
-                    sig { returns(T::Array[T.untyped]) }
+                    sig { returns(::T::Array[::T.untyped]) }
                     def photos_blob_ids; end
 
-                    sig { params(ids: T::Array[T.untyped]).returns(T::Array[T.untyped]) }
+                    sig { params(ids: ::T::Array[::T.untyped]).returns(::T::Array[::T.untyped]) }
                     def photos_blob_ids=(ids); end
 
                     # This method is created by ActiveRecord on the `Post` class because it declared `has_many :photos_blobs, through: :photos_attachments`.
@@ -1695,7 +1695,7 @@ module Tapioca
                     sig { returns(::ActiveStorage::Blob::PrivateCollectionProxy) }
                     def photos_blobs; end
 
-                    sig { params(value: T::Enumerable[::ActiveStorage::Blob]).void }
+                    sig { params(value: ::T::Enumerable[::ActiveStorage::Blob]).void }
                     def photos_blobs=(value); end
                   end
                 end

--- a/spec/tapioca/dsl/compilers/active_record_columns_spec.rb
+++ b/spec/tapioca/dsl/compilers/active_record_columns_spec.rb
@@ -85,37 +85,37 @@ module Tapioca
                       sig { params(value: ::Integer).returns(::Integer) }
                       def id=(value); end
 
-                      sig { returns(T::Boolean) }
+                      sig { returns(::T::Boolean) }
                       def id?; end
 
-                      sig { returns(T.nilable(::Integer)) }
+                      sig { returns(::T.nilable(::Integer)) }
                       def id_before_last_save; end
 
-                      sig { returns(T.untyped) }
+                      sig { returns(::T.untyped) }
                       def id_before_type_cast; end
 
-                      sig { returns(T::Boolean) }
+                      sig { returns(::T::Boolean) }
                       def id_came_from_user?; end
 
-                      sig { returns(T.nilable([::Integer, ::Integer])) }
+                      sig { returns(::T.nilable([::Integer, ::Integer])) }
                       def id_change; end
 
-                      sig { returns(T.nilable([::Integer, ::Integer])) }
+                      sig { returns(::T.nilable([::Integer, ::Integer])) }
                       def id_change_to_be_saved; end
 
-                      sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
-                      def id_changed?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+                      sig { params(from: ::T.untyped, to: ::T.untyped).returns(::T::Boolean) }
+                      def id_changed?(from: ::T.unsafe(nil), to: ::T.unsafe(nil)); end
 
-                      sig { returns(T.nilable(::Integer)) }
+                      sig { returns(::T.nilable(::Integer)) }
                       def id_in_database; end
 
-                      sig { returns(T.nilable([::Integer, ::Integer])) }
+                      sig { returns(::T.nilable([::Integer, ::Integer])) }
                       def id_previous_change; end
 
-                      sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
-                      def id_previously_changed?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+                      sig { params(from: ::T.untyped, to: ::T.untyped).returns(::T::Boolean) }
+                      def id_previously_changed?(from: ::T.unsafe(nil), to: ::T.unsafe(nil)); end
 
-                      sig { returns(T.nilable(::Integer)) }
+                      sig { returns(::T.nilable(::Integer)) }
                       def id_previously_was; end
 
                       sig { returns(::Integer) }
@@ -124,46 +124,46 @@ module Tapioca
                       sig { params(value: ::Integer).returns(::Integer) }
                       def id_value=(value); end
 
-                      sig { returns(T::Boolean) }
+                      sig { returns(::T::Boolean) }
                       def id_value?; end
 
-                      sig { returns(T.nilable(::Integer)) }
+                      sig { returns(::T.nilable(::Integer)) }
                       def id_value_before_last_save; end
 
-                      sig { returns(T.untyped) }
+                      sig { returns(::T.untyped) }
                       def id_value_before_type_cast; end
 
-                      sig { returns(T::Boolean) }
+                      sig { returns(::T::Boolean) }
                       def id_value_came_from_user?; end
 
-                      sig { returns(T.nilable([::Integer, ::Integer])) }
+                      sig { returns(::T.nilable([::Integer, ::Integer])) }
                       def id_value_change; end
 
-                      sig { returns(T.nilable([::Integer, ::Integer])) }
+                      sig { returns(::T.nilable([::Integer, ::Integer])) }
                       def id_value_change_to_be_saved; end
 
-                      sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
-                      def id_value_changed?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+                      sig { params(from: ::T.untyped, to: ::T.untyped).returns(::T::Boolean) }
+                      def id_value_changed?(from: ::T.unsafe(nil), to: ::T.unsafe(nil)); end
 
-                      sig { returns(T.nilable(::Integer)) }
+                      sig { returns(::T.nilable(::Integer)) }
                       def id_value_in_database; end
 
-                      sig { returns(T.nilable([::Integer, ::Integer])) }
+                      sig { returns(::T.nilable([::Integer, ::Integer])) }
                       def id_value_previous_change; end
 
-                      sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
-                      def id_value_previously_changed?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+                      sig { params(from: ::T.untyped, to: ::T.untyped).returns(::T::Boolean) }
+                      def id_value_previously_changed?(from: ::T.unsafe(nil), to: ::T.unsafe(nil)); end
 
-                      sig { returns(T.nilable(::Integer)) }
+                      sig { returns(::T.nilable(::Integer)) }
                       def id_value_previously_was; end
 
-                      sig { returns(T.nilable(::Integer)) }
+                      sig { returns(::T.nilable(::Integer)) }
                       def id_value_was; end
 
                       sig { void }
                       def id_value_will_change!; end
 
-                      sig { returns(T.nilable(::Integer)) }
+                      sig { returns(::T.nilable(::Integer)) }
                       def id_was; end
 
                       sig { void }
@@ -175,23 +175,23 @@ module Tapioca
                       sig { void }
                       def restore_id_value!; end
 
-                      sig { returns(T.nilable([::Integer, ::Integer])) }
+                      sig { returns(::T.nilable([::Integer, ::Integer])) }
                       def saved_change_to_id; end
 
-                      sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
-                      def saved_change_to_id?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+                      sig { params(from: ::T.untyped, to: ::T.untyped).returns(::T::Boolean) }
+                      def saved_change_to_id?(from: ::T.unsafe(nil), to: ::T.unsafe(nil)); end
 
-                      sig { returns(T.nilable([::Integer, ::Integer])) }
+                      sig { returns(::T.nilable([::Integer, ::Integer])) }
                       def saved_change_to_id_value; end
 
-                      sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
-                      def saved_change_to_id_value?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+                      sig { params(from: ::T.untyped, to: ::T.untyped).returns(::T::Boolean) }
+                      def saved_change_to_id_value?(from: ::T.unsafe(nil), to: ::T.unsafe(nil)); end
 
-                      sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
-                      def will_save_change_to_id?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+                      sig { params(from: ::T.untyped, to: ::T.untyped).returns(::T::Boolean) }
+                      def will_save_change_to_id?(from: ::T.unsafe(nil), to: ::T.unsafe(nil)); end
 
-                      sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
-                      def will_save_change_to_id_value?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+                      sig { params(from: ::T.untyped, to: ::T.untyped).returns(::T::Boolean) }
+                      def will_save_change_to_id_value?(from: ::T.unsafe(nil), to: ::T.unsafe(nil)); end
                     end
                   end
                 RBI
@@ -217,13 +217,13 @@ module Tapioca
 
                 expected = indented(<<~RBI, 2)
                   module GeneratedAttributeMethods
-                    sig { returns(T.nilable(::String)) }
+                    sig { returns(::T.nilable(::String)) }
                     def body; end
 
-                    sig { params(value: T.nilable(::String)).returns(T.nilable(::String)) }
+                    sig { params(value: ::T.nilable(::String)).returns(::T.nilable(::String)) }
                     def body=(value); end
 
-                    sig { returns(T::Boolean) }
+                    sig { returns(::T::Boolean) }
                     def body?; end
                 RBI
 
@@ -291,14 +291,14 @@ module Tapioca
 
                 expected = indented(<<~RBI, 2)
                   module GeneratedAttributeMethods
-                    sig { returns(T.nilable(::CustomType)) }
+                    sig { returns(::T.nilable(::CustomType)) }
                     def custom; end
                 RBI
 
                 assert_includes(rbi_for(:Post), expected)
               end
 
-              it "strips T.nilable from sigs in persisted mode when using EncryptedAttributeType" do
+              it "strips ::T.nilable from sigs in persisted mode when using EncryptedAttributeType" do
                 add_ruby_file("schema.rb", <<~RUBY)
                   ActiveRecord::Migration.suppress_messages do
                     ActiveRecord::Schema.define do
@@ -362,13 +362,13 @@ module Tapioca
                 output = rbi_for(:Post)
 
                 expected = indented(<<~RBI, 4)
-                  sig { returns(T.nilable(::String)) }
+                  sig { returns(::T.nilable(::String)) }
                   def body; end
 
-                  sig { params(value: T.nilable(::String)).returns(T.nilable(::String)) }
+                  sig { params(value: ::T.nilable(::String)).returns(::T.nilable(::String)) }
                   def body=(value); end
 
-                  sig { returns(T::Boolean) }
+                  sig { returns(::T::Boolean) }
                   def body?; end
                 RBI
                 assert_includes(output, expected)
@@ -380,7 +380,7 @@ module Tapioca
                   sig { params(value: ::String).returns(::String) }
                   def title=(value); end
 
-                  sig { returns(T::Boolean) }
+                  sig { returns(::T::Boolean) }
                   def title?; end
                 RBI
                 assert_includes(output, expected)
@@ -453,91 +453,91 @@ module Tapioca
                 output = rbi_for(:Post)
 
                 expected = indented(<<~RBI, 4)
-                  sig { params(value: T.nilable(::Integer)).returns(T.nilable(::Integer)) }
+                  sig { params(value: ::T.nilable(::Integer)).returns(::T.nilable(::Integer)) }
                   def integer_column=(value); end
                 RBI
                 assert_includes(output, expected)
 
                 expected = indented(<<~RBI, 4)
-                  sig { params(value: T.nilable(::String)).returns(T.nilable(::String)) }
+                  sig { params(value: ::T.nilable(::String)).returns(::T.nilable(::String)) }
                   def string_column=(value); end
                 RBI
                 assert_includes(output, expected)
 
                 expected = indented(<<~RBI, 4)
-                  sig { params(value: T.nilable(::Date)).returns(T.nilable(::Date)) }
+                  sig { params(value: ::T.nilable(::Date)).returns(::T.nilable(::Date)) }
                   def date_column=(value); end
                 RBI
                 assert_includes(output, expected)
 
                 expected = indented(<<~RBI, 4)
-                  sig { params(value: T.nilable(::BigDecimal)).returns(T.nilable(::BigDecimal)) }
+                  sig { params(value: ::T.nilable(::BigDecimal)).returns(::T.nilable(::BigDecimal)) }
                   def decimal_column=(value); end
                 RBI
                 assert_includes(output, expected)
 
                 expected = indented(<<~RBI, 4)
-                  sig { params(value: T.nilable(::Float)).returns(T.nilable(::Float)) }
+                  sig { params(value: ::T.nilable(::Float)).returns(::T.nilable(::Float)) }
                   def float_column=(value); end
                 RBI
                 assert_includes(output, expected)
 
                 expected = indented(<<~RBI, 4)
-                  sig { params(value: T.nilable(T::Boolean)).returns(T.nilable(T::Boolean)) }
+                  sig { params(value: ::T.nilable(::T::Boolean)).returns(::T.nilable(::T::Boolean)) }
                   def boolean_column=(value); end
                 RBI
                 assert_includes(output, expected)
 
                 expected = indented(<<~RBI, 4)
-                  sig { params(value: T.nilable(::Time)).returns(T.nilable(::Time)) }
+                  sig { params(value: ::T.nilable(::Time)).returns(::T.nilable(::Time)) }
                   def datetime_column=(value); end
                 RBI
                 assert_includes(output, expected)
 
                 expected = indented(<<~RBI, 4)
-                  sig { params(value: T.nilable(::Money)).returns(T.nilable(::Money)) }
+                  sig { params(value: ::T.nilable(::Money)).returns(::T.nilable(::Money)) }
                   def money_column=(value); end
                 RBI
                 assert_includes(output, expected)
 
                 expected = indented(<<~RBI, 4)
-                  sig { params(value: T.untyped).returns(T.untyped) }
+                  sig { params(value: ::T.untyped).returns(::T.untyped) }
                   def serialized_column=(value); end
                 RBI
                 assert_includes(output, expected)
 
                 expected = indented(<<~RBI, 4)
-                  sig { returns(T.nilable(::String)) }
+                  sig { returns(::T.nilable(::String)) }
                   def integer_enum_column; end
                 RBI
                 assert_includes(output, expected)
 
                 expected = indented(<<~RBI, 4)
-                  sig { params(value: T.nilable(T.any(::String, ::Symbol, ::Integer))).returns(T.nilable(T.any(::String, ::Symbol, ::Integer))) }
+                  sig { params(value: ::T.nilable(::T.any(::String, ::Symbol, ::Integer))).returns(::T.nilable(::T.any(::String, ::Symbol, ::Integer))) }
                   def integer_enum_column=(value); end
                 RBI
                 assert_includes(output, expected)
 
                 expected = indented(<<~RBI, 4)
-                  sig { returns(T.nilable(::String)) }
+                  sig { returns(::T.nilable(::String)) }
                   def string_enum_column; end
                 RBI
                 assert_includes(output, expected)
 
                 expected = indented(<<~RBI, 4)
-                  sig { params(value: T.nilable(T.any(::String, ::Symbol))).returns(T.nilable(T.any(::String, ::Symbol))) }
+                  sig { params(value: ::T.nilable(::T.any(::String, ::Symbol))).returns(::T.nilable(::T.any(::String, ::Symbol))) }
                   def string_enum_column=(value); end
                 RBI
                 assert_includes(output, expected)
 
                 expected = indented(<<~RBI, 4)
-                  sig { returns(T.nilable(::String)) }
+                  sig { returns(::T.nilable(::String)) }
                   def binary_column; end
                 RBI
                 assert_includes(output, expected)
 
                 expected = indented(<<~RBI, 4)
-                  sig { params(value: T.nilable(::String)).returns(T.nilable(::String)) }
+                  sig { params(value: ::T.nilable(::String)).returns(::T.nilable(::String)) }
                   def binary_column=(value); end
                 RBI
                 assert_includes(output, expected)
@@ -574,49 +574,49 @@ module Tapioca
                 output = rbi_for(:Post)
 
                 expected = indented(<<~RBI, 4)
-                  sig { params(value: T.nilable(T::Array[T.untyped])).returns(T.nilable(T::Array[T.untyped])) }
+                  sig { params(value: ::T.nilable(::T::Array[::T.untyped])).returns(::T.nilable(::T::Array[::T.untyped])) }
                   def serialized_column_array=(value); end
                 RBI
                 assert_includes(output, expected)
 
                 expected = indented(<<~RBI, 4)
-                  sig { returns(T::Array[T.untyped]) }
+                  sig { returns(::T::Array[::T.untyped]) }
                   def serialized_column_array; end
                 RBI
                 assert_includes(output, expected)
 
                 expected = indented(<<~RBI, 4)
-                  sig { params(value: T.untyped).returns(T.untyped) }
+                  sig { params(value: ::T.untyped).returns(::T.untyped) }
                   def serialized_column_custom=(value); end
                 RBI
                 assert_includes(output, expected)
 
                 expected = indented(<<~RBI, 4)
-                  sig { returns(T.untyped) }
+                  sig { returns(::T.untyped) }
                   def serialized_column_custom; end
                 RBI
                 assert_includes(output, expected)
 
                 expected = indented(<<~RBI, 4)
-                  sig { params(value: T.nilable(T::Hash[T.untyped, T.untyped])).returns(T.nilable(T::Hash[T.untyped, T.untyped])) }
+                  sig { params(value: ::T.nilable(::T::Hash[::T.untyped, ::T.untyped])).returns(::T.nilable(::T::Hash[::T.untyped, ::T.untyped])) }
                   def serialized_column_hash=(value); end
                 RBI
                 assert_includes(output, expected)
 
                 expected = indented(<<~RBI, 4)
-                  sig { returns(T::Hash[T.untyped, T.untyped]) }
+                  sig { returns(::T::Hash[::T.untyped, ::T.untyped]) }
                   def serialized_column_hash; end
                 RBI
                 assert_includes(output, expected)
 
                 expected = indented(<<~RBI, 4)
-                  sig { params(value: T.untyped).returns(T.untyped) }
+                  sig { params(value: ::T.untyped).returns(::T.untyped) }
                   def serialized_column_json=(value); end
                 RBI
                 assert_includes(output, expected)
 
                 expected = indented(<<~RBI, 4)
-                  sig { returns(T.untyped) }
+                  sig { returns(::T.untyped) }
                   def serialized_column_json; end
                 RBI
                 assert_includes(output, expected)
@@ -648,7 +648,7 @@ module Tapioca
                 output = rbi_for(:Post)
 
                 expected = indented(<<~RBI, 4)
-                  sig { params(value: T.nilable(::BigDecimal)).returns(T.nilable(::BigDecimal)) }
+                  sig { params(value: ::T.nilable(::BigDecimal)).returns(::T.nilable(::BigDecimal)) }
                   def money_column=(value); end
                 RBI
                 assert_includes(output, expected)
@@ -676,19 +676,19 @@ module Tapioca
                 output = rbi_for(:Post)
 
                 expected = indented(<<~RBI, 4)
-                  sig { params(value: T.nilable(::ActiveSupport::TimeWithZone)).returns(T.nilable(::ActiveSupport::TimeWithZone)) }
+                  sig { params(value: ::T.nilable(::ActiveSupport::TimeWithZone)).returns(::T.nilable(::ActiveSupport::TimeWithZone)) }
                   def timestamp_column=(value); end
                 RBI
                 assert_includes(output, expected)
 
                 expected = indented(<<~RBI, 4)
-                  sig { params(value: T.nilable(::ActiveSupport::TimeWithZone)).returns(T.nilable(::ActiveSupport::TimeWithZone)) }
+                  sig { params(value: ::T.nilable(::ActiveSupport::TimeWithZone)).returns(::T.nilable(::ActiveSupport::TimeWithZone)) }
                   def datetime_column=(value); end
                 RBI
                 assert_includes(output, expected)
 
                 expected = indented(<<~RBI, 4)
-                  sig { params(value: T.nilable(::ActiveSupport::TimeWithZone)).returns(T.nilable(::ActiveSupport::TimeWithZone)) }
+                  sig { params(value: ::T.nilable(::ActiveSupport::TimeWithZone)).returns(::T.nilable(::ActiveSupport::TimeWithZone)) }
                   def time_column=(value); end
                 RBI
                 assert_includes(output, expected)
@@ -715,46 +715,46 @@ module Tapioca
 
                 expected = indented(<<~RBI, 2)
                   module GeneratedAttributeMethods
-                    sig { returns(T.nilable(::String)) }
+                    sig { returns(::T.nilable(::String)) }
                     def author; end
 
-                    sig { params(value: T.nilable(::String)).returns(T.nilable(::String)) }
+                    sig { params(value: ::T.nilable(::String)).returns(::T.nilable(::String)) }
                     def author=(value); end
 
-                    sig { returns(T::Boolean) }
+                    sig { returns(::T::Boolean) }
                     def author?; end
 
-                    sig { returns(T.nilable(::String)) }
+                    sig { returns(::T.nilable(::String)) }
                     def author_before_last_save; end
 
-                    sig { returns(T.untyped) }
+                    sig { returns(::T.untyped) }
                     def author_before_type_cast; end
 
-                    sig { returns(T::Boolean) }
+                    sig { returns(::T::Boolean) }
                     def author_came_from_user?; end
 
-                    sig { returns(T.nilable([T.nilable(::String), T.nilable(::String)])) }
+                    sig { returns(::T.nilable([::T.nilable(::String), ::T.nilable(::String)])) }
                     def author_change; end
 
-                    sig { returns(T.nilable([T.nilable(::String), T.nilable(::String)])) }
+                    sig { returns(::T.nilable([::T.nilable(::String), ::T.nilable(::String)])) }
                     def author_change_to_be_saved; end
 
-                    sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
-                    def author_changed?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+                    sig { params(from: ::T.untyped, to: ::T.untyped).returns(::T::Boolean) }
+                    def author_changed?(from: ::T.unsafe(nil), to: ::T.unsafe(nil)); end
 
-                    sig { returns(T.nilable(::String)) }
+                    sig { returns(::T.nilable(::String)) }
                     def author_in_database; end
 
-                    sig { returns(T.nilable([T.nilable(::String), T.nilable(::String)])) }
+                    sig { returns(::T.nilable([::T.nilable(::String), ::T.nilable(::String)])) }
                     def author_previous_change; end
 
-                    sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
-                    def author_previously_changed?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+                    sig { params(from: ::T.untyped, to: ::T.untyped).returns(::T::Boolean) }
+                    def author_previously_changed?(from: ::T.unsafe(nil), to: ::T.unsafe(nil)); end
 
-                    sig { returns(T.nilable(::String)) }
+                    sig { returns(::T.nilable(::String)) }
                     def author_previously_was; end
 
-                    sig { returns(T.nilable(::String)) }
+                    sig { returns(::T.nilable(::String)) }
                     def author_was; end
 
                     sig { void }
@@ -769,17 +769,17 @@ module Tapioca
                 assert_includes(output, expected)
 
                 expected = indented(<<~RBI, 4)
-                  sig { returns(T.nilable([T.nilable(::String), T.nilable(::String)])) }
+                  sig { returns(::T.nilable([::T.nilable(::String), ::T.nilable(::String)])) }
                   def saved_change_to_author; end
 
-                  sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
-                  def saved_change_to_author?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+                  sig { params(from: ::T.untyped, to: ::T.untyped).returns(::T::Boolean) }
+                  def saved_change_to_author?(from: ::T.unsafe(nil), to: ::T.unsafe(nil)); end
                 RBI
                 assert_includes(output, expected)
 
                 expected = indented(<<~RBI, 4)
-                  sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
-                  def will_save_change_to_author?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+                  sig { params(from: ::T.untyped, to: ::T.untyped).returns(::T::Boolean) }
+                  def will_save_change_to_author?(from: ::T.unsafe(nil), to: ::T.unsafe(nil)); end
                 RBI
                 assert_includes(output, expected)
               end
@@ -805,46 +805,46 @@ module Tapioca
 
                 expected = indented(<<~RBI, 2)
                   module GeneratedAttributeMethods
-                    sig { returns(T.nilable(::String)) }
+                    sig { returns(::T.nilable(::String)) }
                     def body; end
 
-                    sig { params(value: T.nilable(::String)).returns(T.nilable(::String)) }
+                    sig { params(value: ::T.nilable(::String)).returns(::T.nilable(::String)) }
                     def body=(value); end
 
-                    sig { returns(T::Boolean) }
+                    sig { returns(::T::Boolean) }
                     def body?; end
 
-                    sig { returns(T.nilable(::String)) }
+                    sig { returns(::T.nilable(::String)) }
                     def body_before_last_save; end
 
-                    sig { returns(T.untyped) }
+                    sig { returns(::T.untyped) }
                     def body_before_type_cast; end
 
-                    sig { returns(T::Boolean) }
+                    sig { returns(::T::Boolean) }
                     def body_came_from_user?; end
 
-                    sig { returns(T.nilable([T.nilable(::String), T.nilable(::String)])) }
+                    sig { returns(::T.nilable([::T.nilable(::String), ::T.nilable(::String)])) }
                     def body_change; end
 
-                    sig { returns(T.nilable([T.nilable(::String), T.nilable(::String)])) }
+                    sig { returns(::T.nilable([::T.nilable(::String), ::T.nilable(::String)])) }
                     def body_change_to_be_saved; end
 
-                    sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
-                    def body_changed?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+                    sig { params(from: ::T.untyped, to: ::T.untyped).returns(::T::Boolean) }
+                    def body_changed?(from: ::T.unsafe(nil), to: ::T.unsafe(nil)); end
 
-                    sig { returns(T.nilable(::String)) }
+                    sig { returns(::T.nilable(::String)) }
                     def body_in_database; end
 
-                    sig { returns(T.nilable([T.nilable(::String), T.nilable(::String)])) }
+                    sig { returns(::T.nilable([::T.nilable(::String), ::T.nilable(::String)])) }
                     def body_previous_change; end
 
-                    sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
-                    def body_previously_changed?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+                    sig { params(from: ::T.untyped, to: ::T.untyped).returns(::T::Boolean) }
+                    def body_previously_changed?(from: ::T.unsafe(nil), to: ::T.unsafe(nil)); end
 
-                    sig { returns(T.nilable(::String)) }
+                    sig { returns(::T.nilable(::String)) }
                     def body_previously_was; end
 
-                    sig { returns(T.nilable(::String)) }
+                    sig { returns(::T.nilable(::String)) }
                     def body_was; end
 
                     sig { void }
@@ -859,17 +859,17 @@ module Tapioca
                 assert_includes(output, expected)
 
                 expected = indented(<<~RBI, 4)
-                  sig { returns(T.nilable([T.nilable(::String), T.nilable(::String)])) }
+                  sig { returns(::T.nilable([::T.nilable(::String), ::T.nilable(::String)])) }
                   def saved_change_to_body; end
 
-                  sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
-                  def saved_change_to_body?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+                  sig { params(from: ::T.untyped, to: ::T.untyped).returns(::T::Boolean) }
+                  def saved_change_to_body?(from: ::T.unsafe(nil), to: ::T.unsafe(nil)); end
                 RBI
                 assert_includes(output, expected)
 
                 expected = indented(<<~RBI, 4)
-                  sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
-                  def will_save_change_to_body?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+                  sig { params(from: ::T.untyped, to: ::T.untyped).returns(::T::Boolean) }
+                  def will_save_change_to_body?(from: ::T.unsafe(nil), to: ::T.unsafe(nil)); end
                 RBI
                 assert_includes(output, expected)
               end
@@ -899,40 +899,40 @@ module Tapioca
                   sig { params(value: ::Date).returns(::Date) }
                   def publication_date=(value); end
 
-                  sig { returns(T::Boolean) }
+                  sig { returns(::T::Boolean) }
                   def publication_date?; end
 
-                  sig { returns(T.nilable(::Date)) }
+                  sig { returns(::T.nilable(::Date)) }
                   def publication_date_before_last_save; end
 
-                  sig { returns(T.untyped) }
+                  sig { returns(::T.untyped) }
                   def publication_date_before_type_cast; end
 
-                  sig { returns(T::Boolean) }
+                  sig { returns(::T::Boolean) }
                   def publication_date_came_from_user?; end
 
-                  sig { returns(T.nilable([::Date, ::Date])) }
+                  sig { returns(::T.nilable([::Date, ::Date])) }
                   def publication_date_change; end
 
-                  sig { returns(T.nilable([::Date, ::Date])) }
+                  sig { returns(::T.nilable([::Date, ::Date])) }
                   def publication_date_change_to_be_saved; end
 
-                  sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
-                  def publication_date_changed?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+                  sig { params(from: ::T.untyped, to: ::T.untyped).returns(::T::Boolean) }
+                  def publication_date_changed?(from: ::T.unsafe(nil), to: ::T.unsafe(nil)); end
 
-                  sig { returns(T.nilable(::Date)) }
+                  sig { returns(::T.nilable(::Date)) }
                   def publication_date_in_database; end
 
-                  sig { returns(T.nilable([::Date, ::Date])) }
+                  sig { returns(::T.nilable([::Date, ::Date])) }
                   def publication_date_previous_change; end
 
-                  sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
-                  def publication_date_previously_changed?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+                  sig { params(from: ::T.untyped, to: ::T.untyped).returns(::T::Boolean) }
+                  def publication_date_previously_changed?(from: ::T.unsafe(nil), to: ::T.unsafe(nil)); end
 
-                  sig { returns(T.nilable(::Date)) }
+                  sig { returns(::T.nilable(::Date)) }
                   def publication_date_previously_was; end
 
-                  sig { returns(T.nilable(::Date)) }
+                  sig { returns(::T.nilable(::Date)) }
                   def publication_date_was; end
 
                   sig { void }
@@ -947,17 +947,17 @@ module Tapioca
                 assert_includes(output, expected)
 
                 expected = indented(<<~RBI, 4)
-                  sig { returns(T.nilable([::Date, ::Date])) }
+                  sig { returns(::T.nilable([::Date, ::Date])) }
                   def saved_change_to_publication_date; end
 
-                  sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
-                  def saved_change_to_publication_date?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+                  sig { params(from: ::T.untyped, to: ::T.untyped).returns(::T::Boolean) }
+                  def saved_change_to_publication_date?(from: ::T.unsafe(nil), to: ::T.unsafe(nil)); end
                 RBI
                 assert_includes(output, expected)
 
                 expected = indented(<<~RBI, 4)
-                  sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
-                  def will_save_change_to_publication_date?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+                  sig { params(from: ::T.untyped, to: ::T.untyped).returns(::T::Boolean) }
+                  def will_save_change_to_publication_date?(from: ::T.unsafe(nil), to: ::T.unsafe(nil)); end
                 RBI
                 assert_includes(output, expected)
               end
@@ -980,13 +980,13 @@ module Tapioca
                 RUBY
 
                 expected = indented(<<~RBI, 4)
-                  sig { returns(T.nilable(::String)) }
+                  sig { returns(::T.nilable(::String)) }
                   def title; end
 
-                  sig { params(value: T.nilable(::String)).returns(T.nilable(::String)) }
+                  sig { params(value: ::T.nilable(::String)).returns(::T.nilable(::String)) }
                   def title=(value); end
 
-                  sig { returns(T::Boolean) }
+                  sig { returns(::T::Boolean) }
                   def title?; end
                 RBI
 
@@ -1030,17 +1030,17 @@ module Tapioca
                 RUBY
 
                 expected = indented(<<~RBI, 4)
-                  sig { returns(T.nilable(::CustomType)) }
+                  sig { returns(::T.nilable(::CustomType)) }
                   def cost; end
 
-                  sig { params(value: T.nilable(::CustomType)).returns(T.nilable(::CustomType)) }
+                  sig { params(value: ::T.nilable(::CustomType)).returns(::T.nilable(::CustomType)) }
                   def cost=(value); end
                 RBI
 
                 assert_includes(rbi_for(:Post), expected)
               end
 
-              it "strips T.nilable from reflected signatures method for non-nilable columns in persisted mode" do
+              it "strips ::T.nilable from reflected signatures method for non-nilable columns in persisted mode" do
                 add_ruby_file("schema.rb", <<~RUBY)
                   ActiveRecord::Migration.suppress_messages do
                     ActiveRecord::Schema.define do
@@ -1131,13 +1131,13 @@ module Tapioca
 
                 expected = indented(<<~RBI, 2)
                   module GeneratedAttributeMethods
-                    sig { returns(T.untyped) }
+                    sig { returns(::T.untyped) }
                     def body; end
 
-                    sig { params(value: T.untyped).returns(T.untyped) }
+                    sig { params(value: ::T.untyped).returns(::T.untyped) }
                     def body=(value); end
 
-                    sig { returns(T::Boolean) }
+                    sig { returns(::T::Boolean) }
                     def body?; end
                 RBI
 
@@ -1166,91 +1166,91 @@ module Tapioca
                     include GeneratedAttributeMethods
 
                     module GeneratedAttributeMethods
-                      sig { returns(T.untyped) }
+                      sig { returns(::T.untyped) }
                       def id; end
 
-                      sig { params(value: T.untyped).returns(T.untyped) }
+                      sig { params(value: ::T.untyped).returns(::T.untyped) }
                       def id=(value); end
 
-                      sig { returns(T::Boolean) }
+                      sig { returns(::T::Boolean) }
                       def id?; end
 
-                      sig { returns(T.untyped) }
+                      sig { returns(::T.untyped) }
                       def id_before_last_save; end
 
-                      sig { returns(T.untyped) }
+                      sig { returns(::T.untyped) }
                       def id_before_type_cast; end
 
-                      sig { returns(T::Boolean) }
+                      sig { returns(::T::Boolean) }
                       def id_came_from_user?; end
 
-                      sig { returns(T.nilable([T.untyped, T.untyped])) }
+                      sig { returns(::T.nilable([::T.untyped, ::T.untyped])) }
                       def id_change; end
 
-                      sig { returns(T.nilable([T.untyped, T.untyped])) }
+                      sig { returns(::T.nilable([::T.untyped, ::T.untyped])) }
                       def id_change_to_be_saved; end
 
-                      sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
-                      def id_changed?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+                      sig { params(from: ::T.untyped, to: ::T.untyped).returns(::T::Boolean) }
+                      def id_changed?(from: ::T.unsafe(nil), to: ::T.unsafe(nil)); end
 
-                      sig { returns(T.untyped) }
+                      sig { returns(::T.untyped) }
                       def id_in_database; end
 
-                      sig { returns(T.nilable([T.untyped, T.untyped])) }
+                      sig { returns(::T.nilable([::T.untyped, ::T.untyped])) }
                       def id_previous_change; end
 
-                      sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
-                      def id_previously_changed?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+                      sig { params(from: ::T.untyped, to: ::T.untyped).returns(::T::Boolean) }
+                      def id_previously_changed?(from: ::T.unsafe(nil), to: ::T.unsafe(nil)); end
 
-                      sig { returns(T.untyped) }
+                      sig { returns(::T.untyped) }
                       def id_previously_was; end
 
-                      sig { returns(T.untyped) }
+                      sig { returns(::T.untyped) }
                       def id_value; end
 
-                      sig { params(value: T.untyped).returns(T.untyped) }
+                      sig { params(value: ::T.untyped).returns(::T.untyped) }
                       def id_value=(value); end
 
-                      sig { returns(T::Boolean) }
+                      sig { returns(::T::Boolean) }
                       def id_value?; end
 
-                      sig { returns(T.untyped) }
+                      sig { returns(::T.untyped) }
                       def id_value_before_last_save; end
 
-                      sig { returns(T.untyped) }
+                      sig { returns(::T.untyped) }
                       def id_value_before_type_cast; end
 
-                      sig { returns(T::Boolean) }
+                      sig { returns(::T::Boolean) }
                       def id_value_came_from_user?; end
 
-                      sig { returns(T.nilable([T.untyped, T.untyped])) }
+                      sig { returns(::T.nilable([::T.untyped, ::T.untyped])) }
                       def id_value_change; end
 
-                      sig { returns(T.nilable([T.untyped, T.untyped])) }
+                      sig { returns(::T.nilable([::T.untyped, ::T.untyped])) }
                       def id_value_change_to_be_saved; end
 
-                      sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
-                      def id_value_changed?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+                      sig { params(from: ::T.untyped, to: ::T.untyped).returns(::T::Boolean) }
+                      def id_value_changed?(from: ::T.unsafe(nil), to: ::T.unsafe(nil)); end
 
-                      sig { returns(T.untyped) }
+                      sig { returns(::T.untyped) }
                       def id_value_in_database; end
 
-                      sig { returns(T.nilable([T.untyped, T.untyped])) }
+                      sig { returns(::T.nilable([::T.untyped, ::T.untyped])) }
                       def id_value_previous_change; end
 
-                      sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
-                      def id_value_previously_changed?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+                      sig { params(from: ::T.untyped, to: ::T.untyped).returns(::T::Boolean) }
+                      def id_value_previously_changed?(from: ::T.unsafe(nil), to: ::T.unsafe(nil)); end
 
-                      sig { returns(T.untyped) }
+                      sig { returns(::T.untyped) }
                       def id_value_previously_was; end
 
-                      sig { returns(T.untyped) }
+                      sig { returns(::T.untyped) }
                       def id_value_was; end
 
                       sig { void }
                       def id_value_will_change!; end
 
-                      sig { returns(T.untyped) }
+                      sig { returns(::T.untyped) }
                       def id_was; end
 
                       sig { void }
@@ -1262,23 +1262,23 @@ module Tapioca
                       sig { void }
                       def restore_id_value!; end
 
-                      sig { returns(T.nilable([T.untyped, T.untyped])) }
+                      sig { returns(::T.nilable([::T.untyped, ::T.untyped])) }
                       def saved_change_to_id; end
 
-                      sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
-                      def saved_change_to_id?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+                      sig { params(from: ::T.untyped, to: ::T.untyped).returns(::T::Boolean) }
+                      def saved_change_to_id?(from: ::T.unsafe(nil), to: ::T.unsafe(nil)); end
 
-                      sig { returns(T.nilable([T.untyped, T.untyped])) }
+                      sig { returns(::T.nilable([::T.untyped, ::T.untyped])) }
                       def saved_change_to_id_value; end
 
-                      sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
-                      def saved_change_to_id_value?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+                      sig { params(from: ::T.untyped, to: ::T.untyped).returns(::T::Boolean) }
+                      def saved_change_to_id_value?(from: ::T.unsafe(nil), to: ::T.unsafe(nil)); end
 
-                      sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
-                      def will_save_change_to_id?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+                      sig { params(from: ::T.untyped, to: ::T.untyped).returns(::T::Boolean) }
+                      def will_save_change_to_id?(from: ::T.unsafe(nil), to: ::T.unsafe(nil)); end
 
-                      sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
-                      def will_save_change_to_id_value?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+                      sig { params(from: ::T.untyped, to: ::T.untyped).returns(::T::Boolean) }
+                      def will_save_change_to_id_value?(from: ::T.unsafe(nil), to: ::T.unsafe(nil)); end
                     end
                   end
                 RBI
@@ -1308,13 +1308,13 @@ module Tapioca
 
                 expected = indented(<<~RBI, 2)
                   module GeneratedAttributeMethods
-                    sig { returns(T.nilable(::String)) }
+                    sig { returns(::T.nilable(::String)) }
                     def body; end
 
-                    sig { params(value: T.nilable(::String)).returns(T.nilable(::String)) }
+                    sig { params(value: ::T.nilable(::String)).returns(::T.nilable(::String)) }
                     def body=(value); end
 
-                    sig { returns(T::Boolean) }
+                    sig { returns(::T::Boolean) }
                     def body?; end
                 RBI
 
@@ -1343,91 +1343,91 @@ module Tapioca
                     include GeneratedAttributeMethods
 
                     module GeneratedAttributeMethods
-                      sig { returns(T.nilable(::Integer)) }
+                      sig { returns(::T.nilable(::Integer)) }
                       def id; end
 
-                      sig { params(value: T.nilable(::Integer)).returns(T.nilable(::Integer)) }
+                      sig { params(value: ::T.nilable(::Integer)).returns(::T.nilable(::Integer)) }
                       def id=(value); end
 
-                      sig { returns(T::Boolean) }
+                      sig { returns(::T::Boolean) }
                       def id?; end
 
-                      sig { returns(T.nilable(::Integer)) }
+                      sig { returns(::T.nilable(::Integer)) }
                       def id_before_last_save; end
 
-                      sig { returns(T.untyped) }
+                      sig { returns(::T.untyped) }
                       def id_before_type_cast; end
 
-                      sig { returns(T::Boolean) }
+                      sig { returns(::T::Boolean) }
                       def id_came_from_user?; end
 
-                      sig { returns(T.nilable([T.nilable(::Integer), T.nilable(::Integer)])) }
+                      sig { returns(::T.nilable([::T.nilable(::Integer), ::T.nilable(::Integer)])) }
                       def id_change; end
 
-                      sig { returns(T.nilable([T.nilable(::Integer), T.nilable(::Integer)])) }
+                      sig { returns(::T.nilable([::T.nilable(::Integer), ::T.nilable(::Integer)])) }
                       def id_change_to_be_saved; end
 
-                      sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
-                      def id_changed?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+                      sig { params(from: ::T.untyped, to: ::T.untyped).returns(::T::Boolean) }
+                      def id_changed?(from: ::T.unsafe(nil), to: ::T.unsafe(nil)); end
 
-                      sig { returns(T.nilable(::Integer)) }
+                      sig { returns(::T.nilable(::Integer)) }
                       def id_in_database; end
 
-                      sig { returns(T.nilable([T.nilable(::Integer), T.nilable(::Integer)])) }
+                      sig { returns(::T.nilable([::T.nilable(::Integer), ::T.nilable(::Integer)])) }
                       def id_previous_change; end
 
-                      sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
-                      def id_previously_changed?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+                      sig { params(from: ::T.untyped, to: ::T.untyped).returns(::T::Boolean) }
+                      def id_previously_changed?(from: ::T.unsafe(nil), to: ::T.unsafe(nil)); end
 
-                      sig { returns(T.nilable(::Integer)) }
+                      sig { returns(::T.nilable(::Integer)) }
                       def id_previously_was; end
 
-                      sig { returns(T.nilable(::Integer)) }
+                      sig { returns(::T.nilable(::Integer)) }
                       def id_value; end
 
-                      sig { params(value: T.nilable(::Integer)).returns(T.nilable(::Integer)) }
+                      sig { params(value: ::T.nilable(::Integer)).returns(::T.nilable(::Integer)) }
                       def id_value=(value); end
 
-                      sig { returns(T::Boolean) }
+                      sig { returns(::T::Boolean) }
                       def id_value?; end
 
-                      sig { returns(T.nilable(::Integer)) }
+                      sig { returns(::T.nilable(::Integer)) }
                       def id_value_before_last_save; end
 
-                      sig { returns(T.untyped) }
+                      sig { returns(::T.untyped) }
                       def id_value_before_type_cast; end
 
-                      sig { returns(T::Boolean) }
+                      sig { returns(::T::Boolean) }
                       def id_value_came_from_user?; end
 
-                      sig { returns(T.nilable([T.nilable(::Integer), T.nilable(::Integer)])) }
+                      sig { returns(::T.nilable([::T.nilable(::Integer), ::T.nilable(::Integer)])) }
                       def id_value_change; end
 
-                      sig { returns(T.nilable([T.nilable(::Integer), T.nilable(::Integer)])) }
+                      sig { returns(::T.nilable([::T.nilable(::Integer), ::T.nilable(::Integer)])) }
                       def id_value_change_to_be_saved; end
 
-                      sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
-                      def id_value_changed?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+                      sig { params(from: ::T.untyped, to: ::T.untyped).returns(::T::Boolean) }
+                      def id_value_changed?(from: ::T.unsafe(nil), to: ::T.unsafe(nil)); end
 
-                      sig { returns(T.nilable(::Integer)) }
+                      sig { returns(::T.nilable(::Integer)) }
                       def id_value_in_database; end
 
-                      sig { returns(T.nilable([T.nilable(::Integer), T.nilable(::Integer)])) }
+                      sig { returns(::T.nilable([::T.nilable(::Integer), ::T.nilable(::Integer)])) }
                       def id_value_previous_change; end
 
-                      sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
-                      def id_value_previously_changed?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+                      sig { params(from: ::T.untyped, to: ::T.untyped).returns(::T::Boolean) }
+                      def id_value_previously_changed?(from: ::T.unsafe(nil), to: ::T.unsafe(nil)); end
 
-                      sig { returns(T.nilable(::Integer)) }
+                      sig { returns(::T.nilable(::Integer)) }
                       def id_value_previously_was; end
 
-                      sig { returns(T.nilable(::Integer)) }
+                      sig { returns(::T.nilable(::Integer)) }
                       def id_value_was; end
 
                       sig { void }
                       def id_value_will_change!; end
 
-                      sig { returns(T.nilable(::Integer)) }
+                      sig { returns(::T.nilable(::Integer)) }
                       def id_was; end
 
                       sig { void }
@@ -1439,23 +1439,23 @@ module Tapioca
                       sig { void }
                       def restore_id_value!; end
 
-                      sig { returns(T.nilable([T.nilable(::Integer), T.nilable(::Integer)])) }
+                      sig { returns(::T.nilable([::T.nilable(::Integer), ::T.nilable(::Integer)])) }
                       def saved_change_to_id; end
 
-                      sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
-                      def saved_change_to_id?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+                      sig { params(from: ::T.untyped, to: ::T.untyped).returns(::T::Boolean) }
+                      def saved_change_to_id?(from: ::T.unsafe(nil), to: ::T.unsafe(nil)); end
 
-                      sig { returns(T.nilable([T.nilable(::Integer), T.nilable(::Integer)])) }
+                      sig { returns(::T.nilable([::T.nilable(::Integer), ::T.nilable(::Integer)])) }
                       def saved_change_to_id_value; end
 
-                      sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
-                      def saved_change_to_id_value?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+                      sig { params(from: ::T.untyped, to: ::T.untyped).returns(::T::Boolean) }
+                      def saved_change_to_id_value?(from: ::T.unsafe(nil), to: ::T.unsafe(nil)); end
 
-                      sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
-                      def will_save_change_to_id?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+                      sig { params(from: ::T.untyped, to: ::T.untyped).returns(::T::Boolean) }
+                      def will_save_change_to_id?(from: ::T.unsafe(nil), to: ::T.unsafe(nil)); end
 
-                      sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
-                      def will_save_change_to_id_value?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+                      sig { params(from: ::T.untyped, to: ::T.untyped).returns(::T::Boolean) }
+                      def will_save_change_to_id_value?(from: ::T.unsafe(nil), to: ::T.unsafe(nil)); end
                     end
                   end
                 RBI
@@ -1493,7 +1493,7 @@ module Tapioca
                     sig { params(value: ::String).returns(::String) }
                     def body=(value); end
 
-                    sig { returns(T::Boolean) }
+                    sig { returns(::T::Boolean) }
                     def body?; end
                 RBI
 

--- a/spec/tapioca/dsl/compilers/active_record_delegated_types_spec.rb
+++ b/spec/tapioca/dsl/compilers/active_record_delegated_types_spec.rb
@@ -104,31 +104,31 @@ module Tapioca
                   include GeneratedDelegatedTypeMethods
 
                   module GeneratedDelegatedTypeMethods
-                    sig { params(args: T.untyped).returns(T.any(Message, Comment)) }
+                    sig { params(args: ::T.untyped).returns(::T.any(Message, Comment)) }
                     def build_entryable(*args); end
 
-                    sig { returns(T.nilable(Comment)) }
+                    sig { returns(::T.nilable(Comment)) }
                     def comment; end
 
-                    sig { returns(T::Boolean) }
+                    sig { returns(::T::Boolean) }
                     def comment?; end
 
-                    sig { returns(T.nilable(::Integer)) }
+                    sig { returns(::T.nilable(::Integer)) }
                     def comment_id; end
 
-                    sig { returns(T::Class[T.anything]) }
+                    sig { returns(::T::Class[::T.anything]) }
                     def entryable_class; end
 
                     sig { returns(ActiveSupport::StringInquirer) }
                     def entryable_name; end
 
-                    sig { returns(T.nilable(Message)) }
+                    sig { returns(::T.nilable(Message)) }
                     def message; end
 
-                    sig { returns(T::Boolean) }
+                    sig { returns(::T::Boolean) }
                     def message?; end
 
-                    sig { returns(T.nilable(::Integer)) }
+                    sig { returns(::T.nilable(::Integer)) }
                     def message_id; end
                   end
                 end
@@ -172,31 +172,31 @@ module Tapioca
                   include GeneratedDelegatedTypeMethods
 
                   module GeneratedDelegatedTypeMethods
-                    sig { params(args: T.untyped).returns(T.any(Message, Comment)) }
+                    sig { params(args: ::T.untyped).returns(::T.any(Message, Comment)) }
                     def build_entryable(*args); end
 
-                    sig { returns(T.nilable(Comment)) }
+                    sig { returns(::T.nilable(Comment)) }
                     def comment; end
 
-                    sig { returns(T::Boolean) }
+                    sig { returns(::T::Boolean) }
                     def comment?; end
 
-                    sig { returns(T.nilable(::String)) }
+                    sig { returns(::T.nilable(::String)) }
                     def comment_uuid; end
 
-                    sig { returns(T::Class[T.anything]) }
+                    sig { returns(::T::Class[::T.anything]) }
                     def entryable_class; end
 
                     sig { returns(ActiveSupport::StringInquirer) }
                     def entryable_name; end
 
-                    sig { returns(T.nilable(Message)) }
+                    sig { returns(::T.nilable(Message)) }
                     def message; end
 
-                    sig { returns(T::Boolean) }
+                    sig { returns(::T::Boolean) }
                     def message?; end
 
-                    sig { returns(T.nilable(::String)) }
+                    sig { returns(::T.nilable(::String)) }
                     def message_uuid; end
                   end
                 end
@@ -235,22 +235,22 @@ module Tapioca
                   include GeneratedDelegatedTypeMethods
 
                   module GeneratedDelegatedTypeMethods
-                    sig { params(args: T.untyped).returns(Message) }
+                    sig { params(args: ::T.untyped).returns(Message) }
                     def build_entryable(*args); end
 
-                    sig { returns(T::Class[T.anything]) }
+                    sig { returns(::T::Class[::T.anything]) }
                     def entryable_class; end
 
                     sig { returns(ActiveSupport::StringInquirer) }
                     def entryable_name; end
 
-                    sig { returns(T.nilable(Message)) }
+                    sig { returns(::T.nilable(Message)) }
                     def message; end
 
-                    sig { returns(T::Boolean) }
+                    sig { returns(::T::Boolean) }
                     def message?; end
 
-                    sig { returns(T.nilable(::Integer)) }
+                    sig { returns(::T.nilable(::Integer)) }
                     def message_id; end
                   end
                 end

--- a/spec/tapioca/dsl/compilers/active_record_enum_spec.rb
+++ b/spec/tapioca/dsl/compilers/active_record_enum_spec.rb
@@ -50,7 +50,7 @@ module Tapioca
                   include EnumMethodsModule
 
                   class << self
-                    sig { returns(T::Hash[T.any(String, Symbol), Integer]) }
+                    sig { returns(::T::Hash[::T.any(String, Symbol), Integer]) }
                     def statuses; end
                   end
 
@@ -58,13 +58,13 @@ module Tapioca
                     sig { void }
                     def active!; end
 
-                    sig { returns(T::Boolean) }
+                    sig { returns(::T::Boolean) }
                     def active?; end
 
                     sig { void }
                     def archived!; end
 
-                    sig { returns(T::Boolean) }
+                    sig { returns(::T::Boolean) }
                     def archived?; end
                   end
                 end
@@ -88,7 +88,7 @@ module Tapioca
                   include EnumMethodsModule
 
                   class << self
-                    sig { returns(T::Hash[T.any(String, Symbol), String]) }
+                    sig { returns(::T::Hash[::T.any(String, Symbol), String]) }
                     def statuses; end
                   end
 
@@ -96,13 +96,13 @@ module Tapioca
                     sig { void }
                     def active!; end
 
-                    sig { returns(T::Boolean) }
+                    sig { returns(::T::Boolean) }
                     def active?; end
 
                     sig { void }
                     def archived!; end
 
-                    sig { returns(T::Boolean) }
+                    sig { returns(::T::Boolean) }
                     def archived?; end
                   end
                 end
@@ -125,7 +125,7 @@ module Tapioca
                   include EnumMethodsModule
 
                   class << self
-                    sig { returns(T::Hash[T.any(String, Symbol), T.any(Integer, TrueClass, String)]) }
+                    sig { returns(::T::Hash[::T.any(String, Symbol), ::T.any(Integer, TrueClass, String)]) }
                     def statuses; end
                   end
 
@@ -133,19 +133,19 @@ module Tapioca
                     sig { void }
                     def active!; end
 
-                    sig { returns(T::Boolean) }
+                    sig { returns(::T::Boolean) }
                     def active?; end
 
                     sig { void }
                     def archived!; end
 
-                    sig { returns(T::Boolean) }
+                    sig { returns(::T::Boolean) }
                     def archived?; end
 
                     sig { void }
                     def inactive!; end
 
-                    sig { returns(T::Boolean) }
+                    sig { returns(::T::Boolean) }
                     def inactive?; end
                   end
                 end
@@ -169,10 +169,10 @@ module Tapioca
                   include EnumMethodsModule
 
                   class << self
-                    sig { returns(T::Hash[T.any(String, Symbol), Integer]) }
+                    sig { returns(::T::Hash[::T.any(String, Symbol), Integer]) }
                     def comments_statuses; end
 
-                    sig { returns(T::Hash[T.any(String, Symbol), Integer]) }
+                    sig { returns(::T::Hash[::T.any(String, Symbol), Integer]) }
                     def statuses; end
                   end
 
@@ -180,25 +180,25 @@ module Tapioca
                     sig { void }
                     def active!; end
 
-                    sig { returns(T::Boolean) }
+                    sig { returns(::T::Boolean) }
                     def active?; end
 
                     sig { void }
                     def archived!; end
 
-                    sig { returns(T::Boolean) }
+                    sig { returns(::T::Boolean) }
                     def archived?; end
 
                     sig { void }
                     def off!; end
 
-                    sig { returns(T::Boolean) }
+                    sig { returns(::T::Boolean) }
                     def off?; end
 
                     sig { void }
                     def on!; end
 
-                    sig { returns(T::Boolean) }
+                    sig { returns(::T::Boolean) }
                     def on?; end
                   end
                 end
@@ -222,10 +222,10 @@ module Tapioca
                   include EnumMethodsModule
 
                   class << self
-                    sig { returns(T::Hash[T.any(String, Symbol), T.any(Integer, FalseClass, String)]) }
+                    sig { returns(::T::Hash[::T.any(String, Symbol), ::T.any(Integer, FalseClass, String)]) }
                     def comments_statuses; end
 
-                    sig { returns(T::Hash[T.any(String, Symbol), T.any(Integer, TrueClass, String)]) }
+                    sig { returns(::T::Hash[::T.any(String, Symbol), ::T.any(Integer, TrueClass, String)]) }
                     def statuses; end
                   end
 
@@ -233,37 +233,37 @@ module Tapioca
                     sig { void }
                     def active!; end
 
-                    sig { returns(T::Boolean) }
+                    sig { returns(::T::Boolean) }
                     def active?; end
 
                     sig { void }
                     def archived!; end
 
-                    sig { returns(T::Boolean) }
+                    sig { returns(::T::Boolean) }
                     def archived?; end
 
                     sig { void }
                     def inactive!; end
 
-                    sig { returns(T::Boolean) }
+                    sig { returns(::T::Boolean) }
                     def inactive?; end
 
                     sig { void }
                     def off!; end
 
-                    sig { returns(T::Boolean) }
+                    sig { returns(::T::Boolean) }
                     def off?; end
 
                     sig { void }
                     def on!; end
 
-                    sig { returns(T::Boolean) }
+                    sig { returns(::T::Boolean) }
                     def on?; end
 
                     sig { void }
                     def ongoing!; end
 
-                    sig { returns(T::Boolean) }
+                    sig { returns(::T::Boolean) }
                     def ongoing?; end
                   end
                 end
@@ -286,7 +286,7 @@ module Tapioca
                   include EnumMethodsModule
 
                   class << self
-                    sig { returns(T::Hash[T.any(String, Symbol), Integer]) }
+                    sig { returns(::T::Hash[::T.any(String, Symbol), Integer]) }
                     def statuses; end
                   end
 
@@ -294,13 +294,13 @@ module Tapioca
                     sig { void }
                     def active_status!; end
 
-                    sig { returns(T::Boolean) }
+                    sig { returns(::T::Boolean) }
                     def active_status?; end
 
                     sig { void }
                     def archived_status!; end
 
-                    sig { returns(T::Boolean) }
+                    sig { returns(::T::Boolean) }
                     def archived_status?; end
                   end
                 end
@@ -323,7 +323,7 @@ module Tapioca
                   include EnumMethodsModule
 
                   class << self
-                    sig { returns(T::Hash[T.any(String, Symbol), Integer]) }
+                    sig { returns(::T::Hash[::T.any(String, Symbol), Integer]) }
                     def statuses; end
                   end
 
@@ -331,13 +331,13 @@ module Tapioca
                     sig { void }
                     def comments_active!; end
 
-                    sig { returns(T::Boolean) }
+                    sig { returns(::T::Boolean) }
                     def comments_active?; end
 
                     sig { void }
                     def comments_archived!; end
 
-                    sig { returns(T::Boolean) }
+                    sig { returns(::T::Boolean) }
                     def comments_archived?; end
                   end
                 end
@@ -364,7 +364,7 @@ module Tapioca
                   include EnumMethodsModule
 
                   class << self
-                    sig { returns(T::Hash[T.any(String, Symbol), Integer]) }
+                    sig { returns(::T::Hash[::T.any(String, Symbol), Integer]) }
                     def statuses; end
                   end
 
@@ -372,7 +372,7 @@ module Tapioca
                     sig { void }
                     def inactive!; end
 
-                    sig { returns(T::Boolean) }
+                    sig { returns(::T::Boolean) }
                     def inactive?; end
                   end
                 end
@@ -387,7 +387,7 @@ module Tapioca
                   include EnumMethodsModule
 
                   class << self
-                    sig { returns(T::Hash[T.any(String, Symbol), Integer]) }
+                    sig { returns(::T::Hash[::T.any(String, Symbol), Integer]) }
                     def statuses; end
                   end
 
@@ -395,13 +395,13 @@ module Tapioca
                     sig { void }
                     def active!; end
 
-                    sig { returns(T::Boolean) }
+                    sig { returns(::T::Boolean) }
                     def active?; end
 
                     sig { void }
                     def archived!; end
 
-                    sig { returns(T::Boolean) }
+                    sig { returns(::T::Boolean) }
                     def archived?; end
                   end
                 end
@@ -430,7 +430,7 @@ module Tapioca
                   include EnumMethodsModule
 
                   class << self
-                    sig { returns(T::Hash[T.any(String, Symbol), Integer]) }
+                    sig { returns(::T::Hash[::T.any(String, Symbol), Integer]) }
                     def statuses; end
                   end
 
@@ -438,7 +438,7 @@ module Tapioca
                     sig { void }
                     def inactive!; end
 
-                    sig { returns(T::Boolean) }
+                    sig { returns(::T::Boolean) }
                     def inactive?; end
                   end
                 end
@@ -453,7 +453,7 @@ module Tapioca
                   include EnumMethodsModule
 
                   class << self
-                    sig { returns(T::Hash[T.any(String, Symbol), Integer]) }
+                    sig { returns(::T::Hash[::T.any(String, Symbol), Integer]) }
                     def statuses; end
                   end
 
@@ -461,13 +461,13 @@ module Tapioca
                     sig { void }
                     def active!; end
 
-                    sig { returns(T::Boolean) }
+                    sig { returns(::T::Boolean) }
                     def active?; end
 
                     sig { void }
                     def archived!; end
 
-                    sig { returns(T::Boolean) }
+                    sig { returns(::T::Boolean) }
                     def archived?; end
                   end
                 end

--- a/spec/tapioca/dsl/compilers/active_record_fixtures_spec.rb
+++ b/spec/tapioca/dsl/compilers/active_record_fixtures_spec.rb
@@ -79,9 +79,9 @@ module Tapioca
                 # typed: strong
 
                 class ActiveSupport::TestCase
-                  sig { params(fixture_name: NilClass, other_fixtures: NilClass).returns(T::Array[Post]) }
-                  sig { params(fixture_name: T.any(String, Symbol), other_fixtures: NilClass).returns(Post) }
-                  sig { params(fixture_name: T.any(String, Symbol), other_fixtures: T.any(String, Symbol)).returns(T::Array[Post]) }
+                  sig { params(fixture_name: ::NilClass, other_fixtures: ::NilClass).returns(::T::Array[Post]) }
+                  sig { params(fixture_name: ::T.any(String, Symbol), other_fixtures: ::NilClass).returns(Post) }
+                  sig { params(fixture_name: ::T.any(String, Symbol), other_fixtures: ::T.any(String, Symbol)).returns(::T::Array[Post]) }
                   def posts(fixture_name = nil, *other_fixtures); end
                 end
               RBI
@@ -107,9 +107,9 @@ module Tapioca
                 # typed: strong
 
                 class ActiveSupport::TestCase
-                  sig { params(fixture_name: NilClass, other_fixtures: NilClass).returns(T::Array[Post]) }
-                  sig { params(fixture_name: T.any(String, Symbol), other_fixtures: NilClass).returns(Post) }
-                  sig { params(fixture_name: T.any(String, Symbol), other_fixtures: T.any(String, Symbol)).returns(T::Array[Post]) }
+                  sig { params(fixture_name: ::NilClass, other_fixtures: ::NilClass).returns(::T::Array[Post]) }
+                  sig { params(fixture_name: ::T.any(String, Symbol), other_fixtures: ::NilClass).returns(Post) }
+                  sig { params(fixture_name: ::T.any(String, Symbol), other_fixtures: ::T.any(String, Symbol)).returns(::T::Array[Post]) }
                   def posts(fixture_name = nil, *other_fixtures); end
                 end
               RBI
@@ -146,14 +146,14 @@ module Tapioca
                 # typed: strong
 
                 class ActiveSupport::TestCase
-                  sig { params(fixture_name: NilClass, other_fixtures: NilClass).returns(T::Array[Blog::Post]) }
-                  sig { params(fixture_name: T.any(String, Symbol), other_fixtures: NilClass).returns(Blog::Post) }
-                  sig { params(fixture_name: T.any(String, Symbol), other_fixtures: T.any(String, Symbol)).returns(T::Array[Blog::Post]) }
+                  sig { params(fixture_name: ::NilClass, other_fixtures: ::NilClass).returns(::T::Array[Blog::Post]) }
+                  sig { params(fixture_name: ::T.any(String, Symbol), other_fixtures: ::NilClass).returns(Blog::Post) }
+                  sig { params(fixture_name: ::T.any(String, Symbol), other_fixtures: ::T.any(String, Symbol)).returns(::T::Array[Blog::Post]) }
                   def blog_posts(fixture_name = nil, *other_fixtures); end
 
-                  sig { params(fixture_name: NilClass, other_fixtures: NilClass).returns(T::Array[User]) }
-                  sig { params(fixture_name: T.any(String, Symbol), other_fixtures: NilClass).returns(User) }
-                  sig { params(fixture_name: T.any(String, Symbol), other_fixtures: T.any(String, Symbol)).returns(T::Array[User]) }
+                  sig { params(fixture_name: ::NilClass, other_fixtures: ::NilClass).returns(::T::Array[User]) }
+                  sig { params(fixture_name: ::T.any(String, Symbol), other_fixtures: ::NilClass).returns(User) }
+                  sig { params(fixture_name: ::T.any(String, Symbol), other_fixtures: ::T.any(String, Symbol)).returns(::T::Array[User]) }
                   def users(fixture_name = nil, *other_fixtures); end
                 end
               RBI
@@ -181,9 +181,9 @@ module Tapioca
                 # typed: strong
 
                 class ActiveSupport::TestCase
-                  sig { params(fixture_name: NilClass, other_fixtures: NilClass).returns(T::Array[Post]) }
-                  sig { params(fixture_name: T.any(String, Symbol), other_fixtures: NilClass).returns(Post) }
-                  sig { params(fixture_name: T.any(String, Symbol), other_fixtures: T.any(String, Symbol)).returns(T::Array[Post]) }
+                  sig { params(fixture_name: ::NilClass, other_fixtures: ::NilClass).returns(::T::Array[Post]) }
+                  sig { params(fixture_name: ::T.any(String, Symbol), other_fixtures: ::NilClass).returns(Post) }
+                  sig { params(fixture_name: ::T.any(String, Symbol), other_fixtures: ::T.any(String, Symbol)).returns(::T::Array[Post]) }
                   def posts_with_other_names(fixture_name = nil, *other_fixtures); end
                 end
               RBI
@@ -191,7 +191,7 @@ module Tapioca
               assert_equal(expected, rbi_for("ActiveSupport::TestCase"))
             end
 
-            it "generates methods for fixtures with a fallback to T.untyped if no matching model exists" do
+            it "generates methods for fixtures with a fallback to ::T.untyped if no matching model exists" do
               add_content_file("test/fixtures/posts.yml", <<~YAML)
                 super_post:
                   title: An incredible Ruby post
@@ -204,9 +204,9 @@ module Tapioca
                 # typed: strong
 
                 class ActiveSupport::TestCase
-                  sig { params(fixture_name: NilClass, other_fixtures: NilClass).returns(T::Array[T.untyped]) }
-                  sig { params(fixture_name: T.any(String, Symbol), other_fixtures: NilClass).returns(T.untyped) }
-                  sig { params(fixture_name: T.any(String, Symbol), other_fixtures: T.any(String, Symbol)).returns(T::Array[T.untyped]) }
+                  sig { params(fixture_name: ::NilClass, other_fixtures: ::NilClass).returns(::T::Array[::T.untyped]) }
+                  sig { params(fixture_name: ::T.any(String, Symbol), other_fixtures: ::NilClass).returns(::T.untyped) }
+                  sig { params(fixture_name: ::T.any(String, Symbol), other_fixtures: ::T.any(String, Symbol)).returns(::T::Array[::T.untyped]) }
                   def posts(fixture_name = nil, *other_fixtures); end
                 end
               RBI

--- a/spec/tapioca/dsl/compilers/active_record_relations_spec.rb
+++ b/spec/tapioca/dsl/compilers/active_record_relations_spec.rb
@@ -87,211 +87,211 @@ module Tapioca
 
                   private
 
-                  sig { returns(NilClass) }
+                  sig { returns(::NilClass) }
                   def to_ary; end
 
                   class << self
-                    sig { params(attributes: T.untyped, block: T.nilable(T.proc.params(object: ::Post).void)).returns(::Post) }
+                    sig { params(attributes: ::T.untyped, block: ::T.nilable(::T.proc.params(object: ::Post).void)).returns(::Post) }
                     def new(attributes = nil, &block); end
                   end
 
                   module CommonRelationMethods
-                    sig { params(block: T.nilable(T.proc.params(record: ::Post).returns(T.untyped))).returns(T::Boolean) }
+                    sig { params(block: ::T.nilable(::T.proc.params(record: ::Post).returns(::T.untyped))).returns(::T::Boolean) }
                     def any?(&block); end
 
-                    sig { params(column_name: T.any(String, Symbol)).returns(T.any(Integer, Float, BigDecimal)) }
+                    sig { params(column_name: ::T.any(String, Symbol)).returns(::T.any(Integer, Float, BigDecimal)) }
                     def average(column_name); end
 
-                    sig { params(block: T.nilable(T.proc.params(object: ::Post).void)).returns(::Post) }
-                    sig { params(attributes: T::Array[T.untyped], block: T.nilable(T.proc.params(object: ::Post).void)).returns(T::Array[::Post]) }
-                    sig { params(attributes: T.untyped, block: T.nilable(T.proc.params(object: ::Post).void)).returns(::Post) }
+                    sig { params(block: ::T.nilable(::T.proc.params(object: ::Post).void)).returns(::Post) }
+                    sig { params(attributes: ::T::Array[::T.untyped], block: ::T.nilable(::T.proc.params(object: ::Post).void)).returns(::T::Array[::Post]) }
+                    sig { params(attributes: ::T.untyped, block: ::T.nilable(::T.proc.params(object: ::Post).void)).returns(::Post) }
                     def build(attributes = nil, &block); end
 
-                    sig { params(operation: Symbol, column_name: T.any(String, Symbol)).returns(T.any(Integer, Float, BigDecimal)) }
+                    sig { params(operation: Symbol, column_name: ::T.any(String, Symbol)).returns(::T.any(Integer, Float, BigDecimal)) }
                     def calculate(operation, column_name); end
 
-                    sig { params(column_name: T.nilable(T.any(String, Symbol))).returns(Integer) }
-                    sig { params(column_name: NilClass, block: T.proc.params(object: ::Post).void).returns(Integer) }
+                    sig { params(column_name: ::T.nilable(::T.any(String, Symbol))).returns(Integer) }
+                    sig { params(column_name: ::NilClass, block: ::T.proc.params(object: ::Post).void).returns(Integer) }
                     def count(column_name = nil, &block); end
 
-                    sig { params(block: T.nilable(T.proc.params(object: ::Post).void)).returns(::Post) }
-                    sig { params(attributes: T::Array[T.untyped], block: T.nilable(T.proc.params(object: ::Post).void)).returns(T::Array[::Post]) }
-                    sig { params(attributes: T.untyped, block: T.nilable(T.proc.params(object: ::Post).void)).returns(::Post) }
+                    sig { params(block: ::T.nilable(::T.proc.params(object: ::Post).void)).returns(::Post) }
+                    sig { params(attributes: ::T::Array[::T.untyped], block: ::T.nilable(::T.proc.params(object: ::Post).void)).returns(::T::Array[::Post]) }
+                    sig { params(attributes: ::T.untyped, block: ::T.nilable(::T.proc.params(object: ::Post).void)).returns(::Post) }
                     def create(attributes = nil, &block); end
 
-                    sig { params(block: T.nilable(T.proc.params(object: ::Post).void)).returns(::Post) }
-                    sig { params(attributes: T::Array[T.untyped], block: T.nilable(T.proc.params(object: ::Post).void)).returns(T::Array[::Post]) }
-                    sig { params(attributes: T.untyped, block: T.nilable(T.proc.params(object: ::Post).void)).returns(::Post) }
+                    sig { params(block: ::T.nilable(::T.proc.params(object: ::Post).void)).returns(::Post) }
+                    sig { params(attributes: ::T::Array[::T.untyped], block: ::T.nilable(::T.proc.params(object: ::Post).void)).returns(::T::Array[::Post]) }
+                    sig { params(attributes: ::T.untyped, block: ::T.nilable(::T.proc.params(object: ::Post).void)).returns(::Post) }
                     def create!(attributes = nil, &block); end
 
-                    sig { params(attributes: T::Array[T.untyped], block: T.nilable(T.proc.params(object: ::Post).void)).returns(T::Array[::Post]) }
-                    sig { params(attributes: T.untyped, block: T.nilable(T.proc.params(object: ::Post).void)).returns(::Post) }
+                    sig { params(attributes: ::T::Array[::T.untyped], block: ::T.nilable(::T.proc.params(object: ::Post).void)).returns(::T::Array[::Post]) }
+                    sig { params(attributes: ::T.untyped, block: ::T.nilable(::T.proc.params(object: ::Post).void)).returns(::Post) }
                     def create_or_find_by(attributes, &block); end
 
-                    sig { params(attributes: T::Array[T.untyped], block: T.nilable(T.proc.params(object: ::Post).void)).returns(T::Array[::Post]) }
-                    sig { params(attributes: T.untyped, block: T.nilable(T.proc.params(object: ::Post).void)).returns(::Post) }
+                    sig { params(attributes: ::T::Array[::T.untyped], block: ::T.nilable(::T.proc.params(object: ::Post).void)).returns(::T::Array[::Post]) }
+                    sig { params(attributes: ::T.untyped, block: ::T.nilable(::T.proc.params(object: ::Post).void)).returns(::Post) }
                     def create_or_find_by!(attributes, &block); end
 
-                    sig { params(records: T.any(::Post, Integer, String, T::Enumerable[T.any(::Post, Integer, String, T::Enumerable[::Post])])).returns(Integer) }
+                    sig { params(records: ::T.any(::Post, Integer, String, ::T::Enumerable[::T.any(::Post, Integer, String, ::T::Enumerable[::Post])])).returns(Integer) }
                     def delete(*records); end
 
                     sig { returns(Integer) }
                     def delete_all; end
 
-                    sig { params(args: T.untyped).returns(Integer) }
+                    sig { params(args: ::T.untyped).returns(Integer) }
                     def delete_by(*args); end
 
-                    sig { params(records: T.any(::Post, Integer, String, T::Enumerable[T.any(::Post, Integer, String, T::Enumerable[::Post])])).returns(T::Array[::Post]) }
+                    sig { params(records: ::T.any(::Post, Integer, String, ::T::Enumerable[::T.any(::Post, Integer, String, ::T::Enumerable[::Post])])).returns(::T::Array[::Post]) }
                     def destroy(*records); end
 
-                    sig { returns(T::Array[::Post]) }
+                    sig { returns(::T::Array[::Post]) }
                     def destroy_all; end
 
-                    sig { returns(T::Array[::Post]) }
+                    sig { returns(::T::Array[::Post]) }
                     def destroy_all; end
 
-                    sig { params(args: T.untyped).returns(T::Array[::Post]) }
+                    sig { params(args: ::T.untyped).returns(::T::Array[::Post]) }
                     def destroy_by(*args); end
 
-                    sig { params(conditions: T.untyped).returns(T::Boolean) }
+                    sig { params(conditions: ::T.untyped).returns(::T::Boolean) }
                     def exists?(conditions = :none); end
 
-                    sig { returns(T.nilable(::Post)) }
+                    sig { returns(::T.nilable(::Post)) }
                     def fifth; end
 
                     sig { returns(::Post) }
                     def fifth!; end
 
-                    sig { params(args: T.any(String, Symbol, ::ActiveSupport::Multibyte::Chars, T::Boolean, BigDecimal, Numeric, ::ActiveRecord::Type::Binary::Data, ::ActiveRecord::Type::Time::Value, Date, Time, ::ActiveSupport::Duration, T::Class[T.anything], ::CustomId)).returns(::Post) }
-                    sig { params(args: T::Array[T.any(String, Symbol, ::ActiveSupport::Multibyte::Chars, T::Boolean, BigDecimal, Numeric, ::ActiveRecord::Type::Binary::Data, ::ActiveRecord::Type::Time::Value, Date, Time, ::ActiveSupport::Duration, T::Class[T.anything], ::CustomId)]).returns(T::Enumerable[::Post]) }
-                    sig { params(args: NilClass, block: T.proc.params(object: ::Post).void).returns(T.nilable(::Post)) }
+                    sig { params(args: ::T.any(String, Symbol, ::ActiveSupport::Multibyte::Chars, ::T::Boolean, BigDecimal, Numeric, ::ActiveRecord::Type::Binary::Data, ::ActiveRecord::Type::Time::Value, Date, Time, ::ActiveSupport::Duration, ::T::Class[::T.anything], ::CustomId)).returns(::Post) }
+                    sig { params(args: ::T::Array[::T.any(String, Symbol, ::ActiveSupport::Multibyte::Chars, ::T::Boolean, BigDecimal, Numeric, ::ActiveRecord::Type::Binary::Data, ::ActiveRecord::Type::Time::Value, Date, Time, ::ActiveSupport::Duration, ::T::Class[::T.anything], ::CustomId)]).returns(::T::Enumerable[::Post]) }
+                    sig { params(args: ::NilClass, block: ::T.proc.params(object: ::Post).void).returns(::T.nilable(::Post)) }
                     def find(args = nil, &block); end
 
-                    sig { params(args: T.untyped).returns(T.nilable(::Post)) }
+                    sig { params(args: ::T.untyped).returns(::T.nilable(::Post)) }
                     def find_by(*args); end
 
-                    sig { params(args: T.untyped).returns(::Post) }
+                    sig { params(args: ::T.untyped).returns(::Post) }
                     def find_by!(*args); end
 
                 <% if rails_version(">= 8.0") %>
-                    sig { params(start: T.untyped, finish: T.untyped, batch_size: Integer, error_on_ignore: T.untyped, cursor: T.untyped, order: T.any(Symbol, T::Array[Symbol]), block: T.proc.params(object: ::Post).void).void }
-                    sig { params(start: T.untyped, finish: T.untyped, batch_size: Integer, error_on_ignore: T.untyped, cursor: T.untyped, order: T.any(Symbol, T::Array[Symbol])).returns(T::Enumerator[::Post]) }
+                    sig { params(start: ::T.untyped, finish: ::T.untyped, batch_size: Integer, error_on_ignore: ::T.untyped, cursor: ::T.untyped, order: ::T.any(Symbol, ::T::Array[Symbol]), block: ::T.proc.params(object: ::Post).void).void }
+                    sig { params(start: ::T.untyped, finish: ::T.untyped, batch_size: Integer, error_on_ignore: ::T.untyped, cursor: ::T.untyped, order: ::T.any(Symbol, ::T::Array[Symbol])).returns(::T::Enumerator[::Post]) }
                     def find_each(start: nil, finish: nil, batch_size: 1000, error_on_ignore: nil, cursor: primary_key, order: :asc, &block); end
                 <% else %>
-                    sig { params(start: T.untyped, finish: T.untyped, batch_size: Integer, error_on_ignore: T.untyped, order: T.any(Symbol, T::Array[Symbol]), block: T.proc.params(object: ::Post).void).void }
-                    sig { params(start: T.untyped, finish: T.untyped, batch_size: Integer, error_on_ignore: T.untyped, order: T.any(Symbol, T::Array[Symbol])).returns(T::Enumerator[::Post]) }
+                    sig { params(start: ::T.untyped, finish: ::T.untyped, batch_size: Integer, error_on_ignore: ::T.untyped, order: ::T.any(Symbol, ::T::Array[Symbol]), block: ::T.proc.params(object: ::Post).void).void }
+                    sig { params(start: ::T.untyped, finish: ::T.untyped, batch_size: Integer, error_on_ignore: ::T.untyped, order: ::T.any(Symbol, ::T::Array[Symbol])).returns(::T::Enumerator[::Post]) }
                     def find_each(start: nil, finish: nil, batch_size: 1000, error_on_ignore: nil, order: :asc, &block); end
                 <% end %>
 
                 <% if rails_version(">= 8.0") %>
-                    sig { params(start: T.untyped, finish: T.untyped, batch_size: Integer, error_on_ignore: T.untyped, cursor: T.untyped, order: T.any(Symbol, T::Array[Symbol]), block: T.proc.params(object: T::Array[::Post]).void).void }
-                    sig { params(start: T.untyped, finish: T.untyped, batch_size: Integer, error_on_ignore: T.untyped, cursor: T.untyped, order: T.any(Symbol, T::Array[Symbol])).returns(T::Enumerator[T::Array[::Post]]) }
+                    sig { params(start: ::T.untyped, finish: ::T.untyped, batch_size: Integer, error_on_ignore: ::T.untyped, cursor: ::T.untyped, order: ::T.any(Symbol, ::T::Array[Symbol]), block: ::T.proc.params(object: ::T::Array[::Post]).void).void }
+                    sig { params(start: ::T.untyped, finish: ::T.untyped, batch_size: Integer, error_on_ignore: ::T.untyped, cursor: ::T.untyped, order: ::T.any(Symbol, ::T::Array[Symbol])).returns(::T::Enumerator[::T::Array[::Post]]) }
                     def find_in_batches(start: nil, finish: nil, batch_size: 1000, error_on_ignore: nil, cursor: primary_key, order: :asc, &block); end
                 <% else %>
-                    sig { params(start: T.untyped, finish: T.untyped, batch_size: Integer, error_on_ignore: T.untyped, order: T.any(Symbol, T::Array[Symbol]), block: T.proc.params(object: T::Array[::Post]).void).void }
-                    sig { params(start: T.untyped, finish: T.untyped, batch_size: Integer, error_on_ignore: T.untyped, order: T.any(Symbol, T::Array[Symbol])).returns(T::Enumerator[T::Array[::Post]]) }
+                    sig { params(start: ::T.untyped, finish: ::T.untyped, batch_size: Integer, error_on_ignore: ::T.untyped, order: ::T.any(Symbol, ::T::Array[Symbol]), block: ::T.proc.params(object: ::T::Array[::Post]).void).void }
+                    sig { params(start: ::T.untyped, finish: ::T.untyped, batch_size: Integer, error_on_ignore: ::T.untyped, order: ::T.any(Symbol, ::T::Array[Symbol])).returns(::T::Enumerator[::T::Array[::Post]]) }
                     def find_in_batches(start: nil, finish: nil, batch_size: 1000, error_on_ignore: nil, order: :asc, &block); end
                 <% end %>
 
-                    sig { params(attributes: T::Array[T.untyped], block: T.nilable(T.proc.params(object: ::Post).void)).returns(T::Array[::Post]) }
-                    sig { params(attributes: T.untyped, block: T.nilable(T.proc.params(object: ::Post).void)).returns(::Post) }
+                    sig { params(attributes: ::T::Array[::T.untyped], block: ::T.nilable(::T.proc.params(object: ::Post).void)).returns(::T::Array[::Post]) }
+                    sig { params(attributes: ::T.untyped, block: ::T.nilable(::T.proc.params(object: ::Post).void)).returns(::Post) }
                     def find_or_create_by(attributes, &block); end
 
-                    sig { params(attributes: T::Array[T.untyped], block: T.nilable(T.proc.params(object: ::Post).void)).returns(T::Array[::Post]) }
-                    sig { params(attributes: T.untyped, block: T.nilable(T.proc.params(object: ::Post).void)).returns(::Post) }
+                    sig { params(attributes: ::T::Array[::T.untyped], block: ::T.nilable(::T.proc.params(object: ::Post).void)).returns(::T::Array[::Post]) }
+                    sig { params(attributes: ::T.untyped, block: ::T.nilable(::T.proc.params(object: ::Post).void)).returns(::Post) }
                     def find_or_create_by!(attributes, &block); end
 
-                    sig { params(attributes: T::Array[T.untyped], block: T.nilable(T.proc.params(object: ::Post).void)).returns(T::Array[::Post]) }
-                    sig { params(attributes: T.untyped, block: T.nilable(T.proc.params(object: ::Post).void)).returns(::Post) }
+                    sig { params(attributes: ::T::Array[::T.untyped], block: ::T.nilable(::T.proc.params(object: ::Post).void)).returns(::T::Array[::Post]) }
+                    sig { params(attributes: ::T.untyped, block: ::T.nilable(::T.proc.params(object: ::Post).void)).returns(::Post) }
                     def find_or_initialize_by(attributes, &block); end
 
-                    sig { params(signed_id: T.untyped, purpose: T.untyped).returns(T.nilable(::Post)) }
+                    sig { params(signed_id: ::T.untyped, purpose: ::T.untyped).returns(::T.nilable(::Post)) }
                     def find_signed(signed_id, purpose: nil); end
 
-                    sig { params(signed_id: T.untyped, purpose: T.untyped).returns(::Post) }
+                    sig { params(signed_id: ::T.untyped, purpose: ::T.untyped).returns(::Post) }
                     def find_signed!(signed_id, purpose: nil); end
 
-                    sig { params(arg: T.untyped, args: T.untyped).returns(::Post) }
+                    sig { params(arg: ::T.untyped, args: ::T.untyped).returns(::Post) }
                     def find_sole_by(arg, *args); end
 
-                    sig { returns(T.nilable(::Post)) }
-                    sig { params(limit: Integer).returns(T::Array[::Post]) }
+                    sig { returns(::T.nilable(::Post)) }
+                    sig { params(limit: Integer).returns(::T::Array[::Post]) }
                     def first(limit = nil); end
 
                     sig { returns(::Post) }
                     def first!; end
 
-                    sig { returns(T.nilable(::Post)) }
+                    sig { returns(::T.nilable(::Post)) }
                     def forty_two; end
 
                     sig { returns(::Post) }
                     def forty_two!; end
 
-                    sig { returns(T.nilable(::Post)) }
+                    sig { returns(::T.nilable(::Post)) }
                     def fourth; end
 
                     sig { returns(::Post) }
                     def fourth!; end
 
-                    sig { returns(T::Array[::CustomId]) }
+                    sig { returns(::T::Array[::CustomId]) }
                     def ids; end
 
                 <% if rails_version(">= 8.0") %>
-                    sig { params(of: Integer, start: T.untyped, finish: T.untyped, load: T.untyped, error_on_ignore: T.untyped, cursor: T.untyped, order: T.any(Symbol, T::Array[Symbol]), use_ranges: T.untyped, block: T.proc.params(object: PrivateRelation).void).void }
-                    sig { params(of: Integer, start: T.untyped, finish: T.untyped, load: T.untyped, error_on_ignore: T.untyped, cursor: T.untyped, order: T.any(Symbol, T::Array[Symbol]), use_ranges: T.untyped).returns(::ActiveRecord::Batches::BatchEnumerator) }
+                    sig { params(of: Integer, start: ::T.untyped, finish: ::T.untyped, load: ::T.untyped, error_on_ignore: ::T.untyped, cursor: ::T.untyped, order: ::T.any(Symbol, ::T::Array[Symbol]), use_ranges: ::T.untyped, block: ::T.proc.params(object: PrivateRelation).void).void }
+                    sig { params(of: Integer, start: ::T.untyped, finish: ::T.untyped, load: ::T.untyped, error_on_ignore: ::T.untyped, cursor: ::T.untyped, order: ::T.any(Symbol, ::T::Array[Symbol]), use_ranges: ::T.untyped).returns(::ActiveRecord::Batches::BatchEnumerator) }
                     def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, cursor: primary_key, order: :asc, use_ranges: nil, &block); end
                 <% else %>
-                    sig { params(of: Integer, start: T.untyped, finish: T.untyped, load: T.untyped, error_on_ignore: T.untyped, order: T.any(Symbol, T::Array[Symbol]), use_ranges: T.untyped, block: T.proc.params(object: PrivateRelation).void).void }
-                    sig { params(of: Integer, start: T.untyped, finish: T.untyped, load: T.untyped, error_on_ignore: T.untyped, order: T.any(Symbol, T::Array[Symbol]), use_ranges: T.untyped).returns(::ActiveRecord::Batches::BatchEnumerator) }
+                    sig { params(of: Integer, start: ::T.untyped, finish: ::T.untyped, load: ::T.untyped, error_on_ignore: ::T.untyped, order: ::T.any(Symbol, ::T::Array[Symbol]), use_ranges: ::T.untyped, block: ::T.proc.params(object: PrivateRelation).void).void }
+                    sig { params(of: Integer, start: ::T.untyped, finish: ::T.untyped, load: ::T.untyped, error_on_ignore: ::T.untyped, order: ::T.any(Symbol, ::T::Array[Symbol]), use_ranges: ::T.untyped).returns(::ActiveRecord::Batches::BatchEnumerator) }
                     def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, order: :asc, use_ranges: nil, &block); end
                 <% end %>
 
-                    sig { params(record: T.untyped).returns(T::Boolean) }
+                    sig { params(record: ::T.untyped).returns(::T::Boolean) }
                     def include?(record); end
 
-                    sig { returns(T.nilable(::Post)) }
-                    sig { params(limit: Integer).returns(T::Array[::Post]) }
+                    sig { returns(::T.nilable(::Post)) }
+                    sig { params(limit: Integer).returns(::T::Array[::Post]) }
                     def last(limit = nil); end
 
                     sig { returns(::Post) }
                     def last!; end
 
-                    sig { params(block: T.nilable(T.proc.params(record: ::Post).returns(T.untyped))).returns(T::Boolean) }
+                    sig { params(block: ::T.nilable(::T.proc.params(record: ::Post).returns(::T.untyped))).returns(::T::Boolean) }
                     def many?(&block); end
 
-                    sig { params(column_name: T.any(String, Symbol)).returns(T.untyped) }
+                    sig { params(column_name: ::T.any(String, Symbol)).returns(::T.untyped) }
                     def maximum(column_name); end
 
-                    sig { params(record: T.untyped).returns(T::Boolean) }
+                    sig { params(record: ::T.untyped).returns(::T::Boolean) }
                     def member?(record); end
 
-                    sig { params(column_name: T.any(String, Symbol)).returns(T.untyped) }
+                    sig { params(column_name: ::T.any(String, Symbol)).returns(::T.untyped) }
                     def minimum(column_name); end
 
-                    sig { params(block: T.nilable(T.proc.params(object: ::Post).void)).returns(::Post) }
-                    sig { params(attributes: T::Array[T.untyped], block: T.nilable(T.proc.params(object: ::Post).void)).returns(T::Array[::Post]) }
-                    sig { params(attributes: T.untyped, block: T.nilable(T.proc.params(object: ::Post).void)).returns(::Post) }
+                    sig { params(block: ::T.nilable(::T.proc.params(object: ::Post).void)).returns(::Post) }
+                    sig { params(attributes: ::T::Array[::T.untyped], block: ::T.nilable(::T.proc.params(object: ::Post).void)).returns(::T::Array[::Post]) }
+                    sig { params(attributes: ::T.untyped, block: ::T.nilable(::T.proc.params(object: ::Post).void)).returns(::Post) }
                     def new(attributes = nil, &block); end
 
-                    sig { params(block: T.nilable(T.proc.params(record: ::Post).returns(T.untyped))).returns(T::Boolean) }
+                    sig { params(block: ::T.nilable(::T.proc.params(record: ::Post).returns(::T.untyped))).returns(::T::Boolean) }
                     def none?(&block); end
 
-                    sig { params(block: T.nilable(T.proc.params(record: ::Post).returns(T.untyped))).returns(T::Boolean) }
+                    sig { params(block: ::T.nilable(::T.proc.params(record: ::Post).returns(::T.untyped))).returns(::T::Boolean) }
                     def one?(&block); end
 
-                    sig { params(column_names: T.untyped).returns(T.untyped) }
+                    sig { params(column_names: ::T.untyped).returns(::T.untyped) }
                     def pick(*column_names); end
 
-                    sig { params(column_names: T.untyped).returns(T.untyped) }
+                    sig { params(column_names: ::T.untyped).returns(::T.untyped) }
                     def pluck(*column_names); end
 
-                    sig { returns(T.nilable(::Post)) }
+                    sig { returns(::T.nilable(::Post)) }
                     def second; end
 
                     sig { returns(::Post) }
                     def second!; end
 
-                    sig { returns(T.nilable(::Post)) }
+                    sig { returns(::T.nilable(::Post)) }
                     def second_to_last; end
 
                     sig { returns(::Post) }
@@ -300,24 +300,24 @@ module Tapioca
                     sig { returns(::Post) }
                     def sole; end
 
-                    sig { params(initial_value_or_column: T.untyped).returns(T.any(Integer, Float, BigDecimal)) }
-                    sig { type_parameters(:U).params(initial_value_or_column: T.nilable(T.type_parameter(:U)), block: T.proc.params(object: ::Post).returns(T.type_parameter(:U))).returns(T.type_parameter(:U)) }
+                    sig { params(initial_value_or_column: ::T.untyped).returns(::T.any(Integer, Float, BigDecimal)) }
+                    sig { type_parameters(:U).params(initial_value_or_column: ::T.nilable(::T.type_parameter(:U)), block: ::T.proc.params(object: ::Post).returns(::T.type_parameter(:U))).returns(::T.type_parameter(:U)) }
                     def sum(initial_value_or_column = nil, &block); end
 
-                    sig { returns(T.nilable(::Post)) }
-                    sig { params(limit: Integer).returns(T::Array[::Post]) }
+                    sig { returns(::T.nilable(::Post)) }
+                    sig { params(limit: Integer).returns(::T::Array[::Post]) }
                     def take(limit = nil); end
 
                     sig { returns(::Post) }
                     def take!; end
 
-                    sig { returns(T.nilable(::Post)) }
+                    sig { returns(::T.nilable(::Post)) }
                     def third; end
 
                     sig { returns(::Post) }
                     def third!; end
 
-                    sig { returns(T.nilable(::Post)) }
+                    sig { returns(::T.nilable(::Post)) }
                     def third_to_last; end
 
                     sig { returns(::Post) }
@@ -328,148 +328,148 @@ module Tapioca
                     sig { returns(PrivateAssociationRelation) }
                     def all; end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateAssociationRelation) }
                     def and(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateAssociationRelation) }
                     def annotate(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateAssociationRelation) }
                     def arel_columns(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateAssociationRelation) }
                     def create_with(*args, &blk); end
 
-                    sig { params(value: T::Boolean).returns(PrivateAssociationRelation) }
+                    sig { params(value: ::T::Boolean).returns(PrivateAssociationRelation) }
                     def distinct(value = true); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateAssociationRelation) }
                     def eager_load(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateAssociationRelation) }
                     def except(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateAssociationRelation) }
                     def excluding(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateAssociationRelation) }
                     def extending(*args, &blk); end
 
-                    sig { params(association: Symbol).returns(T::Array[T.untyped]) }
+                    sig { params(association: Symbol).returns(::T::Array[::T.untyped]) }
                     def extract_associated(association); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateAssociationRelation) }
                     def from(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelationGroupChain) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateAssociationRelationGroupChain) }
                     def group(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateAssociationRelation) }
                     def having(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateAssociationRelation) }
                     def in_order_of(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateAssociationRelation) }
                     def includes(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateAssociationRelation) }
                     def invert_where(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateAssociationRelation) }
                     def joins(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateAssociationRelation) }
                     def left_joins(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateAssociationRelation) }
                     def left_outer_joins(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateAssociationRelation) }
                     def limit(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateAssociationRelation) }
                     def lock(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateAssociationRelation) }
                     def merge(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateAssociationRelation) }
                     def none(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateAssociationRelation) }
                     def null_relation?(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateAssociationRelation) }
                     def offset(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateAssociationRelation) }
                     def only(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateAssociationRelation) }
                     def optimizer_hints(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateAssociationRelation) }
                     def or(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateAssociationRelation) }
                     def order(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateAssociationRelation) }
                     def preload(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateAssociationRelation) }
                     def readonly(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateAssociationRelation) }
                     def references(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateAssociationRelation) }
                     def regroup(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateAssociationRelation) }
                     def reorder(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateAssociationRelation) }
                     def reselect(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateAssociationRelation) }
                     def reverse_order(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateAssociationRelation) }
                     def rewhere(*args, &blk); end
 
-                    sig { params(args: T.untyped).returns(PrivateAssociationRelation) }
-                    sig { params(blk: T.proc.params(record: ::Post).returns(BasicObject)).returns(T::Array[::Post]) }
+                    sig { params(args: ::T.untyped).returns(PrivateAssociationRelation) }
+                    sig { params(blk: ::T.proc.params(record: ::Post).returns(BasicObject)).returns(::T::Array[::Post]) }
                     def select(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateAssociationRelation) }
                     def strict_loading(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateAssociationRelation) }
                     def structurally_compatible?(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateAssociationRelation) }
                     def uniq!(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateAssociationRelation) }
                     def unscope(*args, &blk); end
 
                     sig { returns(PrivateAssociationRelation) }
-                    sig { type_parameters(:U).params(block: T.proc.returns(T.type_parameter(:U))).returns(T.type_parameter(:U)) }
+                    sig { type_parameters(:U).params(block: ::T.proc.returns(::T.type_parameter(:U))).returns(::T.type_parameter(:U)) }
                     def unscoped(&block); end
 
                     sig { returns(PrivateAssociationRelationWhereChain) }
-                    sig { params(args: T.untyped).returns(PrivateAssociationRelation) }
+                    sig { params(args: ::T.untyped).returns(PrivateAssociationRelation) }
                     def where(*args); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateAssociationRelation) }
                     def with(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateAssociationRelation) }
                     def with_recursive(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateAssociationRelation) }
                     def without(*args, &blk); end
                   end
 
@@ -477,148 +477,148 @@ module Tapioca
                     sig { returns(PrivateRelation) }
                     def all; end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateRelation) }
                     def and(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateRelation) }
                     def annotate(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateRelation) }
                     def arel_columns(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateRelation) }
                     def create_with(*args, &blk); end
 
-                    sig { params(value: T::Boolean).returns(PrivateRelation) }
+                    sig { params(value: ::T::Boolean).returns(PrivateRelation) }
                     def distinct(value = true); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateRelation) }
                     def eager_load(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateRelation) }
                     def except(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateRelation) }
                     def excluding(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateRelation) }
                     def extending(*args, &blk); end
 
-                    sig { params(association: Symbol).returns(T::Array[T.untyped]) }
+                    sig { params(association: Symbol).returns(::T::Array[::T.untyped]) }
                     def extract_associated(association); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateRelation) }
                     def from(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelationGroupChain) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateRelationGroupChain) }
                     def group(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateRelation) }
                     def having(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateRelation) }
                     def in_order_of(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateRelation) }
                     def includes(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateRelation) }
                     def invert_where(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateRelation) }
                     def joins(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateRelation) }
                     def left_joins(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateRelation) }
                     def left_outer_joins(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateRelation) }
                     def limit(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateRelation) }
                     def lock(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateRelation) }
                     def merge(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateRelation) }
                     def none(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateRelation) }
                     def null_relation?(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateRelation) }
                     def offset(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateRelation) }
                     def only(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateRelation) }
                     def optimizer_hints(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateRelation) }
                     def or(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateRelation) }
                     def order(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateRelation) }
                     def preload(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateRelation) }
                     def readonly(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateRelation) }
                     def references(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateRelation) }
                     def regroup(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateRelation) }
                     def reorder(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateRelation) }
                     def reselect(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateRelation) }
                     def reverse_order(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateRelation) }
                     def rewhere(*args, &blk); end
 
-                    sig { params(args: T.untyped).returns(PrivateRelation) }
-                    sig { params(blk: T.proc.params(record: ::Post).returns(BasicObject)).returns(T::Array[::Post]) }
+                    sig { params(args: ::T.untyped).returns(PrivateRelation) }
+                    sig { params(blk: ::T.proc.params(record: ::Post).returns(BasicObject)).returns(::T::Array[::Post]) }
                     def select(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateRelation) }
                     def strict_loading(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateRelation) }
                     def structurally_compatible?(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateRelation) }
                     def uniq!(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateRelation) }
                     def unscope(*args, &blk); end
 
                     sig { returns(PrivateRelation) }
-                    sig { type_parameters(:U).params(block: T.proc.returns(T.type_parameter(:U))).returns(T.type_parameter(:U)) }
+                    sig { type_parameters(:U).params(block: ::T.proc.returns(::T.type_parameter(:U))).returns(::T.type_parameter(:U)) }
                     def unscoped(&block); end
 
                     sig { returns(PrivateRelationWhereChain) }
-                    sig { params(args: T.untyped).returns(PrivateRelation) }
+                    sig { params(args: ::T.untyped).returns(PrivateRelation) }
                     def where(*args); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateRelation) }
                     def with(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateRelation) }
                     def with_recursive(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateRelation) }
                     def without(*args, &blk); end
                   end
 
@@ -628,51 +628,51 @@ module Tapioca
 
                     Elem = type_member { { fixed: ::Post } }
 
-                    sig { returns(T::Array[::Post]) }
+                    sig { returns(::T::Array[::Post]) }
                     def to_a; end
 
-                    sig { returns(T::Array[::Post]) }
+                    sig { returns(::T::Array[::Post]) }
                     def to_ary; end
                   end
 
                   class PrivateAssociationRelationGroupChain < PrivateAssociationRelation
                     Elem = type_member { { fixed: ::Post } }
 
-                    sig { params(column_name: T.any(String, Symbol)).returns(T::Hash[T.untyped, T.any(Integer, Float, BigDecimal)]) }
+                    sig { params(column_name: ::T.any(String, Symbol)).returns(::T::Hash[::T.untyped, ::T.any(Integer, Float, BigDecimal)]) }
                     def average(column_name); end
 
-                    sig { params(operation: Symbol, column_name: T.any(String, Symbol)).returns(T::Hash[T.untyped, T.any(Integer, Float, BigDecimal)]) }
+                    sig { params(operation: Symbol, column_name: ::T.any(String, Symbol)).returns(::T::Hash[::T.untyped, ::T.any(Integer, Float, BigDecimal)]) }
                     def calculate(operation, column_name); end
 
-                    sig { params(column_name: T.untyped).returns(T::Hash[T.untyped, Integer]) }
+                    sig { params(column_name: ::T.untyped).returns(::T::Hash[::T.untyped, Integer]) }
                     def count(column_name = nil); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(T.self_type) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(::T.self_type) }
                     def having(*args, &blk); end
 
-                    sig { params(column_name: T.any(String, Symbol)).returns(T::Hash[T.untyped, T.untyped]) }
+                    sig { params(column_name: ::T.any(String, Symbol)).returns(::T::Hash[::T.untyped, ::T.untyped]) }
                     def maximum(column_name); end
 
-                    sig { params(column_name: T.any(String, Symbol)).returns(T::Hash[T.untyped, T.untyped]) }
+                    sig { params(column_name: ::T.any(String, Symbol)).returns(::T::Hash[::T.untyped, ::T.untyped]) }
                     def minimum(column_name); end
 
-                    sig { returns(T::Hash[T.untyped, Integer]) }
+                    sig { returns(::T::Hash[::T.untyped, Integer]) }
                     def size; end
 
-                    sig { params(column_name: T.nilable(T.any(String, Symbol)), block: T.nilable(T.proc.params(record: T.untyped).returns(T.untyped))).returns(T::Hash[T.untyped, T.any(Integer, Float, BigDecimal)]) }
+                    sig { params(column_name: ::T.nilable(::T.any(String, Symbol)), block: ::T.nilable(::T.proc.params(record: ::T.untyped).returns(::T.untyped))).returns(::T::Hash[::T.untyped, ::T.any(Integer, Float, BigDecimal)]) }
                     def sum(column_name = nil, &block); end
                   end
 
                   class PrivateAssociationRelationWhereChain
                     Elem = type_member { { fixed: ::Post } }
 
-                    sig { params(args: T.untyped).returns(PrivateAssociationRelation) }
+                    sig { params(args: ::T.untyped).returns(PrivateAssociationRelation) }
                     def associated(*args); end
 
-                    sig { params(args: T.untyped).returns(PrivateAssociationRelation) }
+                    sig { params(args: ::T.untyped).returns(PrivateAssociationRelation) }
                     def missing(*args); end
 
-                    sig { params(opts: T.untyped, rest: T.untyped).returns(PrivateAssociationRelation) }
+                    sig { params(opts: ::T.untyped, rest: ::T.untyped).returns(PrivateAssociationRelation) }
                     def not(opts, *rest); end
                   end
 
@@ -682,40 +682,40 @@ module Tapioca
 
                     Elem = type_member { { fixed: ::Post } }
 
-                    sig { params(records: T.any(::Post, T::Enumerable[T.any(::Post, T::Enumerable[::Post])])).returns(PrivateCollectionProxy) }
+                    sig { params(records: ::T.any(::Post, ::T::Enumerable[::T.any(::Post, ::T::Enumerable[::Post])])).returns(PrivateCollectionProxy) }
                     def <<(*records); end
 
-                    sig { params(records: T.any(::Post, T::Enumerable[T.any(::Post, T::Enumerable[::Post])])).returns(PrivateCollectionProxy) }
+                    sig { params(records: ::T.any(::Post, ::T::Enumerable[::T.any(::Post, ::T::Enumerable[::Post])])).returns(PrivateCollectionProxy) }
                     def append(*records); end
 
                     sig { returns(PrivateCollectionProxy) }
                     def clear; end
 
-                    sig { params(records: T.any(::Post, T::Enumerable[T.any(::Post, T::Enumerable[::Post])])).returns(PrivateCollectionProxy) }
+                    sig { params(records: ::T.any(::Post, ::T::Enumerable[::T.any(::Post, ::T::Enumerable[::Post])])).returns(PrivateCollectionProxy) }
                     def concat(*records); end
 
-                    sig { returns(T::Array[::Post]) }
+                    sig { returns(::T::Array[::Post]) }
                     def load_target; end
 
-                    sig { params(records: T.any(::Post, T::Enumerable[T.any(::Post, T::Enumerable[::Post])])).returns(PrivateCollectionProxy) }
+                    sig { params(records: ::T.any(::Post, ::T::Enumerable[::T.any(::Post, ::T::Enumerable[::Post])])).returns(PrivateCollectionProxy) }
                     def prepend(*records); end
 
-                    sig { params(records: T.any(::Post, T::Enumerable[T.any(::Post, T::Enumerable[::Post])])).returns(PrivateCollectionProxy) }
+                    sig { params(records: ::T.any(::Post, ::T::Enumerable[::T.any(::Post, ::T::Enumerable[::Post])])).returns(PrivateCollectionProxy) }
                     def push(*records); end
 
-                    sig { params(other_array: T.any(::Post, T::Enumerable[T.any(::Post, T::Enumerable[::Post])])).returns(T::Array[::Post]) }
+                    sig { params(other_array: ::T.any(::Post, ::T::Enumerable[::T.any(::Post, ::T::Enumerable[::Post])])).returns(::T::Array[::Post]) }
                     def replace(other_array); end
 
                     sig { returns(PrivateAssociationRelation) }
                     def scope; end
 
-                    sig { returns(T::Array[::Post]) }
+                    sig { returns(::T::Array[::Post]) }
                     def target; end
 
-                    sig { returns(T::Array[::Post]) }
+                    sig { returns(::T::Array[::Post]) }
                     def to_a; end
 
-                    sig { returns(T::Array[::Post]) }
+                    sig { returns(::T::Array[::Post]) }
                     def to_ary; end
                   end
 
@@ -725,51 +725,51 @@ module Tapioca
 
                     Elem = type_member { { fixed: ::Post } }
 
-                    sig { returns(T::Array[::Post]) }
+                    sig { returns(::T::Array[::Post]) }
                     def to_a; end
 
-                    sig { returns(T::Array[::Post]) }
+                    sig { returns(::T::Array[::Post]) }
                     def to_ary; end
                   end
 
                   class PrivateRelationGroupChain < PrivateRelation
                     Elem = type_member { { fixed: ::Post } }
 
-                    sig { params(column_name: T.any(String, Symbol)).returns(T::Hash[T.untyped, T.any(Integer, Float, BigDecimal)]) }
+                    sig { params(column_name: ::T.any(String, Symbol)).returns(::T::Hash[::T.untyped, ::T.any(Integer, Float, BigDecimal)]) }
                     def average(column_name); end
 
-                    sig { params(operation: Symbol, column_name: T.any(String, Symbol)).returns(T::Hash[T.untyped, T.any(Integer, Float, BigDecimal)]) }
+                    sig { params(operation: Symbol, column_name: ::T.any(String, Symbol)).returns(::T::Hash[::T.untyped, ::T.any(Integer, Float, BigDecimal)]) }
                     def calculate(operation, column_name); end
 
-                    sig { params(column_name: T.untyped).returns(T::Hash[T.untyped, Integer]) }
+                    sig { params(column_name: ::T.untyped).returns(::T::Hash[::T.untyped, Integer]) }
                     def count(column_name = nil); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(T.self_type) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(::T.self_type) }
                     def having(*args, &blk); end
 
-                    sig { params(column_name: T.any(String, Symbol)).returns(T::Hash[T.untyped, T.untyped]) }
+                    sig { params(column_name: ::T.any(String, Symbol)).returns(::T::Hash[::T.untyped, ::T.untyped]) }
                     def maximum(column_name); end
 
-                    sig { params(column_name: T.any(String, Symbol)).returns(T::Hash[T.untyped, T.untyped]) }
+                    sig { params(column_name: ::T.any(String, Symbol)).returns(::T::Hash[::T.untyped, ::T.untyped]) }
                     def minimum(column_name); end
 
-                    sig { returns(T::Hash[T.untyped, Integer]) }
+                    sig { returns(::T::Hash[::T.untyped, Integer]) }
                     def size; end
 
-                    sig { params(column_name: T.nilable(T.any(String, Symbol)), block: T.nilable(T.proc.params(record: T.untyped).returns(T.untyped))).returns(T::Hash[T.untyped, T.any(Integer, Float, BigDecimal)]) }
+                    sig { params(column_name: ::T.nilable(::T.any(String, Symbol)), block: ::T.nilable(::T.proc.params(record: ::T.untyped).returns(::T.untyped))).returns(::T::Hash[::T.untyped, ::T.any(Integer, Float, BigDecimal)]) }
                     def sum(column_name = nil, &block); end
                   end
 
                   class PrivateRelationWhereChain
                     Elem = type_member { { fixed: ::Post } }
 
-                    sig { params(args: T.untyped).returns(PrivateRelation) }
+                    sig { params(args: ::T.untyped).returns(PrivateRelation) }
                     def associated(*args); end
 
-                    sig { params(args: T.untyped).returns(PrivateRelation) }
+                    sig { params(args: ::T.untyped).returns(PrivateRelation) }
                     def missing(*args); end
 
-                    sig { params(opts: T.untyped, rest: T.untyped).returns(PrivateRelation) }
+                    sig { params(opts: ::T.untyped, rest: ::T.untyped).returns(PrivateRelation) }
                     def not(opts, *rest); end
                   end
                 end
@@ -794,147 +794,147 @@ module Tapioca
 
                   private
 
-                  sig { returns(NilClass) }
+                  sig { returns(::NilClass) }
                   def to_ary; end
 
                   class << self
-                    sig { params(attributes: T.untyped, block: T.nilable(T.proc.params(object: ::Post).void)).returns(::Post) }
+                    sig { params(attributes: ::T.untyped, block: ::T.nilable(::T.proc.params(object: ::Post).void)).returns(::Post) }
                     def new(attributes = nil, &block); end
                   end
 
                   module CommonRelationMethods
-                    sig { params(block: T.nilable(T.proc.params(record: ::Post).returns(T.untyped))).returns(T::Boolean) }
+                    sig { params(block: ::T.nilable(::T.proc.params(record: ::Post).returns(::T.untyped))).returns(::T::Boolean) }
                     def any?(&block); end
 
-                    sig { params(column_name: T.any(String, Symbol)).returns(T.any(Integer, Float, BigDecimal)) }
+                    sig { params(column_name: ::T.any(String, Symbol)).returns(::T.any(Integer, Float, BigDecimal)) }
                     def average(column_name); end
 
-                    sig { params(block: T.nilable(T.proc.params(object: ::Post).void)).returns(::Post) }
-                    sig { params(attributes: T::Array[T.untyped], block: T.nilable(T.proc.params(object: ::Post).void)).returns(T::Array[::Post]) }
-                    sig { params(attributes: T.untyped, block: T.nilable(T.proc.params(object: ::Post).void)).returns(::Post) }
+                    sig { params(block: ::T.nilable(::T.proc.params(object: ::Post).void)).returns(::Post) }
+                    sig { params(attributes: ::T::Array[::T.untyped], block: ::T.nilable(::T.proc.params(object: ::Post).void)).returns(::T::Array[::Post]) }
+                    sig { params(attributes: ::T.untyped, block: ::T.nilable(::T.proc.params(object: ::Post).void)).returns(::Post) }
                     def build(attributes = nil, &block); end
 
-                    sig { params(operation: Symbol, column_name: T.any(String, Symbol)).returns(T.any(Integer, Float, BigDecimal)) }
+                    sig { params(operation: Symbol, column_name: ::T.any(String, Symbol)).returns(::T.any(Integer, Float, BigDecimal)) }
                     def calculate(operation, column_name); end
 
-                    sig { params(column_name: T.nilable(T.any(String, Symbol))).returns(Integer) }
-                    sig { params(column_name: NilClass, block: T.proc.params(object: ::Post).void).returns(Integer) }
+                    sig { params(column_name: ::T.nilable(::T.any(String, Symbol))).returns(Integer) }
+                    sig { params(column_name: ::NilClass, block: ::T.proc.params(object: ::Post).void).returns(Integer) }
                     def count(column_name = nil, &block); end
 
-                    sig { params(block: T.nilable(T.proc.params(object: ::Post).void)).returns(::Post) }
-                    sig { params(attributes: T::Array[T.untyped], block: T.nilable(T.proc.params(object: ::Post).void)).returns(T::Array[::Post]) }
-                    sig { params(attributes: T.untyped, block: T.nilable(T.proc.params(object: ::Post).void)).returns(::Post) }
+                    sig { params(block: ::T.nilable(::T.proc.params(object: ::Post).void)).returns(::Post) }
+                    sig { params(attributes: ::T::Array[::T.untyped], block: ::T.nilable(::T.proc.params(object: ::Post).void)).returns(::T::Array[::Post]) }
+                    sig { params(attributes: ::T.untyped, block: ::T.nilable(::T.proc.params(object: ::Post).void)).returns(::Post) }
                     def create(attributes = nil, &block); end
 
-                    sig { params(block: T.nilable(T.proc.params(object: ::Post).void)).returns(::Post) }
-                    sig { params(attributes: T::Array[T.untyped], block: T.nilable(T.proc.params(object: ::Post).void)).returns(T::Array[::Post]) }
-                    sig { params(attributes: T.untyped, block: T.nilable(T.proc.params(object: ::Post).void)).returns(::Post) }
+                    sig { params(block: ::T.nilable(::T.proc.params(object: ::Post).void)).returns(::Post) }
+                    sig { params(attributes: ::T::Array[::T.untyped], block: ::T.nilable(::T.proc.params(object: ::Post).void)).returns(::T::Array[::Post]) }
+                    sig { params(attributes: ::T.untyped, block: ::T.nilable(::T.proc.params(object: ::Post).void)).returns(::Post) }
                     def create!(attributes = nil, &block); end
 
-                    sig { params(attributes: T::Array[T.untyped], block: T.nilable(T.proc.params(object: ::Post).void)).returns(T::Array[::Post]) }
-                    sig { params(attributes: T.untyped, block: T.nilable(T.proc.params(object: ::Post).void)).returns(::Post) }
+                    sig { params(attributes: ::T::Array[::T.untyped], block: ::T.nilable(::T.proc.params(object: ::Post).void)).returns(::T::Array[::Post]) }
+                    sig { params(attributes: ::T.untyped, block: ::T.nilable(::T.proc.params(object: ::Post).void)).returns(::Post) }
                     def create_or_find_by(attributes, &block); end
 
-                    sig { params(attributes: T::Array[T.untyped], block: T.nilable(T.proc.params(object: ::Post).void)).returns(T::Array[::Post]) }
-                    sig { params(attributes: T.untyped, block: T.nilable(T.proc.params(object: ::Post).void)).returns(::Post) }
+                    sig { params(attributes: ::T::Array[::T.untyped], block: ::T.nilable(::T.proc.params(object: ::Post).void)).returns(::T::Array[::Post]) }
+                    sig { params(attributes: ::T.untyped, block: ::T.nilable(::T.proc.params(object: ::Post).void)).returns(::Post) }
                     def create_or_find_by!(attributes, &block); end
 
-                    sig { params(records: T.any(::Post, Integer, String, T::Enumerable[T.any(::Post, Integer, String, T::Enumerable[::Post])])).returns(Integer) }
+                    sig { params(records: ::T.any(::Post, Integer, String, ::T::Enumerable[::T.any(::Post, Integer, String, ::T::Enumerable[::Post])])).returns(Integer) }
                     def delete(*records); end
 
                     sig { returns(Integer) }
                     def delete_all; end
 
-                    sig { params(args: T.untyped).returns(Integer) }
+                    sig { params(args: ::T.untyped).returns(Integer) }
                     def delete_by(*args); end
 
-                    sig { params(records: T.any(::Post, Integer, String, T::Enumerable[T.any(::Post, Integer, String, T::Enumerable[::Post])])).returns(T::Array[::Post]) }
+                    sig { params(records: ::T.any(::Post, Integer, String, ::T::Enumerable[::T.any(::Post, Integer, String, ::T::Enumerable[::Post])])).returns(::T::Array[::Post]) }
                     def destroy(*records); end
 
-                    sig { returns(T::Array[::Post]) }
+                    sig { returns(::T::Array[::Post]) }
                     def destroy_all; end
 
-                    sig { returns(T::Array[::Post]) }
+                    sig { returns(::T::Array[::Post]) }
                     def destroy_all; end
 
-                    sig { params(args: T.untyped).returns(T::Array[::Post]) }
+                    sig { params(args: ::T.untyped).returns(::T::Array[::Post]) }
                     def destroy_by(*args); end
 
-                    sig { params(conditions: T.untyped).returns(T::Boolean) }
+                    sig { params(conditions: ::T.untyped).returns(::T::Boolean) }
                     def exists?(conditions = :none); end
 
-                    sig { returns(T.nilable(::Post)) }
+                    sig { returns(::T.nilable(::Post)) }
                     def fifth; end
 
                     sig { returns(::Post) }
                     def fifth!; end
 
-                    sig { params(args: T::Array[T.any(String, Symbol, ::ActiveSupport::Multibyte::Chars, T::Boolean, BigDecimal, Numeric, ::ActiveRecord::Type::Binary::Data, ::ActiveRecord::Type::Time::Value, Date, Time, ::ActiveSupport::Duration, T::Class[T.anything])]).returns(::Post) }
-                    sig { params(args: T::Array[T::Array[T.any(String, Symbol, ::ActiveSupport::Multibyte::Chars, T::Boolean, BigDecimal, Numeric, ::ActiveRecord::Type::Binary::Data, ::ActiveRecord::Type::Time::Value, Date, Time, ::ActiveSupport::Duration, T::Class[T.anything])]]).returns(T::Enumerable[::Post]) }
-                    sig { params(args: NilClass, block: T.proc.params(object: ::Post).void).returns(T.nilable(::Post)) }
+                    sig { params(args: ::T::Array[::T.any(String, Symbol, ::ActiveSupport::Multibyte::Chars, ::T::Boolean, BigDecimal, Numeric, ::ActiveRecord::Type::Binary::Data, ::ActiveRecord::Type::Time::Value, Date, Time, ::ActiveSupport::Duration, ::T::Class[::T.anything])]).returns(::Post) }
+                    sig { params(args: ::T::Array[::T::Array[::T.any(String, Symbol, ::ActiveSupport::Multibyte::Chars, ::T::Boolean, BigDecimal, Numeric, ::ActiveRecord::Type::Binary::Data, ::ActiveRecord::Type::Time::Value, Date, Time, ::ActiveSupport::Duration, ::T::Class[::T.anything])]]).returns(::T::Enumerable[::Post]) }
+                    sig { params(args: ::NilClass, block: ::T.proc.params(object: ::Post).void).returns(::T.nilable(::Post)) }
                     def find(args = nil, &block); end
 
-                    sig { params(args: T.untyped).returns(T.nilable(::Post)) }
+                    sig { params(args: ::T.untyped).returns(::T.nilable(::Post)) }
                     def find_by(*args); end
 
-                    sig { params(args: T.untyped).returns(::Post) }
+                    sig { params(args: ::T.untyped).returns(::Post) }
                     def find_by!(*args); end
 
                 <% if rails_version(">= 8.0") %>
-                    sig { params(start: T.untyped, finish: T.untyped, batch_size: Integer, error_on_ignore: T.untyped, cursor: T.untyped, order: T.any(Symbol, T::Array[Symbol]), block: T.proc.params(object: ::Post).void).void }
-                    sig { params(start: T.untyped, finish: T.untyped, batch_size: Integer, error_on_ignore: T.untyped, cursor: T.untyped, order: T.any(Symbol, T::Array[Symbol])).returns(T::Enumerator[::Post]) }
+                    sig { params(start: ::T.untyped, finish: ::T.untyped, batch_size: Integer, error_on_ignore: ::T.untyped, cursor: ::T.untyped, order: ::T.any(Symbol, ::T::Array[Symbol]), block: ::T.proc.params(object: ::Post).void).void }
+                    sig { params(start: ::T.untyped, finish: ::T.untyped, batch_size: Integer, error_on_ignore: ::T.untyped, cursor: ::T.untyped, order: ::T.any(Symbol, ::T::Array[Symbol])).returns(::T::Enumerator[::Post]) }
                     def find_each(start: nil, finish: nil, batch_size: 1000, error_on_ignore: nil, cursor: primary_key, order: :asc, &block); end
                 <% else %>
-                    sig { params(start: T.untyped, finish: T.untyped, batch_size: Integer, error_on_ignore: T.untyped, order: T.any(Symbol, T::Array[Symbol]), block: T.proc.params(object: ::Post).void).void }
-                    sig { params(start: T.untyped, finish: T.untyped, batch_size: Integer, error_on_ignore: T.untyped, order: T.any(Symbol, T::Array[Symbol])).returns(T::Enumerator[::Post]) }
+                    sig { params(start: ::T.untyped, finish: ::T.untyped, batch_size: Integer, error_on_ignore: ::T.untyped, order: ::T.any(Symbol, ::T::Array[Symbol]), block: ::T.proc.params(object: ::Post).void).void }
+                    sig { params(start: ::T.untyped, finish: ::T.untyped, batch_size: Integer, error_on_ignore: ::T.untyped, order: ::T.any(Symbol, ::T::Array[Symbol])).returns(::T::Enumerator[::Post]) }
                     def find_each(start: nil, finish: nil, batch_size: 1000, error_on_ignore: nil, order: :asc, &block); end
                 <% end %>
 
                 <% if rails_version(">= 8.0") %>
-                    sig { params(start: T.untyped, finish: T.untyped, batch_size: Integer, error_on_ignore: T.untyped, cursor: T.untyped, order: T.any(Symbol, T::Array[Symbol]), block: T.proc.params(object: T::Array[::Post]).void).void }
-                    sig { params(start: T.untyped, finish: T.untyped, batch_size: Integer, error_on_ignore: T.untyped, cursor: T.untyped, order: T.any(Symbol, T::Array[Symbol])).returns(T::Enumerator[T::Array[::Post]]) }
+                    sig { params(start: ::T.untyped, finish: ::T.untyped, batch_size: Integer, error_on_ignore: ::T.untyped, cursor: ::T.untyped, order: ::T.any(Symbol, ::T::Array[Symbol]), block: ::T.proc.params(object: ::T::Array[::Post]).void).void }
+                    sig { params(start: ::T.untyped, finish: ::T.untyped, batch_size: Integer, error_on_ignore: ::T.untyped, cursor: ::T.untyped, order: ::T.any(Symbol, ::T::Array[Symbol])).returns(::T::Enumerator[::T::Array[::Post]]) }
                     def find_in_batches(start: nil, finish: nil, batch_size: 1000, error_on_ignore: nil, cursor: primary_key, order: :asc, &block); end
                 <% else %>
-                    sig { params(start: T.untyped, finish: T.untyped, batch_size: Integer, error_on_ignore: T.untyped, order: T.any(Symbol, T::Array[Symbol]), block: T.proc.params(object: T::Array[::Post]).void).void }
-                    sig { params(start: T.untyped, finish: T.untyped, batch_size: Integer, error_on_ignore: T.untyped, order: T.any(Symbol, T::Array[Symbol])).returns(T::Enumerator[T::Array[::Post]]) }
+                    sig { params(start: ::T.untyped, finish: ::T.untyped, batch_size: Integer, error_on_ignore: ::T.untyped, order: ::T.any(Symbol, ::T::Array[Symbol]), block: ::T.proc.params(object: ::T::Array[::Post]).void).void }
+                    sig { params(start: ::T.untyped, finish: ::T.untyped, batch_size: Integer, error_on_ignore: ::T.untyped, order: ::T.any(Symbol, ::T::Array[Symbol])).returns(::T::Enumerator[::T::Array[::Post]]) }
                     def find_in_batches(start: nil, finish: nil, batch_size: 1000, error_on_ignore: nil, order: :asc, &block); end
                 <% end %>
 
-                    sig { params(attributes: T::Array[T.untyped], block: T.nilable(T.proc.params(object: ::Post).void)).returns(T::Array[::Post]) }
-                    sig { params(attributes: T.untyped, block: T.nilable(T.proc.params(object: ::Post).void)).returns(::Post) }
+                    sig { params(attributes: ::T::Array[::T.untyped], block: ::T.nilable(::T.proc.params(object: ::Post).void)).returns(::T::Array[::Post]) }
+                    sig { params(attributes: ::T.untyped, block: ::T.nilable(::T.proc.params(object: ::Post).void)).returns(::Post) }
                     def find_or_create_by(attributes, &block); end
 
-                    sig { params(attributes: T::Array[T.untyped], block: T.nilable(T.proc.params(object: ::Post).void)).returns(T::Array[::Post]) }
-                    sig { params(attributes: T.untyped, block: T.nilable(T.proc.params(object: ::Post).void)).returns(::Post) }
+                    sig { params(attributes: ::T::Array[::T.untyped], block: ::T.nilable(::T.proc.params(object: ::Post).void)).returns(::T::Array[::Post]) }
+                    sig { params(attributes: ::T.untyped, block: ::T.nilable(::T.proc.params(object: ::Post).void)).returns(::Post) }
                     def find_or_create_by!(attributes, &block); end
 
-                    sig { params(attributes: T::Array[T.untyped], block: T.nilable(T.proc.params(object: ::Post).void)).returns(T::Array[::Post]) }
-                    sig { params(attributes: T.untyped, block: T.nilable(T.proc.params(object: ::Post).void)).returns(::Post) }
+                    sig { params(attributes: ::T::Array[::T.untyped], block: ::T.nilable(::T.proc.params(object: ::Post).void)).returns(::T::Array[::Post]) }
+                    sig { params(attributes: ::T.untyped, block: ::T.nilable(::T.proc.params(object: ::Post).void)).returns(::Post) }
                     def find_or_initialize_by(attributes, &block); end
 
-                    sig { params(signed_id: T.untyped, purpose: T.untyped).returns(T.nilable(::Post)) }
+                    sig { params(signed_id: ::T.untyped, purpose: ::T.untyped).returns(::T.nilable(::Post)) }
                     def find_signed(signed_id, purpose: nil); end
 
-                    sig { params(signed_id: T.untyped, purpose: T.untyped).returns(::Post) }
+                    sig { params(signed_id: ::T.untyped, purpose: ::T.untyped).returns(::Post) }
                     def find_signed!(signed_id, purpose: nil); end
 
-                    sig { params(arg: T.untyped, args: T.untyped).returns(::Post) }
+                    sig { params(arg: ::T.untyped, args: ::T.untyped).returns(::Post) }
                     def find_sole_by(arg, *args); end
 
-                    sig { returns(T.nilable(::Post)) }
-                    sig { params(limit: Integer).returns(T::Array[::Post]) }
+                    sig { returns(::T.nilable(::Post)) }
+                    sig { params(limit: Integer).returns(::T::Array[::Post]) }
                     def first(limit = nil); end
 
                     sig { returns(::Post) }
                     def first!; end
 
-                    sig { returns(T.nilable(::Post)) }
+                    sig { returns(::T.nilable(::Post)) }
                     def forty_two; end
 
                     sig { returns(::Post) }
                     def forty_two!; end
 
-                    sig { returns(T.nilable(::Post)) }
+                    sig { returns(::T.nilable(::Post)) }
                     def fourth; end
 
                     sig { returns(::Post) }
@@ -944,61 +944,61 @@ module Tapioca
                     def ids; end
 
                 <% if rails_version(">= 8.0") %>
-                    sig { params(of: Integer, start: T.untyped, finish: T.untyped, load: T.untyped, error_on_ignore: T.untyped, cursor: T.untyped, order: T.any(Symbol, T::Array[Symbol]), use_ranges: T.untyped, block: T.proc.params(object: PrivateRelation).void).void }
-                    sig { params(of: Integer, start: T.untyped, finish: T.untyped, load: T.untyped, error_on_ignore: T.untyped, cursor: T.untyped, order: T.any(Symbol, T::Array[Symbol]), use_ranges: T.untyped).returns(::ActiveRecord::Batches::BatchEnumerator) }
+                    sig { params(of: Integer, start: ::T.untyped, finish: ::T.untyped, load: ::T.untyped, error_on_ignore: ::T.untyped, cursor: ::T.untyped, order: ::T.any(Symbol, ::T::Array[Symbol]), use_ranges: ::T.untyped, block: ::T.proc.params(object: PrivateRelation).void).void }
+                    sig { params(of: Integer, start: ::T.untyped, finish: ::T.untyped, load: ::T.untyped, error_on_ignore: ::T.untyped, cursor: ::T.untyped, order: ::T.any(Symbol, ::T::Array[Symbol]), use_ranges: ::T.untyped).returns(::ActiveRecord::Batches::BatchEnumerator) }
                     def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, cursor: primary_key, order: :asc, use_ranges: nil, &block); end
                 <% else %>
-                    sig { params(of: Integer, start: T.untyped, finish: T.untyped, load: T.untyped, error_on_ignore: T.untyped, order: T.any(Symbol, T::Array[Symbol]), use_ranges: T.untyped, block: T.proc.params(object: PrivateRelation).void).void }
-                    sig { params(of: Integer, start: T.untyped, finish: T.untyped, load: T.untyped, error_on_ignore: T.untyped, order: T.any(Symbol, T::Array[Symbol]), use_ranges: T.untyped).returns(::ActiveRecord::Batches::BatchEnumerator) }
+                    sig { params(of: Integer, start: ::T.untyped, finish: ::T.untyped, load: ::T.untyped, error_on_ignore: ::T.untyped, order: ::T.any(Symbol, ::T::Array[Symbol]), use_ranges: ::T.untyped, block: ::T.proc.params(object: PrivateRelation).void).void }
+                    sig { params(of: Integer, start: ::T.untyped, finish: ::T.untyped, load: ::T.untyped, error_on_ignore: ::T.untyped, order: ::T.any(Symbol, ::T::Array[Symbol]), use_ranges: ::T.untyped).returns(::ActiveRecord::Batches::BatchEnumerator) }
                     def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, order: :asc, use_ranges: nil, &block); end
                 <% end %>
 
-                    sig { params(record: T.untyped).returns(T::Boolean) }
+                    sig { params(record: ::T.untyped).returns(::T::Boolean) }
                     def include?(record); end
 
-                    sig { returns(T.nilable(::Post)) }
-                    sig { params(limit: Integer).returns(T::Array[::Post]) }
+                    sig { returns(::T.nilable(::Post)) }
+                    sig { params(limit: Integer).returns(::T::Array[::Post]) }
                     def last(limit = nil); end
 
                     sig { returns(::Post) }
                     def last!; end
 
-                    sig { params(block: T.nilable(T.proc.params(record: ::Post).returns(T.untyped))).returns(T::Boolean) }
+                    sig { params(block: ::T.nilable(::T.proc.params(record: ::Post).returns(::T.untyped))).returns(::T::Boolean) }
                     def many?(&block); end
 
-                    sig { params(column_name: T.any(String, Symbol)).returns(T.untyped) }
+                    sig { params(column_name: ::T.any(String, Symbol)).returns(::T.untyped) }
                     def maximum(column_name); end
 
-                    sig { params(record: T.untyped).returns(T::Boolean) }
+                    sig { params(record: ::T.untyped).returns(::T::Boolean) }
                     def member?(record); end
 
-                    sig { params(column_name: T.any(String, Symbol)).returns(T.untyped) }
+                    sig { params(column_name: ::T.any(String, Symbol)).returns(::T.untyped) }
                     def minimum(column_name); end
 
-                    sig { params(block: T.nilable(T.proc.params(object: ::Post).void)).returns(::Post) }
-                    sig { params(attributes: T::Array[T.untyped], block: T.nilable(T.proc.params(object: ::Post).void)).returns(T::Array[::Post]) }
-                    sig { params(attributes: T.untyped, block: T.nilable(T.proc.params(object: ::Post).void)).returns(::Post) }
+                    sig { params(block: ::T.nilable(::T.proc.params(object: ::Post).void)).returns(::Post) }
+                    sig { params(attributes: ::T::Array[::T.untyped], block: ::T.nilable(::T.proc.params(object: ::Post).void)).returns(::T::Array[::Post]) }
+                    sig { params(attributes: ::T.untyped, block: ::T.nilable(::T.proc.params(object: ::Post).void)).returns(::Post) }
                     def new(attributes = nil, &block); end
 
-                    sig { params(block: T.nilable(T.proc.params(record: ::Post).returns(T.untyped))).returns(T::Boolean) }
+                    sig { params(block: ::T.nilable(::T.proc.params(record: ::Post).returns(::T.untyped))).returns(::T::Boolean) }
                     def none?(&block); end
 
-                    sig { params(block: T.nilable(T.proc.params(record: ::Post).returns(T.untyped))).returns(T::Boolean) }
+                    sig { params(block: ::T.nilable(::T.proc.params(record: ::Post).returns(::T.untyped))).returns(::T::Boolean) }
                     def one?(&block); end
 
-                    sig { params(column_names: T.untyped).returns(T.untyped) }
+                    sig { params(column_names: ::T.untyped).returns(::T.untyped) }
                     def pick(*column_names); end
 
-                    sig { params(column_names: T.untyped).returns(T.untyped) }
+                    sig { params(column_names: ::T.untyped).returns(::T.untyped) }
                     def pluck(*column_names); end
 
-                    sig { returns(T.nilable(::Post)) }
+                    sig { returns(::T.nilable(::Post)) }
                     def second; end
 
                     sig { returns(::Post) }
                     def second!; end
 
-                    sig { returns(T.nilable(::Post)) }
+                    sig { returns(::T.nilable(::Post)) }
                     def second_to_last; end
 
                     sig { returns(::Post) }
@@ -1007,24 +1007,24 @@ module Tapioca
                     sig { returns(::Post) }
                     def sole; end
 
-                    sig { params(initial_value_or_column: T.untyped).returns(T.any(Integer, Float, BigDecimal)) }
-                    sig { type_parameters(:U).params(initial_value_or_column: T.nilable(T.type_parameter(:U)), block: T.proc.params(object: ::Post).returns(T.type_parameter(:U))).returns(T.type_parameter(:U)) }
+                    sig { params(initial_value_or_column: ::T.untyped).returns(::T.any(Integer, Float, BigDecimal)) }
+                    sig { type_parameters(:U).params(initial_value_or_column: ::T.nilable(::T.type_parameter(:U)), block: ::T.proc.params(object: ::Post).returns(::T.type_parameter(:U))).returns(::T.type_parameter(:U)) }
                     def sum(initial_value_or_column = nil, &block); end
 
-                    sig { returns(T.nilable(::Post)) }
-                    sig { params(limit: Integer).returns(T::Array[::Post]) }
+                    sig { returns(::T.nilable(::Post)) }
+                    sig { params(limit: Integer).returns(::T::Array[::Post]) }
                     def take(limit = nil); end
 
                     sig { returns(::Post) }
                     def take!; end
 
-                    sig { returns(T.nilable(::Post)) }
+                    sig { returns(::T.nilable(::Post)) }
                     def third; end
 
                     sig { returns(::Post) }
                     def third!; end
 
-                    sig { returns(T.nilable(::Post)) }
+                    sig { returns(::T.nilable(::Post)) }
                     def third_to_last; end
 
                     sig { returns(::Post) }
@@ -1035,148 +1035,148 @@ module Tapioca
                     sig { returns(PrivateAssociationRelation) }
                     def all; end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateAssociationRelation) }
                     def and(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateAssociationRelation) }
                     def annotate(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateAssociationRelation) }
                     def arel_columns(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateAssociationRelation) }
                     def create_with(*args, &blk); end
 
-                    sig { params(value: T::Boolean).returns(PrivateAssociationRelation) }
+                    sig { params(value: ::T::Boolean).returns(PrivateAssociationRelation) }
                     def distinct(value = true); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateAssociationRelation) }
                     def eager_load(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateAssociationRelation) }
                     def except(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateAssociationRelation) }
                     def excluding(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateAssociationRelation) }
                     def extending(*args, &blk); end
 
-                    sig { params(association: Symbol).returns(T::Array[T.untyped]) }
+                    sig { params(association: Symbol).returns(::T::Array[::T.untyped]) }
                     def extract_associated(association); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateAssociationRelation) }
                     def from(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelationGroupChain) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateAssociationRelationGroupChain) }
                     def group(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateAssociationRelation) }
                     def having(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateAssociationRelation) }
                     def in_order_of(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateAssociationRelation) }
                     def includes(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateAssociationRelation) }
                     def invert_where(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateAssociationRelation) }
                     def joins(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateAssociationRelation) }
                     def left_joins(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateAssociationRelation) }
                     def left_outer_joins(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateAssociationRelation) }
                     def limit(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateAssociationRelation) }
                     def lock(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateAssociationRelation) }
                     def merge(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateAssociationRelation) }
                     def none(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateAssociationRelation) }
                     def null_relation?(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateAssociationRelation) }
                     def offset(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateAssociationRelation) }
                     def only(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateAssociationRelation) }
                     def optimizer_hints(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateAssociationRelation) }
                     def or(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateAssociationRelation) }
                     def order(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateAssociationRelation) }
                     def preload(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateAssociationRelation) }
                     def readonly(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateAssociationRelation) }
                     def references(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateAssociationRelation) }
                     def regroup(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateAssociationRelation) }
                     def reorder(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateAssociationRelation) }
                     def reselect(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateAssociationRelation) }
                     def reverse_order(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateAssociationRelation) }
                     def rewhere(*args, &blk); end
 
-                    sig { params(args: T.untyped).returns(PrivateAssociationRelation) }
-                    sig { params(blk: T.proc.params(record: ::Post).returns(BasicObject)).returns(T::Array[::Post]) }
+                    sig { params(args: ::T.untyped).returns(PrivateAssociationRelation) }
+                    sig { params(blk: ::T.proc.params(record: ::Post).returns(BasicObject)).returns(::T::Array[::Post]) }
                     def select(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateAssociationRelation) }
                     def strict_loading(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateAssociationRelation) }
                     def structurally_compatible?(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateAssociationRelation) }
                     def uniq!(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateAssociationRelation) }
                     def unscope(*args, &blk); end
 
                     sig { returns(PrivateAssociationRelation) }
-                    sig { type_parameters(:U).params(block: T.proc.returns(T.type_parameter(:U))).returns(T.type_parameter(:U)) }
+                    sig { type_parameters(:U).params(block: ::T.proc.returns(::T.type_parameter(:U))).returns(::T.type_parameter(:U)) }
                     def unscoped(&block); end
 
                     sig { returns(PrivateAssociationRelationWhereChain) }
-                    sig { params(args: T.untyped).returns(PrivateAssociationRelation) }
+                    sig { params(args: ::T.untyped).returns(PrivateAssociationRelation) }
                     def where(*args); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateAssociationRelation) }
                     def with(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateAssociationRelation) }
                     def with_recursive(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateAssociationRelation) }
                     def without(*args, &blk); end
                   end
 
@@ -1184,148 +1184,148 @@ module Tapioca
                     sig { returns(PrivateRelation) }
                     def all; end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateRelation) }
                     def and(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateRelation) }
                     def annotate(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateRelation) }
                     def arel_columns(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateRelation) }
                     def create_with(*args, &blk); end
 
-                    sig { params(value: T::Boolean).returns(PrivateRelation) }
+                    sig { params(value: ::T::Boolean).returns(PrivateRelation) }
                     def distinct(value = true); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateRelation) }
                     def eager_load(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateRelation) }
                     def except(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateRelation) }
                     def excluding(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateRelation) }
                     def extending(*args, &blk); end
 
-                    sig { params(association: Symbol).returns(T::Array[T.untyped]) }
+                    sig { params(association: Symbol).returns(::T::Array[::T.untyped]) }
                     def extract_associated(association); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateRelation) }
                     def from(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelationGroupChain) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateRelationGroupChain) }
                     def group(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateRelation) }
                     def having(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateRelation) }
                     def in_order_of(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateRelation) }
                     def includes(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateRelation) }
                     def invert_where(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateRelation) }
                     def joins(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateRelation) }
                     def left_joins(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateRelation) }
                     def left_outer_joins(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateRelation) }
                     def limit(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateRelation) }
                     def lock(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateRelation) }
                     def merge(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateRelation) }
                     def none(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateRelation) }
                     def null_relation?(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateRelation) }
                     def offset(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateRelation) }
                     def only(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateRelation) }
                     def optimizer_hints(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateRelation) }
                     def or(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateRelation) }
                     def order(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateRelation) }
                     def preload(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateRelation) }
                     def readonly(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateRelation) }
                     def references(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateRelation) }
                     def regroup(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateRelation) }
                     def reorder(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateRelation) }
                     def reselect(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateRelation) }
                     def reverse_order(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateRelation) }
                     def rewhere(*args, &blk); end
 
-                    sig { params(args: T.untyped).returns(PrivateRelation) }
-                    sig { params(blk: T.proc.params(record: ::Post).returns(BasicObject)).returns(T::Array[::Post]) }
+                    sig { params(args: ::T.untyped).returns(PrivateRelation) }
+                    sig { params(blk: ::T.proc.params(record: ::Post).returns(BasicObject)).returns(::T::Array[::Post]) }
                     def select(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateRelation) }
                     def strict_loading(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateRelation) }
                     def structurally_compatible?(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateRelation) }
                     def uniq!(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateRelation) }
                     def unscope(*args, &blk); end
 
                     sig { returns(PrivateRelation) }
-                    sig { type_parameters(:U).params(block: T.proc.returns(T.type_parameter(:U))).returns(T.type_parameter(:U)) }
+                    sig { type_parameters(:U).params(block: ::T.proc.returns(::T.type_parameter(:U))).returns(::T.type_parameter(:U)) }
                     def unscoped(&block); end
 
                     sig { returns(PrivateRelationWhereChain) }
-                    sig { params(args: T.untyped).returns(PrivateRelation) }
+                    sig { params(args: ::T.untyped).returns(PrivateRelation) }
                     def where(*args); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateRelation) }
                     def with(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateRelation) }
                     def with_recursive(*args, &blk); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateRelation) }
                     def without(*args, &blk); end
                   end
 
@@ -1335,51 +1335,51 @@ module Tapioca
 
                     Elem = type_member { { fixed: ::Post } }
 
-                    sig { returns(T::Array[::Post]) }
+                    sig { returns(::T::Array[::Post]) }
                     def to_a; end
 
-                    sig { returns(T::Array[::Post]) }
+                    sig { returns(::T::Array[::Post]) }
                     def to_ary; end
                   end
 
                   class PrivateAssociationRelationGroupChain < PrivateAssociationRelation
                     Elem = type_member { { fixed: ::Post } }
 
-                    sig { params(column_name: T.any(String, Symbol)).returns(T::Hash[T.untyped, T.any(Integer, Float, BigDecimal)]) }
+                    sig { params(column_name: ::T.any(String, Symbol)).returns(::T::Hash[::T.untyped, ::T.any(Integer, Float, BigDecimal)]) }
                     def average(column_name); end
 
-                    sig { params(operation: Symbol, column_name: T.any(String, Symbol)).returns(T::Hash[T.untyped, T.any(Integer, Float, BigDecimal)]) }
+                    sig { params(operation: Symbol, column_name: ::T.any(String, Symbol)).returns(::T::Hash[::T.untyped, ::T.any(Integer, Float, BigDecimal)]) }
                     def calculate(operation, column_name); end
 
-                    sig { params(column_name: T.untyped).returns(T::Hash[T.untyped, Integer]) }
+                    sig { params(column_name: ::T.untyped).returns(::T::Hash[::T.untyped, Integer]) }
                     def count(column_name = nil); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(T.self_type) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(::T.self_type) }
                     def having(*args, &blk); end
 
-                    sig { params(column_name: T.any(String, Symbol)).returns(T::Hash[T.untyped, T.untyped]) }
+                    sig { params(column_name: ::T.any(String, Symbol)).returns(::T::Hash[::T.untyped, ::T.untyped]) }
                     def maximum(column_name); end
 
-                    sig { params(column_name: T.any(String, Symbol)).returns(T::Hash[T.untyped, T.untyped]) }
+                    sig { params(column_name: ::T.any(String, Symbol)).returns(::T::Hash[::T.untyped, ::T.untyped]) }
                     def minimum(column_name); end
 
-                    sig { returns(T::Hash[T.untyped, Integer]) }
+                    sig { returns(::T::Hash[::T.untyped, Integer]) }
                     def size; end
 
-                    sig { params(column_name: T.nilable(T.any(String, Symbol)), block: T.nilable(T.proc.params(record: T.untyped).returns(T.untyped))).returns(T::Hash[T.untyped, T.any(Integer, Float, BigDecimal)]) }
+                    sig { params(column_name: ::T.nilable(::T.any(String, Symbol)), block: ::T.nilable(::T.proc.params(record: ::T.untyped).returns(::T.untyped))).returns(::T::Hash[::T.untyped, ::T.any(Integer, Float, BigDecimal)]) }
                     def sum(column_name = nil, &block); end
                   end
 
                   class PrivateAssociationRelationWhereChain
                     Elem = type_member { { fixed: ::Post } }
 
-                    sig { params(args: T.untyped).returns(PrivateAssociationRelation) }
+                    sig { params(args: ::T.untyped).returns(PrivateAssociationRelation) }
                     def associated(*args); end
 
-                    sig { params(args: T.untyped).returns(PrivateAssociationRelation) }
+                    sig { params(args: ::T.untyped).returns(PrivateAssociationRelation) }
                     def missing(*args); end
 
-                    sig { params(opts: T.untyped, rest: T.untyped).returns(PrivateAssociationRelation) }
+                    sig { params(opts: ::T.untyped, rest: ::T.untyped).returns(PrivateAssociationRelation) }
                     def not(opts, *rest); end
                   end
 
@@ -1389,40 +1389,40 @@ module Tapioca
 
                     Elem = type_member { { fixed: ::Post } }
 
-                    sig { params(records: T.any(::Post, T::Enumerable[T.any(::Post, T::Enumerable[::Post])])).returns(PrivateCollectionProxy) }
+                    sig { params(records: ::T.any(::Post, ::T::Enumerable[::T.any(::Post, ::T::Enumerable[::Post])])).returns(PrivateCollectionProxy) }
                     def <<(*records); end
 
-                    sig { params(records: T.any(::Post, T::Enumerable[T.any(::Post, T::Enumerable[::Post])])).returns(PrivateCollectionProxy) }
+                    sig { params(records: ::T.any(::Post, ::T::Enumerable[::T.any(::Post, ::T::Enumerable[::Post])])).returns(PrivateCollectionProxy) }
                     def append(*records); end
 
                     sig { returns(PrivateCollectionProxy) }
                     def clear; end
 
-                    sig { params(records: T.any(::Post, T::Enumerable[T.any(::Post, T::Enumerable[::Post])])).returns(PrivateCollectionProxy) }
+                    sig { params(records: ::T.any(::Post, ::T::Enumerable[::T.any(::Post, ::T::Enumerable[::Post])])).returns(PrivateCollectionProxy) }
                     def concat(*records); end
 
-                    sig { returns(T::Array[::Post]) }
+                    sig { returns(::T::Array[::Post]) }
                     def load_target; end
 
-                    sig { params(records: T.any(::Post, T::Enumerable[T.any(::Post, T::Enumerable[::Post])])).returns(PrivateCollectionProxy) }
+                    sig { params(records: ::T.any(::Post, ::T::Enumerable[::T.any(::Post, ::T::Enumerable[::Post])])).returns(PrivateCollectionProxy) }
                     def prepend(*records); end
 
-                    sig { params(records: T.any(::Post, T::Enumerable[T.any(::Post, T::Enumerable[::Post])])).returns(PrivateCollectionProxy) }
+                    sig { params(records: ::T.any(::Post, ::T::Enumerable[::T.any(::Post, ::T::Enumerable[::Post])])).returns(PrivateCollectionProxy) }
                     def push(*records); end
 
-                    sig { params(other_array: T.any(::Post, T::Enumerable[T.any(::Post, T::Enumerable[::Post])])).returns(T::Array[::Post]) }
+                    sig { params(other_array: ::T.any(::Post, ::T::Enumerable[::T.any(::Post, ::T::Enumerable[::Post])])).returns(::T::Array[::Post]) }
                     def replace(other_array); end
 
                     sig { returns(PrivateAssociationRelation) }
                     def scope; end
 
-                    sig { returns(T::Array[::Post]) }
+                    sig { returns(::T::Array[::Post]) }
                     def target; end
 
-                    sig { returns(T::Array[::Post]) }
+                    sig { returns(::T::Array[::Post]) }
                     def to_a; end
 
-                    sig { returns(T::Array[::Post]) }
+                    sig { returns(::T::Array[::Post]) }
                     def to_ary; end
                   end
 
@@ -1432,51 +1432,51 @@ module Tapioca
 
                     Elem = type_member { { fixed: ::Post } }
 
-                    sig { returns(T::Array[::Post]) }
+                    sig { returns(::T::Array[::Post]) }
                     def to_a; end
 
-                    sig { returns(T::Array[::Post]) }
+                    sig { returns(::T::Array[::Post]) }
                     def to_ary; end
                   end
 
                   class PrivateRelationGroupChain < PrivateRelation
                     Elem = type_member { { fixed: ::Post } }
 
-                    sig { params(column_name: T.any(String, Symbol)).returns(T::Hash[T.untyped, T.any(Integer, Float, BigDecimal)]) }
+                    sig { params(column_name: ::T.any(String, Symbol)).returns(::T::Hash[::T.untyped, ::T.any(Integer, Float, BigDecimal)]) }
                     def average(column_name); end
 
-                    sig { params(operation: Symbol, column_name: T.any(String, Symbol)).returns(T::Hash[T.untyped, T.any(Integer, Float, BigDecimal)]) }
+                    sig { params(operation: Symbol, column_name: ::T.any(String, Symbol)).returns(::T::Hash[::T.untyped, ::T.any(Integer, Float, BigDecimal)]) }
                     def calculate(operation, column_name); end
 
-                    sig { params(column_name: T.untyped).returns(T::Hash[T.untyped, Integer]) }
+                    sig { params(column_name: ::T.untyped).returns(::T::Hash[::T.untyped, Integer]) }
                     def count(column_name = nil); end
 
-                    sig { params(args: T.untyped, blk: T.untyped).returns(T.self_type) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(::T.self_type) }
                     def having(*args, &blk); end
 
-                    sig { params(column_name: T.any(String, Symbol)).returns(T::Hash[T.untyped, T.untyped]) }
+                    sig { params(column_name: ::T.any(String, Symbol)).returns(::T::Hash[::T.untyped, ::T.untyped]) }
                     def maximum(column_name); end
 
-                    sig { params(column_name: T.any(String, Symbol)).returns(T::Hash[T.untyped, T.untyped]) }
+                    sig { params(column_name: ::T.any(String, Symbol)).returns(::T::Hash[::T.untyped, ::T.untyped]) }
                     def minimum(column_name); end
 
-                    sig { returns(T::Hash[T.untyped, Integer]) }
+                    sig { returns(::T::Hash[::T.untyped, Integer]) }
                     def size; end
 
-                    sig { params(column_name: T.nilable(T.any(String, Symbol)), block: T.nilable(T.proc.params(record: T.untyped).returns(T.untyped))).returns(T::Hash[T.untyped, T.any(Integer, Float, BigDecimal)]) }
+                    sig { params(column_name: ::T.nilable(::T.any(String, Symbol)), block: ::T.nilable(::T.proc.params(record: ::T.untyped).returns(::T.untyped))).returns(::T::Hash[::T.untyped, ::T.any(Integer, Float, BigDecimal)]) }
                     def sum(column_name = nil, &block); end
                   end
 
                   class PrivateRelationWhereChain
                     Elem = type_member { { fixed: ::Post } }
 
-                    sig { params(args: T.untyped).returns(PrivateRelation) }
+                    sig { params(args: ::T.untyped).returns(PrivateRelation) }
                     def associated(*args); end
 
-                    sig { params(args: T.untyped).returns(PrivateRelation) }
+                    sig { params(args: ::T.untyped).returns(PrivateRelation) }
                     def missing(*args); end
 
-                    sig { params(opts: T.untyped, rest: T.untyped).returns(PrivateRelation) }
+                    sig { params(opts: ::T.untyped, rest: ::T.untyped).returns(PrivateRelation) }
                     def not(opts, *rest); end
                   end
                 end

--- a/spec/tapioca/dsl/compilers/active_record_scope_spec.rb
+++ b/spec/tapioca/dsl/compilers/active_record_scope_spec.rb
@@ -69,12 +69,12 @@ module Tapioca
                     extend GeneratedRelationMethods
 
                     module GeneratedAssociationRelationMethods
-                      sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
+                      sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateAssociationRelation) }
                       def public_kind(*args, &blk); end
                     end
 
                     module GeneratedRelationMethods
-                      sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
+                      sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateRelation) }
                       def public_kind(*args, &blk); end
                     end
                   end
@@ -98,18 +98,18 @@ module Tapioca
                     extend GeneratedRelationMethods
 
                     module GeneratedAssociationRelationMethods
-                      sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
+                      sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateAssociationRelation) }
                       def private_kind(*args, &blk); end
 
-                      sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
+                      sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateAssociationRelation) }
                       def public_kind(*args, &blk); end
                     end
 
                     module GeneratedRelationMethods
-                      sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
+                      sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateRelation) }
                       def private_kind(*args, &blk); end
 
-                      sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
+                      sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateRelation) }
                       def public_kind(*args, &blk); end
                     end
                   end
@@ -140,24 +140,24 @@ module Tapioca
                     extend GeneratedRelationMethods
 
                     module GeneratedAssociationRelationMethods
-                      sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
+                      sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateAssociationRelation) }
                       def custom_post_scope(*args, &blk); end
 
-                      sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
+                      sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateAssociationRelation) }
                       def post_scope(*args, &blk); end
 
-                      sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
+                      sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateAssociationRelation) }
                       def super_custom_post_scope(*args, &blk); end
                     end
 
                     module GeneratedRelationMethods
-                      sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
+                      sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateRelation) }
                       def custom_post_scope(*args, &blk); end
 
-                      sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
+                      sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateRelation) }
                       def post_scope(*args, &blk); end
 
-                      sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
+                      sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateRelation) }
                       def super_custom_post_scope(*args, &blk); end
                     end
                   end
@@ -186,18 +186,18 @@ module Tapioca
                     extend GeneratedRelationMethods
 
                     module GeneratedAssociationRelationMethods
-                      sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
+                      sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateAssociationRelation) }
                       def app_scope(*args, &blk); end
 
-                      sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
+                      sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateAssociationRelation) }
                       def post_scope(*args, &blk); end
                     end
 
                     module GeneratedRelationMethods
-                      sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
+                      sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateRelation) }
                       def app_scope(*args, &blk); end
 
-                      sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
+                      sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateRelation) }
                       def post_scope(*args, &blk); end
                     end
                   end
@@ -234,12 +234,12 @@ module Tapioca
                     extend GeneratedRelationMethods
 
                     module GeneratedAssociationRelationMethods
-                      sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
+                      sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateAssociationRelation) }
                       def post_scope(*args, &blk); end
                     end
 
                     module GeneratedRelationMethods
-                      sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
+                      sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateRelation) }
                       def post_scope(*args, &blk); end
                     end
                   end
@@ -277,7 +277,7 @@ module Tapioca
                     extend GeneratedRelationMethods
 
                     module GeneratedRelationMethods
-                      sig { params(args: T.untyped, blk: T.untyped).returns(T.untyped) }
+                      sig { params(args: ::T.untyped, blk: ::T.untyped).returns(::T.untyped) }
                       def public_kind(*args, &blk); end
                     end
                   end
@@ -301,10 +301,10 @@ module Tapioca
                     extend GeneratedRelationMethods
 
                     module GeneratedRelationMethods
-                      sig { params(args: T.untyped, blk: T.untyped).returns(T.untyped) }
+                      sig { params(args: ::T.untyped, blk: ::T.untyped).returns(::T.untyped) }
                       def private_kind(*args, &blk); end
 
-                      sig { params(args: T.untyped, blk: T.untyped).returns(T.untyped) }
+                      sig { params(args: ::T.untyped, blk: ::T.untyped).returns(::T.untyped) }
                       def public_kind(*args, &blk); end
                     end
                   end
@@ -327,16 +327,16 @@ module Tapioca
                     extend GeneratedRelationMethods
 
                     module GeneratedRelationMethods
-                      sig { params(args: T.untyped, blk: T.untyped).returns(T.untyped) }
+                      sig { params(args: ::T.untyped, blk: ::T.untyped).returns(::T.untyped) }
                       def active(*args, &blk); end
 
-                      sig { params(args: T.untyped, blk: T.untyped).returns(T.untyped) }
+                      sig { params(args: ::T.untyped, blk: ::T.untyped).returns(::T.untyped) }
                       def archived(*args, &blk); end
 
-                      sig { params(args: T.untyped, blk: T.untyped).returns(T.untyped) }
+                      sig { params(args: ::T.untyped, blk: ::T.untyped).returns(::T.untyped) }
                       def not_active(*args, &blk); end
 
-                      sig { params(args: T.untyped, blk: T.untyped).returns(T.untyped) }
+                      sig { params(args: ::T.untyped, blk: ::T.untyped).returns(::T.untyped) }
                       def not_archived(*args, &blk); end
                     end
                   end
@@ -367,13 +367,13 @@ module Tapioca
                     extend GeneratedRelationMethods
 
                     module GeneratedRelationMethods
-                      sig { params(args: T.untyped, blk: T.untyped).returns(T.untyped) }
+                      sig { params(args: ::T.untyped, blk: ::T.untyped).returns(::T.untyped) }
                       def custom_post_scope(*args, &blk); end
 
-                      sig { params(args: T.untyped, blk: T.untyped).returns(T.untyped) }
+                      sig { params(args: ::T.untyped, blk: ::T.untyped).returns(::T.untyped) }
                       def post_scope(*args, &blk); end
 
-                      sig { params(args: T.untyped, blk: T.untyped).returns(T.untyped) }
+                      sig { params(args: ::T.untyped, blk: ::T.untyped).returns(::T.untyped) }
                       def super_custom_post_scope(*args, &blk); end
                     end
                   end
@@ -402,10 +402,10 @@ module Tapioca
                     extend GeneratedRelationMethods
 
                     module GeneratedRelationMethods
-                      sig { params(args: T.untyped, blk: T.untyped).returns(T.untyped) }
+                      sig { params(args: ::T.untyped, blk: ::T.untyped).returns(::T.untyped) }
                       def app_scope(*args, &blk); end
 
-                      sig { params(args: T.untyped, blk: T.untyped).returns(T.untyped) }
+                      sig { params(args: ::T.untyped, blk: ::T.untyped).returns(::T.untyped) }
                       def post_scope(*args, &blk); end
                     end
                   end
@@ -438,12 +438,12 @@ module Tapioca
                   extend GeneratedRelationMethods
 
                   module GeneratedAssociationRelationMethods
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateAssociationRelation) }
                     def with_attached_photo(*args, &blk); end
                   end
 
                   module GeneratedRelationMethods
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateRelation) }
                     def with_attached_photo(*args, &blk); end
                   end
                 end
@@ -466,12 +466,12 @@ module Tapioca
                   extend GeneratedRelationMethods
 
                   module GeneratedAssociationRelationMethods
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateAssociationRelation) }
                     def with_attached_photos(*args, &blk); end
                   end
 
                   module GeneratedRelationMethods
-                    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(PrivateRelation) }
                     def with_attached_photos(*args, &blk); end
                   end
                 end

--- a/spec/tapioca/dsl/compilers/active_record_secure_token_spec.rb
+++ b/spec/tapioca/dsl/compilers/active_record_secure_token_spec.rb
@@ -60,7 +60,7 @@ module Tapioca
                   include GeneratedSecureTokenMethods
 
                   module GeneratedSecureTokenMethods
-                    sig { returns(T::Boolean) }
+                    sig { returns(::T::Boolean) }
                     def regenerate_token; end
                   end
                 end
@@ -84,7 +84,7 @@ module Tapioca
                   include GeneratedSecureTokenMethods
 
                   module GeneratedSecureTokenMethods
-                    sig { returns(T::Boolean) }
+                    sig { returns(::T::Boolean) }
                     def regenerate_auth_token; end
                   end
                 end
@@ -109,10 +109,10 @@ module Tapioca
                   include GeneratedSecureTokenMethods
 
                   module GeneratedSecureTokenMethods
-                    sig { returns(T::Boolean) }
+                    sig { returns(::T::Boolean) }
                     def regenerate_auth_token; end
 
-                    sig { returns(T::Boolean) }
+                    sig { returns(::T::Boolean) }
                     def regenerate_token; end
                   end
                 end

--- a/spec/tapioca/dsl/compilers/active_record_store_spec.rb
+++ b/spec/tapioca/dsl/compilers/active_record_store_spec.rb
@@ -60,28 +60,28 @@ module Tapioca
                   include GeneratedStoredAttributesMethods
 
                   module GeneratedStoredAttributesMethods
-                    sig { returns(T.untyped) }
+                    sig { returns(::T.untyped) }
                     def saved_change_to_theme; end
 
-                    sig { returns(T::Boolean) }
+                    sig { returns(::T::Boolean) }
                     def saved_change_to_theme?; end
 
-                    sig { returns(T.untyped) }
+                    sig { returns(::T.untyped) }
                     def theme; end
 
-                    sig { params(value: T.untyped).returns(T.untyped) }
+                    sig { params(value: ::T.untyped).returns(::T.untyped) }
                     def theme=(value); end
 
-                    sig { returns(T.untyped) }
+                    sig { returns(::T.untyped) }
                     def theme_before_last_save; end
 
-                    sig { returns(T.untyped) }
+                    sig { returns(::T.untyped) }
                     def theme_change; end
 
-                    sig { returns(T::Boolean) }
+                    sig { returns(::T::Boolean) }
                     def theme_changed?; end
 
-                    sig { returns(T.untyped) }
+                    sig { returns(::T.untyped) }
                     def theme_was; end
                   end
                 end
@@ -104,28 +104,28 @@ module Tapioca
                   include GeneratedStoredAttributesMethods
 
                   module GeneratedStoredAttributesMethods
-                    sig { returns(T.untyped) }
+                    sig { returns(::T.untyped) }
                     def saved_change_to_theme; end
 
-                    sig { returns(T::Boolean) }
+                    sig { returns(::T::Boolean) }
                     def saved_change_to_theme?; end
 
-                    sig { returns(T.untyped) }
+                    sig { returns(::T.untyped) }
                     def theme; end
 
-                    sig { params(value: T.untyped).returns(T.untyped) }
+                    sig { params(value: ::T.untyped).returns(::T.untyped) }
                     def theme=(value); end
 
-                    sig { returns(T.untyped) }
+                    sig { returns(::T.untyped) }
                     def theme_before_last_save; end
 
-                    sig { returns(T.untyped) }
+                    sig { returns(::T.untyped) }
                     def theme_change; end
 
-                    sig { returns(T::Boolean) }
+                    sig { returns(::T::Boolean) }
                     def theme_changed?; end
 
-                    sig { returns(T.untyped) }
+                    sig { returns(::T.untyped) }
                     def theme_was; end
                   end
                 end
@@ -145,25 +145,25 @@ module Tapioca
               output = rbi_for(:User)
 
               expected = indented(<<~RBI, 4)
-                sig { params(value: T.untyped).returns(T.untyped) }
+                sig { params(value: ::T.untyped).returns(::T.untyped) }
                 def theme=(value); end
               RBI
               assert_includes(output, expected)
 
               expected = indented(<<~RBI, 4)
-                sig { params(value: T.untyped).returns(T.untyped) }
+                sig { params(value: ::T.untyped).returns(::T.untyped) }
                 def language=(value); end
               RBI
               assert_includes(output, expected)
 
               expected = indented(<<~RBI, 4)
-                sig { params(value: T.untyped).returns(T.untyped) }
+                sig { params(value: ::T.untyped).returns(::T.untyped) }
                 def power_source=(value); end
               RBI
               assert_includes(output, expected)
 
               expected = indented(<<~RBI, 4)
-                sig { params(value: T.untyped).returns(T.untyped) }
+                sig { params(value: ::T.untyped).returns(::T.untyped) }
                 def expiry=(value); end
               RBI
               assert_includes(output, expected)
@@ -180,13 +180,13 @@ module Tapioca
               output = rbi_for(:User)
 
               expected = indented(<<~RBI, 4)
-                sig { params(value: T.untyped).returns(T.untyped) }
+                sig { params(value: ::T.untyped).returns(::T.untyped) }
                 def settings_theme=(value); end
               RBI
               assert_includes(output, expected)
 
               expected = indented(<<~RBI, 4)
-                sig { params(value: T.untyped).returns(T.untyped) }
+                sig { params(value: ::T.untyped).returns(::T.untyped) }
                 def prefs_power_source=(value); end
               RBI
               assert_includes(output, expected)
@@ -203,13 +203,13 @@ module Tapioca
               output = rbi_for(:User)
 
               expected = indented(<<~RBI, 4)
-                sig { params(value: T.untyped).returns(T.untyped) }
+                sig { params(value: ::T.untyped).returns(::T.untyped) }
                 def theme_settings=(value); end
               RBI
               assert_includes(output, expected)
 
               expected = indented(<<~RBI, 4)
-                sig { params(value: T.untyped).returns(T.untyped) }
+                sig { params(value: ::T.untyped).returns(::T.untyped) }
                 def power_source_prefs=(value); end
               RBI
               assert_includes(output, expected)

--- a/spec/tapioca/dsl/compilers/active_record_typed_store_spec.rb
+++ b/spec/tapioca/dsl/compilers/active_record_typed_store_spec.rb
@@ -83,58 +83,58 @@ module Tapioca
                   include StoreAccessors
 
                   module StoreAccessors
-                    sig { returns(T.nilable(String)) }
+                    sig { returns(::T.nilable(String)) }
                     def reviewer; end
 
-                    sig { params(reviewer: T.nilable(String)).returns(T.nilable(String)) }
+                    sig { params(reviewer: ::T.nilable(String)).returns(::T.nilable(String)) }
                     def reviewer=(reviewer); end
 
-                    sig { returns(T::Boolean) }
+                    sig { returns(::T::Boolean) }
                     def reviewer?; end
 
-                    sig { returns(T.nilable(String)) }
+                    sig { returns(::T.nilable(String)) }
                     def reviewer_before_last_save; end
 
-                    sig { returns(T.nilable([T.nilable(String), T.nilable(String)])) }
+                    sig { returns(::T.nilable([::T.nilable(String), ::T.nilable(String)])) }
                     def reviewer_change; end
 
-                    sig { returns(T::Boolean) }
+                    sig { returns(::T::Boolean) }
                     def reviewer_changed?; end
 
-                    sig { returns(T.nilable(String)) }
+                    sig { returns(::T.nilable(String)) }
                     def reviewer_was; end
 
-                    sig { returns(T.nilable([T.nilable(String), T.nilable(String)])) }
+                    sig { returns(::T.nilable([::T.nilable(String), ::T.nilable(String)])) }
                     def saved_change_to_reviewer; end
 
-                    sig { returns(T::Boolean) }
+                    sig { returns(::T::Boolean) }
                     def saved_change_to_reviewer?; end
 
-                    sig { returns(T.nilable([T.nilable(String), T.nilable(String)])) }
+                    sig { returns(::T.nilable([::T.nilable(String), ::T.nilable(String)])) }
                     def saved_change_to_title; end
 
-                    sig { returns(T::Boolean) }
+                    sig { returns(::T::Boolean) }
                     def saved_change_to_title?; end
 
-                    sig { returns(T.nilable(String)) }
+                    sig { returns(::T.nilable(String)) }
                     def title; end
 
-                    sig { params(title: T.nilable(String)).returns(T.nilable(String)) }
+                    sig { params(title: ::T.nilable(String)).returns(::T.nilable(String)) }
                     def title=(title); end
 
-                    sig { returns(T::Boolean) }
+                    sig { returns(::T::Boolean) }
                     def title?; end
 
-                    sig { returns(T.nilable(String)) }
+                    sig { returns(::T.nilable(String)) }
                     def title_before_last_save; end
 
-                    sig { returns(T.nilable([T.nilable(String), T.nilable(String)])) }
+                    sig { returns(::T.nilable([::T.nilable(String), ::T.nilable(String)])) }
                     def title_change; end
 
-                    sig { returns(T::Boolean) }
+                    sig { returns(::T::Boolean) }
                     def title_changed?; end
 
-                    sig { returns(T.nilable(String)) }
+                    sig { returns(::T.nilable(String)) }
                     def title_was; end
                   end
                 end
@@ -159,31 +159,31 @@ module Tapioca
                   include StoreAccessors
 
                   module StoreAccessors
-                    sig { returns(T::Boolean) }
+                    sig { returns(::T::Boolean) }
                     def reviewed; end
 
-                    sig { params(reviewed: T::Boolean).returns(T::Boolean) }
+                    sig { params(reviewed: ::T::Boolean).returns(::T::Boolean) }
                     def reviewed=(reviewed); end
 
-                    sig { returns(T::Boolean) }
+                    sig { returns(::T::Boolean) }
                     def reviewed?; end
 
-                    sig { returns(T::Boolean) }
+                    sig { returns(::T::Boolean) }
                     def reviewed_before_last_save; end
 
-                    sig { returns(T.nilable([T::Boolean, T::Boolean])) }
+                    sig { returns(::T.nilable([::T::Boolean, ::T::Boolean])) }
                     def reviewed_change; end
 
-                    sig { returns(T::Boolean) }
+                    sig { returns(::T::Boolean) }
                     def reviewed_changed?; end
 
-                    sig { returns(T::Boolean) }
+                    sig { returns(::T::Boolean) }
                     def reviewed_was; end
 
-                    sig { returns(T.nilable([T::Boolean, T::Boolean])) }
+                    sig { returns(::T.nilable([::T::Boolean, ::T::Boolean])) }
                     def saved_change_to_reviewed; end
 
-                    sig { returns(T::Boolean) }
+                    sig { returns(::T::Boolean) }
                     def saved_change_to_reviewed?; end
                   end
                 end
@@ -212,58 +212,58 @@ module Tapioca
                   include StoreAccessors
 
                   module StoreAccessors
-                    sig { returns(T.nilable(Date)) }
+                    sig { returns(::T.nilable(Date)) }
                     def review_date; end
 
-                    sig { params(review_date: T.nilable(Date)).returns(T.nilable(Date)) }
+                    sig { params(review_date: ::T.nilable(Date)).returns(::T.nilable(Date)) }
                     def review_date=(review_date); end
 
-                    sig { returns(T::Boolean) }
+                    sig { returns(::T::Boolean) }
                     def review_date?; end
 
-                    sig { returns(T.nilable(Date)) }
+                    sig { returns(::T.nilable(Date)) }
                     def review_date_before_last_save; end
 
-                    sig { returns(T.nilable([T.nilable(Date), T.nilable(Date)])) }
+                    sig { returns(::T.nilable([::T.nilable(Date), ::T.nilable(Date)])) }
                     def review_date_change; end
 
-                    sig { returns(T::Boolean) }
+                    sig { returns(::T::Boolean) }
                     def review_date_changed?; end
 
-                    sig { returns(T.nilable(Date)) }
+                    sig { returns(::T.nilable(Date)) }
                     def review_date_was; end
 
-                    sig { returns(T.nilable([T.nilable(Date), T.nilable(Date)])) }
+                    sig { returns(::T.nilable([::T.nilable(Date), ::T.nilable(Date)])) }
                     def saved_change_to_review_date; end
 
-                    sig { returns(T::Boolean) }
+                    sig { returns(::T::Boolean) }
                     def saved_change_to_review_date?; end
 
-                    sig { returns(T.nilable([T.nilable(Date), T.nilable(Date)])) }
+                    sig { returns(::T.nilable([::T.nilable(Date), ::T.nilable(Date)])) }
                     def saved_change_to_title_date; end
 
-                    sig { returns(T::Boolean) }
+                    sig { returns(::T::Boolean) }
                     def saved_change_to_title_date?; end
 
-                    sig { returns(T.nilable(Date)) }
+                    sig { returns(::T.nilable(Date)) }
                     def title_date; end
 
-                    sig { params(title_date: T.nilable(Date)).returns(T.nilable(Date)) }
+                    sig { params(title_date: ::T.nilable(Date)).returns(::T.nilable(Date)) }
                     def title_date=(title_date); end
 
-                    sig { returns(T::Boolean) }
+                    sig { returns(::T::Boolean) }
                     def title_date?; end
 
-                    sig { returns(T.nilable(Date)) }
+                    sig { returns(::T.nilable(Date)) }
                     def title_date_before_last_save; end
 
-                    sig { returns(T.nilable([T.nilable(Date), T.nilable(Date)])) }
+                    sig { returns(::T.nilable([::T.nilable(Date), ::T.nilable(Date)])) }
                     def title_date_change; end
 
-                    sig { returns(T::Boolean) }
+                    sig { returns(::T::Boolean) }
                     def title_date_changed?; end
 
-                    sig { returns(T.nilable(Date)) }
+                    sig { returns(::T.nilable(Date)) }
                     def title_date_was; end
                   end
                 end
@@ -288,10 +288,10 @@ module Tapioca
                   include StoreAccessors
 
                   module StoreAccessors
-                    sig { returns(T.nilable(DateTime)) }
+                    sig { returns(::T.nilable(DateTime)) }
                     def review_date; end
 
-                    sig { params(review_date: T.nilable(DateTime)).returns(T.nilable(DateTime)) }
+                    sig { params(review_date: ::T.nilable(DateTime)).returns(::T.nilable(DateTime)) }
                     def review_date=(review_date); end
               RBI
 
@@ -314,10 +314,10 @@ module Tapioca
                   include StoreAccessors
 
                   module StoreAccessors
-                    sig { returns(T.nilable(Time)) }
+                    sig { returns(::T.nilable(Time)) }
                     def review_time; end
 
-                    sig { params(review_time: T.nilable(Time)).returns(T.nilable(Time)) }
+                    sig { params(review_time: ::T.nilable(Time)).returns(::T.nilable(Time)) }
                     def review_time=(review_time); end
               RBI
 
@@ -340,17 +340,17 @@ module Tapioca
                   include StoreAccessors
 
                   module StoreAccessors
-                    sig { returns(T.nilable(BigDecimal)) }
+                    sig { returns(::T.nilable(BigDecimal)) }
                     def rate; end
 
-                    sig { params(rate: T.nilable(BigDecimal)).returns(T.nilable(BigDecimal)) }
+                    sig { params(rate: ::T.nilable(BigDecimal)).returns(::T.nilable(BigDecimal)) }
                     def rate=(rate); end
               RBI
 
               assert_includes(rbi_for(:Post), expected)
             end
 
-            it "generates methods with T.untyped type for attributes with any type" do
+            it "generates methods with ::T.untyped type for attributes with any type" do
               add_ruby_file("post.rb", <<~RUBY)
                 class Post < ActiveRecord::Base
                   typed_store :metadata do |s|
@@ -366,10 +366,10 @@ module Tapioca
                   include StoreAccessors
 
                   module StoreAccessors
-                    sig { returns(T.untyped) }
+                    sig { returns(::T.untyped) }
                     def kind; end
 
-                    sig { params(kind: T.untyped).returns(T.untyped) }
+                    sig { params(kind: ::T.untyped).returns(::T.untyped) }
                     def kind=(kind); end
               RBI
 
@@ -392,10 +392,10 @@ module Tapioca
                   include StoreAccessors
 
                   module StoreAccessors
-                    sig { returns(T.nilable(Integer)) }
+                    sig { returns(::T.nilable(Integer)) }
                     def rate; end
 
-                    sig { params(rate: T.nilable(Integer)).returns(T.nilable(Integer)) }
+                    sig { params(rate: ::T.nilable(Integer)).returns(::T.nilable(Integer)) }
                     def rate=(rate); end
               RBI
 
@@ -418,10 +418,10 @@ module Tapioca
                   include StoreAccessors
 
                   module StoreAccessors
-                    sig { returns(T.nilable(Float)) }
+                    sig { returns(::T.nilable(Float)) }
                     def rate; end
 
-                    sig { params(rate: T.nilable(Float)).returns(T.nilable(Float)) }
+                    sig { params(rate: ::T.nilable(Float)).returns(::T.nilable(Float)) }
                     def rate=(rate); end
               RBI
 
@@ -444,10 +444,10 @@ module Tapioca
                   include StoreAccessors
 
                   module StoreAccessors
-                    sig { returns(T.nilable(T::Array[T.nilable(String)])) }
+                    sig { returns(::T.nilable(::T::Array[::T.nilable(String)])) }
                     def comments; end
 
-                    sig { params(comments: T.nilable(T::Array[T.nilable(String)])).returns(T.nilable(T::Array[T.nilable(String)])) }
+                    sig { params(comments: ::T.nilable(::T::Array[::T.nilable(String)])).returns(::T.nilable(::T::Array[::T.nilable(String)])) }
                     def comments=(comments); end
               RBI
 
@@ -471,10 +471,10 @@ module Tapioca
                   include StoreAccessors
 
                   module StoreAccessors
-                    sig { returns(T::Array[T.nilable(String)]) }
+                    sig { returns(::T::Array[::T.nilable(String)]) }
                     def comments; end
 
-                    sig { params(comments: T::Array[T.nilable(String)]).returns(T::Array[T.nilable(String)]) }
+                    sig { params(comments: ::T::Array[::T.nilable(String)]).returns(::T::Array[::T.nilable(String)]) }
                     def comments=(comments); end
               RBI
 
@@ -498,10 +498,10 @@ module Tapioca
                   include StoreAccessors
 
                   module StoreAccessors
-                    sig { returns(T.nilable(String)) }
+                    sig { returns(::T.nilable(String)) }
                     def metadata_rate_metadata; end
 
-                    sig { params(metadata_rate_metadata: T.nilable(String)).returns(T.nilable(String)) }
+                    sig { params(metadata_rate_metadata: ::T.nilable(String)).returns(::T.nilable(String)) }
                     def metadata_rate_metadata=(metadata_rate_metadata); end
               RBI
 

--- a/spec/tapioca/dsl/compilers/active_resource_spec.rb
+++ b/spec/tapioca/dsl/compilers/active_resource_spec.rb
@@ -54,7 +54,7 @@ module Tapioca
                   sig { params(value: Integer).returns(Integer) }
                   def id=(value); end
 
-                  sig { returns(T::Boolean) }
+                  sig { returns(::T::Boolean) }
                   def id?; end
                 end
               RBI
@@ -81,7 +81,7 @@ module Tapioca
                   sig { params(value: Integer).returns(Integer) }
                   def id=(value); end
 
-                  sig { returns(T::Boolean) }
+                  sig { returns(::T::Boolean) }
                   def id?; end
 
                   sig { returns(Integer) }
@@ -90,7 +90,7 @@ module Tapioca
                   sig { params(value: Integer).returns(Integer) }
                   def month=(value); end
 
-                  sig { returns(T::Boolean) }
+                  sig { returns(::T::Boolean) }
                   def month?; end
 
                   sig { returns(Integer) }
@@ -99,7 +99,7 @@ module Tapioca
                   sig { params(value: Integer).returns(Integer) }
                   def year=(value); end
 
-                  sig { returns(T::Boolean) }
+                  sig { returns(::T::Boolean) }
                   def year?; end
                 end
               RBI
@@ -127,7 +127,7 @@ module Tapioca
                   sig { params(value: Integer).returns(Integer) }
                   def month=(value); end
 
-                  sig { returns(T::Boolean) }
+                  sig { returns(::T::Boolean) }
                   def month?; end
 
                   sig { returns(String) }
@@ -136,7 +136,7 @@ module Tapioca
                   sig { params(value: String).returns(String) }
                   def title=(value); end
 
-                  sig { returns(T::Boolean) }
+                  sig { returns(::T::Boolean) }
                   def title?; end
                 end
               RBI
@@ -157,13 +157,13 @@ module Tapioca
                 # typed: strong
 
                 class Post
-                  sig { returns(T.untyped) }
+                  sig { returns(::T.untyped) }
                   def id; end
 
-                  sig { params(value: T.untyped).returns(T.untyped) }
+                  sig { params(value: ::T.untyped).returns(::T.untyped) }
                   def id=(value); end
 
-                  sig { returns(T::Boolean) }
+                  sig { returns(::T::Boolean) }
                   def id?; end
                 end
               RBI
@@ -192,7 +192,7 @@ module Tapioca
               rbi_output = rbi_for(:Post)
 
               assert_includes(rbi_output, indented(<<~RBI, 2))
-                sig { params(value: T::Boolean).returns(T::Boolean) }
+                sig { params(value: ::T::Boolean).returns(::T::Boolean) }
                 def reviewed=(value); end
               RBI
 

--- a/spec/tapioca/dsl/compilers/active_storage_spec.rb
+++ b/spec/tapioca/dsl/compilers/active_storage_spec.rb
@@ -79,7 +79,7 @@ module Tapioca
                   sig { returns(ActiveStorage::Attached::One) }
                   def photo; end
 
-                  sig { params(attachable: T.untyped).returns(T.untyped) }
+                  sig { params(attachable: ::T.untyped).returns(::T.untyped) }
                   def photo=(attachable); end
                 end
               RBI
@@ -101,7 +101,7 @@ module Tapioca
                   sig { returns(ActiveStorage::Attached::Many) }
                   def photos; end
 
-                  sig { params(attachable: T.untyped).returns(T.untyped) }
+                  sig { params(attachable: ::T.untyped).returns(::T.untyped) }
                   def photos=(attachable); end
                 end
               RBI

--- a/spec/tapioca/dsl/compilers/active_support_current_attributes_spec.rb
+++ b/spec/tapioca/dsl/compilers/active_support_current_attributes_spec.rb
@@ -60,30 +60,30 @@ module Tapioca
                   include GeneratedAttributeMethods
 
                   class << self
-                    sig { returns(T.untyped) }
+                    sig { returns(::T.untyped) }
                     def account; end
 
-                    sig { params(value: T.untyped).returns(T.untyped) }
+                    sig { params(value: ::T.untyped).returns(::T.untyped) }
                     def account=(value); end
 
-                    sig { returns(T.untyped) }
+                    sig { returns(::T.untyped) }
                     def user; end
 
-                    sig { params(value: T.untyped).returns(T.untyped) }
+                    sig { params(value: ::T.untyped).returns(::T.untyped) }
                     def user=(value); end
                   end
 
                   module GeneratedAttributeMethods
-                    sig { returns(T.untyped) }
+                    sig { returns(::T.untyped) }
                     def account; end
 
-                    sig { params(value: T.untyped).returns(T.untyped) }
+                    sig { params(value: ::T.untyped).returns(::T.untyped) }
                     def account=(value); end
 
-                    sig { returns(T.untyped) }
+                    sig { returns(::T.untyped) }
                     def user; end
 
-                    sig { params(value: T.untyped).returns(T.untyped) }
+                    sig { params(value: ::T.untyped).returns(::T.untyped) }
                     def user=(value); end
                   end
                 end
@@ -117,24 +117,24 @@ module Tapioca
                   include GeneratedAttributeMethods
 
                   class << self
-                    sig { returns(T.untyped) }
+                    sig { returns(::T.untyped) }
                     def account; end
 
-                    sig { params(value: T.untyped).returns(T.untyped) }
+                    sig { params(value: ::T.untyped).returns(::T.untyped) }
                     def account=(value); end
 
-                    sig { params(user_id: ::Integer, block: T.proc.void).void }
+                    sig { params(user_id: ::Integer, block: ::T.proc.void).void }
                     def authenticate(user_id, &block); end
 
-                    sig { returns(T.untyped) }
+                    sig { returns(::T.untyped) }
                     def helper; end
                   end
 
                   module GeneratedAttributeMethods
-                    sig { returns(T.untyped) }
+                    sig { returns(::T.untyped) }
                     def account; end
 
-                    sig { params(value: T.untyped).returns(T.untyped) }
+                    sig { params(value: ::T.untyped).returns(::T.untyped) }
                     def account=(value); end
                   end
                 end
@@ -174,10 +174,10 @@ module Tapioca
                   include GeneratedAttributeMethods
 
                   class << self
-                    sig { returns(T.nilable(::Integer)) }
+                    sig { returns(::T.nilable(::Integer)) }
                     def user_id; end
 
-                    sig { params(value: T.nilable(::Integer)).void }
+                    sig { params(value: ::T.nilable(::Integer)).void }
                     def user_id=(value); end
 
                     sig { type_parameters(:T).params(t: T.untyped, blk: T.proc.returns(T.type_parameter(:T))).returns(T.type_parameter(:T)) }
@@ -185,10 +185,10 @@ module Tapioca
                   end
 
                   module GeneratedAttributeMethods
-                    sig { returns(T.nilable(::Integer)) }
+                    sig { returns(::T.nilable(::Integer)) }
                     def user_id; end
 
-                    sig { params(value: T.nilable(::Integer)).void }
+                    sig { params(value: ::T.nilable(::Integer)).void }
                     def user_id=(value); end
                   end
                 end

--- a/spec/tapioca/dsl/compilers/active_support_environment_inquirer_spec.rb
+++ b/spec/tapioca/dsl/compilers/active_support_environment_inquirer_spec.rb
@@ -46,10 +46,10 @@ module Tapioca
                   # typed: strong
 
                   class ActiveSupport::EnvironmentInquirer
-                    sig { returns(T::Boolean) }
+                    sig { returns(::T::Boolean) }
                     def demo?; end
 
-                    sig { returns(T::Boolean) }
+                    sig { returns(::T::Boolean) }
                     def staging?; end
                   end
                 RBI

--- a/spec/tapioca/dsl/compilers/config_spec.rb
+++ b/spec/tapioca/dsl/compilers/config_spec.rb
@@ -43,23 +43,23 @@ module Tapioca
               expected = <<~RBI
                 # typed: strong
 
-                Settings = T.let(T.unsafe(nil), SettingsConfigOptions)
+                Settings = ::T.let(::T.unsafe(nil), SettingsConfigOptions)
 
                 class SettingsConfigOptions < ::Config::Options
-                  extend T::Generic
+                  extend ::T::Generic
 
-                  Elem = type_member { { fixed: T.untyped } }
+                  Elem = type_member { { fixed: ::T.untyped } }
 
-                  sig { returns(T.untyped) }
+                  sig { returns(::T.untyped) }
                   def github_key; end
 
-                  sig { params(value: T.untyped).returns(T.untyped) }
+                  sig { params(value: ::T.untyped).returns(::T.untyped) }
                   def github_key=(value); end
 
-                  sig { returns(T.untyped) }
+                  sig { returns(::T.untyped) }
                   def slack_token; end
 
-                  sig { params(value: T.untyped).returns(T.untyped) }
+                  sig { params(value: ::T.untyped).returns(::T.untyped) }
                   def slack_token=(value); end
                 end
               RBI
@@ -81,23 +81,23 @@ module Tapioca
               expected = <<~RBI
                 # typed: strong
 
-                Foo = T.let(T.unsafe(nil), FooConfigOptions)
+                Foo = ::T.let(::T.unsafe(nil), FooConfigOptions)
 
                 class FooConfigOptions < ::Config::Options
-                  extend T::Generic
+                  extend ::T::Generic
 
-                  Elem = type_member { { fixed: T.untyped } }
+                  Elem = type_member { { fixed: ::T.untyped } }
 
-                  sig { returns(T.untyped) }
+                  sig { returns(::T.untyped) }
                   def github_key; end
 
-                  sig { params(value: T.untyped).returns(T.untyped) }
+                  sig { params(value: ::T.untyped).returns(::T.untyped) }
                   def github_key=(value); end
 
-                  sig { returns(T.untyped) }
+                  sig { returns(::T.untyped) }
                   def slack_token; end
 
-                  sig { params(value: T.untyped).returns(T.untyped) }
+                  sig { params(value: ::T.untyped).returns(::T.untyped) }
                   def slack_token=(value); end
                 end
               RBI
@@ -122,23 +122,23 @@ module Tapioca
               expected = <<~RBI
                 # typed: strong
 
-                Settings = T.let(T.unsafe(nil), SettingsConfigOptions)
+                Settings = ::T.let(::T.unsafe(nil), SettingsConfigOptions)
 
                 class SettingsConfigOptions < ::Config::Options
-                  extend T::Generic
+                  extend ::T::Generic
 
-                  Elem = type_member { { fixed: T.untyped } }
+                  Elem = type_member { { fixed: ::T.untyped } }
 
-                  sig { returns(T.untyped) }
+                  sig { returns(::T.untyped) }
                   def github; end
 
-                  sig { params(value: T.untyped).returns(T.untyped) }
+                  sig { params(value: ::T.untyped).returns(::T.untyped) }
                   def github=(value); end
 
-                  sig { returns(T.untyped) }
+                  sig { returns(::T.untyped) }
                   def slack; end
 
-                  sig { params(value: T.untyped).returns(T.untyped) }
+                  sig { params(value: ::T.untyped).returns(::T.untyped) }
                   def slack=(value); end
                 end
               RBI

--- a/spec/tapioca/dsl/compilers/frozen_record_spec.rb
+++ b/spec/tapioca/dsl/compilers/frozen_record_spec.rb
@@ -74,22 +74,22 @@ module Tapioca
                   include FrozenRecordAttributeMethods
 
                   module FrozenRecordAttributeMethods
-                    sig { returns(T.untyped) }
+                    sig { returns(::T.untyped) }
                     def first_name; end
 
-                    sig { returns(T::Boolean) }
+                    sig { returns(::T::Boolean) }
                     def first_name?; end
 
-                    sig { returns(T.untyped) }
+                    sig { returns(::T.untyped) }
                     def id; end
 
-                    sig { returns(T::Boolean) }
+                    sig { returns(::T::Boolean) }
                     def id?; end
 
-                    sig { returns(T.untyped) }
+                    sig { returns(::T.untyped) }
                     def last_name; end
 
-                    sig { returns(T::Boolean) }
+                    sig { returns(::T::Boolean) }
                     def last_name?; end
                   end
                 end
@@ -122,21 +122,21 @@ module Tapioca
                   extend GeneratedRelationMethods
 
                   module FrozenRecordAttributeMethods
-                    sig { returns(T.untyped) }
+                    sig { returns(::T.untyped) }
                     def course; end
 
-                    sig { returns(T::Boolean) }
+                    sig { returns(::T::Boolean) }
                     def course?; end
 
-                    sig { returns(T.untyped) }
+                    sig { returns(::T.untyped) }
                     def id; end
 
-                    sig { returns(T::Boolean) }
+                    sig { returns(::T::Boolean) }
                     def id?; end
                   end
 
                   module GeneratedRelationMethods
-                    sig { params(args: T.untyped, blk: T.untyped).returns(T.untyped) }
+                    sig { params(args: ::T.untyped, blk: ::T.untyped).returns(::T.untyped) }
                     def programmers(*args, &blk); end
                   end
                 end

--- a/spec/tapioca/dsl/compilers/graphql_input_object_spec.rb
+++ b/spec/tapioca/dsl/compilers/graphql_input_object_spec.rb
@@ -126,7 +126,7 @@ module Tapioca
                 # typed: strong
 
                 class CreateCommentInput
-                  sig { returns(T.untyped) }
+                  sig { returns(::T.untyped) }
                   def transport; end
                 end
               RBI

--- a/spec/tapioca/dsl/compilers/graphql_mutation_spec.rb
+++ b/spec/tapioca/dsl/compilers/graphql_mutation_spec.rb
@@ -73,7 +73,7 @@ module Tapioca
                 # typed: strong
 
                 class CreateComment
-                  sig { params(body: ::String, post_id: ::String).returns(T.untyped) }
+                  sig { params(body: ::String, post_id: ::String).returns(::T.untyped) }
                   def resolve(body:, post_id:); end
                 end
               RBI
@@ -120,7 +120,7 @@ module Tapioca
                 # typed: strong
 
                 class CreateComment
-                  sig { params(body: ::String, author: T.nilable(::String), post_id: ::String).returns(T.untyped) }
+                  sig { params(body: ::String, author: ::T.nilable(::String), post_id: ::String).returns(::T.untyped) }
                   def resolve(body:, author:, post_id:); end
                 end
               RBI
@@ -169,7 +169,7 @@ module Tapioca
                 # typed: strong
 
                 class CreateComment
-                  sig { params(boolean: T::Boolean, float: ::Float, id: ::String, int: ::Integer, big_int: ::Integer, date: ::Date, datetime: ::Time, json: T::Hash[::String, T.untyped], string: ::String, enum_a: ::String, enum_b: T.any(::String, ::Symbol), input_object: ::CreateCommentInput, custom_scalar: T.untyped).returns(T.untyped) }
+                  sig { params(boolean: ::T::Boolean, float: ::Float, id: ::String, int: ::Integer, big_int: ::Integer, date: ::Date, datetime: ::Time, json: ::T::Hash[::String, ::T.untyped], string: ::String, enum_a: ::String, enum_b: ::T.any(::String, ::Symbol), input_object: ::CreateCommentInput, custom_scalar: ::T.untyped).returns(::T.untyped) }
                   def resolve(boolean:, float:, id:, int:, big_int:, date:, datetime:, json:, string:, enum_a:, enum_b:, input_object:, custom_scalar:); end
                 end
               RBI
@@ -216,7 +216,7 @@ module Tapioca
                 # typed: strong
 
                 class CreateComment
-                  sig { params(min: T::Range[::Date], max: ::Date, other: ::Date, proc: ::Date).returns(T.untyped) }
+                  sig { params(min: ::T::Range[::Date], max: ::Date, other: ::Date, proc: ::Date).returns(::T.untyped) }
                   def resolve(min:, max:, other:, proc:); end
                 end
               RBI
@@ -264,7 +264,7 @@ module Tapioca
                 # typed: strong
 
                 class CreateComment
-                  sig { params(comment_input: T.untyped).returns(T.untyped) }
+                  sig { params(comment_input: ::T.untyped).returns(::T.untyped) }
                   def resolve(comment_input:); end
                 end
               RBI
@@ -322,7 +322,7 @@ module Tapioca
                 # typed: strong
 
                 class CreateComment
-                  sig { params(date_range: T::Range[::Date], void_input: ::VoidInput, untyped_input: ::UntypedInput).returns(T.untyped) }
+                  sig { params(date_range: ::T::Range[::Date], void_input: ::VoidInput, untyped_input: ::UntypedInput).returns(::T.untyped) }
                   def resolve(date_range:, void_input:, untyped_input:); end
                 end
               RBI
@@ -353,8 +353,8 @@ module Tapioca
                 # typed: strong
 
                 class CreateComment
-                  sig { params(loaded_argument: ::LoadedType, loaded_arguments: T::Array[::LoadedType], custom_name: ::LoadedType, optional_loaded_argument: T.nilable(::LoadedType), optional_loaded_arguments: T.nilable(T::Array[::LoadedType])).returns(T.untyped) }
-                  def resolve(loaded_argument:, loaded_arguments:, custom_name:, optional_loaded_argument: T.unsafe(nil), optional_loaded_arguments: T.unsafe(nil)); end
+                  sig { params(loaded_argument: ::LoadedType, loaded_arguments: ::T::Array[::LoadedType], custom_name: ::LoadedType, optional_loaded_argument: ::T.nilable(::LoadedType), optional_loaded_arguments: ::T.nilable(::T::Array[::LoadedType])).returns(::T.untyped) }
+                  def resolve(loaded_argument:, loaded_arguments:, custom_name:, optional_loaded_argument: ::T.unsafe(nil), optional_loaded_arguments: ::T.unsafe(nil)); end
                 end
               RBI
 
@@ -410,8 +410,8 @@ module Tapioca
                 # typed: strong
 
                 class CreateComment
-                  sig { params(custom_scalar: ::CustomScalar, custom_scalar_array: T::Array[::CustomScalar], broken_scalar: T.untyped, no_sig_scalar: T.untyped, optional_custom_scalar: T.nilable(::CustomScalar)).returns(T.untyped) }
-                  def resolve(custom_scalar:, custom_scalar_array:, broken_scalar:, no_sig_scalar:, optional_custom_scalar: T.unsafe(nil)); end
+                  sig { params(custom_scalar: ::CustomScalar, custom_scalar_array: ::T::Array[::CustomScalar], broken_scalar: ::T.untyped, no_sig_scalar: ::T.untyped, optional_custom_scalar: ::T.nilable(::CustomScalar)).returns(::T.untyped) }
+                  def resolve(custom_scalar:, custom_scalar_array:, broken_scalar:, no_sig_scalar:, optional_custom_scalar: ::T.unsafe(nil)); end
                 end
               RBI
 

--- a/spec/tapioca/dsl/compilers/identity_cache_spec.rb
+++ b/spec/tapioca/dsl/compilers/identity_cache_spec.rb
@@ -84,28 +84,28 @@ module Tapioca
 
                 class Post
                   class << self
-                    sig { params(blog_id: T.untyped, includes: T.untyped).returns(T::Array[::Post]) }
+                    sig { params(blog_id: ::T.untyped, includes: ::T.untyped).returns(::T::Array[::Post]) }
                     def fetch_by_blog_id(blog_id, includes: nil); end
 
-                    sig { params(title: T.untyped, includes: T.untyped).returns(T::Array[::Post]) }
+                    sig { params(title: ::T.untyped, includes: ::T.untyped).returns(::T::Array[::Post]) }
                     def fetch_by_title(title, includes: nil); end
 
-                    sig { params(blog_id: T.untyped).returns(T::Array[::T.nilable(::Integer)]) }
+                    sig { params(blog_id: ::T.untyped).returns(::T::Array[::T.nilable(::Integer)]) }
                     def fetch_id_by_blog_id(blog_id); end
 
-                    sig { params(title: T.untyped).returns(T::Array[::T.nilable(::Integer)]) }
+                    sig { params(title: ::T.untyped).returns(::T::Array[::T.nilable(::Integer)]) }
                     def fetch_id_by_title(title); end
 
-                    sig { params(index_values: T::Enumerable[T.untyped], includes: T.untyped).returns(T::Array[::Post]) }
+                    sig { params(index_values: ::T::Enumerable[::T.untyped], includes: ::T.untyped).returns(::T::Array[::Post]) }
                     def fetch_multi_by_blog_id(index_values, includes: nil); end
 
-                    sig { params(index_values: T::Enumerable[T.untyped], includes: T.untyped).returns(T::Array[::Post]) }
+                    sig { params(index_values: ::T::Enumerable[::T.untyped], includes: ::T.untyped).returns(::T::Array[::Post]) }
                     def fetch_multi_by_title(index_values, includes: nil); end
 
-                    sig { params(keys: T::Enumerable[T.untyped]).returns(T::Array[::Integer]) }
+                    sig { params(keys: ::T::Enumerable[::T.untyped]).returns(::T::Array[::Integer]) }
                     def fetch_multi_id_by_blog_id(keys); end
 
-                    sig { params(keys: T::Enumerable[T.untyped]).returns(T::Array[::Integer]) }
+                    sig { params(keys: ::T::Enumerable[::T.untyped]).returns(::T::Array[::Integer]) }
                     def fetch_multi_id_by_title(keys); end
                   end
                 end
@@ -139,31 +139,31 @@ module Tapioca
 
                 class Post
                   class << self
-                    sig { params(blog_id: T.untyped, includes: T.untyped).returns(T::Array[::Post]) }
+                    sig { params(blog_id: ::T.untyped, includes: ::T.untyped).returns(::T::Array[::Post]) }
                     def fetch_by_blog_id(blog_id, includes: nil); end
 
-                    sig { params(title: T.untyped, includes: T.untyped).returns(T.nilable(::Post)) }
+                    sig { params(title: ::T.untyped, includes: ::T.untyped).returns(::T.nilable(::Post)) }
                     def fetch_by_title(title, includes: nil); end
 
-                    sig { params(title: T.untyped, includes: T.untyped).returns(::Post) }
+                    sig { params(title: ::T.untyped, includes: ::T.untyped).returns(::Post) }
                     def fetch_by_title!(title, includes: nil); end
 
-                    sig { params(blog_id: T.untyped).returns(T::Array[::T.nilable(::Integer)]) }
+                    sig { params(blog_id: ::T.untyped).returns(::T::Array[::T.nilable(::Integer)]) }
                     def fetch_id_by_blog_id(blog_id); end
 
-                    sig { params(title: T.untyped).returns(T.nilable(::Integer)) }
+                    sig { params(title: ::T.untyped).returns(::T.nilable(::Integer)) }
                     def fetch_id_by_title(title); end
 
-                    sig { params(index_values: T::Enumerable[T.untyped], includes: T.untyped).returns(T::Array[::Post]) }
+                    sig { params(index_values: ::T::Enumerable[::T.untyped], includes: ::T.untyped).returns(::T::Array[::Post]) }
                     def fetch_multi_by_blog_id(index_values, includes: nil); end
 
-                    sig { params(index_values: T::Enumerable[T.untyped], includes: T.untyped).returns(T::Array[::Post]) }
+                    sig { params(index_values: ::T::Enumerable[::T.untyped], includes: ::T.untyped).returns(::T::Array[::Post]) }
                     def fetch_multi_by_title(index_values, includes: nil); end
 
-                    sig { params(keys: T::Enumerable[T.untyped]).returns(T::Array[::Integer]) }
+                    sig { params(keys: ::T::Enumerable[::T.untyped]).returns(::T::Array[::Integer]) }
                     def fetch_multi_id_by_blog_id(keys); end
 
-                    sig { params(keys: T::Enumerable[T.untyped]).returns(T::Array[::Integer]) }
+                    sig { params(keys: ::T::Enumerable[::T.untyped]).returns(::T::Array[::Integer]) }
                     def fetch_multi_id_by_title(keys); end
                   end
                 end
@@ -196,16 +196,16 @@ module Tapioca
 
                 class Post
                   class << self
-                    sig { params(blog_id: T.untyped, title: T.untyped, includes: T.untyped).returns(T::Array[::Post]) }
+                    sig { params(blog_id: ::T.untyped, title: ::T.untyped, includes: ::T.untyped).returns(::T::Array[::Post]) }
                     def fetch_by_blog_id_and_title(blog_id, title, includes: nil); end
 
-                    sig { params(blog_id: T.untyped, title: T.untyped).returns(T::Array[::T.nilable(::Integer)]) }
+                    sig { params(blog_id: ::T.untyped, title: ::T.untyped).returns(::T::Array[::T.nilable(::Integer)]) }
                     def fetch_id_by_blog_id_and_title(blog_id, title); end
 
-                    sig { params(index_values: T::Enumerable[T.untyped], includes: T.untyped).returns(T::Array[::Post]) }
+                    sig { params(index_values: ::T::Enumerable[::T.untyped], includes: ::T.untyped).returns(::T::Array[::Post]) }
                     def fetch_multi_by_blog_id_and_title(index_values, includes: nil); end
 
-                    sig { params(keys: T::Enumerable[T.untyped]).returns(T::Array[::Integer]) }
+                    sig { params(keys: ::T::Enumerable[::T.untyped]).returns(::T::Array[::Integer]) }
                     def fetch_multi_id_by_blog_id_and_title(keys); end
                   end
                 end
@@ -239,31 +239,31 @@ module Tapioca
 
                 class Post
                   class << self
-                    sig { params(title: T.untyped, includes: T.untyped).returns(T::Array[::Post]) }
+                    sig { params(title: ::T.untyped, includes: ::T.untyped).returns(::T::Array[::Post]) }
                     def fetch_by_title(title, includes: nil); end
 
-                    sig { params(title: T.untyped, review_date: T.untyped, includes: T.untyped).returns(T.nilable(::Post)) }
+                    sig { params(title: ::T.untyped, review_date: ::T.untyped, includes: ::T.untyped).returns(::T.nilable(::Post)) }
                     def fetch_by_title_and_review_date(title, review_date, includes: nil); end
 
-                    sig { params(title: T.untyped, review_date: T.untyped, includes: T.untyped).returns(::Post) }
+                    sig { params(title: ::T.untyped, review_date: ::T.untyped, includes: ::T.untyped).returns(::Post) }
                     def fetch_by_title_and_review_date!(title, review_date, includes: nil); end
 
-                    sig { params(title: T.untyped).returns(T::Array[::T.nilable(::Integer)]) }
+                    sig { params(title: ::T.untyped).returns(::T::Array[::T.nilable(::Integer)]) }
                     def fetch_id_by_title(title); end
 
-                    sig { params(title: T.untyped, review_date: T.untyped).returns(T.nilable(::Integer)) }
+                    sig { params(title: ::T.untyped, review_date: ::T.untyped).returns(::T.nilable(::Integer)) }
                     def fetch_id_by_title_and_review_date(title, review_date); end
 
-                    sig { params(index_values: T::Enumerable[T.untyped], includes: T.untyped).returns(T::Array[::Post]) }
+                    sig { params(index_values: ::T::Enumerable[::T.untyped], includes: ::T.untyped).returns(::T::Array[::Post]) }
                     def fetch_multi_by_title(index_values, includes: nil); end
 
-                    sig { params(index_values: T::Enumerable[T.untyped], includes: T.untyped).returns(T::Array[::Post]) }
+                    sig { params(index_values: ::T::Enumerable[::T.untyped], includes: ::T.untyped).returns(::T::Array[::Post]) }
                     def fetch_multi_by_title_and_review_date(index_values, includes: nil); end
 
-                    sig { params(keys: T::Enumerable[T.untyped]).returns(T::Array[::Integer]) }
+                    sig { params(keys: ::T::Enumerable[::T.untyped]).returns(::T::Array[::Integer]) }
                     def fetch_multi_id_by_title(keys); end
 
-                    sig { params(keys: T::Enumerable[T.untyped]).returns(T::Array[::Integer]) }
+                    sig { params(keys: ::T::Enumerable[::T.untyped]).returns(::T::Array[::Integer]) }
                     def fetch_multi_id_by_title_and_review_date(keys); end
                   end
                 end
@@ -303,10 +303,10 @@ module Tapioca
                 # typed: strong
 
                 class Post
-                  sig { returns(T::Array[T.untyped]) }
+                  sig { returns(::T::Array[::T.untyped]) }
                   def fetch_user_ids; end
 
-                  sig { returns(T::Array[::User]) }
+                  sig { returns(::T::Array[::User]) }
                   def fetch_users; end
                 end
               RBI
@@ -345,10 +345,10 @@ module Tapioca
                 # typed: strong
 
                 class Post
-                  sig { returns(T.nilable(::User)) }
+                  sig { returns(::T.nilable(::User)) }
                   def fetch_user; end
 
-                  sig { returns(T.untyped) }
+                  sig { returns(::T.untyped) }
                   def fetch_user_id; end
                 end
               RBI
@@ -387,7 +387,7 @@ module Tapioca
                 # typed: strong
 
                 class Post
-                  sig { returns(T.untyped) }
+                  sig { returns(::T.untyped) }
                   def fetch_user; end
                 end
               RBI
@@ -420,16 +420,16 @@ module Tapioca
 
                 class Post
                   class << self
-                    sig { params(id: T.untyped).returns(T.nilable(::String)) }
+                    sig { params(id: ::T.untyped).returns(::T.nilable(::String)) }
                     def fetch_author_by_id(id); end
 
-                    sig { params(id: T.untyped, author: T.untyped).returns(T.nilable(::String)) }
+                    sig { params(id: ::T.untyped, author: ::T.untyped).returns(::T.nilable(::String)) }
                     def fetch_author_by_id_and_author(id, author); end
 
-                    sig { params(keys: T::Enumerable[T.untyped]).returns(T::Array[::String]) }
+                    sig { params(keys: ::T::Enumerable[::T.untyped]).returns(::T::Array[::String]) }
                     def fetch_multi_author_by_id(keys); end
 
-                    sig { params(keys: T::Enumerable[T.untyped]).returns(T::Array[::String]) }
+                    sig { params(keys: ::T::Enumerable[::T.untyped]).returns(::T::Array[::String]) }
                     def fetch_multi_author_by_id_and_author(keys); end
                   end
                 end
@@ -469,7 +469,7 @@ module Tapioca
                 # typed: strong
 
                 class Post
-                  sig { returns(T.nilable(::User)) }
+                  sig { returns(::T.nilable(::User)) }
                   def fetch_user; end
                 end
               RBI

--- a/spec/tapioca/dsl/compilers/json_api_client_resource_spec.rb
+++ b/spec/tapioca/dsl/compilers/json_api_client_resource_spec.rb
@@ -78,22 +78,22 @@ module Tapioca
                   include JsonApiClientResourceGeneratedMethods
 
                   module JsonApiClientResourceGeneratedMethods
-                    sig { returns(T::Boolean) }
+                    sig { returns(::T::Boolean) }
                     def is_admin; end
 
-                    sig { params(is_admin: T::Boolean).returns(T::Boolean) }
+                    sig { params(is_admin: ::T::Boolean).returns(::T::Boolean) }
                     def is_admin=(is_admin); end
 
-                    sig { returns(T.nilable(::String)) }
+                    sig { returns(::T.nilable(::String)) }
                     def name; end
 
-                    sig { params(name: T.nilable(::String)).returns(T.nilable(::String)) }
+                    sig { params(name: ::T.nilable(::String)).returns(::T.nilable(::String)) }
                     def name=(name); end
 
-                    sig { returns(T.nilable(T::Array[Post])) }
+                    sig { returns(::T.nilable(::T::Array[Post])) }
                     def posts; end
 
-                    sig { params(posts: T.nilable(T::Array[Post])).returns(T.nilable(T::Array[Post])) }
+                    sig { params(posts: ::T.nilable(::T::Array[Post])).returns(::T.nilable(::T::Array[Post])) }
                     def posts=(posts); end
                   end
                 end
@@ -106,16 +106,16 @@ module Tapioca
                   include JsonApiClientResourceGeneratedMethods
 
                   module JsonApiClientResourceGeneratedMethods
-                    sig { returns(T.nilable(::String)) }
+                    sig { returns(::T.nilable(::String)) }
                     def title; end
 
-                    sig { params(title: T.nilable(::String)).returns(T.nilable(::String)) }
+                    sig { params(title: ::T.nilable(::String)).returns(::T.nilable(::String)) }
                     def title=(title); end
 
-                    sig { returns(T.nilable(::String)) }
+                    sig { returns(::T.nilable(::String)) }
                     def user_id; end
 
-                    sig { params(user_id: T.nilable(::String)).returns(T.nilable(::String)) }
+                    sig { params(user_id: ::T.nilable(::String)).returns(::T.nilable(::String)) }
                     def user_id=(user_id); end
                   end
                 end
@@ -150,16 +150,16 @@ module Tapioca
                   include JsonApiClientResourceGeneratedMethods
 
                   module JsonApiClientResourceGeneratedMethods
-                    sig { returns(T.nilable(::String)) }
+                    sig { returns(::T.nilable(::String)) }
                     def name; end
 
-                    sig { params(name: T.nilable(::String)).returns(T.nilable(::String)) }
+                    sig { params(name: ::T.nilable(::String)).returns(::T.nilable(::String)) }
                     def name=(name); end
 
-                    sig { returns(T.nilable(::String)) }
+                    sig { returns(::T.nilable(::String)) }
                     def title; end
 
-                    sig { params(title: T.nilable(::String)).returns(T.nilable(::String)) }
+                    sig { params(title: ::T.nilable(::String)).returns(::T.nilable(::String)) }
                     def title=(title); end
                   end
                 end
@@ -206,10 +206,10 @@ module Tapioca
                   include JsonApiClientResourceGeneratedMethods
 
                   module JsonApiClientResourceGeneratedMethods
-                    sig { returns(T.nilable(::String)) }
+                    sig { returns(::T.nilable(::String)) }
                     def user_id; end
 
-                    sig { params(user_id: T.nilable(::String)).returns(T.nilable(::String)) }
+                    sig { params(user_id: ::T.nilable(::String)).returns(::T.nilable(::String)) }
                     def user_id=(user_id); end
                   end
                 end
@@ -222,16 +222,16 @@ module Tapioca
                   include JsonApiClientResourceGeneratedMethods
 
                   module JsonApiClientResourceGeneratedMethods
-                    sig { returns(T.nilable(Image)) }
+                    sig { returns(::T.nilable(Image)) }
                     def image; end
 
-                    sig { params(image: T.nilable(Image)).returns(T.nilable(Image)) }
+                    sig { params(image: ::T.nilable(Image)).returns(::T.nilable(Image)) }
                     def image=(image); end
 
-                    sig { returns(T.nilable(T::Array[Post])) }
+                    sig { returns(::T.nilable(::T::Array[Post])) }
                     def posts; end
 
-                    sig { params(posts: T.nilable(T::Array[Post])).returns(T.nilable(T::Array[Post])) }
+                    sig { params(posts: ::T.nilable(::T::Array[Post])).returns(::T.nilable(::T::Array[Post])) }
                     def posts=(posts); end
                   end
                 end
@@ -244,10 +244,10 @@ module Tapioca
                   include JsonApiClientResourceGeneratedMethods
 
                   module JsonApiClientResourceGeneratedMethods
-                    sig { returns(T.nilable(::String)) }
+                    sig { returns(::T.nilable(::String)) }
                     def user_id; end
 
-                    sig { params(user_id: T.nilable(::String)).returns(T.nilable(::String)) }
+                    sig { params(user_id: ::T.nilable(::String)).returns(::T.nilable(::String)) }
                     def user_id=(user_id); end
                   end
                 end
@@ -269,16 +269,16 @@ module Tapioca
                   include JsonApiClientResourceGeneratedMethods
 
                   module JsonApiClientResourceGeneratedMethods
-                    sig { returns(T.untyped) }
+                    sig { returns(::T.untyped) }
                     def name; end
 
-                    sig { params(name: T.untyped).returns(T.untyped) }
+                    sig { params(name: ::T.untyped).returns(::T.untyped) }
                     def name=(name); end
 
-                    sig { returns(T.untyped) }
+                    sig { returns(::T.untyped) }
                     def title; end
 
-                    sig { params(title: T.untyped).returns(T.untyped) }
+                    sig { params(title: ::T.untyped).returns(::T.untyped) }
                     def title=(title); end
                   end
                 end
@@ -318,10 +318,10 @@ module Tapioca
                     include JsonApiClientResourceGeneratedMethods
 
                     module JsonApiClientResourceGeneratedMethods
-                      sig { returns(T.untyped) }
+                      sig { returns(::T.untyped) }
                       def name; end
 
-                      sig { params(name: T.untyped).returns(T.untyped) }
+                      sig { params(name: ::T.untyped).returns(::T.untyped) }
                       def name=(name); end
                     end
                   end
@@ -351,10 +351,10 @@ module Tapioca
                     include JsonApiClientResourceGeneratedMethods
 
                     module JsonApiClientResourceGeneratedMethods
-                      sig { returns(T.nilable(Integer)) }
+                      sig { returns(::T.nilable(Integer)) }
                       def comment_count; end
 
-                      sig { params(comment_count: T.nilable(Integer)).returns(T.nilable(Integer)) }
+                      sig { params(comment_count: ::T.nilable(Integer)).returns(::T.nilable(Integer)) }
                       def comment_count=(comment_count); end
 
                       sig { returns(Integer) }

--- a/spec/tapioca/dsl/compilers/kredis_spec.rb
+++ b/spec/tapioca/dsl/compilers/kredis_spec.rb
@@ -129,7 +129,7 @@ module Tapioca
                     sig { returns(Kredis::Types::Flag) }
                     def my_flag; end
 
-                    sig { returns(T::Boolean) }
+                    sig { returns(::T::Boolean) }
                     def my_flag?; end
 
                     sig { returns(Kredis::Types::Scalar) }
@@ -169,13 +169,13 @@ module Tapioca
                       sig { void }
                       def green!; end
 
-                      sig { returns(T::Boolean) }
+                      sig { returns(::T::Boolean) }
                       def green?; end
 
                       sig { void }
                       def red!; end
 
-                      sig { returns(T::Boolean) }
+                      sig { returns(::T::Boolean) }
                       def red?; end
                     end
 
@@ -183,19 +183,19 @@ module Tapioca
                       sig { void }
                       def large!; end
 
-                      sig { returns(T::Boolean) }
+                      sig { returns(::T::Boolean) }
                       def large?; end
 
                       sig { void }
                       def medium!; end
 
-                      sig { returns(T::Boolean) }
+                      sig { returns(::T::Boolean) }
                       def medium?; end
 
                       sig { void }
                       def small!; end
 
-                      sig { returns(T::Boolean) }
+                      sig { returns(::T::Boolean) }
                       def small?; end
                     end
                   end

--- a/spec/tapioca/dsl/compilers/protobuf_spec.rb
+++ b/spec/tapioca/dsl/compilers/protobuf_spec.rb
@@ -52,13 +52,13 @@ module Tapioca
                 # typed: strong
 
                 class Cart < Google::Protobuf::AbstractMessage
-                  sig { params(customer_id: T.nilable(Integer), shop_id: T.nilable(Integer)).void }
+                  sig { params(customer_id: ::T.nilable(Integer), shop_id: ::T.nilable(Integer)).void }
                   def initialize(customer_id: nil, shop_id: nil); end
 
-                  sig { returns(T.nilable(Symbol)) }
+                  sig { returns(::T.nilable(Symbol)) }
                   def _customer_id; end
 
-                  sig { returns(T.nilable(Symbol)) }
+                  sig { returns(::T.nilable(Symbol)) }
                   def _shop_id; end
 
                   sig { void }
@@ -103,10 +103,10 @@ module Tapioca
                 # typed: strong
 
                 class Cart < Google::Protobuf::AbstractMessage
-                  sig { params(events: T.nilable(String)).void }
+                  sig { params(events: ::T.nilable(String)).void }
                   def initialize(events: nil); end
 
-                  sig { returns(T.nilable(Symbol)) }
+                  sig { returns(::T.nilable(Symbol)) }
                   def _events; end
 
                   sig { void }
@@ -140,16 +140,16 @@ module Tapioca
                 # typed: strong
 
                 class Cart < Google::Protobuf::AbstractMessage
-                  sig { params(cart_item_index: T.nilable(Google::Protobuf::UInt64Value)).void }
+                  sig { params(cart_item_index: ::T.nilable(Google::Protobuf::UInt64Value)).void }
                   def initialize(cart_item_index: nil); end
 
-                  sig { returns(T.nilable(Symbol)) }
+                  sig { returns(::T.nilable(Symbol)) }
                   def _cart_item_index; end
 
-                  sig { returns(T.nilable(Google::Protobuf::UInt64Value)) }
+                  sig { returns(::T.nilable(Google::Protobuf::UInt64Value)) }
                   def cart_item_index; end
 
-                  sig { params(value: T.nilable(Google::Protobuf::UInt64Value)).void }
+                  sig { params(value: ::T.nilable(Google::Protobuf::UInt64Value)).void }
                   def cart_item_index=(value); end
 
                   sig { void }
@@ -182,10 +182,10 @@ module Tapioca
                 # typed: strong
 
                 class Cart < Google::Protobuf::AbstractMessage
-                  sig { params(value_type: T.nilable(T.any(Symbol, Integer))).void }
+                  sig { params(value_type: ::T.nilable(::T.any(Symbol, Integer))).void }
                   def initialize(value_type: nil); end
 
-                  sig { returns(T.nilable(Symbol)) }
+                  sig { returns(::T.nilable(Symbol)) }
                   def _value_type; end
 
                   sig { void }
@@ -194,10 +194,10 @@ module Tapioca
                   sig { returns(Object) }
                   def has_value_type?; end
 
-                  sig { returns(T.any(Symbol, Integer)) }
+                  sig { returns(::T.any(Symbol, Integer)) }
                   def value_type; end
 
-                  sig { params(value: T.any(Symbol, Integer)).void }
+                  sig { params(value: ::T.any(Symbol, Integer)).void }
                   def value_type=(value); end
                 end
               RBI
@@ -210,10 +210,10 @@ module Tapioca
                     sig { returns(Google::Protobuf::EnumDescriptor) }
                     def descriptor; end
 
-                    sig { params(number: Integer).returns(T.nilable(Symbol)) }
+                    sig { params(number: Integer).returns(::T.nilable(Symbol)) }
                     def lookup(number); end
 
-                    sig { params(symbol: Symbol).returns(T.nilable(Integer)) }
+                    sig { params(symbol: Symbol).returns(::T.nilable(Integer)) }
                     def resolve(symbol); end
                   end
                 end
@@ -242,8 +242,8 @@ module Tapioca
                 # typed: strong
 
                 class Cart < Google::Protobuf::AbstractMessage
-                  sig { params(customer_ids: T.nilable(T::Array[Integer]), indices: T.nilable(T::Array[Google::Protobuf::UInt64Value])).void }
-                  def initialize(customer_ids: T.unsafe(nil), indices: T.unsafe(nil)); end
+                  sig { params(customer_ids: ::T.nilable(::T::Array[Integer]), indices: ::T.nilable(::T::Array[Google::Protobuf::UInt64Value])).void }
+                  def initialize(customer_ids: ::T.unsafe(nil), indices: ::T.unsafe(nil)); end
 
                   sig { void }
                   def clear_customer_ids; end
@@ -281,7 +281,7 @@ module Tapioca
                 # typed: strong
 
                 class Cart < Google::Protobuf::AbstractMessage
-                  sig { params(shop_id: T.nilable(Integer)).void }
+                  sig { params(shop_id: ::T.nilable(Integer)).void }
                   def initialize(shop_id: nil); end
 
                   sig { void }
@@ -313,8 +313,8 @@ module Tapioca
                 # typed: strong
 
                 class Cart < Google::Protobuf::AbstractMessage
-                  sig { params(customers: T.nilable(T.any(Google::Protobuf::Map[String, Integer], T::Hash[String, Integer])), stores: T.nilable(T.any(Google::Protobuf::Map[String, Google::Protobuf::UInt64Value], T::Hash[String, Google::Protobuf::UInt64Value]))).void }
-                  def initialize(customers: T.unsafe(nil), stores: T.unsafe(nil)); end
+                  sig { params(customers: ::T.nilable(::T.any(Google::Protobuf::Map[String, Integer], ::T::Hash[String, Integer])), stores: ::T.nilable(::T.any(Google::Protobuf::Map[String, Google::Protobuf::UInt64Value], ::T::Hash[String, Google::Protobuf::UInt64Value]))).void }
+                  def initialize(customers: ::T.unsafe(nil), stores: ::T.unsafe(nil)); end
 
                   sig { void }
                   def clear_customers; end
@@ -360,7 +360,7 @@ module Tapioca
               rbi_output = rbi_for(:Cart)
 
               assert_includes(rbi_output, indented(<<~RBI, 2))
-                sig { params(value: T::Boolean).void }
+                sig { params(value: ::T::Boolean).void }
                 def bool_value=(value); end
               RBI
 
@@ -419,7 +419,7 @@ module Tapioca
                 # typed: strong
 
                 class Cart < Google::Protobuf::AbstractMessage
-                  sig { params(fields: T.untyped).void }
+                  sig { params(fields: ::T.untyped).void }
                   def initialize(**fields); end
 
                   sig { returns(Integer) }
@@ -434,10 +434,10 @@ module Tapioca
                   sig { params(value: String).void }
                   def ShopName=(value); end
 
-                  sig { returns(T.nilable(Symbol)) }
+                  sig { returns(::T.nilable(Symbol)) }
                   def _ShopID; end
 
-                  sig { returns(T.nilable(Symbol)) }
+                  sig { returns(::T.nilable(Symbol)) }
                   def _ShopName; end
 
                   sig { void }
@@ -479,7 +479,7 @@ module Tapioca
                 sig { void }
                 def clear_phone_number; end
 
-                sig { returns(T.nilable(Symbol)) }
+                sig { returns(::T.nilable(Symbol)) }
                 def contact_info; end
               RBI
             end
@@ -510,8 +510,8 @@ module Tapioca
                 # typed: strong
 
                 class Google::Protobuf::Struct < Google::Protobuf::AbstractMessage
-                  sig { params(fields: T.nilable(T.any(Google::Protobuf::Map[String, Google::Protobuf::Value], T::Hash[String, Google::Protobuf::Value]))).void }
-                  def initialize(fields: T.unsafe(nil)); end
+                  sig { params(fields: ::T.nilable(::T.any(Google::Protobuf::Map[String, Google::Protobuf::Value], ::T::Hash[String, Google::Protobuf::Value]))).void }
+                  def initialize(fields: ::T.unsafe(nil)); end
 
                   sig { void }
                   def clear_fields; end
@@ -569,8 +569,8 @@ module Tapioca
                 # typed: strong
 
                 class Cart < Google::Protobuf::AbstractMessage
-                  sig { params(progress: T.nilable(T.any(Google::Protobuf::Map[String, Cart::Progress], T::Hash[String, Cart::Progress]))).void }
-                  def initialize(progress: T.unsafe(nil)); end
+                  sig { params(progress: ::T.nilable(::T.any(Google::Protobuf::Map[String, Cart::Progress], ::T::Hash[String, Cart::Progress]))).void }
+                  def initialize(progress: ::T.unsafe(nil)); end
 
                   sig { void }
                   def clear_progress; end

--- a/spec/tapioca/dsl/compilers/rails_generators_spec.rb
+++ b/spec/tapioca/dsl/compilers/rails_generators_spec.rb
@@ -87,10 +87,10 @@ module Tapioca
                 # typed: strong
 
                 class ArgumentGenerator
-                  sig { returns(T::Array[::String]) }
+                  sig { returns(::T::Array[::String]) }
                   def array; end
 
-                  sig { returns(T::Hash[::String, ::String]) }
+                  sig { returns(::T::Hash[::String, ::String]) }
                   def hash; end
 
                   sig { returns(::Numeric) }
@@ -119,19 +119,19 @@ module Tapioca
                 # typed: strong
 
                 class OptionGenerator
-                  sig { returns(T.nilable(T::Array[::String])) }
+                  sig { returns(::T.nilable(::T::Array[::String])) }
                   def array; end
 
-                  sig { returns(T.nilable(T::Boolean)) }
+                  sig { returns(::T.nilable(::T::Boolean)) }
                   def bool; end
 
-                  sig { returns(T.nilable(T::Hash[::String, ::String])) }
+                  sig { returns(::T.nilable(::T::Hash[::String, ::String])) }
                   def hash; end
 
-                  sig { returns(T.nilable(::Numeric)) }
+                  sig { returns(::T.nilable(::Numeric)) }
                   def numeric; end
 
-                  sig { returns(T.nilable(::String)) }
+                  sig { returns(::T.nilable(::String)) }
                   def string; end
                 end
               RBI
@@ -151,7 +151,7 @@ module Tapioca
                 # typed: strong
 
                 class OptionsWithDefaultsGenerator
-                  sig { returns(T::Array[::String]) }
+                  sig { returns(::T::Array[::String]) }
                   def array; end
 
                   sig { returns(::String) }
@@ -173,7 +173,7 @@ module Tapioca
                 # typed: strong
 
                 class OverrideGenerator
-                  sig { returns(T.nilable(::Numeric)) }
+                  sig { returns(::T.nilable(::Numeric)) }
                   def force; end
                 end
               RBI
@@ -201,10 +201,10 @@ module Tapioca
                   sig { returns(::String) }
                   def child_arg; end
 
-                  sig { returns(T.nilable(::String)) }
+                  sig { returns(::T.nilable(::String)) }
                   def child_opt; end
 
-                  sig { returns(T.nilable(::Numeric)) }
+                  sig { returns(::T.nilable(::Numeric)) }
                   def number; end
 
                   sig { returns(::String) }

--- a/spec/tapioca/dsl/compilers/sidekiq_worker_spec.rb
+++ b/spec/tapioca/dsl/compilers/sidekiq_worker_spec.rb
@@ -77,13 +77,13 @@ module Tapioca
 
                 class NotifierWorker
                   class << self
-                    sig { params(customer_id: T.untyped).returns(String) }
+                    sig { params(customer_id: ::T.untyped).returns(String) }
                     def perform_async(customer_id); end
 
-                    sig { params(interval: T.any(DateTime, Time), customer_id: T.untyped).returns(String) }
+                    sig { params(interval: ::T.any(DateTime, Time), customer_id: ::T.untyped).returns(String) }
                     def perform_at(interval, customer_id); end
 
-                    sig { params(interval: Numeric, customer_id: T.untyped).returns(String) }
+                    sig { params(interval: Numeric, customer_id: ::T.untyped).returns(String) }
                     def perform_in(interval, customer_id); end
                   end
                 end
@@ -110,13 +110,13 @@ module Tapioca
 
                 class NotifierWorker
                   class << self
-                    sig { params(customer_id: T.untyped).returns(String) }
+                    sig { params(customer_id: ::T.untyped).returns(String) }
                     def perform_async(customer_id); end
 
-                    sig { params(interval: T.any(DateTime, Time, ActiveSupport::TimeWithZone), customer_id: T.untyped).returns(String) }
+                    sig { params(interval: ::T.any(DateTime, Time, ActiveSupport::TimeWithZone), customer_id: ::T.untyped).returns(String) }
                     def perform_at(interval, customer_id); end
 
-                    sig { params(interval: T.any(Numeric, ActiveSupport::Duration), customer_id: T.untyped).returns(String) }
+                    sig { params(interval: ::T.any(Numeric, ActiveSupport::Duration), customer_id: ::T.untyped).returns(String) }
                     def perform_in(interval, customer_id); end
                   end
                 end
@@ -145,7 +145,7 @@ module Tapioca
                     sig { params(customer_id: ::Integer).returns(String) }
                     def perform_async(customer_id); end
 
-                    sig { params(interval: T.any(DateTime, Time), customer_id: ::Integer).returns(String) }
+                    sig { params(interval: ::T.any(DateTime, Time), customer_id: ::Integer).returns(String) }
                     def perform_at(interval, customer_id); end
 
                     sig { params(interval: Numeric, customer_id: ::Integer).returns(String) }
@@ -175,13 +175,13 @@ module Tapioca
 
                 class SecondaryWorker
                   class << self
-                    sig { params(customer_id: T.untyped).returns(String) }
+                    sig { params(customer_id: ::T.untyped).returns(String) }
                     def perform_async(customer_id); end
 
-                    sig { params(interval: T.any(DateTime, Time), customer_id: T.untyped).returns(String) }
+                    sig { params(interval: ::T.any(DateTime, Time), customer_id: ::T.untyped).returns(String) }
                     def perform_at(interval, customer_id); end
 
-                    sig { params(interval: Numeric, customer_id: T.untyped).returns(String) }
+                    sig { params(interval: Numeric, customer_id: ::T.untyped).returns(String) }
                     def perform_in(interval, customer_id); end
                   end
                 end
@@ -213,10 +213,10 @@ module Tapioca
 
                 class SecondaryWorker
                   class << self
-                    sig { params(customer_id: T.untyped, other_id: T.untyped).returns(String) }
+                    sig { params(customer_id: ::T.untyped, other_id: ::T.untyped).returns(String) }
                     def perform_async(customer_id, other_id); end
 
-                    sig { params(interval: Numeric, customer_id: T.untyped, other_id: T.untyped).returns(String) }
+                    sig { params(interval: Numeric, customer_id: ::T.untyped, other_id: ::T.untyped).returns(String) }
                     def perform_in(interval, customer_id, other_id); end
                   end
                 end

--- a/spec/tapioca/dsl/compilers/smart_properties_spec.rb
+++ b/spec/tapioca/dsl/compilers/smart_properties_spec.rb
@@ -87,10 +87,10 @@ module Tapioca
                   include SmartPropertiesGeneratedMethods
 
                   module SmartPropertiesGeneratedMethods
-                    sig { returns(T.nilable(::String)) }
+                    sig { returns(::T.nilable(::String)) }
                     def title; end
 
-                    sig { params(title: T.nilable(::String)).returns(T.nilable(::String)) }
+                    sig { params(title: ::T.nilable(::String)).returns(::T.nilable(::String)) }
                     def title=(title); end
                   end
                 end
@@ -114,10 +114,10 @@ module Tapioca
                   include SmartPropertiesGeneratedMethods
 
                   module SmartPropertiesGeneratedMethods
-                    sig { returns(T.nilable(::String)) }
+                    sig { returns(::T.nilable(::String)) }
                     def title; end
 
-                    sig { params(title: T.nilable(::String)).returns(T.nilable(::String)) }
+                    sig { params(title: ::T.nilable(::String)).returns(::T.nilable(::String)) }
                     def title=(title); end
                   end
                 end
@@ -153,7 +153,7 @@ module Tapioca
               assert_equal(expected, rbi_for(:Post))
             end
 
-            it "defaults to T.untyped for smart property that does not have an accepter" do
+            it "defaults to ::T.untyped for smart property that does not have an accepter" do
               add_ruby_file("post.rb", <<~RUBY)
                 class Post
                   include SmartProperties
@@ -168,10 +168,10 @@ module Tapioca
                   include SmartPropertiesGeneratedMethods
 
                   module SmartPropertiesGeneratedMethods
-                    sig { returns(T.untyped) }
+                    sig { returns(::T.untyped) }
                     def title; end
 
-                    sig { params(title: T.untyped).returns(T.untyped) }
+                    sig { params(title: ::T.untyped).returns(::T.untyped) }
                     def title=(title); end
                   end
                 end
@@ -180,7 +180,7 @@ module Tapioca
               assert_equal(expected, rbi_for(:Post))
             end
 
-            it "defaults to T::Array for smart property that accepts Arrays" do
+            it "defaults to ::T::Array for smart property that accepts Arrays" do
               add_ruby_file("post.rb", <<~RUBY)
                 class Post
                   include SmartProperties
@@ -195,10 +195,10 @@ module Tapioca
                   include SmartPropertiesGeneratedMethods
 
                   module SmartPropertiesGeneratedMethods
-                    sig { returns(T.nilable(T::Array[T.untyped])) }
+                    sig { returns(::T.nilable(::T::Array[::T.untyped])) }
                     def categories; end
 
-                    sig { params(categories: T.nilable(T::Array[T.untyped])).returns(T.nilable(T::Array[T.untyped])) }
+                    sig { params(categories: ::T.nilable(::T::Array[::T.untyped])).returns(::T.nilable(::T::Array[::T.untyped])) }
                     def categories=(categories); end
                   end
                 end
@@ -222,10 +222,10 @@ module Tapioca
                   include SmartPropertiesGeneratedMethods
 
                   module SmartPropertiesGeneratedMethods
-                    sig { returns(T.nilable(T::Boolean)) }
+                    sig { returns(::T.nilable(::T::Boolean)) }
                     def published; end
 
-                    sig { params(published: T.nilable(T::Boolean)).returns(T.nilable(T::Boolean)) }
+                    sig { params(published: ::T.nilable(::T::Boolean)).returns(::T.nilable(::T::Boolean)) }
                     def published=(published); end
                   end
                 end
@@ -249,10 +249,10 @@ module Tapioca
                   include SmartPropertiesGeneratedMethods
 
                   module SmartPropertiesGeneratedMethods
-                    sig { returns(T.nilable(T.any(::String, ::Integer))) }
+                    sig { returns(::T.nilable(::T.any(::String, ::Integer))) }
                     def status; end
 
-                    sig { params(status: T.nilable(T.any(::String, ::Integer))).returns(T.nilable(T.any(::String, ::Integer))) }
+                    sig { params(status: ::T.nilable(::T.any(::String, ::Integer))).returns(::T.nilable(::T.any(::String, ::Integer))) }
                     def status=(status); end
                   end
                 end
@@ -261,7 +261,7 @@ module Tapioca
               assert_equal(expected, rbi_for(:Post))
             end
 
-            it "defaults to T.untyped if a converter is defined" do
+            it "defaults to ::T.untyped if a converter is defined" do
               add_ruby_file("post.rb", <<~RUBY)
                 class Post
                   include SmartProperties
@@ -276,10 +276,10 @@ module Tapioca
                   include SmartPropertiesGeneratedMethods
 
                   module SmartPropertiesGeneratedMethods
-                    sig { returns(T.untyped) }
+                    sig { returns(::T.untyped) }
                     def status; end
 
-                    sig { params(status: T.untyped).returns(T.untyped) }
+                    sig { params(status: ::T.untyped).returns(::T.untyped) }
                     def status=(status); end
                   end
                 end
@@ -303,10 +303,10 @@ module Tapioca
                   include SmartPropertiesGeneratedMethods
 
                   module SmartPropertiesGeneratedMethods
-                    sig { returns(T.nilable(::Integer)) }
+                    sig { returns(::T.nilable(::Integer)) }
                     def status; end
 
-                    sig { params(status: T.nilable(::Integer)).returns(T.nilable(::Integer)) }
+                    sig { params(status: ::T.nilable(::Integer)).returns(::T.nilable(::Integer)) }
                     def status=(status); end
                   end
                 end
@@ -330,10 +330,10 @@ module Tapioca
                   include SmartPropertiesGeneratedMethods
 
                   module SmartPropertiesGeneratedMethods
-                    sig { returns(T.untyped) }
+                    sig { returns(::T.untyped) }
                     def status; end
 
-                    sig { params(status: T.untyped).returns(T.untyped) }
+                    sig { params(status: ::T.untyped).returns(::T.untyped) }
                     def status=(status); end
                   end
                 end
@@ -357,10 +357,10 @@ module Tapioca
                   include SmartPropertiesGeneratedMethods
 
                   module SmartPropertiesGeneratedMethods
-                    sig { returns(T.nilable(::Integer)) }
+                    sig { returns(::T.nilable(::Integer)) }
                     def reader_for_status; end
 
-                    sig { params(status: T.nilable(::Integer)).returns(T.nilable(::Integer)) }
+                    sig { params(status: ::T.nilable(::Integer)).returns(::T.nilable(::Integer)) }
                     def status=(status); end
                   end
                 end
@@ -384,10 +384,10 @@ module Tapioca
                   include SmartPropertiesGeneratedMethods
 
                   module SmartPropertiesGeneratedMethods
-                    sig { returns(T.nilable(T::Boolean)) }
+                    sig { returns(::T.nilable(::T::Boolean)) }
                     def enabled; end
 
-                    sig { params(enabled: T.nilable(T::Boolean)).returns(T.nilable(T::Boolean)) }
+                    sig { params(enabled: ::T.nilable(::T::Boolean)).returns(::T.nilable(::T::Boolean)) }
                     def enabled=(enabled); end
                   end
                 end
@@ -411,10 +411,10 @@ module Tapioca
                   include SmartPropertiesGeneratedMethods
 
                   module SmartPropertiesGeneratedMethods
-                    sig { returns(T.nilable(T::Boolean)) }
+                    sig { returns(::T.nilable(::T::Boolean)) }
                     def enabled; end
 
-                    sig { params(enabled: T.nilable(T::Boolean)).returns(T.nilable(T::Boolean)) }
+                    sig { params(enabled: ::T.nilable(::T::Boolean)).returns(::T.nilable(::T::Boolean)) }
                     def enabled=(enabled); end
                   end
                 end
@@ -438,10 +438,10 @@ module Tapioca
                   include SmartPropertiesGeneratedMethods
 
                   module SmartPropertiesGeneratedMethods
-                    sig { returns(T.nilable(::String)) }
+                    sig { returns(::T.nilable(::String)) }
                     def title; end
 
-                    sig { params(title: T.nilable(::String)).returns(T.nilable(::String)) }
+                    sig { params(title: ::T.nilable(::String)).returns(::T.nilable(::String)) }
                     def title=(title); end
                   end
                 end
@@ -465,10 +465,10 @@ module Tapioca
                   include SmartPropertiesGeneratedMethods
 
                   module SmartPropertiesGeneratedMethods
-                    sig { returns(T.nilable(::String)) }
+                    sig { returns(::T.nilable(::String)) }
                     def title; end
 
-                    sig { params(title: T.nilable(::String)).returns(T.nilable(::String)) }
+                    sig { params(title: ::T.nilable(::String)).returns(::T.nilable(::String)) }
                     def title=(title); end
                   end
                 end
@@ -492,10 +492,10 @@ module Tapioca
                   include SmartPropertiesGeneratedMethods
 
                   module SmartPropertiesGeneratedMethods
-                    sig { returns(T.untyped) }
+                    sig { returns(::T.untyped) }
                     def title; end
 
-                    sig { params(title: T.untyped).returns(T.untyped) }
+                    sig { params(title: ::T.untyped).returns(::T.untyped) }
                     def title=(title); end
                   end
                 end
@@ -533,16 +533,16 @@ module Tapioca
                   include SmartPropertiesGeneratedMethods
 
                   module SmartPropertiesGeneratedMethods
-                    sig { returns(T.nilable(::String)) }
+                    sig { returns(::T.nilable(::String)) }
                     def body; end
 
-                    sig { params(body: T.nilable(::String)).returns(T.nilable(::String)) }
+                    sig { params(body: ::T.nilable(::String)).returns(::T.nilable(::String)) }
                     def body=(body); end
 
-                    sig { returns(T.nilable(::String)) }
+                    sig { returns(::T.nilable(::String)) }
                     def title; end
 
-                    sig { params(title: T.nilable(::String)).returns(T.nilable(::String)) }
+                    sig { params(title: ::T.nilable(::String)).returns(::T.nilable(::String)) }
                     def title=(title); end
                   end
                 end
@@ -575,10 +575,10 @@ module Tapioca
                   include SmartPropertiesGeneratedMethods
 
                   module SmartPropertiesGeneratedMethods
-                    sig { returns(T.nilable(::Post::TrackingInfoInput)) }
+                    sig { returns(::T.nilable(::Post::TrackingInfoInput)) }
                     def title; end
 
-                    sig { params(title: T.nilable(::Post::TrackingInfoInput)).returns(T.nilable(::Post::TrackingInfoInput)) }
+                    sig { params(title: ::T.nilable(::Post::TrackingInfoInput)).returns(::T.nilable(::Post::TrackingInfoInput)) }
                     def title=(title); end
                   end
                 end
@@ -593,10 +593,10 @@ module Tapioca
                   include SmartPropertiesGeneratedMethods
 
                   module SmartPropertiesGeneratedMethods
-                    sig { returns(T.nilable(::String)) }
+                    sig { returns(::T.nilable(::String)) }
                     def carrier_id; end
 
-                    sig { params(carrier_id: T.nilable(::String)).returns(T.nilable(::String)) }
+                    sig { params(carrier_id: ::T.nilable(::String)).returns(::T.nilable(::String)) }
                     def carrier_id=(carrier_id); end
 
                     sig { returns(::String) }
@@ -605,10 +605,10 @@ module Tapioca
                     sig { params(number: ::String).returns(::String) }
                     def number=(number); end
 
-                    sig { returns(T.nilable(::String)) }
+                    sig { returns(::T.nilable(::String)) }
                     def url; end
 
-                    sig { params(url: T.nilable(::String)).returns(T.nilable(::String)) }
+                    sig { params(url: ::T.nilable(::String)).returns(::T.nilable(::String)) }
                     def url=(url); end
                   end
                 end

--- a/spec/tapioca/dsl/compilers/state_machines_spec.rb
+++ b/spec/tapioca/dsl/compilers/state_machines_spec.rb
@@ -63,18 +63,18 @@ module Tapioca
                   extend StateMachineClassHelperModule
 
                   module StateMachineClassHelperModule
-                    sig { params(event: T.any(String, Symbol)).returns(String) }
+                    sig { params(event: ::T.any(String, Symbol)).returns(String) }
                     def human_alarm_state_event_name(event); end
 
-                    sig { params(state: T.any(String, Symbol)).returns(String) }
+                    sig { params(state: ::T.any(String, Symbol)).returns(String) }
                     def human_alarm_state_name(state); end
                   end
 
                   module StateMachineInstanceHelperModule
-                    sig { returns(T::Boolean) }
+                    sig { returns(::T::Boolean) }
                     def alarm_active?; end
 
-                    sig { returns(T::Boolean) }
+                    sig { returns(::T::Boolean) }
                     def alarm_off?; end
 
                     sig { returns(Integer) }
@@ -83,46 +83,46 @@ module Tapioca
                     sig { params(value: Integer).returns(Integer) }
                     def alarm_state=(value); end
 
-                    sig { params(state: T.any(String, Symbol)).returns(T::Boolean) }
+                    sig { params(state: ::T.any(String, Symbol)).returns(::T::Boolean) }
                     def alarm_state?(state); end
 
-                    sig { params(args: T.untyped).returns(T::Array[T.any(String, Symbol)]) }
+                    sig { params(args: ::T.untyped).returns(::T::Array[::T.any(String, Symbol)]) }
                     def alarm_state_events(*args); end
 
-                    sig { returns(T.any(String, Symbol)) }
+                    sig { returns(::T.any(String, Symbol)) }
                     def alarm_state_name; end
 
-                    sig { params(args: T.untyped).returns(T::Array[::StateMachines::Transition]) }
+                    sig { params(args: ::T.untyped).returns(::T::Array[::StateMachines::Transition]) }
                     def alarm_state_paths(*args); end
 
-                    sig { params(args: T.untyped).returns(T::Array[::StateMachines::Transition]) }
+                    sig { params(args: ::T.untyped).returns(::T::Array[::StateMachines::Transition]) }
                     def alarm_state_transitions(*args); end
 
-                    sig { returns(T::Boolean) }
+                    sig { returns(::T::Boolean) }
                     def can_disable_alarm?; end
 
-                    sig { returns(T::Boolean) }
+                    sig { returns(::T::Boolean) }
                     def can_enable_alarm?; end
 
-                    sig { params(args: T.untyped).returns(T::Boolean) }
+                    sig { params(args: ::T.untyped).returns(::T::Boolean) }
                     def disable_alarm(*args); end
 
-                    sig { params(args: T.untyped).returns(T::Boolean) }
+                    sig { params(args: ::T.untyped).returns(::T::Boolean) }
                     def disable_alarm!(*args); end
 
-                    sig { params(args: T.untyped).returns(T.nilable(::StateMachines::Transition)) }
+                    sig { params(args: ::T.untyped).returns(::T.nilable(::StateMachines::Transition)) }
                     def disable_alarm_transition(*args); end
 
-                    sig { params(args: T.untyped).returns(T::Boolean) }
+                    sig { params(args: ::T.untyped).returns(::T::Boolean) }
                     def enable_alarm(*args); end
 
-                    sig { params(args: T.untyped).returns(T::Boolean) }
+                    sig { params(args: ::T.untyped).returns(::T::Boolean) }
                     def enable_alarm!(*args); end
 
-                    sig { params(args: T.untyped).returns(T.nilable(::StateMachines::Transition)) }
+                    sig { params(args: ::T.untyped).returns(::T.nilable(::StateMachines::Transition)) }
                     def enable_alarm_transition(*args); end
 
-                    sig { params(event: T.any(String, Symbol), args: T.untyped).returns(T::Boolean) }
+                    sig { params(event: ::T.any(String, Symbol), args: ::T.untyped).returns(::T::Boolean) }
                     def fire_alarm_state_event(event, *args); end
 
                     sig { returns(String) }
@@ -155,10 +155,10 @@ module Tapioca
                   extend StateMachineClassHelperModule
 
                   module StateMachineClassHelperModule
-                    sig { params(event: T.any(String, Symbol)).returns(String) }
+                    sig { params(event: ::T.any(String, Symbol)).returns(String) }
                     def human_alarm_state_event_name(event); end
 
-                    sig { params(state: T.any(String, Symbol)).returns(String) }
+                    sig { params(state: ::T.any(String, Symbol)).returns(String) }
                     def human_alarm_state_name(state); end
                   end
               RBI
@@ -178,10 +178,10 @@ module Tapioca
 
               expected = indented(<<~RBI, 2)
                 module StateMachineInstanceHelperModule
-                  sig { returns(T::Boolean) }
+                  sig { returns(::T::Boolean) }
                   def alarm_active?; end
 
-                  sig { returns(T::Boolean) }
+                  sig { returns(::T::Boolean) }
                   def alarm_off?; end
 
                   sig { returns(Integer) }
@@ -190,22 +190,22 @@ module Tapioca
                   sig { params(value: Integer).returns(Integer) }
                   def alarm_state=(value); end
 
-                  sig { params(state: T.any(String, Symbol)).returns(T::Boolean) }
+                  sig { params(state: ::T.any(String, Symbol)).returns(::T::Boolean) }
                   def alarm_state?(state); end
 
-                  sig { params(args: T.untyped).returns(T::Array[T.any(String, Symbol)]) }
+                  sig { params(args: ::T.untyped).returns(::T::Array[::T.any(String, Symbol)]) }
                   def alarm_state_events(*args); end
 
-                  sig { returns(T.any(String, Symbol)) }
+                  sig { returns(::T.any(String, Symbol)) }
                   def alarm_state_name; end
 
-                  sig { params(args: T.untyped).returns(T::Array[::StateMachines::Transition]) }
+                  sig { params(args: ::T.untyped).returns(::T::Array[::StateMachines::Transition]) }
                   def alarm_state_paths(*args); end
 
-                  sig { params(args: T.untyped).returns(T::Array[::StateMachines::Transition]) }
+                  sig { params(args: ::T.untyped).returns(::T::Array[::StateMachines::Transition]) }
                   def alarm_state_transitions(*args); end
 
-                  sig { params(event: T.any(String, Symbol), args: T.untyped).returns(T::Boolean) }
+                  sig { params(event: ::T.any(String, Symbol), args: ::T.untyped).returns(::T::Boolean) }
                   def fire_alarm_state_event(event, *args); end
 
                   sig { returns(String) }
@@ -228,7 +228,7 @@ module Tapioca
               RUBY
 
               expected = indented(<<~RBI, 4)
-                sig { params(args: T.untyped).returns(T::Array[::StateMachines::Transition]) }
+                sig { params(args: ::T.untyped).returns(::T::Array[::StateMachines::Transition]) }
                 def state_paths(*args); end
               RBI
 
@@ -261,16 +261,16 @@ module Tapioca
               RUBY
 
               expected = indented(<<~RBI, 4)
-                sig { params(states: T.any(String, Symbol)).returns(T.untyped) }
+                sig { params(states: ::T.any(String, Symbol)).returns(::T.untyped) }
                 def with_state(*states); end
 
-                sig { params(states: T.any(String, Symbol)).returns(T.untyped) }
+                sig { params(states: ::T.any(String, Symbol)).returns(::T.untyped) }
                 def with_states(*states); end
 
-                sig { params(states: T.any(String, Symbol)).returns(T.untyped) }
+                sig { params(states: ::T.any(String, Symbol)).returns(::T.untyped) }
                 def without_state(*states); end
 
-                sig { params(states: T.any(String, Symbol)).returns(T.untyped) }
+                sig { params(states: ::T.any(String, Symbol)).returns(::T.untyped) }
                 def without_states(*states); end
               RBI
 
@@ -297,13 +297,13 @@ module Tapioca
               RUBY
 
               expected = indented(<<~RBI, 4)
-                sig { returns(T.nilable(Symbol)) }
+                sig { returns(::T.nilable(Symbol)) }
                 def state_event; end
 
-                sig { params(value: T.any(String, Symbol)).returns(T.any(String, Symbol)) }
+                sig { params(value: ::T.any(String, Symbol)).returns(::T.any(String, Symbol)) }
                 def state_event=(value); end
 
-                sig { returns(T.nilable(::StateMachines::Transition)) }
+                sig { returns(::T.nilable(::StateMachines::Transition)) }
                 def state_event_transition; end
 
                 sig { params(value: ::StateMachines::Transition).returns(::StateMachines::Transition) }

--- a/spec/tapioca/dsl/compilers/url_helpers_spec.rb
+++ b/spec/tapioca/dsl/compilers/url_helpers_spec.rb
@@ -247,13 +247,13 @@ module Tapioca
                   include ::ActionDispatch::Routing::UrlFor
                   include ::ActionDispatch::Routing::PolymorphicRoutes
 
-                  sig { params(args: T.untyped).returns(String) }
+                  sig { params(args: ::T.untyped).returns(String) }
                   def edit_index_path(*args); end
 
-                  sig { params(args: T.untyped).returns(String) }
+                  sig { params(args: ::T.untyped).returns(String) }
                   def index_path(*args); end
 
-                  sig { params(args: T.untyped).returns(String) }
+                  sig { params(args: ::T.untyped).returns(String) }
                   def new_index_path(*args); end
                 end
               RBI
@@ -277,13 +277,13 @@ module Tapioca
                   include ::ActionDispatch::Routing::UrlFor
                   include ::ActionDispatch::Routing::PolymorphicRoutes
 
-                  sig { params(args: T.untyped).returns(String) }
+                  sig { params(args: ::T.untyped).returns(String) }
                   def edit_index_url(*args); end
 
-                  sig { params(args: T.untyped).returns(String) }
+                  sig { params(args: ::T.untyped).returns(String) }
                   def index_url(*args); end
 
-                  sig { params(args: T.untyped).returns(String) }
+                  sig { params(args: ::T.untyped).returns(String) }
                   def new_index_url(*args); end
                 end
               RBI

--- a/spec/tapioca/dsl/helpers/active_model_type_helper_spec.rb
+++ b/spec/tapioca/dsl/helpers/active_model_type_helper_spec.rb
@@ -56,7 +56,7 @@ module Tapioca
             end
 
             assert_equal(
-              "T.any(::Integer, ::String)",
+              "::T.any(::Integer, ::String)",
               Tapioca::Dsl::Helpers::ActiveModelTypeHelper.type_for(klass.new),
               "The type returned from `__tapioca_type` has the highest priority.",
             )
@@ -210,7 +210,7 @@ module Tapioca
 
           it "returns a weak type when the custom column type is a type variable" do
             assert_equal(
-              "T.untyped",
+              "::T.untyped",
               Tapioca::Dsl::Helpers::ActiveModelTypeHelper.type_for(CustomWithTypeVariable[Integer].new),
             )
           end
@@ -239,7 +239,7 @@ module Tapioca
             end
 
             assert_equal(
-              "T.untyped",
+              "::T.untyped",
               Tapioca::Dsl::Helpers::ActiveModelTypeHelper.type_for(klass.new),
             )
           end
@@ -264,7 +264,7 @@ module Tapioca
             end
 
             assert_equal(
-              "T.untyped",
+              "::T.untyped",
               Tapioca::Dsl::Helpers::ActiveModelTypeHelper.type_for(klass.new),
             )
           end
@@ -273,7 +273,7 @@ module Tapioca
             klass = Class.new(ActiveModel::Type::Value)
 
             assert_equal(
-              "T.untyped",
+              "::T.untyped",
               Tapioca::Dsl::Helpers::ActiveModelTypeHelper.type_for(klass.new),
             )
           end

--- a/spec/tapioca/dsl/helpers/graphql_type_helper_spec.rb
+++ b/spec/tapioca/dsl/helpers/graphql_type_helper_spec.rb
@@ -16,19 +16,19 @@ module Tapioca
         it "generates the expected sorbet type expression when using type GraphQL::Types::Boolean" do
           type = GraphQL::Types::Boolean
           assert_equal(
-            "T.nilable(T::Boolean)",
+            "::T.nilable(::T::Boolean)",
             Tapioca::Dsl::Helpers::GraphqlTypeHelper.type_for(type),
           )
           assert_equal(
-            "T.nilable(T::Boolean)",
+            "::T.nilable(::T::Boolean)",
             Tapioca::Dsl::Helpers::GraphqlTypeHelper.type_for(GraphQL::Schema::Wrapper.new(type)),
           )
           assert_equal(
-            "T.nilable(T::Array[T::Boolean])",
+            "::T.nilable(::T::Array[::T::Boolean])",
             Tapioca::Dsl::Helpers::GraphqlTypeHelper.type_for(GraphQL::Schema::List.new(type)),
           )
           assert_equal(
-            "T::Boolean",
+            "::T::Boolean",
             Tapioca::Dsl::Helpers::GraphqlTypeHelper.type_for(GraphQL::Schema::NonNull.new(type)),
           )
         end
@@ -36,15 +36,15 @@ module Tapioca
         it "generates the expected sorbet type expression when using type GraphQL::Types::String" do
           type = GraphQL::Types::String
           assert_equal(
-            "T.nilable(::String)",
+            "::T.nilable(::String)",
             Tapioca::Dsl::Helpers::GraphqlTypeHelper.type_for(type),
           )
           assert_equal(
-            "T.nilable(::String)",
+            "::T.nilable(::String)",
             Tapioca::Dsl::Helpers::GraphqlTypeHelper.type_for(GraphQL::Schema::Wrapper.new(type)),
           )
           assert_equal(
-            "T.nilable(T::Array[::String])",
+            "::T.nilable(::T::Array[::String])",
             Tapioca::Dsl::Helpers::GraphqlTypeHelper.type_for(GraphQL::Schema::List.new(type)),
           )
           assert_equal(
@@ -56,15 +56,15 @@ module Tapioca
         it "generates the expected sorbet type expression when using type GraphQL::Types::Float" do
           type = GraphQL::Types::Float
           assert_equal(
-            "T.nilable(::Float)",
+            "::T.nilable(::Float)",
             Tapioca::Dsl::Helpers::GraphqlTypeHelper.type_for(type),
           )
           assert_equal(
-            "T.nilable(::Float)",
+            "::T.nilable(::Float)",
             Tapioca::Dsl::Helpers::GraphqlTypeHelper.type_for(GraphQL::Schema::Wrapper.new(type)),
           )
           assert_equal(
-            "T.nilable(T::Array[::Float])",
+            "::T.nilable(::T::Array[::Float])",
             Tapioca::Dsl::Helpers::GraphqlTypeHelper.type_for(GraphQL::Schema::List.new(type)),
           )
           assert_equal(
@@ -76,15 +76,15 @@ module Tapioca
         it "generates the expected sorbet type expression when using type GraphQL::Types::ID" do
           type = GraphQL::Types::ID
           assert_equal(
-            "T.nilable(::String)",
+            "::T.nilable(::String)",
             Tapioca::Dsl::Helpers::GraphqlTypeHelper.type_for(type),
           )
           assert_equal(
-            "T.nilable(::String)",
+            "::T.nilable(::String)",
             Tapioca::Dsl::Helpers::GraphqlTypeHelper.type_for(GraphQL::Schema::Wrapper.new(type)),
           )
           assert_equal(
-            "T.nilable(T::Array[::String])",
+            "::T.nilable(::T::Array[::String])",
             Tapioca::Dsl::Helpers::GraphqlTypeHelper.type_for(GraphQL::Schema::List.new(type)),
           )
           assert_equal(
@@ -96,15 +96,15 @@ module Tapioca
         it "generates the expected sorbet type expression when using type GraphQL::Types::Int" do
           type = GraphQL::Types::Int
           assert_equal(
-            "T.nilable(::Integer)",
+            "::T.nilable(::Integer)",
             Tapioca::Dsl::Helpers::GraphqlTypeHelper.type_for(type),
           )
           assert_equal(
-            "T.nilable(::Integer)",
+            "::T.nilable(::Integer)",
             Tapioca::Dsl::Helpers::GraphqlTypeHelper.type_for(GraphQL::Schema::Wrapper.new(type)),
           )
           assert_equal(
-            "T.nilable(T::Array[::Integer])",
+            "::T.nilable(::T::Array[::Integer])",
             Tapioca::Dsl::Helpers::GraphqlTypeHelper.type_for(GraphQL::Schema::List.new(type)),
           )
           assert_equal(
@@ -116,15 +116,15 @@ module Tapioca
         it "generates the expected sorbet type expression when using type GraphQL::Types::BigInt" do
           type = GraphQL::Types::BigInt
           assert_equal(
-            "T.nilable(::Integer)",
+            "::T.nilable(::Integer)",
             Tapioca::Dsl::Helpers::GraphqlTypeHelper.type_for(type),
           )
           assert_equal(
-            "T.nilable(::Integer)",
+            "::T.nilable(::Integer)",
             Tapioca::Dsl::Helpers::GraphqlTypeHelper.type_for(GraphQL::Schema::Wrapper.new(type)),
           )
           assert_equal(
-            "T.nilable(T::Array[::Integer])",
+            "::T.nilable(::T::Array[::Integer])",
             Tapioca::Dsl::Helpers::GraphqlTypeHelper.type_for(GraphQL::Schema::List.new(type)),
           )
           assert_equal(
@@ -136,15 +136,15 @@ module Tapioca
         it "generates the expected sorbet type expression when using type GraphQL::Types::ISO8601Date" do
           type = GraphQL::Types::ISO8601Date
           assert_equal(
-            "T.nilable(::Date)",
+            "::T.nilable(::Date)",
             Tapioca::Dsl::Helpers::GraphqlTypeHelper.type_for(type),
           )
           assert_equal(
-            "T.nilable(::Date)",
+            "::T.nilable(::Date)",
             Tapioca::Dsl::Helpers::GraphqlTypeHelper.type_for(GraphQL::Schema::Wrapper.new(type)),
           )
           assert_equal(
-            "T.nilable(T::Array[::Date])",
+            "::T.nilable(::T::Array[::Date])",
             Tapioca::Dsl::Helpers::GraphqlTypeHelper.type_for(GraphQL::Schema::List.new(type)),
           )
           assert_equal(
@@ -156,15 +156,15 @@ module Tapioca
         it "generates the expected sorbet type expression when using type GraphQL::Types::ISO8601DateTime" do
           type = GraphQL::Types::ISO8601DateTime
           assert_equal(
-            "T.nilable(::Time)",
+            "::T.nilable(::Time)",
             Tapioca::Dsl::Helpers::GraphqlTypeHelper.type_for(type),
           )
           assert_equal(
-            "T.nilable(::Time)",
+            "::T.nilable(::Time)",
             Tapioca::Dsl::Helpers::GraphqlTypeHelper.type_for(GraphQL::Schema::Wrapper.new(type)),
           )
           assert_equal(
-            "T.nilable(T::Array[::Time])",
+            "::T.nilable(::T::Array[::Time])",
             Tapioca::Dsl::Helpers::GraphqlTypeHelper.type_for(GraphQL::Schema::List.new(type)),
           )
           assert_equal(
@@ -176,19 +176,19 @@ module Tapioca
         it "generates the expected sorbet type expression when using type GraphQL::Types::JSON" do
           type = GraphQL::Types::JSON
           assert_equal(
-            "T.nilable(T::Hash[::String, T.untyped])",
+            "::T.nilable(::T::Hash[::String, ::T.untyped])",
             Tapioca::Dsl::Helpers::GraphqlTypeHelper.type_for(type),
           )
           assert_equal(
-            "T.nilable(T::Hash[::String, T.untyped])",
+            "::T.nilable(::T::Hash[::String, ::T.untyped])",
             Tapioca::Dsl::Helpers::GraphqlTypeHelper.type_for(GraphQL::Schema::Wrapper.new(type)),
           )
           assert_equal(
-            "T.nilable(T::Array[T::Hash[::String, T.untyped]])",
+            "::T.nilable(::T::Array[::T::Hash[::String, ::T.untyped]])",
             Tapioca::Dsl::Helpers::GraphqlTypeHelper.type_for(GraphQL::Schema::List.new(type)),
           )
           assert_equal(
-            "T::Hash[::String, T.untyped]",
+            "::T::Hash[::String, ::T.untyped]",
             Tapioca::Dsl::Helpers::GraphqlTypeHelper.type_for(GraphQL::Schema::NonNull.new(type)),
           )
         end

--- a/spec/tapioca/gem/pipeline_spec.rb
+++ b/spec/tapioca/gem/pipeline_spec.rb
@@ -156,7 +156,7 @@ class Tapioca::Gem::PipelineSpec < Minitest::HooksSpec
 
       output = template(<<~RBI)
         module Bar
-          extend T::Generic
+          extend ::T::Generic
 
           interface!
 
@@ -165,8 +165,8 @@ class Tapioca::Gem::PipelineSpec < Minitest::HooksSpec
           V = type_member { { lower: String } }
         end
 
-        Bar::Arr = T.let(T.unsafe(nil), Array)
-        Bar::Foo = T.type_alias { T.any(::String, ::Symbol) }
+        Bar::Arr = ::T.let(::T.unsafe(nil), Array)
+        Bar::Foo = ::T.type_alias { ::T.any(::String, ::Symbol) }
 
         module Base
           include ::T::Props
@@ -359,7 +359,7 @@ class Tapioca::Gem::PipelineSpec < Minitest::HooksSpec
         module Bar; end
         module Bar::A; end
         class Bar::A::B; end
-        Bar::A::Foo = T.type_alias { T.any(::Bar::A, ::Bar::A::B, ::String, ::Symbol) }
+        Bar::A::Foo = ::T.type_alias { ::T.any(::Bar::A, ::Bar::A::B, ::String, ::Symbol) }
       RBI
 
       assert_equal(output, compile)
@@ -855,7 +855,7 @@ class Tapioca::Gem::PipelineSpec < Minitest::HooksSpec
           include ::Comparable
           include ::Foo::Bar
 
-          def to_foo(base = T.unsafe(nil)); end
+          def to_foo(base = ::T.unsafe(nil)); end
         end
 
         class Symbol
@@ -1050,11 +1050,11 @@ class Tapioca::Gem::PipelineSpec < Minitest::HooksSpec
       output = template(<<~RBI)
         module A; end
         <% if ruby_version(">= 2.4.0") %>
-        A::ABC = T.let(T.unsafe(nil), Integer)
+        A::ABC = ::T.let(::T.unsafe(nil), Integer)
         <% else %>
-        A::ABC = T.let(T.unsafe(nil), Fixnum)
+        A::ABC = ::T.let(::T.unsafe(nil), Fixnum)
         <% end %>
-        A::DEF = T.let(T.unsafe(nil), String)
+        A::DEF = ::T.let(::T.unsafe(nil), String)
       RBI
 
       assert_equal(output, compile)
@@ -1087,7 +1087,7 @@ class Tapioca::Gem::PipelineSpec < Minitest::HooksSpec
 
       output = template(<<~RBI)
         class Foo
-          def add(a = T.unsafe(nil), b: T.unsafe(nil)); end
+          def add(a = ::T.unsafe(nil), b: ::T.unsafe(nil)); end
         end
       RBI
 
@@ -1274,7 +1274,7 @@ class Tapioca::Gem::PipelineSpec < Minitest::HooksSpec
         class Bar; end
 
         class Foo
-          sig { params(x: T.any(::Bar, ::String)).returns(::Bar) }
+          sig { params(x: ::T.any(::Bar, ::String)).returns(::Bar) }
           def bar(x); end
 
           sig { params(x: ::Foo::Bar).returns(::Foo::Bar) }
@@ -2291,11 +2291,11 @@ class Tapioca::Gem::PipelineSpec < Minitest::HooksSpec
 
       output = template(<<~RBI)
         module Toto; end
-        Toto::A = T.let(T.unsafe(nil), String)
-        Toto::B = T.let(T.unsafe(nil), String)
-        Toto::C = T.let(T.unsafe(nil), String)
-        Toto::D = T.let(T.unsafe(nil), Array)
-        Toto::NUMS = T.let(T.unsafe(nil), Array)
+        Toto::A = ::T.let(::T.unsafe(nil), String)
+        Toto::B = ::T.let(::T.unsafe(nil), String)
+        Toto::C = ::T.let(::T.unsafe(nil), String)
+        Toto::D = ::T.let(::T.unsafe(nil), Array)
+        Toto::NUMS = ::T.let(::T.unsafe(nil), Array)
       RBI
 
       assert_equal(output, compile)
@@ -2332,7 +2332,7 @@ class Tapioca::Gem::PipelineSpec < Minitest::HooksSpec
 
       output = template(<<~RBI)
         module Toto; end
-        Toto::A = T.let(T.unsafe(nil), Range)
+        Toto::A = ::T.let(::T.unsafe(nil), Range)
       RBI
 
       assert_equal(output, compile)
@@ -2344,7 +2344,7 @@ class Tapioca::Gem::PipelineSpec < Minitest::HooksSpec
       RUBY
 
       output = template(<<~RBI)
-        Foo = T.let(T.unsafe(nil), ObjectSpace::WeakMap)
+        Foo = ::T.let(::T.unsafe(nil), ObjectSpace::WeakMap)
       RBI
 
       assert_equal(output, compile)
@@ -2408,8 +2408,8 @@ class Tapioca::Gem::PipelineSpec < Minitest::HooksSpec
       output = template(<<~RBI)
         module BasicObjectTest; end
         class BasicObjectTest::B < ::BasicObject; end
-        BasicObjectTest::Basic = T.let(T.unsafe(nil), BasicObjectTest::B)
-        BasicObjectTest::VeryBasic = T.let(T.unsafe(nil), BasicObject)
+        BasicObjectTest::Basic = ::T.let(::T.unsafe(nil), BasicObjectTest::B)
+        BasicObjectTest::VeryBasic = ::T.let(::T.unsafe(nil), BasicObject)
       RBI
 
       assert_equal(output, compile)
@@ -2720,7 +2720,7 @@ class Tapioca::Gem::PipelineSpec < Minitest::HooksSpec
           end
         end
 
-        Bar = T.let(T.unsafe(nil), ActiveSupport::Deprecation::DeprecatedConstantProxy)
+        Bar = ::T.let(::T.unsafe(nil), ActiveSupport::Deprecation::DeprecatedConstantProxy)
 
         class Foo
           class << self
@@ -2819,7 +2819,7 @@ class Tapioca::Gem::PipelineSpec < Minitest::HooksSpec
       assert_equal(output, compile)
     end
 
-    it "properly filters out T::Private modules" do
+    it "properly filters out ::T::Private modules" do
       add_ruby_file("foo.rb", <<~RUBY)
         class Foo
           extend(T::Private::Methods::SingletonMethodHooks)
@@ -2844,7 +2844,7 @@ class Tapioca::Gem::PipelineSpec < Minitest::HooksSpec
       assert_equal(output, compile)
     end
 
-    it "doesn't filter out T::Props modules" do
+    it "doesn't filter out ::T::Props modules" do
       add_ruby_file("foo.rb", <<~RUBY)
         class Foo
           extend(T::Props)
@@ -2930,7 +2930,7 @@ class Tapioca::Gem::PipelineSpec < Minitest::HooksSpec
       assert_equal(output, compile)
     end
 
-    it "compiles T::Enum" do
+    it "compiles ::T::Enum" do
       add_ruby_file("foo.rb", <<~RUBY)
         class Bar
           class Baz < T::Enum
@@ -2972,13 +2972,13 @@ class Tapioca::Gem::PipelineSpec < Minitest::HooksSpec
         end
 
         class Foo::C; end
-        Foo::CONSTANT = T.let(T.unsafe(nil), Integer)
+        Foo::CONSTANT = ::T.let(::T.unsafe(nil), Integer)
       RBI
 
       assert_equal(output, compile)
     end
 
-    it "does not think random types that override < are T::Enum" do
+    it "does not think random types that override < are ::T::Enum" do
       add_ruby_file("foo.rb", <<~RUBY)
         class Foo
           def self.<(other)
@@ -3042,7 +3042,7 @@ class Tapioca::Gem::PipelineSpec < Minitest::HooksSpec
           sig(:final) { void }
           def foo; end
 
-          sig(:final) { returns(T.proc.params(x: ::String).void) }
+          sig(:final) { returns(::T.proc.params(x: ::String).void) }
           def some_attribute; end
 
           class << self
@@ -3270,11 +3270,11 @@ class Tapioca::Gem::PipelineSpec < Minitest::HooksSpec
         class Bar < ::T::Struct
           const :foo, ::Integer
           prop :bar, ::String
-          const :baz, T::Hash[::String, T.untyped]
-          prop :quux, T.untyped, default: T.unsafe(nil)
-          const :quuz, ::Integer, default: T.unsafe(nil)
-          prop :fuzz, T.proc.returns(::String), default: T.unsafe(nil)
-          prop :buzz, T.proc.void, default: T.unsafe(nil)
+          const :baz, ::T::Hash[::String, ::T.untyped]
+          prop :quux, ::T.untyped, default: ::T.unsafe(nil)
+          const :quuz, ::Integer, default: ::T.unsafe(nil)
+          prop :fuzz, ::T.proc.returns(::String), default: ::T.unsafe(nil)
+          prop :buzz, ::T.proc.void, default: ::T.unsafe(nil)
         end
 
         class Baz
@@ -3295,17 +3295,17 @@ class Tapioca::Gem::PipelineSpec < Minitest::HooksSpec
 
           const :foo, ::Integer
           prop :bar, ::String
-          const :baz, T.proc.params(arg0: ::String).void
+          const :baz, ::T.proc.params(arg0: ::String).void
         end
 
         module ClassMethods
-          extend T::Generic
+          extend ::T::Generic
 
           has_attached_class!
         end
 
         module ClassMethodsWithVariance
-          extend T::Generic
+          extend ::T::Generic
 
           has_attached_class!(:out) { { upper: String } }
         end
@@ -3314,16 +3314,16 @@ class Tapioca::Gem::PipelineSpec < Minitest::HooksSpec
           sig { params(a: ::Integer, b: ::String).returns(::Integer) }
           def bar(a, b:); end
 
-          sig { type_parameters(:U).params(a: T.type_parameter(:U)).returns(T.type_parameter(:U)) }
+          sig { type_parameters(:U).params(a: ::T.type_parameter(:U)).returns(::T.type_parameter(:U)) }
           def baz(a); end
 
           sig { params(a: ::Integer, b: ::String).void }
           def foo(a, b:); end
 
-          sig { params(a: ::Integer, b: ::Integer, c: ::Integer, d: ::Integer, e: ::Integer, f: ::Integer, blk: T.proc.void).void }
-          def many_kinds_of_args(*a, b, c, d:, e: T.unsafe(nil), **f, &blk); end
+          sig { params(a: ::Integer, b: ::Integer, c: ::Integer, d: ::Integer, e: ::Integer, f: ::Integer, blk: ::T.proc.void).void }
+          def many_kinds_of_args(*a, b, c, d:, e: ::T.unsafe(nil), **f, &blk); end
 
-          sig { returns(T.proc.params(x: ::String).void) }
+          sig { returns(::T.proc.params(x: ::String).void) }
           def some_attribute; end
 
           class << self
@@ -3335,20 +3335,20 @@ class Tapioca::Gem::PipelineSpec < Minitest::HooksSpec
         module Generics; end
 
         class Generics::ComplexGenericType
-          extend T::Generic
+          extend ::T::Generic
 
           A = type_template(:in)
           B = type_template(:out)
           C = type_template
           D = type_member { { fixed: Integer } }
-          E = type_member { { fixed: Integer, upper: T::Array[::Numeric] } }
-          F = type_member { { fixed: Integer, lower: T.any(::Complex, T::Hash[::Symbol, T::Array[::Integer]]), upper: T.nilable(::Numeric) } }
+          E = type_member { { fixed: Integer, upper: ::T::Array[::Numeric] } }
+          F = type_member { { fixed: Integer, lower: ::T.any(::Complex, ::T::Hash[::Symbol, ::T::Array[::Integer]]), upper: ::T.nilable(::Numeric) } }
           G = type_member(:in) { { fixed: Integer } }
           H = type_member(:in) { { fixed: Integer, upper: Numeric } }
           I = type_member(:in) { { fixed: Integer, lower: Complex, upper: Numeric } }
 
           class << self
-            extend T::Generic
+            extend ::T::Generic
 
             A = type_template(:in)
             B = type_template(:out)
@@ -3363,7 +3363,7 @@ class Tapioca::Gem::PipelineSpec < Minitest::HooksSpec
         end
 
         module Generics::ForwardDeclaration
-          extend T::Generic
+          extend ::T::Generic
 
           Elem = type_member { { fixed: Generics::ForwardDeclaration::LateDeclaredModule } }
         end
@@ -3371,7 +3371,7 @@ class Tapioca::Gem::PipelineSpec < Minitest::HooksSpec
         module Generics::ForwardDeclaration::LateDeclaredModule; end
 
         class Generics::SimpleGenericType
-          extend T::Generic
+          extend ::T::Generic
 
           Template = type_template
           Elem = type_member
@@ -3379,14 +3379,14 @@ class Tapioca::Gem::PipelineSpec < Minitest::HooksSpec
           sig { params(foo: Elem).void }
           def initialize(foo); end
 
-          sig { params(foo: T::Hash[T::Array[Template], T::Set[Elem]]).void }
+          sig { params(foo: ::T::Hash[::T::Array[Template], ::T::Set[Elem]]).void }
           def complex(foo); end
 
           sig { params(foo: Template).returns(Template) }
           def something(foo); end
         end
 
-        Generics::SimpleGenericType::NullGenericType = T.let(T.unsafe(nil), Generics::SimpleGenericType[::Integer])
+        Generics::SimpleGenericType::NullGenericType = ::T.let(::T.unsafe(nil), Generics::SimpleGenericType[::Integer])
 
         module Quux
           interface!
@@ -3401,10 +3401,10 @@ class Tapioca::Gem::PipelineSpec < Minitest::HooksSpec
           sig { returns(::String) }
           def bar; end
 
-          sig { params(baz: T::Hash[::String, ::Object]).returns(T::Hash[::String, ::Object]) }
+          sig { params(baz: ::T::Hash[::String, ::Object]).returns(::T::Hash[::String, ::Object]) }
           def baz=(baz); end
 
-          sig { returns(T::Array[::Integer]) }
+          sig { returns(::T::Array[::Integer]) }
           def foo; end
 
           def foo=(_arg0); end
@@ -3455,7 +3455,7 @@ class Tapioca::Gem::PipelineSpec < Minitest::HooksSpec
 
       output = template(<<~RBI)
         class Foo
-          extend T::Generic
+          extend ::T::Generic
 
           sealed!
 
@@ -3504,36 +3504,36 @@ class Tapioca::Gem::PipelineSpec < Minitest::HooksSpec
       RUBY
 
       output = template(<<~RBI)
-        BAR = T.let(T.unsafe(nil), Bar[T.untyped, T.untyped])
-        BAZ = T.let(T.unsafe(nil), Baz[T.untyped])
+        BAR = ::T.let(::T.unsafe(nil), Bar[::T.untyped, ::T.untyped])
+        BAZ = ::T.let(::T.unsafe(nil), Baz[::T.untyped])
 
         class Bar
-          extend T::Generic
+          extend ::T::Generic
 
           Key = type_member
           Value = type_member
         end
 
         class Baz
-          extend T::Generic
+          extend ::T::Generic
 
           Key = type_member { { fixed: Symbol } }
           Value = type_member
         end
 
-        FOO = T.let(T.unsafe(nil), Foo[T.untyped])
-        FUZ = T.let(T.unsafe(nil), Fuz)
+        FOO = ::T.let(::T.unsafe(nil), Foo[::T.untyped])
+        FUZ = ::T.let(::T.unsafe(nil), Fuz)
 
         class Foo
-          extend T::Generic
+          extend ::T::Generic
 
           Elem = type_member
         end
 
         class Fuz
-          extend T::Generic
+          extend ::T::Generic
 
-          Elem = type_member { { fixed: NilClass } }
+          Elem = type_member { { fixed: ::NilClass } }
         end
       RBI
 
@@ -3560,14 +3560,14 @@ class Tapioca::Gem::PipelineSpec < Minitest::HooksSpec
 
       output = template(<<~RBI)
         class Result
-          extend T::Generic
+          extend ::T::Generic
 
           OkType = type_member
           ErrType = type_member
         end
 
         class Service
-          extend T::Generic
+          extend ::T::Generic
 
           InputType = type_member { { upper: Result[::Integer, ::String] } }
           ReturnType = type_member { { fixed: Result[::Integer, ::String] } }
@@ -3593,7 +3593,7 @@ class Tapioca::Gem::PipelineSpec < Minitest::HooksSpec
 
       output = template(<<~RBI)
         class Foo < ::T::Struct
-          extend T::Generic
+          extend ::T::Generic
 
           Elem = type_member
 
@@ -3626,7 +3626,7 @@ class Tapioca::Gem::PipelineSpec < Minitest::HooksSpec
 
       output = template(<<~RBI)
         class Foo
-          extend T::Generic
+          extend ::T::Generic
 
           Elem = type_member
 
@@ -3691,41 +3691,41 @@ class Tapioca::Gem::PipelineSpec < Minitest::HooksSpec
 
       output = template(<<~RBI)
         module Node
-          extend T::Generic
+          extend ::T::Generic
 
           Elem = type_member
         end
 
         class OtherRoot
-          extend T::Generic
+          extend ::T::Generic
           include ::Root
 
           Elem = type_member { { fixed: Integer } }
 
-          sig { override.returns(T::Array[Node[::Integer]]) }
+          sig { override.returns(::T::Array[Node[::Integer]]) }
           def children; end
 
-          sig { override.returns(T::Array[Node[::Integer]]) }
+          sig { override.returns(::T::Array[Node[::Integer]]) }
           def non_abstract_but_overridden_children; end
         end
 
         module Root
-          extend T::Generic
+          extend ::T::Generic
 
           abstract!
 
           Elem = type_member
 
-          sig { abstract.returns(T::Array[Node[Elem]]) }
+          sig { abstract.returns(::T::Array[Node[Elem]]) }
           def abstract_but_not_overridden_children; end
 
-          sig { abstract.returns(T::Array[Node[Elem]]) }
+          sig { abstract.returns(::T::Array[Node[Elem]]) }
           def children; end
 
-          sig { returns(T::Array[Node[Elem]]) }
+          sig { returns(::T::Array[Node[Elem]]) }
           def non_abstract_but_overridden_children; end
 
-          sig { returns(T::Array[Node[Elem]]) }
+          sig { returns(::T::Array[Node[Elem]]) }
           def non_abstract_children; end
         end
       RBI
@@ -3758,16 +3758,16 @@ class Tapioca::Gem::PipelineSpec < Minitest::HooksSpec
 
       output = template(<<~RBI)
         class Concrete
-          extend T::Generic
+          extend ::T::Generic
           include ::GenericInterface
 
           Parameter = type_member
         end
 
-        GENERIC_CONSTANT = T.let(T.unsafe(nil), Concrete[T.untyped])
+        GENERIC_CONSTANT = ::T.let(::T.unsafe(nil), Concrete[::T.untyped])
 
         module GenericInterface
-          extend T::Generic
+          extend ::T::Generic
 
           interface!
 
@@ -3795,7 +3795,7 @@ class Tapioca::Gem::PipelineSpec < Minitest::HooksSpec
       output = template(<<~RBI)
         class Foo
           class << self
-            sig { returns(T::Array[::T.untyped]) }
+            sig { returns(::T::Array[::T.untyped]) }
             def foo; end
           end
         end
@@ -3828,19 +3828,19 @@ class Tapioca::Gem::PipelineSpec < Minitest::HooksSpec
 
       output = template(<<~RBI)
         class Foo < ::T::Struct
-          prop :a, T.nilable(::Integer), default: T.unsafe(nil)
-          prop :b, T::Boolean, default: T.unsafe(nil)
-          prop :c, T::Boolean, default: T.unsafe(nil)
-          prop :d, ::Symbol, default: T.unsafe(nil)
-          prop :e, ::String, default: T.unsafe(nil)
-          prop :f, ::Integer, default: T.unsafe(nil)
-          prop :g, ::Float, default: T.unsafe(nil)
-          prop :h, T::Array[::String], default: T.unsafe(nil)
-          prop :i, T::Hash[::String, ::Integer], default: T.unsafe(nil)
-          prop :k, ::Foo, default: T.unsafe(nil)
-          prop :l, T::Array[::Foo], default: T.unsafe(nil)
-          prop :m, T::Hash[::Foo, ::Foo], default: T.unsafe(nil)
-          prop :n, ::Foo, default: T.unsafe(nil)
+          prop :a, ::T.nilable(::Integer), default: ::T.unsafe(nil)
+          prop :b, ::T::Boolean, default: ::T.unsafe(nil)
+          prop :c, ::T::Boolean, default: ::T.unsafe(nil)
+          prop :d, ::Symbol, default: ::T.unsafe(nil)
+          prop :e, ::String, default: ::T.unsafe(nil)
+          prop :f, ::Integer, default: ::T.unsafe(nil)
+          prop :g, ::Float, default: ::T.unsafe(nil)
+          prop :h, ::T::Array[::String], default: ::T.unsafe(nil)
+          prop :i, ::T::Hash[::String, ::Integer], default: ::T.unsafe(nil)
+          prop :k, ::Foo, default: ::T.unsafe(nil)
+          prop :l, ::T::Array[::Foo], default: ::T.unsafe(nil)
+          prop :m, ::T::Hash[::Foo, ::Foo], default: ::T.unsafe(nil)
+          prop :n, ::Foo, default: ::T.unsafe(nil)
         end
       RBI
 
@@ -3942,7 +3942,7 @@ class Tapioca::Gem::PipelineSpec < Minitest::HooksSpec
           def bar(*args, &blk); end
         <% end %>
 
-          sig { type_parameters(:U).params(a: T.type_parameter(:U)).returns(T.type_parameter(:U)) }
+          sig { type_parameters(:U).params(a: ::T.type_parameter(:U)).returns(::T.type_parameter(:U)) }
           def baz(a); end
 
         <% if ruby_version(">= 3.1") %>
@@ -3995,13 +3995,13 @@ class Tapioca::Gem::PipelineSpec < Minitest::HooksSpec
       output = template(<<~RBI)
         class Foo
           class << self
-            sig { returns(T.attached_class) }
+            sig { returns(::T.attached_class) }
             def a; end
 
-            sig { returns(T::Hash[T.attached_class, T::Array[T.attached_class]]) }
+            sig { returns(::T::Hash[::T.attached_class, ::T::Array[::T.attached_class]]) }
             def b; end
 
-            sig { returns(T.any(::Foo::AttachedClass, ::Foo::FooAttachedClass)) }
+            sig { returns(::T.any(::Foo::AttachedClass, ::Foo::FooAttachedClass)) }
             def c; end
           end
         end
@@ -4100,7 +4100,7 @@ class Tapioca::Gem::PipelineSpec < Minitest::HooksSpec
 
       output = template(<<~RBI)
         class Container; end
-        Container::Bar = T.let(T.unsafe(nil), Integer)
+        Container::Bar = ::T.let(::T.unsafe(nil), Integer)
         class Container::Baz; end
         class Container::FooClass; end
         module Container::FooModule; end
@@ -4292,7 +4292,7 @@ class Tapioca::Gem::PipelineSpec < Minitest::HooksSpec
         end
 
         # This secret constant unlocks the magic behind Foo
-        Namespace::Foo::CONSTANT = T.let(T.unsafe(nil), String)
+        Namespace::Foo::CONSTANT = ::T.let(::T.unsafe(nil), String)
       RBI
 
       assert_equal(output, compile(include_doc: true))
@@ -4384,7 +4384,7 @@ class Tapioca::Gem::PipelineSpec < Minitest::HooksSpec
           end
         end
 
-        Namespace::Foo::CONSTANT = T.let(T.unsafe(nil), String)
+        Namespace::Foo::CONSTANT = ::T.let(::T.unsafe(nil), String)
       RBI
 
       assert_equal(output, compile(include_doc: false))
@@ -4399,7 +4399,7 @@ class Tapioca::Gem::PipelineSpec < Minitest::HooksSpec
 
       output = template(<<~RBI)
         module Foo; end
-        Foo::MyType = T.type_alias { T.proc.params(val: T.untyped).void }
+        Foo::MyType = ::T.type_alias { ::T.proc.params(val: ::T.untyped).void }
       RBI
 
       assert_equal(output, compile)
@@ -4451,8 +4451,8 @@ class Tapioca::Gem::PipelineSpec < Minitest::HooksSpec
         end
 
         module TestHelper
+          requires_ancestor { ::T.class_of(String) }
           requires_ancestor { Base::Helper }
-          requires_ancestor { T.class_of(String) }
           requires_ancestor { TestHelper::Assertions }
           requires_ancestor { TestHelper::Hooks }
           requires_ancestor { ViewHelpers::UrlHelper }
@@ -4482,10 +4482,10 @@ class Tapioca::Gem::PipelineSpec < Minitest::HooksSpec
 
       output = template(<<~RBI)
         class Foo
-          sig { params(block: T.proc.bind(::String).void).void }
+          sig { params(block: ::T.proc.bind(::String).void).void }
           def bar(&block); end
 
-          sig { params(block: T.proc.bind(::String).params(arg0: ::Integer).void).void }
+          sig { params(block: ::T.proc.bind(::String).params(arg0: ::Integer).void).void }
           def baz(&block); end
         end
       RBI
@@ -4575,7 +4575,7 @@ class Tapioca::Gem::PipelineSpec < Minitest::HooksSpec
         end
 
         # pkg:gem/#{DEFAULT_GEM_NAME}#lib/bar.rb:11
-        Bar::BAR = T.let(T.unsafe(nil), Integer)
+        Bar::BAR = ::T.let(::T.unsafe(nil), Integer)
 
         # pkg:gem/#{DEFAULT_GEM_NAME}#lib/foo.rb:23
         class BasicFoo < ::BasicObject
@@ -4636,7 +4636,7 @@ class Tapioca::Gem::PipelineSpec < Minitest::HooksSpec
 
       output = template(<<~RBI)
         class Foo; end
-        Foo::BAR = T.let(T.unsafe(nil), T.untyped)
+        Foo::BAR = ::T.let(::T.unsafe(nil), ::T.untyped)
       RBI
 
       assert_equal(output, compile)
@@ -4681,7 +4681,7 @@ class Tapioca::Gem::PipelineSpec < Minitest::HooksSpec
           def qux; end
 
           class << self
-            sig { returns(T.proc.params(arg0: ::String).void) }
+            sig { returns(::T.proc.params(arg0: ::String).void) }
             def baz; end
 
             sig { void }
@@ -4766,7 +4766,7 @@ class Tapioca::Gem::PipelineSpec < Minitest::HooksSpec
         class Foo
           requires_ancestor { Kernel }
 
-          sig { returns(T::Array[::String]) }
+          sig { returns(::T::Array[::String]) }
           def bar; end
 
           # :comment:

--- a/spec/tapioca/gemfile_spec.rb
+++ b/spec/tapioca/gemfile_spec.rb
@@ -52,7 +52,7 @@ module Tapioca
             sig { void }
             def bar; end
 
-            def foo(a = T.unsafe(nil), b = T.unsafe(nil)); end
+            def foo(a = ::T.unsafe(nil), b = ::T.unsafe(nil)); end
           end
         RBI
 
@@ -62,8 +62,8 @@ module Tapioca
           module Foo
             def bar; end
 
-            sig { params(a: T.nilable(Integer), b: T.nilable(Integer)).void }
-            def foo(a = T.unsafe(nil), b = T.unsafe(nil)); end
+            sig { params(a: ::T.nilable(Integer), b: ::T.nilable(Integer)).void }
+            def foo(a = ::T.unsafe(nil), b = ::T.unsafe(nil)); end
           end
         RBI
 
@@ -77,8 +77,8 @@ module Tapioca
             sig { void }
             def bar; end
 
-            sig { params(a: T.nilable(Integer), b: T.nilable(Integer)).void }
-            def foo(a = T.unsafe(nil), b = T.unsafe(nil)); end
+            sig { params(a: ::T.nilable(Integer), b: ::T.nilable(Integer)).void }
+            def foo(a = ::T.unsafe(nil), b = ::T.unsafe(nil)); end
           end
         RBI
       end
@@ -90,8 +90,8 @@ module Tapioca
           # typed: true
 
           module Foo
-            sig { params(a: T.nilable(Integer), b: T.nilable(Integer)).void }
-            def foo(a = T.unsafe(nil), b = T.unsafe(nil)); end
+            sig { params(a: ::T.nilable(Integer), b: ::T.nilable(Integer)).void }
+            def foo(a = ::T.unsafe(nil), b = ::T.unsafe(nil)); end
           end
         RBI
 
@@ -99,8 +99,8 @@ module Tapioca
           # typed: true
 
           module Foo
-            sig { params(x: T.nilable(Integer)).void }
-            def foo(x = T.unsafe(nil)); end
+            sig { params(x: ::T.nilable(Integer)).void }
+            def foo(x = ::T.unsafe(nil)); end
           end
         RBI
 
@@ -112,11 +112,11 @@ module Tapioca
 
           module Foo
             <<<<<<< left
-            sig { params(x: T.nilable(Integer)).void }
-            def foo(x = T.unsafe(nil)); end
+            sig { params(x: ::T.nilable(Integer)).void }
+            def foo(x = ::T.unsafe(nil)); end
             =======
-            sig { params(a: T.nilable(Integer), b: T.nilable(Integer)).void }
-            def foo(a = T.unsafe(nil), b = T.unsafe(nil)); end
+            sig { params(a: ::T.nilable(Integer), b: ::T.nilable(Integer)).void }
+            def foo(a = ::T.unsafe(nil), b = ::T.unsafe(nil)); end
             >>>>>>> right
           end
         RBI

--- a/spec/tapioca/helpers/rbi_helper_spec.rb
+++ b/spec/tapioca/helpers/rbi_helper_spec.rb
@@ -7,13 +7,13 @@ class Tapioca::RBIHelperSpec < Minitest::Spec
   include Tapioca::RBIHelper
 
   describe Tapioca::RBIHelper do
-    specify "as_non_nilable_type removes T.nilable() and ::T.nilable() if it's the outermost part of the string" do
+    specify "as_non_nilable_type removes ::T.nilable() and ::T.nilable() if it's the outermost part of the string" do
       T.bind(self, T.untyped)
 
-      assert_equal(as_non_nilable_type("T.nilable(String)"), "String")
+      assert_equal(as_non_nilable_type("::T.nilable(String)"), "String")
       assert_equal(as_non_nilable_type("::T.nilable(String)"), "String")
       assert_equal(as_non_nilable_type("String"), "String")
-      assert_equal(as_non_nilable_type("T.any(T.nilable(String), Integer)"), "T.any(T.nilable(String), Integer)")
+      assert_equal(as_non_nilable_type("::T.any(::T.nilable(String), Integer)"), "::T.any(::T.nilable(String), Integer)")
     end
 
     it "accepts valid method names" do

--- a/spec/tapioca/rbi_builder_spec.rb
+++ b/spec/tapioca/rbi_builder_spec.rb
@@ -28,7 +28,7 @@ module RBI
           G = type_member
           H = type_template(:in) { { fixed: Foo } }
 
-          sig { returns(T.untyped) }
+          sig { returns(::T.untyped) }
           def foo; end
         RBI
       end


### PR DESCRIPTION
## Summary

Fully qualifies `T` references as `::T` and `NilClass` as `::NilClass` in all generated RBI output.

When a class defines a type member named `T` (e.g., via `#: [T]` in RBS), unqualified `T::Boolean`, `T.nilable(...)`, etc. in generated RBI resolve to the type member instead of Sorbet's `::T` module, causing type-checking errors. These types come from RBS translations (`bool` → `T::Boolean`, `untyped` → `T.untyped`, `nil` → `NilClass`) and unambiguously always mean the top-level constants.

## Navigating the diff

> [!TIP]
> Most of this diff is mechanical `T` → `::T` and `NilClass` → `::NilClass` string literal replacements. The interesting logic changes are in a handful of files:

**Core qualification logic:**
- **`lib/tapioca/helpers/rbi_helper.rb`** — Adds catch-all regex to `sanitize_signature_types` that qualifies `T::` → `::T::`, `T.` → `::T.`, and `NilClass` → `::NilClass`. Updates `as_nilable_type` to emit `::T.nilable(...)`.

**Places that called `.to_s` on Sorbet runtime types (producing unqualified strings):**
- **`lib/tapioca/dsl/helpers/active_model_type_helper.rb`** — Applies qualification regex to `type.to_s` output
- **`lib/tapioca/dsl/helpers/graphql_type_helper.rb`** — Includes `RBIHelper`, routes `return_type.to_s` through `sanitize_signature_types`
- **`lib/tapioca/gem/listeners/sorbet_required_ancestors.rb`** — Routes `ancestor.to_s` through `sanitize_signature_types`
- **`lib/tapioca/sorbet_ext/generic_name_patch.rb`** — Routes type variable bounds `.to_s` through `sanitize_signature_types`

**Avoided double-qualification:**
- **`lib/tapioca/dsl/compilers/identity_cache.rb`** — `COLLECTION_TYPE` lambda updated to not blindly prepend `::` when the type string is already qualified

**Everything else** in `lib/` and `spec/` is mechanical `s/T::/::T::/` and `s/T\./::T./` in string literals and test expectations.

## Test plan

- [x] All 784 existing tests pass (0 failures, 0 errors)
- [ ] Run `tapioca dsl` on a project with `#: [T]` generics to confirm the fix
- [ ] Verify Sorbet accepts the fully-qualified output

🤖 Generated with [Claude Code](https://claude.com/claude-code)