### PR TITLE
AASM events yields block on successful state transition

### DIFF
--- a/lib/tapioca/dsl/compilers/aasm.rb
+++ b/lib/tapioca/dsl/compilers/aasm.rb
@@ -90,7 +90,10 @@ module Tapioca
               end
 
               # Create all of the methods for each event
-              parameters = [create_rest_param("opts", type: "T.untyped")]
+              parameters = [
+                create_rest_param("opts", type: "T.untyped"),
+                create_block_param("block", type: "T.nilable(T.proc.void)"),
+              ]
               state_machine.events.each do |event|
                 model.create_method(event.name.to_s, parameters: parameters)
                 model.create_method("#{event.name}!", parameters: parameters)

--- a/spec/tapioca/dsl/compilers/aasm_spec.rb
+++ b/spec/tapioca/dsl/compilers/aasm_spec.rb
@@ -79,14 +79,14 @@ module Tapioca
                   sig { returns(T::Boolean) }
                   def may_run?; end
 
-                  sig { params(opts: T.untyped).returns(T.untyped) }
-                  def run(*opts); end
+                  sig { params(opts: T.untyped, block: T.nilable(T.proc.void)).returns(T.untyped) }
+                  def run(*opts, &block); end
 
-                  sig { params(opts: T.untyped).returns(T.untyped) }
-                  def run!(*opts); end
+                  sig { params(opts: T.untyped, block: T.nilable(T.proc.void)).returns(T.untyped) }
+                  def run!(*opts, &block); end
 
-                  sig { params(opts: T.untyped).returns(T.untyped) }
-                  def run_without_validation!(*opts); end
+                  sig { params(opts: T.untyped, block: T.nilable(T.proc.void)).returns(T.untyped) }
+                  def run_without_validation!(*opts, &block); end
 
                   sig { returns(T::Boolean) }
                   def running?; end
@@ -220,14 +220,14 @@ module Tapioca
                   sig { returns(T::Boolean) }
                   def may_run?; end
 
-                  sig { params(opts: T.untyped).returns(T.untyped) }
-                  def run(*opts); end
+                  sig { params(opts: T.untyped, block: T.nilable(T.proc.void)).returns(T.untyped) }
+                  def run(*opts, &block); end
 
-                  sig { params(opts: T.untyped).returns(T.untyped) }
-                  def run!(*opts); end
+                  sig { params(opts: T.untyped, block: T.nilable(T.proc.void)).returns(T.untyped) }
+                  def run!(*opts, &block); end
 
-                  sig { params(opts: T.untyped).returns(T.untyped) }
-                  def run_without_validation!(*opts); end
+                  sig { params(opts: T.untyped, block: T.nilable(T.proc.void)).returns(T.untyped) }
+                  def run_without_validation!(*opts, &block); end
 
                   sig { returns(T::Boolean) }
                   def running?; end
@@ -364,20 +364,20 @@ module Tapioca
                   sig { returns(T::Boolean) }
                   def may_run_foo?; end
 
-                  sig { params(opts: T.untyped).returns(T.untyped) }
-                  def run(*opts); end
+                  sig { params(opts: T.untyped, block: T.nilable(T.proc.void)).returns(T.untyped) }
+                  def run(*opts, &block); end
 
-                  sig { params(opts: T.untyped).returns(T.untyped) }
-                  def run!(*opts); end
+                  sig { params(opts: T.untyped, block: T.nilable(T.proc.void)).returns(T.untyped) }
+                  def run!(*opts, &block); end
 
-                  sig { params(opts: T.untyped).returns(T.untyped) }
-                  def run_foo(*opts); end
+                  sig { params(opts: T.untyped, block: T.nilable(T.proc.void)).returns(T.untyped) }
+                  def run_foo(*opts, &block); end
 
-                  sig { params(opts: T.untyped).returns(T.untyped) }
-                  def run_foo!(*opts); end
+                  sig { params(opts: T.untyped, block: T.nilable(T.proc.void)).returns(T.untyped) }
+                  def run_foo!(*opts, &block); end
 
-                  sig { params(opts: T.untyped).returns(T.untyped) }
-                  def run_without_validation!(*opts); end
+                  sig { params(opts: T.untyped, block: T.nilable(T.proc.void)).returns(T.untyped) }
+                  def run_without_validation!(*opts, &block); end
 
                   class << self
                     sig { params(args: T.untyped, block: T.nilable(T.proc.bind(PrivateAASMMachine).void)).returns(PrivateAASMMachine) }


### PR DESCRIPTION
### Motivation
Updating to Sorbet 0.6 in our app flagged that the generated signatures did not include a block (https://github.com/sorbet/sorbet/pull/9791), this fixes that.

Relevant source: 
- https://github.com/aasm/aasm/blob/726a578808e0f403bfd24e505f9a45319670a6b7/lib/aasm/base.rb#L126
- https://github.com/aasm/aasm/blob/726a578808e0f403bfd24e505f9a45319670a6b7/lib/aasm/aasm.rb#L107
- https://github.com/aasm/aasm/blob/726a578808e0f403bfd24e505f9a45319670a6b7/lib/aasm/aasm.rb#L159-L166

### Tests
Updated existing tests

