### PR TITLE
Require Sorbet 0.6+ for T::Module

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,7 +22,7 @@ PATH
       rbi (>= 0.3.7)
       require-hooks (>= 0.2.2)
       rubydex (>= 0.1.0.beta10)
-      sorbet-static-and-runtime (>= 0.5.11087)
+      sorbet-static-and-runtime (>= 0.6.12698)
       spoom (>= 1.7.9)
       thor (>= 1.2.0)
       tsort

--- a/tapioca.gemspec
+++ b/tapioca.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency("parallel", ">= 1.21.0")
   spec.add_dependency("require-hooks", ">= 0.2.2")
   spec.add_dependency("rubydex", ">= 0.1.0.beta10")
-  spec.add_dependency("sorbet-static-and-runtime", ">= 0.5.11087")
+  spec.add_dependency("sorbet-static-and-runtime", ">= 0.6.12698")
   spec.add_dependency("thor", ">= 1.2.0")
 
   # Tapioca requires a specific minimum versions of RBI and Spoom


### PR DESCRIPTION
### Motivation
Tapioca 0.18.0 and 0.19.0 crash when running with Sorbet 0.5.x:
```
Loading DSL compiler classes... /Users/bdewater/.rbenv/versions/4.0.2/lib/ruby/gems/4.0.0/gems/tapioca-0.19.0/lib/tapioca/dsl/compilers/url_helpers.rb:134:in 'block in singleton class': uninitialized constant T::Module (NameError)

            own_ancestors = if Class === mod && (superclass = superclass_of(mod))
                               ^^^^^
        from /Users/bdewater/.rbenv/versions/4.0.2/lib/ruby/gems/4.0.0/gems/sorbet-runtime-0.5.12443/lib/types/private/methods/_methods.rb:360:in 'BasicObject#instance_exec'
        from /Users/bdewater/.rbenv/versions/4.0.2/lib/ruby/gems/4.0.0/gems/sorbet-runtime-0.5.12443/lib/types/private/methods/_methods.rb:360:in 'T::Private::Methods.run_builder'
        from /Users/bdewater/.rbenv/versions/4.0.2/lib/ruby/gems/4.0.0/gems/sorbet-runtime-0.5.12443/lib/types/private/methods/_methods.rb:338:in 'T::Private::Methods.run_sig'
        from /Users/bdewater/.rbenv/versions/4.0.2/lib/ruby/gems/4.0.0/gems/sorbet-runtime-0.5.12443/lib/types/private/methods/_methods.rb:248:in 'block in T::Private::Methods._on_method_added'
        from /Users/bdewater/.rbenv/versions/4.0.2/lib/ruby/gems/4.0.0/gems/sorbet-runtime-0.5.12443/lib/types/private/methods/_methods.rb:449:in 'T::Private::Methods.run_sig_block_for_key'
        from /Users/bdewater/.rbenv/versions/4.0.2/lib/ruby/gems/4.0.0/gems/sorbet-runtime-0.5.12443/lib/types/private/methods/_methods.rb:429:in 'T::Private::Methods.maybe_run_sig_block_for_key'
        from /Users/bdewater/.rbenv/versions/4.0.2/lib/ruby/gems/4.0.0/gems/sorbet-runtime-0.5.12443/lib/types/private/methods/_methods.rb:258:in 'block in Tapioca::Dsl::Compilers::UrlHelpers._on_method_added'
        from /Users/bdewater/.rbenv/versions/4.0.2/lib/ruby/gems/4.0.0/gems/tapioca-0.19.0/lib/tapioca/dsl/compilers/url_helpers.rb:164:in '<class:UrlHelpers>'
        from /Users/bdewater/.rbenv/versions/4.0.2/lib/ruby/gems/4.0.0/gems/tapioca-0.19.0/lib/tapioca/dsl/compilers/url_helpers.rb:81:in '<module:Compilers>'
        from /Users/bdewater/.rbenv/versions/4.0.2/lib/ruby/gems/4.0.0/gems/tapioca-0.19.0/lib/tapioca/dsl/compilers/url_helpers.rb:8:in '<module:Dsl>'
        from /Users/bdewater/.rbenv/versions/4.0.2/lib/ruby/gems/4.0.0/gems/tapioca-0.19.0/lib/tapioca/dsl/compilers/url_helpers.rb:7:in '<module:Tapioca>'
```

Similar to https://github.com/angellist/boba/issues/21

