### PR TITLE
Encapsulate `type_param` building in `create_method`

### DIFF
--- a/lib/tapioca/dsl/compiler.rb
+++ b/lib/tapioca/dsl/compiler.rb
@@ -141,14 +141,12 @@ module Tapioca
       def create_method_from_def(scope, method_def, class_method: false)
         parameters = compile_method_parameters_to_rbi(method_def)
         return_type = compile_method_return_type_to_rbi(method_def)
-        type_params = extract_type_parameters(parameters.map(&:type).push(return_type))
 
         scope.create_method(
           method_def.name.to_s,
           parameters: parameters,
           return_type: return_type,
           class_method: class_method,
-          type_params: type_params,
         )
       end
 

--- a/lib/tapioca/gem/listeners/sorbet_signatures.rb
+++ b/lib/tapioca/gem/listeners/sorbet_signatures.rb
@@ -40,7 +40,7 @@ module Tapioca
           sig.return_type = return_type
           @pipeline.push_symbol(return_type)
 
-          sig.type_params.concat(extract_type_parameters(parameter_types.values.map(&:to_s).push(return_type)))
+          sig.type_params.concat(extract_type_parameters(parameter_types.values.map(&:to_s).append(return_type)))
 
           case signature.mode
           when "abstract"

--- a/lib/tapioca/rbi_ext/model.rb
+++ b/lib/tapioca/rbi_ext/model.rb
@@ -65,11 +65,10 @@ module RBI
     #|   ?return_type: String?,
     #|   ?class_method: bool,
     #|   ?visibility: RBI::Visibility,
-    #|   ?comments: Array[RBI::Comment],
-    #|   ?type_params: Array[String]
+    #|   ?comments: Array[RBI::Comment]
     #| ) ?{ (RBI::Method node) -> void } -> void
     def create_method(name, parameters: [], return_type: nil, class_method: false, visibility: RBI::Public.new,
-      comments: [], type_params: [], &block)
+      comments: [], &block)
       return unless Tapioca::RBIHelper.valid_method_name?(name)
 
       sigs = []
@@ -78,7 +77,11 @@ module RBI
         # If there is no block, and the params and return type have not been supplied, then
         # we create a single signature with the given parameters and return type
         params = parameters.map { |param| RBI::SigParam.new(param.param.name.to_s, param.type) }
-        sigs << RBI::Sig.new(params: params, return_type: return_type || "T.untyped", type_params: type_params)
+        return_type ||= "T.untyped"
+        type_params = Tapioca::RBIHelper.extract_type_parameters(parameters.map(&:type).append(return_type))
+
+        sig = RBI::Sig.new(params: params, return_type: return_type, type_params: type_params)
+        sigs << sig
       end
 
       method = RBI::Method.new(


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
Addressing the comment: https://github.com/Shopify/tapioca/pull/2550#discussion_r3002615512

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
We can completely encapsulate the `type_param` building inside of `create_method` since we have all the data that we need to build that already passed into the method.

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->
No added tests
