### PR TITLE
Extract `sorbet_syntax_check!`

### DIFF
--- a/lib/tapioca/helpers/sorbet_helper.rb
+++ b/lib/tapioca/helpers/sorbet_helper.rb
@@ -22,6 +22,25 @@ module Tapioca
       SPOOM_CONTEXT.srb(sorbet_args.join(" "), sorbet_bin: sorbet_path)
     end
 
+    #: (String, rbi_mode: bool) { (String stderr) -> void } -> void
+    def sorbet_syntax_check!(source, rbi_mode:, &on_failure)
+      quoted_source = "\"#{source}\""
+
+      result = if rbi_mode
+        # --e-rbi cannot be used on its own, so we pass a dummy value like `-e ""`
+        sorbet("--no-config", "--stop-after=parser", "-e", '""', "--e-rbi", quoted_source)
+      else
+        sorbet("--no-config", "--stop-after=parser", "-e", quoted_source)
+      end
+
+      unless result.status
+        stderr = result.err #: as !nil
+        on_failure.call(stderr)
+      end
+
+      nil
+    end
+
     #: -> String
     def sorbet_path
       sorbet_path = ENV.fetch(SORBET_EXE_PATH_ENV_VAR, SORBET_BIN)

--- a/lib/tapioca/helpers/test/dsl_compiler.rb
+++ b/lib/tapioca/helpers/test/dsl_compiler.rb
@@ -94,20 +94,14 @@ module Tapioca
             compiler.decorate
 
             rbi = Tapioca::DEFAULT_RBI_FORMATTER.print_file(file)
-            result = sorbet(
-              "--no-config",
-              "--stop-after=parser",
-              "-e",
-              "\"#{rbi}\"",
-            )
 
-            unless result.status
+            sorbet_syntax_check!(rbi, rbi_mode: true) do |stderr|
               raise(SyntaxError, <<~MSG)
                 Expected generated RBI file for `#{constant_name}` to not have any parsing errors.
 
                 Got these parsing errors:
 
-                #{result.err}
+                #{stderr}
               MSG
             end
 


### PR DESCRIPTION
### Motivation

There's a small bug in Prism+Sorbet that requires me to pick between `--stop-after=parser` and `--stop-after=desugar` ([PR for fix](https://github.com/sorbet/sorbet/pull/10076)). It's easy enough to workaround, but needs access to some Sorbet config, which is nicer to keep contained within this `SorbetHelper`.

You can see the usage up-stack in #2567

Along the way, I also discovered the `--e-rbi` Sorbet flag, which is more fitting for this usage. In principle, it would allow us to have multiple overloads in the RBI, though that isn't something that's used by any DSL compilers today.

### Implementation

See the diff I guess

### Tests

Passes existing tests.

