### PR TITLE
Use Sorbet cache (if enabled)

### DIFF
--- a/lib/tapioca/helpers/sorbet_helper.rb
+++ b/lib/tapioca/helpers/sorbet_helper.rb
@@ -39,15 +39,24 @@ module Tapioca
           end.to_h #: Hash[String, String | bool | nil]
 
           new(
+            # `--cache-dir=` disables the cache, modeled here with a `nil` value
+            cache_dir: if (value = options["--cache-dir"]).is_a?(String)
+                         value.empty? ? nil : value
+                       end,
+
             parser: options["--parser"] == "prism" ? :prism : :original,
           )
         end
       end
 
-      #: (parser: Symbol) -> void
-      def initialize(parser:)
+      #: (cache_dir: String?, parser: Symbol) -> void
+      def initialize(cache_dir:, parser:)
+        @cache_dir = cache_dir #: String?
         @parser = parser #: Symbol
       end
+
+      #: String?
+      attr_reader :cache_dir
 
       #: Symbol
       attr_reader :parser
@@ -64,6 +73,10 @@ module Tapioca
 
     #: (*String sorbet_args) -> Spoom::ExecResult
     def sorbet(*sorbet_args)
+      if sorbet_config.cache_dir
+        sorbet_args << "--cache-dir=#{sorbet_config.cache_dir}"
+      end
+
       if sorbet_config.parse_with_prism?
         sorbet_args << "--parser=prism"
       end

--- a/spec/tapioca/helpers/sorbet_helper_spec.rb
+++ b/spec/tapioca/helpers/sorbet_helper_spec.rb
@@ -94,6 +94,32 @@ class Tapioca::SorbetHelperSpec < Minitest::Spec
       end
     end
 
+    describe "--cache-dir" do
+      it "detects --cache-dir" do
+        config = parse(<<~CONFIG)
+          .
+          --cache-dir=/tmp/sorbet-cache
+        CONFIG
+        assert_equal("/tmp/sorbet-cache", config.cache_dir)
+      end
+
+      it "returns nil when not set" do
+        config = parse(<<~CONFIG)
+          .
+          --parser=prism
+        CONFIG
+        assert_nil(config.cache_dir)
+      end
+
+      it "returns nil for empty value" do
+        config = parse(<<~CONFIG)
+          .
+          --cache-dir=
+        CONFIG
+        assert_nil(config.cache_dir)
+      end
+    end
+
     private
 
     #: (String content) -> Tapioca::SorbetHelper::SorbetConfig


### PR DESCRIPTION
### Motivation  
  
If a repo has enabled the Sorbet cache, we should use it.

<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->

### Implementation  
  
Builds upon the `SorbetCache` #2568.

<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->

### Performance

Shaves off around ~3s on the Shopify core monolith.

The cache stores the desugared ASTs, after the parsing, RBS rewriting, and desugaring is done. If there's a cache hit, no parsing happens, so that's why you see the legacy and Prism parsers have the same time. So this mitigates some of the benefit of #2567, but Prism is still helpful when there's a cache miss.

```
hyperfine --warmup 5 --runs 20 \
  -n "prism, with cache"  '~/sorbet-master --no-config --cache-dir=tmp/sorbet_cache --parser=prism    --print=symbol-table-json --quiet --stop-after=namer .' \
  -n "legacy, with cache" '~/sorbet-master --no-config --cache-dir=tmp/sorbet_cache --parser=original --print=symbol-table-json --quiet --stop-after=namer .' \
  -n "legacy, no cache"   '~/sorbet-master --no-config --cache-dir=                 --parser=original --print=symbol-table-json --quiet --stop-after=namer .' \

  -n "prism, no cache"    '~/sorbet-master --no-config --cache-dir=                 --parser=prism    --print=symbol-table-json --quiet --stop-after=namer .'

Benchmark 1: "prism, with cache"
  Time (mean ± σ):     24.932 s ±  0.687 s    [User: 23.678 s, System: 18.433 s]
  Range (min … max):   23.812 s … 26.870 s    20 runs
  
Benchmark 2: "legacy, with cache"
  Time (mean ± σ):     25.031 s ±  0.354 s    [User: 23.550 s, System: 18.331 s]
  Range (min … max):   24.518 s … 25.917 s    20 runs

Benchmark 3: "prism, no cache"
  Time (mean ± σ):     26.880 s ±  0.494 s    [User: 44.113 s, System: 18.467 s]
  Range (min … max):   25.809 s … 27.619 s    20 runs
  
Benchmark 4: "legacy, no cache"
  Time (mean ± σ):     28.100 s ±  0.795 s    [User: 64.862 s, System: 18.303 s]
  Range (min … max):   27.020 s … 29.405 s    20 runs


Summary
  "prism, with cache" ran
    1.00 ± 0.03 times faster than "legacy, with cache"
    1.08 ± 0.04 times faster than "prism, no cache"
    1.13 ± 0.04 times faster than "legacy, no cache"
```

### Tests

Added.