### PR TITLE
Replace T::Module with Module in RBS comment signatures

### DIFF
--- a/lib/tapioca/commands/abstract_dsl.rb
+++ b/lib/tapioca/commands/abstract_dsl.rb
@@ -162,7 +162,7 @@ module Tapioca
         filenames.to_set
       end
 
-      #: (Array[String] constant_names, ?ignore_missing: bool) -> Array[T::Module[top]]
+      #: (Array[String] constant_names, ?ignore_missing: bool) -> Array[Module[top]]
       def constantize(constant_names, ignore_missing: false)
         constant_map = constant_names.to_h do |name|
           [name, Object.const_get(name)]

--- a/lib/tapioca/dsl/compiler.rb
+++ b/lib/tapioca/dsl/compiler.rb
@@ -4,7 +4,7 @@
 module Tapioca
   module Dsl
     # @abstract
-    #: [ConstantType < T::Module[top]]
+    #: [ConstantType < Module[top]]
     class Compiler
       include RBIHelper
       include Runtime::Reflection
@@ -19,24 +19,24 @@ module Tapioca
       #: Hash[String, untyped]
       attr_reader :options
 
-      @@requested_constants = [] #: Array[T::Module[top]] # rubocop:disable Style/ClassVars
+      @@requested_constants = [] #: Array[Module[top]] # rubocop:disable Style/ClassVars
 
       class << self
-        #: (T::Module[top] constant) -> bool
+        #: (Module[top] constant) -> bool
         def handles?(constant)
           processable_constants.include?(constant)
         end
 
         # @abstract
-        #: -> Enumerable[T::Module[top]]
+        #: -> Enumerable[Module[top]]
         def gather_constants = raise NotImplementedError, "Abstract method called"
 
-        #: -> Set[T::Module[top]]
+        #: -> Set[Module[top]]
         def processable_constants
-          @processable_constants ||= T::Set[T::Module[T.anything]].new.compare_by_identity.merge(gather_constants) #: Set[T::Module[top]]?
+          @processable_constants ||= T::Set[T::Module[T.anything]].new.compare_by_identity.merge(gather_constants) #: Set[Module[top]]?
         end
 
-        #: (Array[T::Module[top]] constants) -> void
+        #: (Array[Module[top]] constants) -> void
         def requested_constants=(constants)
           @@requested_constants = constants # rubocop:disable Style/ClassVars
         end
@@ -69,13 +69,13 @@ module Tapioca
           @all_classes ||= all_modules.grep(Class).freeze #: Enumerable[Class[top]]?
         end
 
-        #: -> Enumerable[T::Module[top]]
+        #: -> Enumerable[Module[top]]
         def all_modules
           @all_modules ||= if @@requested_constants.any?
             @@requested_constants.grep(Module)
           else
             ObjectSpace.each_object(Module).to_a
-          end.freeze #: Enumerable[T::Module[top]]?
+          end.freeze #: Enumerable[Module[top]]?
         end
       end
 

--- a/lib/tapioca/dsl/compilers/aasm.rb
+++ b/lib/tapioca/dsl/compilers/aasm.rb
@@ -202,7 +202,7 @@ module Tapioca
 
         class << self
           # @override
-          #: -> Enumerable[T::Module[top]]
+          #: -> Enumerable[Module[top]]
           def gather_constants
             T.cast(ObjectSpace.each_object(::AASM::ClassMethods), T::Enumerable[T::Module[T.anything]])
           end

--- a/lib/tapioca/dsl/compilers/action_controller_helpers.rb
+++ b/lib/tapioca/dsl/compilers/action_controller_helpers.rb
@@ -117,7 +117,7 @@ module Tapioca
 
         class << self
           # @override
-          #: -> Enumerable[T::Module[top]]
+          #: -> Enumerable[Module[top]]
           def gather_constants
             descendants_of(::ActionController::Base).select(&:name).select do |klass|
               klass.const_defined?(:HelperMethods, false)
@@ -148,7 +148,7 @@ module Tapioca
           )
         end
 
-        #: (T::Module[top] mod) -> Array[String]
+        #: (Module[top] mod) -> Array[String]
         def gather_includes(mod)
           mod.ancestors
             .reject { |ancestor| ancestor.is_a?(Class) || ancestor == mod || name_of(ancestor).nil? }

--- a/lib/tapioca/dsl/compilers/action_mailer.rb
+++ b/lib/tapioca/dsl/compilers/action_mailer.rb
@@ -50,7 +50,7 @@ module Tapioca
 
         class << self
           # @override
-          #: -> Enumerable[T::Module[top]]
+          #: -> Enumerable[Module[top]]
           def gather_constants
             descendants_of(::ActionMailer::Base).reject(&:abstract?)
           end

--- a/lib/tapioca/dsl/compilers/action_text.rb
+++ b/lib/tapioca/dsl/compilers/action_text.rb
@@ -80,7 +80,7 @@ module Tapioca
           end
 
           # @override
-          #: -> Enumerable[T::Module[top]]
+          #: -> Enumerable[Module[top]]
           def gather_constants
             descendants_of(::ActiveRecord::Base)
               .reject(&:abstract_class?)

--- a/lib/tapioca/dsl/compilers/active_job.rb
+++ b/lib/tapioca/dsl/compilers/active_job.rb
@@ -84,7 +84,7 @@ module Tapioca
 
         class << self
           # @override
-          #: -> Enumerable[T::Module[top]]
+          #: -> Enumerable[Module[top]]
           def gather_constants
             descendants_of(::ActiveJob::Base)
           end

--- a/lib/tapioca/dsl/compilers/active_model_attributes.rb
+++ b/lib/tapioca/dsl/compilers/active_model_attributes.rb
@@ -59,7 +59,7 @@ module Tapioca
 
         class << self
           # @override
-          #: -> Enumerable[T::Module[top]]
+          #: -> Enumerable[Module[top]]
           def gather_constants
             all_classes.grep(::ActiveModel::Attributes::ClassMethods)
           end

--- a/lib/tapioca/dsl/compilers/active_model_secure_password.rb
+++ b/lib/tapioca/dsl/compilers/active_model_secure_password.rb
@@ -89,7 +89,7 @@ module Tapioca
 
         class << self
           # @override
-          #: -> Enumerable[T::Module[top]]
+          #: -> Enumerable[Module[top]]
           def gather_constants
             # In some versions of Rails 8.1, `ActiveModel::SecurePassword` uses `Numeric#minutes`
             # which isn't explicitly required in the gem, and it might not be loaded already.

--- a/lib/tapioca/dsl/compilers/active_model_validations_confirmation.rb
+++ b/lib/tapioca/dsl/compilers/active_model_validations_confirmation.rb
@@ -44,7 +44,7 @@ module Tapioca
       class ActiveModelValidationsConfirmation < Compiler
         class << self
           # @override
-          #: -> Enumerable[T::Module[top]]
+          #: -> Enumerable[Module[top]]
           def gather_constants
             # Collect all the classes that include ActiveModel::Validations
             all_classes.select { |c| ActiveModel::Validations > c }

--- a/lib/tapioca/dsl/compilers/active_record_associations.rb
+++ b/lib/tapioca/dsl/compilers/active_record_associations.rb
@@ -136,7 +136,7 @@ module Tapioca
 
         class << self
           # @override
-          #: -> Enumerable[T::Module[top]]
+          #: -> Enumerable[Module[top]]
           def gather_constants
             descendants_of(::ActiveRecord::Base).reject(&:abstract_class?)
           end

--- a/lib/tapioca/dsl/compilers/active_record_columns.rb
+++ b/lib/tapioca/dsl/compilers/active_record_columns.rb
@@ -163,7 +163,7 @@ module Tapioca
 
         class << self
           # @override
-          #: -> Enumerable[T::Module[top]]
+          #: -> Enumerable[Module[top]]
           def gather_constants
             descendants_of(::ActiveRecord::Base).reject(&:abstract_class?)
           end

--- a/lib/tapioca/dsl/compilers/active_record_delegated_types.rb
+++ b/lib/tapioca/dsl/compilers/active_record_delegated_types.rb
@@ -88,7 +88,7 @@ module Tapioca
 
         class << self
           # @override
-          #: -> Enumerable[T::Module[top]]
+          #: -> Enumerable[Module[top]]
           def gather_constants
             descendants_of(::ActiveRecord::Base).reject(&:abstract_class?)
           end

--- a/lib/tapioca/dsl/compilers/active_record_enum.rb
+++ b/lib/tapioca/dsl/compilers/active_record_enum.rb
@@ -74,7 +74,7 @@ module Tapioca
 
         class << self
           # @override
-          #: -> Enumerable[T::Module[top]]
+          #: -> Enumerable[Module[top]]
           def gather_constants
             descendants_of(::ActiveRecord::Base)
           end

--- a/lib/tapioca/dsl/compilers/active_record_fixtures.rb
+++ b/lib/tapioca/dsl/compilers/active_record_fixtures.rb
@@ -58,7 +58,7 @@ module Tapioca
 
         class << self
           # @override
-          #: -> Enumerable[T::Module[top]]
+          #: -> Enumerable[Module[top]]
           def gather_constants
             return [] unless defined?(Rails.application) && Rails.application
 

--- a/lib/tapioca/dsl/compilers/active_record_relations.rb
+++ b/lib/tapioca/dsl/compilers/active_record_relations.rb
@@ -181,7 +181,7 @@ module Tapioca
 
         class << self
           # @override
-          #: -> Enumerable[T::Module[top]]
+          #: -> Enumerable[Module[top]]
           def gather_constants
             ActiveRecord::Base.descendants.reject(&:abstract_class?)
           end

--- a/lib/tapioca/dsl/compilers/active_record_scope.rb
+++ b/lib/tapioca/dsl/compilers/active_record_scope.rb
@@ -77,7 +77,7 @@ module Tapioca
 
         class << self
           # @override
-          #: -> Enumerable[T::Module[top]]
+          #: -> Enumerable[Module[top]]
           def gather_constants
             descendants_of(::ActiveRecord::Base).reject(&:abstract_class?)
           end

--- a/lib/tapioca/dsl/compilers/active_record_secure_token.rb
+++ b/lib/tapioca/dsl/compilers/active_record_secure_token.rb
@@ -57,7 +57,7 @@ module Tapioca
 
         class << self
           # @override
-          #: -> Enumerable[T::Module[top]]
+          #: -> Enumerable[Module[top]]
           def gather_constants
             descendants_of(::ActiveRecord::Base).reject(&:abstract_class?)
           end

--- a/lib/tapioca/dsl/compilers/active_record_store.rb
+++ b/lib/tapioca/dsl/compilers/active_record_store.rb
@@ -132,7 +132,7 @@ module Tapioca
 
         class << self
           # @override
-          #: -> Enumerable[T::Module[top]]
+          #: -> Enumerable[Module[top]]
           def gather_constants
             descendants_of(::ActiveRecord::Base).reject(&:abstract_class?)
           end

--- a/lib/tapioca/dsl/compilers/active_record_typed_store.rb
+++ b/lib/tapioca/dsl/compilers/active_record_typed_store.rb
@@ -107,7 +107,7 @@ module Tapioca
 
         class << self
           # @override
-          #: -> Enumerable[T::Module[top]]
+          #: -> Enumerable[Module[top]]
           def gather_constants
             descendants_of(::ActiveRecord::Base).select do |klass|
               klass.include?(ActiveRecord::TypedStore::Behavior)

--- a/lib/tapioca/dsl/compilers/active_resource.rb
+++ b/lib/tapioca/dsl/compilers/active_resource.rb
@@ -70,7 +70,7 @@ module Tapioca
 
         class << self
           # @override
-          #: -> Enumerable[T::Module[top]]
+          #: -> Enumerable[Module[top]]
           def gather_constants
             descendants_of(::ActiveResource::Base)
           end

--- a/lib/tapioca/dsl/compilers/active_storage.rb
+++ b/lib/tapioca/dsl/compilers/active_storage.rb
@@ -38,7 +38,7 @@ module Tapioca
       #   def photo=(attachable); end
       # end
       # ~~~
-      #: [ConstantType = (T::Module[top] & ::ActiveStorage::Reflection::ActiveRecordExtensions::ClassMethods)]
+      #: [ConstantType = (Module[top] & ::ActiveStorage::Reflection::ActiveRecordExtensions::ClassMethods)]
       class ActiveStorage < Compiler
         # @override
         #: -> void
@@ -64,7 +64,7 @@ module Tapioca
 
         class << self
           # @override
-          #: -> Enumerable[T::Module[top]]
+          #: -> Enumerable[Module[top]]
           def gather_constants
             descendants_of(::ActiveRecord::Base)
               .reject(&:abstract_class?)

--- a/lib/tapioca/dsl/compilers/active_support_concern.rb
+++ b/lib/tapioca/dsl/compilers/active_support_concern.rb
@@ -37,7 +37,7 @@ module Tapioca
       #   mixes_in_class_methods(::Foo::ClassMethods)
       # end
       # ~~~
-      #: [ConstantType = T::Module[top]]
+      #: [ConstantType = Module[top]]
       class ActiveSupportConcern < Compiler
         # @override
         #: -> void
@@ -61,7 +61,7 @@ module Tapioca
 
         class << self
           # @override
-          #: -> Enumerable[T::Module[top]]
+          #: -> Enumerable[Module[top]]
           def gather_constants
             all_modules.select do |mod|
               name_of(mod) && # i.e. not anonymous
@@ -72,10 +72,10 @@ module Tapioca
           end
 
           # Returns true when `mod` includes other concerns
-          #: (T::Module[top] mod) -> bool
+          #: (Module[top] mod) -> bool
           def has_dependencies?(mod) = dependencies_of(mod).any?
 
-          #: (T::Module[top] concern) -> Array[T::Module[top]]
+          #: (Module[top] concern) -> Array[Module[top]]
           def dependencies_of(concern)
             concern.instance_variable_get(:@_dependencies) || []
           end
@@ -83,12 +83,12 @@ module Tapioca
 
         private
 
-        #: (T::Module[top] concern) -> Array[T::Module[top]]
+        #: (Module[top] concern) -> Array[Module[top]]
         def dependencies_of(concern)
           self.class.dependencies_of(concern)
         end
 
-        #: (?T::Module[top] concern) -> Array[T::Module[top]]
+        #: (?Module[top] concern) -> Array[Module[top]]
         def linearized_dependencies(concern = constant)
           # Grab all the dependencies of the concern
           dependencies = dependencies_of(concern)

--- a/lib/tapioca/dsl/compilers/active_support_current_attributes.rb
+++ b/lib/tapioca/dsl/compilers/active_support_current_attributes.rb
@@ -93,7 +93,7 @@ module Tapioca
 
         class << self
           # @override
-          #: -> Enumerable[T::Module[top]]
+          #: -> Enumerable[Module[top]]
           def gather_constants
             descendants_of(::ActiveSupport::CurrentAttributes)
           end

--- a/lib/tapioca/dsl/compilers/active_support_environment_inquirer.rb
+++ b/lib/tapioca/dsl/compilers/active_support_environment_inquirer.rb
@@ -47,7 +47,7 @@ module Tapioca
 
         class << self
           # @override
-          #: -> T::Enumerable[T::Module[top]]
+          #: -> T::Enumerable[Module[top]]
           def gather_constants
             return [] unless defined?(Rails.application) && Rails.application
 

--- a/lib/tapioca/dsl/compilers/active_support_time_ext.rb
+++ b/lib/tapioca/dsl/compilers/active_support_time_ext.rb
@@ -54,7 +54,7 @@ module Tapioca
 
         class << self
           # @override
-          #: -> Enumerable[T::Module[top]]
+          #: -> Enumerable[Module[top]]
           def gather_constants
             [::Time]
           end

--- a/lib/tapioca/dsl/compilers/config.rb
+++ b/lib/tapioca/dsl/compilers/config.rb
@@ -40,7 +40,7 @@ module Tapioca
       #   def github=(value); end
       # end
       # ```
-      #: [ConstantType = T::Module[top]]
+      #: [ConstantType = Module[top]]
       class Config < Compiler
         CONFIG_OPTIONS_SUFFIX = "ConfigOptions"
 
@@ -92,7 +92,7 @@ module Tapioca
 
         class << self
           # @override
-          #: -> Enumerable[T::Module[top]]
+          #: -> Enumerable[Module[top]]
           def gather_constants
             name = ::Config.const_name
             return [] unless Object.const_defined?(name)

--- a/lib/tapioca/dsl/compilers/frozen_record.rb
+++ b/lib/tapioca/dsl/compilers/frozen_record.rb
@@ -84,7 +84,7 @@ module Tapioca
 
         class << self
           # @override
-          #: -> Enumerable[T::Module[top]]
+          #: -> Enumerable[Module[top]]
           def gather_constants
             descendants_of(::FrozenRecord::Base).reject(&:abstract_class?)
           end

--- a/lib/tapioca/dsl/compilers/graphql_input_object.rb
+++ b/lib/tapioca/dsl/compilers/graphql_input_object.rb
@@ -73,7 +73,7 @@ module Tapioca
 
         class << self
           # @override
-          #: -> Enumerable[T::Module[top]]
+          #: -> Enumerable[Module[top]]
           def gather_constants
             all_classes.select { |c| GraphQL::Schema::InputObject > c }
           end

--- a/lib/tapioca/dsl/compilers/graphql_mutation.rb
+++ b/lib/tapioca/dsl/compilers/graphql_mutation.rb
@@ -70,7 +70,7 @@ module Tapioca
 
         class << self
           # @override
-          #: -> Enumerable[T::Module[top]]
+          #: -> Enumerable[Module[top]]
           def gather_constants
             all_classes.select { |c| GraphQL::Schema::Mutation > c && GraphQL::Schema::RelayClassicMutation != c }
           end

--- a/lib/tapioca/dsl/compilers/identity_cache.rb
+++ b/lib/tapioca/dsl/compilers/identity_cache.rb
@@ -57,7 +57,7 @@ module Tapioca
       # ~~~
       #: [ConstantType = singleton(::ActiveRecord::Base)]
       class IdentityCache < Compiler
-        COLLECTION_TYPE = ->(type) { "T::Array[::#{type}]" } #: ^((T::Module[top] | String) type) -> String
+        COLLECTION_TYPE = ->(type) { "T::Array[::#{type}]" } #: ^((Module[top] | String) type) -> String
 
         # @override
         #: -> void
@@ -91,7 +91,7 @@ module Tapioca
 
         class << self
           # @override
-          #: -> Enumerable[T::Module[top]]
+          #: -> Enumerable[Module[top]]
           def gather_constants
             descendants_of(::ActiveRecord::Base).select do |klass|
               ::IdentityCache::WithoutPrimaryIndex > klass

--- a/lib/tapioca/dsl/compilers/json_api_client_resource.rb
+++ b/lib/tapioca/dsl/compilers/json_api_client_resource.rb
@@ -105,7 +105,7 @@ module Tapioca
 
         class << self
           # @override
-          #: -> Enumerable[T::Module[top]]
+          #: -> Enumerable[Module[top]]
           def gather_constants
             all_modules.select do |c|
               name_of(c) && ::JsonApiClient::Resource > c

--- a/lib/tapioca/dsl/compilers/kredis.rb
+++ b/lib/tapioca/dsl/compilers/kredis.rb
@@ -84,7 +84,7 @@ module Tapioca
 
         class << self
           # @override
-          #: -> Enumerable[T::Module[top]]
+          #: -> Enumerable[Module[top]]
           def gather_constants
             all_classes
               .grep(::Kredis::Attributes::ClassMethods)

--- a/lib/tapioca/dsl/compilers/mixed_in_class_attributes.rb
+++ b/lib/tapioca/dsl/compilers/mixed_in_class_attributes.rb
@@ -44,7 +44,7 @@ module Tapioca
       #   end
       # end
       # ~~~
-      #: [ConstantType = T::Module[top]]
+      #: [ConstantType = Module[top]]
       class MixedInClassAttributes < Compiler
         # @override
         #: -> void
@@ -59,7 +59,7 @@ module Tapioca
 
         class << self
           # @override
-          #: -> Enumerable[T::Module[top]]
+          #: -> Enumerable[Module[top]]
           def gather_constants
             # Select all non-anonymous modules that have overridden Module.included
             all_modules.select do |mod|

--- a/lib/tapioca/dsl/compilers/protobuf.rb
+++ b/lib/tapioca/dsl/compilers/protobuf.rb
@@ -152,7 +152,7 @@ module Tapioca
 
         class << self
           # @override
-          #: -> Enumerable[T::Module[top]]
+          #: -> Enumerable[Module[top]]
           def gather_constants
             marker = Google::Protobuf::MessageExts::ClassMethods
 

--- a/lib/tapioca/dsl/compilers/rails_generators.rb
+++ b/lib/tapioca/dsl/compilers/rails_generators.rb
@@ -56,7 +56,7 @@ module Tapioca
 
         class << self
           # @override
-          #: -> Enumerable[T::Module[top]]
+          #: -> Enumerable[Module[top]]
           def gather_constants
             all_classes.select do |const|
               name = qualified_name_of(const)

--- a/lib/tapioca/dsl/compilers/sidekiq_worker.rb
+++ b/lib/tapioca/dsl/compilers/sidekiq_worker.rb
@@ -83,7 +83,7 @@ module Tapioca
 
         class << self
           # @override
-          #: -> Enumerable[T::Module[top]]
+          #: -> Enumerable[Module[top]]
           def gather_constants
             all_classes.select { |c| Sidekiq::Worker > c }
           end

--- a/lib/tapioca/dsl/compilers/smart_properties.rb
+++ b/lib/tapioca/dsl/compilers/smart_properties.rb
@@ -80,7 +80,7 @@ module Tapioca
 
         class << self
           # @override
-          #: -> Enumerable[T::Module[top]]
+          #: -> Enumerable[Module[top]]
           def gather_constants
             all_modules.select do |c|
               name_of(c) &&

--- a/lib/tapioca/dsl/compilers/state_machines.rb
+++ b/lib/tapioca/dsl/compilers/state_machines.rb
@@ -109,7 +109,7 @@ module Tapioca
       #   end
       # end
       # ~~~
-      #: [ConstantType = (T::Module[top] & ::StateMachines::ClassMethods)]
+      #: [ConstantType = (Module[top] & ::StateMachines::ClassMethods)]
       class StateMachines < Compiler
         # @override
         #: -> void
@@ -154,7 +154,7 @@ module Tapioca
 
         class << self
           # @override
-          #: -> Enumerable[T::Module[top]]
+          #: -> Enumerable[Module[top]]
           def gather_constants
             all_classes.select { |mod| ::StateMachines::InstanceMethods > mod }
           end

--- a/lib/tapioca/dsl/compilers/url_helpers.rb
+++ b/lib/tapioca/dsl/compilers/url_helpers.rb
@@ -78,7 +78,7 @@ module Tapioca
       #   include GeneratedUrlHelpersModule
       # end
       # ~~~
-      #: [ConstantType = T::Module[top]]
+      #: [ConstantType = Module[top]]
       class UrlHelpers < Compiler
         # @override
         #: -> void
@@ -96,7 +96,7 @@ module Tapioca
 
         class << self
           # @override
-          #: -> Enumerable[T::Module[top]]
+          #: -> Enumerable[Module[top]]
           def gather_constants
             return [] unless defined?(Rails.application) && Rails.application
 
@@ -128,7 +128,7 @@ module Tapioca
             constants.concat(NON_DISCOVERABLE_INCLUDERS).push(GeneratedUrlHelpersModule, GeneratedPathHelpersModule)
           end
 
-          #: -> Array[T::Module[top]]
+          #: -> Array[Module[top]]
           def gather_non_discoverable_includers
             [].tap do |includers|
               if defined?(ActionController::TemplateAssertions) && defined?(ActionDispatch::IntegrationTest)
@@ -143,7 +143,7 @@ module Tapioca
 
           # Returns `true` if `mod` "directly" includes `helper`.
           # For classes, this method will return false if the `helper` is included only by a superclass
-          #: (T::Module[top] mod, T::Module[top] helper) -> bool
+          #: (Module[top] mod, Module[top] helper) -> bool
           private def includes_helper?(mod, helper)
             ancestors = ancestors_of(mod)
 
@@ -158,11 +158,11 @@ module Tapioca
           end
         end
 
-        NON_DISCOVERABLE_INCLUDERS = gather_non_discoverable_includers #: Array[T::Module[top]]
+        NON_DISCOVERABLE_INCLUDERS = gather_non_discoverable_includers #: Array[Module[top]]
 
         private
 
-        #: (RBI::Tree root, T::Module[top] constant) -> void
+        #: (RBI::Tree root, Module[top] constant) -> void
         def generate_module_for(root, constant)
           root.create_module(T.must(constant.name)) do |mod|
             mod.create_include("::ActionDispatch::Routing::UrlFor")
@@ -178,7 +178,7 @@ module Tapioca
           end
         end
 
-        #: (RBI::Scope mod, T::Module[top] helper_module) -> void
+        #: (RBI::Scope mod, Module[top] helper_module) -> void
         def create_mixins_for(mod, helper_module)
           include_helper = constant.ancestors.include?(helper_module) || NON_DISCOVERABLE_INCLUDERS.include?(constant)
           extend_helper = constant.singleton_class.ancestors.include?(helper_module)

--- a/lib/tapioca/dsl/helpers/graphql_type_helper.rb
+++ b/lib/tapioca/dsl/helpers/graphql_type_helper.rb
@@ -110,7 +110,7 @@ module Tapioca
 
         private
 
-        #: (T::Module[top] constant) -> String
+        #: (Module[top] constant) -> String
         def type_for_constant(constant)
           if constant.instance_methods.include?(:prepare)
             prepare_method = constant.instance_method(:prepare)

--- a/lib/tapioca/dsl/pipeline.rb
+++ b/lib/tapioca/dsl/pipeline.rb
@@ -7,13 +7,13 @@ module Tapioca
       #: Enumerable[singleton(Compiler)]
       attr_reader :active_compilers
 
-      #: Array[T::Module[top]]
+      #: Array[Module[top]]
       attr_reader :requested_constants
 
       #: Array[Pathname]
       attr_reader :requested_paths
 
-      #: Array[T::Module[top]]
+      #: Array[Module[top]]
       attr_reader :skipped_constants
 
       #: ^(String error) -> void
@@ -23,12 +23,12 @@ module Tapioca
       attr_reader :errors
 
       #: (
-      #|   requested_constants: Array[T::Module[top]],
+      #|   requested_constants: Array[Module[top]],
       #|   ?requested_paths: Array[Pathname],
       #|   ?requested_compilers: Array[singleton(Compiler)],
       #|   ?excluded_compilers: Array[singleton(Compiler)],
       #|   ?error_handler: ^(String error) -> void,
-      #|   ?skipped_constants: Array[T::Module[top]],
+      #|   ?skipped_constants: Array[Module[top]],
       #|   ?number_of_workers: Integer?,
       #|   ?compiler_options: Hash[String, untyped],
       #|   ?lsp_addon: bool
@@ -56,7 +56,7 @@ module Tapioca
         @errors = [] #: Array[String]
       end
 
-      #: [R] { (T::Module[top] constant, RBI::File rbi) -> R } -> Array[R]
+      #: [R] { (Module[top] constant, RBI::File rbi) -> R } -> Array[R]
       def run(&blk)
         constants_to_process = gather_constants(requested_constants, requested_paths, skipped_constants)
           .select { |c| Module === c } # Filter value constants out
@@ -128,10 +128,10 @@ module Tapioca
       end
 
       #: (
-      #|   Array[T::Module[top]] requested_constants,
+      #|   Array[Module[top]] requested_constants,
       #|   Array[Pathname] requested_paths,
-      #|   Array[T::Module[top]] skipped_constants
-      #| ) -> Set[T::Module[top]]
+      #|   Array[Module[top]] skipped_constants
+      #| ) -> Set[Module[top]]
       def gather_constants(requested_constants, requested_paths, skipped_constants)
         Compiler.requested_constants = requested_constants
         constants = Set.new.compare_by_identity
@@ -153,7 +153,7 @@ module Tapioca
         constants
       end
 
-      #: (Set[T::Module[top]] constants) -> Set[T::Module[top]]
+      #: (Set[Module[top]] constants) -> Set[Module[top]]
       def filter_anonymous_and_reloaded_constants(constants)
         # Group constants by their names
         constants_by_name = constants
@@ -182,7 +182,7 @@ module Tapioca
         Set.new.compare_by_identity.merge(filtered_constants)
       end
 
-      #: (T::Module[top] constant) -> RBI::File?
+      #: (Module[top] constant) -> RBI::File?
       def rbi_for_constant(constant)
         file = RBI::File.new(strictness: "true")
 

--- a/lib/tapioca/gem/events.rb
+++ b/lib/tapioca/gem/events.rb
@@ -37,12 +37,12 @@ module Tapioca
 
     class ForeignConstantFound < ConstantFound
       # @override
-      #: -> T::Module[top]
+      #: -> Module[top]
       def constant
         T.cast(@constant, T::Module[T.anything])
       end
 
-      #: (String symbol, T::Module[top] constant) -> void
+      #: (String symbol, Module[top] constant) -> void
       def initialize(symbol, constant)
         super
       end
@@ -53,10 +53,10 @@ module Tapioca
       #: String
       attr_reader :symbol
 
-      #: T::Module[top]
+      #: Module[top]
       attr_reader :constant
 
-      #: (String symbol, T::Module[top] constant) -> void
+      #: (String symbol, Module[top] constant) -> void
       def initialize(symbol, constant)
         super()
         @symbol = symbol
@@ -68,7 +68,7 @@ module Tapioca
       #: RBI::Const
       attr_reader :node
 
-      #: (String symbol, T::Module[top] constant, RBI::Const node) -> void
+      #: (String symbol, Module[top] constant, RBI::Const node) -> void
       def initialize(symbol, constant, node)
         super(symbol, constant)
         @node = node
@@ -79,7 +79,7 @@ module Tapioca
       #: RBI::Scope
       attr_reader :node
 
-      #: (String symbol, T::Module[top] constant, RBI::Scope node) -> void
+      #: (String symbol, Module[top] constant, RBI::Scope node) -> void
       def initialize(symbol, constant, node)
         super(symbol, constant)
         @node = node
@@ -103,7 +103,7 @@ module Tapioca
 
       #: (
       #|   String symbol,
-      #|   T::Module[top] constant,
+      #|   Module[top] constant,
       #|   UnboundMethod method,
       #|   RBI::Method node,
       #|   untyped signature,

--- a/lib/tapioca/gem/listeners/methods.rb
+++ b/lib/tapioca/gem/listeners/methods.rb
@@ -25,9 +25,9 @@ module Tapioca
         #: (
         #|   RBI::Tree tree,
         #|   String module_name,
-        #|   T::Module[top] mod,
+        #|   Module[top] mod,
         #|   ?Array[Symbol] for_visibility,
-        #|   ?attached_class: T::Module[top]?
+        #|   ?attached_class: Module[top]?
         #| ) -> void
         def compile_directly_owned_methods(
           tree,
@@ -59,7 +59,7 @@ module Tapioca
         #: (
         #|   RBI::Tree tree,
         #|   String symbol_name,
-        #|   T::Module[top] constant,
+        #|   Module[top] constant,
         #|   UnboundMethod? method,
         #|   ?RBI::Visibility visibility
         #| ) -> void
@@ -169,7 +169,7 @@ module Tapioca
         # This method implements a better way of checking whether a constant defines a method.
         # It walks up the ancestor tree via the `super_method` method; if any of the super
         # methods are owned by the constant, it means that the constant declares the method.
-        #: (UnboundMethod method, T::Module[top] constant) -> bool
+        #: (UnboundMethod method, Module[top] constant) -> bool
         def method_owned_by_constant?(method, constant)
           # Widen the type of `method` to be nilable
           method = method #: UnboundMethod?
@@ -183,7 +183,7 @@ module Tapioca
           false
         end
 
-        #: (T::Module[top] mod) -> Hash[Symbol, Array[Symbol]]
+        #: (Module[top] mod) -> Hash[Symbol, Array[Symbol]]
         def method_names_by_visibility(mod)
           {
             public: public_instance_methods_of(mod),
@@ -192,7 +192,7 @@ module Tapioca
           }
         end
 
-        #: (T::Module[top] constant, String method_name) -> bool
+        #: (Module[top] constant, String method_name) -> bool
         def struct_method?(constant, method_name)
           return false unless T::Props::ClassMethods === constant
 
@@ -202,7 +202,7 @@ module Tapioca
             .include?(method_name.gsub(/=$/, "").to_sym)
         end
 
-        #: (T::Module[top]? attached_class, Symbol method_name) -> bool?
+        #: (Module[top]? attached_class, Symbol method_name) -> bool?
         def method_new_in_abstract_class?(attached_class, method_name)
           attached_class &&
             method_name == :new &&
@@ -210,7 +210,7 @@ module Tapioca
             Class === attached_class.singleton_class
         end
 
-        #: (T::Module[top] constant) -> UnboundMethod?
+        #: (Module[top] constant) -> UnboundMethod?
         def initialize_method_for(constant)
           constant.instance_method(:initialize)
         rescue

--- a/lib/tapioca/gem/listeners/mixins.rb
+++ b/lib/tapioca/gem/listeners/mixins.rb
@@ -30,7 +30,7 @@ module Tapioca
           add_mixins(node, constant, extends.reverse, Runtime::Trackers::Mixin::Type::Extend)
         end
 
-        #: (RBI::Tree tree, T::Module[top] constant, Array[T::Module[top]] mods, Runtime::Trackers::Mixin::Type mixin_type) -> void
+        #: (RBI::Tree tree, Module[top] constant, Array[Module[top]] mods, Runtime::Trackers::Mixin::Type mixin_type) -> void
         def add_mixins(tree, constant, mods, mixin_type)
           mods
             .select do |mod|
@@ -57,7 +57,7 @@ module Tapioca
             end
         end
 
-        #: (T::Module[top] constant, T::Module[top] mixin, Runtime::Trackers::Mixin::Type mixin_type) -> bool
+        #: (Module[top] constant, Module[top] mixin, Runtime::Trackers::Mixin::Type mixin_type) -> bool
         def mixed_in_by_gem?(constant, mixin, mixin_type)
           mixin_location = Runtime::Trackers::Mixin.mixin_location(mixin, mixin_type, constant)
 
@@ -73,7 +73,7 @@ module Tapioca
           mixin_name.start_with?("T::") && !mixin_name.start_with?("T::Props")
         end
 
-        #: (T::Module[top] constant) -> Array[T::Module[top]]
+        #: (Module[top] constant) -> Array[Module[top]]
         def interesting_ancestors_of(constant)
           inherited_ancestors = Set.new.compare_by_identity.merge(inherited_ancestors_of(constant))
 

--- a/lib/tapioca/gem/listeners/sorbet_type_variables.rb
+++ b/lib/tapioca/gem/listeners/sorbet_type_variables.rb
@@ -22,7 +22,7 @@ module Tapioca
           node << sclass if sclass.nodes.length > 1
         end
 
-        #: (RBI::Tree tree, T::Module[top] constant) -> void
+        #: (RBI::Tree tree, Module[top] constant) -> void
         def compile_type_variable_declarations(tree, constant)
           # Try to find the type variables defined on this constant, bail if we can't
           type_variables = Runtime::GenericTypeRegistry.lookup_type_variables(constant)

--- a/lib/tapioca/gem/pipeline.rb
+++ b/lib/tapioca/gem/pipeline.rb
@@ -72,29 +72,29 @@ module Tapioca
         @events << Gem::ConstantFound.new(symbol, constant)
       end
 
-      #: (String symbol, T::Module[top] constant) -> void
+      #: (String symbol, Module[top] constant) -> void
       def push_foreign_constant(symbol, constant)
         @events << Gem::ForeignConstantFound.new(symbol, constant)
       end
 
-      #: (String symbol, T::Module[top] constant, RBI::Const node) -> void
+      #: (String symbol, Module[top] constant, RBI::Const node) -> void
       def push_const(symbol, constant, node)
         @events << Gem::ConstNodeAdded.new(symbol, constant, node)
       end
 
-      #: (String symbol, T::Module[top] constant, RBI::Scope node) -> void
+      #: (String symbol, Module[top] constant, RBI::Scope node) -> void
       def push_scope(symbol, constant, node)
         @events << Gem::ScopeNodeAdded.new(symbol, constant, node)
       end
 
-      #: (String symbol, T::Module[top] constant, RBI::Scope node) -> void
+      #: (String symbol, Module[top] constant, RBI::Scope node) -> void
       def push_foreign_scope(symbol, constant, node)
         @events << Gem::ForeignScopeNodeAdded.new(symbol, constant, node)
       end
 
       #: (
       #|   String symbol,
-      #|   T::Module[top] constant,
+      #|   Module[top] constant,
       #|   UnboundMethod method,
       #|   RBI::Method node,
       #|   untyped signature,
@@ -150,7 +150,7 @@ module Tapioca
         end
       end
 
-      #: (Symbol method_name, T::Module[top] owner) -> MethodDefinitionLookupResult
+      #: (Symbol method_name, Module[top] owner) -> MethodDefinitionLookupResult
       def method_definition_in_gem(method_name, owner)
         definitions = Tapioca::Runtime::Trackers::MethodDefinition.method_definitions_for(method_name, owner)
 
@@ -176,7 +176,7 @@ module Tapioca
 
       # Helpers
 
-      #: (T::Module[top] constant) -> String?
+      #: (Module[top] constant) -> String?
       def name_of(constant)
         name = name_of_proxy_target(constant, super(class_of(constant)))
         return name if name
@@ -248,7 +248,7 @@ module Tapioca
 
       # Compiling
 
-      #: (String symbol, T::Module[top] constant) -> void
+      #: (String symbol, Module[top] constant) -> void
       def compile_foreign_constant(symbol, constant)
         return if skip_foreign_constant?(symbol, constant)
         return if seen?(symbol)
@@ -274,7 +274,7 @@ module Tapioca
         end
       end
 
-      #: (String name, T::Module[top] constant) -> void
+      #: (String name, Module[top] constant) -> void
       def compile_alias(name, constant)
         return if seen?(name)
 
@@ -329,7 +329,7 @@ module Tapioca
         @root << node
       end
 
-      #: (String name, T::Module[top] constant) -> void
+      #: (String name, Module[top] constant) -> void
       def compile_module(name, constant)
         return if skip_module?(name, constant)
         return if seen?(name)
@@ -340,7 +340,7 @@ module Tapioca
         push_scope(name, constant, scope)
       end
 
-      #: (String name, T::Module[top] constant) -> RBI::Scope
+      #: (String name, Module[top] constant) -> RBI::Scope
       def compile_scope(name, constant)
         scope = if constant.is_a?(Class)
           superclass = compile_superclass(constant)
@@ -423,7 +423,7 @@ module Tapioca
         false
       end
 
-      #: (String name, T::Module[top] constant) -> bool
+      #: (String name, Module[top] constant) -> bool
       def skip_alias?(name, constant)
         return true if symbol_in_payload?(name)
         return true unless constant_in_gem?(name)
@@ -441,12 +441,12 @@ module Tapioca
         false
       end
 
-      #: (String name, T::Module[top] constant) -> bool
+      #: (String name, Module[top] constant) -> bool
       def skip_foreign_constant?(name, constant)
         Tapioca::TypeVariableModule === constant
       end
 
-      #: (String name, T::Module[top] constant) -> bool
+      #: (String name, Module[top] constant) -> bool
       def skip_module?(name, constant)
         return true unless defined_in_gem?(constant, strict: false)
         return true if Tapioca::TypeVariableModule === constant
@@ -454,7 +454,7 @@ module Tapioca
         false
       end
 
-      #: (T::Module[top] constant, ?strict: bool) -> bool
+      #: (Module[top] constant, ?strict: bool) -> bool
       def defined_in_gem?(constant, strict: true)
         files = get_file_candidates(constant)
           .merge(Runtime::Trackers::ConstantDefinition.files_for(constant))
@@ -466,7 +466,7 @@ module Tapioca
         end
       end
 
-      #: (T::Module[top] constant) -> Set[String]
+      #: (Module[top] constant) -> Set[String]
       def get_file_candidates(constant)
         file_candidates_for(constant)
       rescue ArgumentError, NameError
@@ -497,7 +497,7 @@ module Tapioca
 
       # Helpers
 
-      #: ((T::Module[top] & T::Generic) constant) -> String
+      #: ((Module[top] & T::Generic) constant) -> String
       def generic_name_of(constant)
         type_name = T.must(constant.name)
         return type_name if type_name =~ /\[.*\]$/
@@ -513,7 +513,7 @@ module Tapioca
         "#{type_name}[#{type_variable_names}]"
       end
 
-      #: (T::Module[top] constant, String? class_name) -> String?
+      #: (Module[top] constant, String? class_name) -> String?
       def name_of_proxy_target(constant, class_name)
         return unless class_name == "ActiveSupport::Deprecation::DeprecatedConstantProxy"
 

--- a/lib/tapioca/rbi_ext/model.rb
+++ b/lib/tapioca/rbi_ext/model.rb
@@ -3,7 +3,7 @@
 
 module RBI
   class Tree
-    #: (T::Module[top] constant) ?{ (Scope scope) -> void } -> Scope
+    #: (Module[top] constant) ?{ (Scope scope) -> void } -> Scope
     def create_path(constant, &block)
       constant_name = Tapioca::Runtime::Reflection.name_of(constant)
       raise "given constant does not have a name" unless constant_name

--- a/lib/tapioca/runtime/dynamic_mixin_compiler.rb
+++ b/lib/tapioca/runtime/dynamic_mixin_compiler.rb
@@ -6,7 +6,7 @@ module Tapioca
     class DynamicMixinCompiler
       include Runtime::Reflection
 
-      #: Array[T::Module[top]]
+      #: Array[Module[top]]
       attr_reader :dynamic_extends, :dynamic_includes
 
       #: Array[Symbol]
@@ -15,7 +15,7 @@ module Tapioca
       #: Array[Symbol]
       attr_reader :instance_attribute_readers, :instance_attribute_writers, :instance_attribute_predicates
 
-      #: (T::Module[top] constant) -> void
+      #: (Module[top] constant) -> void
       def initialize(constant)
         @constant = constant
         mixins_from_modules = {}.compare_by_identity
@@ -109,12 +109,12 @@ module Tapioca
         # is the list of all dynamically extended modules because of that
         # constant. We grab that value by deleting the key for the original
         # constant.
-        @dynamic_extends = mixins_from_modules.delete(constant) || [] #: Array[T::Module[top]]
+        @dynamic_extends = mixins_from_modules.delete(constant) || [] #: Array[Module[top]]
 
         # Since we deleted the original constant from the list of keys, all
         # the keys that remain are the ones that are dynamically included modules
         # during the include of the original constant.
-        @dynamic_includes = mixins_from_modules.keys #: Array[T::Module[top]]
+        @dynamic_includes = mixins_from_modules.keys #: Array[Module[top]]
 
         @class_attribute_readers = class_attribute_readers #: Array[Symbol]
         @class_attribute_writers = class_attribute_writers #: Array[Symbol]
@@ -173,7 +173,7 @@ module Tapioca
         tree << RBI::Include.new("GeneratedInstanceMethods")
       end
 
-      #: (RBI::Tree tree) -> [Array[T::Module[top]], Array[T::Module[top]]]
+      #: (RBI::Tree tree) -> [Array[Module[top]], Array[Module[top]]]
       def compile_mixes_in_class_methods(tree)
         includes = dynamic_includes.filter_map do |mod|
           qname = qualified_name_of(mod)
@@ -208,7 +208,7 @@ module Tapioca
         [[], []] # silence errors
       end
 
-      #: (T::Module[top] mod, Array[T::Module[top]] dynamic_extends) -> bool
+      #: (Module[top] mod, Array[Module[top]] dynamic_extends) -> bool
       def module_included_by_another_dynamic_extend?(mod, dynamic_extends)
         dynamic_extends.any? do |dynamic_extend|
           mod != dynamic_extend && ancestors_of(dynamic_extend).include?(mod)

--- a/lib/tapioca/runtime/generic_type_registry.rb
+++ b/lib/tapioca/runtime/generic_type_registry.rb
@@ -21,16 +21,16 @@ module Tapioca
     # variable to type variable serializers. This allows us to associate type variables
     # to the constant names that represent them, easily.
     module GenericTypeRegistry
-      @generic_instances = {} #: Hash[String, T::Module[top]]
+      @generic_instances = {} #: Hash[String, Module[top]]
 
-      @type_variables = {}.compare_by_identity #: Hash[T::Module[top], Array[TypeVariableModule]]
+      @type_variables = {}.compare_by_identity #: Hash[Module[top], Array[TypeVariableModule]]
 
       class GenericType < T::Types::Simple
-        #: (T::Module[top] raw_type, T::Module[top] underlying_type) -> void
+        #: (Module[top] raw_type, Module[top] underlying_type) -> void
         def initialize(raw_type, underlying_type)
           super(raw_type)
 
-          @underlying_type = underlying_type #: T::Module[top]
+          @underlying_type = underlying_type #: Module[top]
         end
 
         # @override
@@ -52,7 +52,7 @@ module Tapioca
         # 2 hash lookups (for the other two `Foo[Integer]`s).
         #
         # This method returns the created or cached clone of the constant.
-        #: (untyped constant, untyped types) -> T::Module[top]
+        #: (untyped constant, untyped types) -> Module[top]
         def register_type(constant, types)
           # Build the name of the instantiated generic type,
           # something like `"Foo[X, Y, Z]"`
@@ -72,7 +72,7 @@ module Tapioca
           @generic_instances.values.any? { |generic_type| generic_type === instance }
         end
 
-        #: (T::Module[top] constant) -> Array[TypeVariableModule]?
+        #: (Module[top] constant) -> Array[TypeVariableModule]?
         def lookup_type_variables(constant)
           @type_variables[constant]
         end
@@ -95,7 +95,7 @@ module Tapioca
 
         private
 
-        #: (T::Module[top] constant, String name) -> T::Module[top]
+        #: (Module[top] constant, String name) -> Module[top]
         def create_generic_type(constant, name)
           generic_type = case constant
           when Class
@@ -164,7 +164,7 @@ module Tapioca
           end
         end
 
-        #: (T::Module[top] constant) -> Array[TypeVariableModule]
+        #: (Module[top] constant) -> Array[TypeVariableModule]
         def lookup_or_initialize_type_variables(constant)
           @type_variables[constant] ||= []
         end

--- a/lib/tapioca/runtime/reflection.rb
+++ b/lib/tapioca/runtime/reflection.rb
@@ -20,7 +20,7 @@ module Tapioca
       PROTECTED_INSTANCE_METHODS_METHOD = Module.instance_method(:protected_instance_methods) #: UnboundMethod
       PRIVATE_INSTANCE_METHODS_METHOD = Module.instance_method(:private_instance_methods) #: UnboundMethod
       METHOD_METHOD = Kernel.instance_method(:method) #: UnboundMethod
-      UNDEFINED_CONSTANT = Module.new.freeze #: T::Module[top]
+      UNDEFINED_CONSTANT = Module.new.freeze #: Module[top]
 
       REQUIRED_FROM_LABELS = ["<top (required)>", "<main>", "<compiled>"].freeze #: Array[String]
 
@@ -31,7 +31,7 @@ module Tapioca
       end
 
       # @without_runtime
-      #: (String symbol, ?inherit: bool, ?namespace: T::Module[top]) -> BasicObject
+      #: (String symbol, ?inherit: bool, ?namespace: Module[top]) -> BasicObject
       def constantize(symbol, inherit: false, namespace: Object)
         namespace.const_get(symbol, inherit)
       rescue NameError, LoadError, RuntimeError, ArgumentError, TypeError
@@ -43,23 +43,23 @@ module Tapioca
         CLASS_METHOD.bind_call(object)
       end
 
-      #: (T::Module[top] constant) -> Array[Symbol]
+      #: (Module[top] constant) -> Array[Symbol]
       def constants_of(constant)
         CONSTANTS_METHOD.bind_call(constant, false)
       end
 
-      #: (T::Module[top] constant) -> String?
+      #: (Module[top] constant) -> String?
       def name_of(constant)
         name = NAME_METHOD.bind_call(constant)
         name&.start_with?("#<") ? nil : name
       end
 
-      #: (T::Module[top] constant) -> Class[top]
+      #: (Module[top] constant) -> Class[top]
       def singleton_class_of(constant)
         SINGLETON_CLASS_METHOD.bind_call(constant)
       end
 
-      #: (T::Module[top] constant) -> Array[T::Module[top]]
+      #: (Module[top] constant) -> Array[Module[top]]
       def ancestors_of(constant)
         ANCESTORS_METHOD.bind_call(constant)
       end
@@ -69,7 +69,7 @@ module Tapioca
         SUPERCLASS_METHOD.bind_call(constant)
       end
 
-      #: (Class[top] singleton_class) -> T::Module[top]?
+      #: (Class[top] singleton_class) -> Module[top]?
       def attached_class_of(singleton_class)
         result = singleton_class.attached_object
         Module === result ? result : nil
@@ -85,22 +85,22 @@ module Tapioca
         EQUAL_METHOD.bind_call(object, other)
       end
 
-      #: (T::Module[top] constant) -> Array[Symbol]
+      #: (Module[top] constant) -> Array[Symbol]
       def public_instance_methods_of(constant)
         PUBLIC_INSTANCE_METHODS_METHOD.bind_call(constant)
       end
 
-      #: (T::Module[top] constant) -> Array[Symbol]
+      #: (Module[top] constant) -> Array[Symbol]
       def protected_instance_methods_of(constant)
         PROTECTED_INSTANCE_METHODS_METHOD.bind_call(constant)
       end
 
-      #: (T::Module[top] constant) -> Array[Symbol]
+      #: (Module[top] constant) -> Array[Symbol]
       def private_instance_methods_of(constant)
         PRIVATE_INSTANCE_METHODS_METHOD.bind_call(constant)
       end
 
-      #: (T::Module[top] constant) -> Array[T::Module[top]]
+      #: (Module[top] constant) -> Array[Module[top]]
       def inherited_ancestors_of(constant)
         if Class === constant
           ancestors_of(superclass_of(constant) || Object)
@@ -109,7 +109,7 @@ module Tapioca
         end
       end
 
-      #: (T::Module[top] constant) -> String?
+      #: (Module[top] constant) -> String?
       def qualified_name_of(constant)
         name = name_of(constant)
         return if name.nil?
@@ -142,7 +142,7 @@ module Tapioca
         type.to_s
       end
 
-      #: (T::Module[top] constant, Symbol method) -> Method
+      #: (Module[top] constant, Symbol method) -> Method
       def method_of(constant, method)
         METHOD_METHOD.bind_call(constant, method)
       end
@@ -211,7 +211,7 @@ module Tapioca
         SourceLocation.from_loc([file, resolved_loc.lineno])
       end
 
-      #: (T::Module[top] constant) -> Set[String]
+      #: (Module[top] constant) -> Set[String]
       def file_candidates_for(constant)
         # Grab all source files for (relevant) methods defined on the constant
         candidates = relevant_methods_for(constant).filter_map do |method|
@@ -225,25 +225,25 @@ module Tapioca
         candidates
       end
 
-      #: (T::Module[top] constant) -> untyped
+      #: (Module[top] constant) -> untyped
       def abstract_type_of(constant)
         T::Private::Abstract::Data.get(constant, :abstract_type) ||
           T::Private::Abstract::Data.get(singleton_class_of(constant), :abstract_type)
       end
 
-      #: (T::Module[top] constant) -> bool
+      #: (Module[top] constant) -> bool
       def final_module?(constant)
         T::Private::Final.final_module?(constant)
       end
 
-      #: (T::Module[top] constant) -> bool
+      #: (Module[top] constant) -> bool
       def sealed_module?(constant)
         T::Private::Sealed.sealed_module?(constant)
       end
 
       private
 
-      #: (T::Module[top] constant) -> Array[UnboundMethod]
+      #: (Module[top] constant) -> Array[UnboundMethod]
       def relevant_methods_for(constant)
         methods = methods_for(constant).select(&:source_location)
           .reject { |x| method_defined_by_forwardable_module?(x) }
@@ -259,7 +259,7 @@ module Tapioca
         end
       end
 
-      #: (T::Module[top] constant) -> Array[UnboundMethod]
+      #: (Module[top] constant) -> Array[UnboundMethod]
       def methods_for(constant)
         modules = [constant, singleton_class_of(constant)]
         method_list_methods = [
@@ -273,7 +273,7 @@ module Tapioca
         end
       end
 
-      #: (T::Module[top] parent, String name) -> T::Module[top]?
+      #: (Module[top] parent, String name) -> Module[top]?
       def child_module_for_parent_with_name(parent, name)
         return if parent.autoload?(name)
 

--- a/lib/tapioca/runtime/trackers/constant_definition.rb
+++ b/lib/tapioca/runtime/trackers/constant_definition.rb
@@ -12,7 +12,7 @@ module Tapioca
         extend Tracker
         extend Reflection
 
-        @class_files = {}.compare_by_identity #: Hash[T::Module[top], Set[SourceLocation]]
+        @class_files = {}.compare_by_identity #: Hash[Module[top], Set[SourceLocation]]
 
         # Immediately activated upon load. Observes class/module definition.
         @class_tracepoint = TracePoint.trace(:class) do |tp|
@@ -83,12 +83,12 @@ module Tapioca
           # Returns the files in which this class or module was opened. Doesn't know
           # about situations where the class was opened prior to +require+ing,
           # or where metaprogramming was used via +eval+, etc.
-          #: (T::Module[top] klass) -> Set[String]
+          #: (Module[top] klass) -> Set[String]
           def files_for(klass)
             locations_for(klass).map(&:file).to_set
           end
 
-          #: (T::Module[top] klass) -> Set[SourceLocation]
+          #: (Module[top] klass) -> Set[SourceLocation]
           def locations_for(klass)
             @class_files.fetch(klass, Set.new)
           end

--- a/lib/tapioca/runtime/trackers/method_definition.rb
+++ b/lib/tapioca/runtime/trackers/method_definition.rb
@@ -7,10 +7,10 @@ module Tapioca
       module MethodDefinition
         extend Tracker
 
-        @method_definitions = {}.compare_by_identity #: Hash[T::Module[top], Hash[Symbol, Array[SourceLocation]]]
+        @method_definitions = {}.compare_by_identity #: Hash[Module[top], Hash[Symbol, Array[SourceLocation]]]
 
         class << self
-          #: (Symbol method_name, T::Module[top] owner, Array[Thread::Backtrace::Location] locations) -> void
+          #: (Symbol method_name, Module[top] owner, Array[Thread::Backtrace::Location] locations) -> void
           def register(method_name, owner, locations)
             return unless enabled?
             # If Sorbet runtime is redefining a method, it sets this to true.
@@ -24,7 +24,7 @@ module Tapioca
             registrations_for(method_name, owner) << loc
           end
 
-          #: (Symbol method_name, T::Module[top] owner) -> Array[SourceLocation]
+          #: (Symbol method_name, Module[top] owner) -> Array[SourceLocation]
           def method_definitions_for(method_name, owner)
             definitions = registrations_for(method_name, owner)
 
@@ -38,7 +38,7 @@ module Tapioca
 
           private
 
-          #: (Symbol method_name, T::Module[top] owner) -> Array[SourceLocation]
+          #: (Symbol method_name, Module[top] owner) -> Array[SourceLocation]
           def registrations_for(method_name, owner)
             owner_lookup = (@method_definitions[owner] ||= {})
             owner_lookup[method_name] ||= []

--- a/lib/tapioca/runtime/trackers/mixin.rb
+++ b/lib/tapioca/runtime/trackers/mixin.rb
@@ -24,7 +24,7 @@ module Tapioca
             with_disabled_tracker(&block)
           end
 
-          #: (T::Module[top] constant, T::Module[top] mixin, Type mixin_type) -> void
+          #: (Module[top] constant, Module[top] mixin, Type mixin_type) -> void
           def register(constant, mixin, mixin_type)
             return unless enabled?
 
@@ -46,19 +46,19 @@ module Tapioca
             attached_class
           end
 
-          #: (T::Module[top] mixin) -> Hash[Type, Hash[T::Module[top], String]]
+          #: (Module[top] mixin) -> Hash[Type, Hash[Module[top], String]]
           def constants_with_mixin(mixin)
             find_or_initialize_mixin_lookup(mixin)
           end
 
-          #: (T::Module[top] mixin, Type mixin_type, T::Module[top] constant) -> String?
+          #: (Module[top] mixin, Type mixin_type, Module[top] constant) -> String?
           def mixin_location(mixin, mixin_type, constant)
             find_or_initialize_mixin_lookup(mixin).dig(mixin_type, constant)
           end
 
           private
 
-          #: (T::Module[top] constant, T::Module[top] mixin, Type mixin_type, String location) -> void
+          #: (Module[top] constant, Module[top] mixin, Type mixin_type, String location) -> void
           def register_with_location(constant, mixin, mixin_type, location)
             return unless @enabled
 
@@ -66,7 +66,7 @@ module Tapioca
             constants.fetch(mixin_type).store(constant, location)
           end
 
-          #: (T::Module[top] mixin) -> Hash[Type, Hash[T::Module[top], String]]
+          #: (Module[top] mixin) -> Hash[Type, Hash[Module[top], String]]
           def find_or_initialize_mixin_lookup(mixin)
             @mixins_to_constants[mixin] ||= {
               Type::Prepend => {}.compare_by_identity,

--- a/lib/tapioca/runtime/trackers/required_ancestor.rb
+++ b/lib/tapioca/runtime/trackers/required_ancestor.rb
@@ -17,12 +17,12 @@ module Tapioca
             ancestors << block
           end
 
-          #: (T::Module[top] mod) -> Array[^-> void]
+          #: (Module[top] mod) -> Array[^-> void]
           def required_ancestors_blocks_by(mod)
             @required_ancestors_map[mod] || []
           end
 
-          #: (T::Module[top] mod) -> Array[untyped]
+          #: (Module[top] mod) -> Array[untyped]
           def required_ancestors_by(mod)
             blocks = required_ancestors_blocks_by(mod)
             blocks.map do |block|

--- a/lib/tapioca/runtime/trackers/tracker.rb
+++ b/lib/tapioca/runtime/trackers/tracker.rb
@@ -7,7 +7,7 @@ module Tapioca
       # @abstract
       module Tracker
         class << self
-          #: ((Tracker & T::Module[top]) base) -> void
+          #: ((Tracker & Module[top]) base) -> void
           def extended(base)
             Trackers.register_tracker(base)
             base.instance_exec do

--- a/lib/tapioca/sorbet_ext/generic_name_patch.rb
+++ b/lib/tapioca/sorbet_ext/generic_name_patch.rb
@@ -133,7 +133,7 @@ module Tapioca
     #: Type
     attr_reader :type
 
-    #: (T::Module[top] context, Type type, Symbol variance, (^-> Hash[Symbol, untyped])? bounds_proc) -> void
+    #: (Module[top] context, Type type, Symbol variance, (^-> Hash[Symbol, untyped])? bounds_proc) -> void
     def initialize(context, type, variance, bounds_proc)
       @context = context
       @type = type

--- a/spec/tapioca/dsl/helpers/active_model_type_helper_spec.rb
+++ b/spec/tapioca/dsl/helpers/active_model_type_helper_spec.rb
@@ -291,7 +291,7 @@ module Tapioca
 
           it "does not assume the type is nilable when `#__tapioca_type` is defined" do
             klass = Class.new(ActiveModel::Type::Value) do
-              #: -> T::Module[top]
+              #: -> Module[top]
               def __tapioca_type = String
             end
 


### PR DESCRIPTION
## Summary

* Replace `T::Module[top]` with `Module[top]` and `T::Module[T.anything]` with `Module[T.anything]` in all RBS comment signatures (`#:` and `#|` lines)
* `T::Module` is Sorbet runtime syntax; in RBS comments, the correct type is just `Module`
* Runtime Sorbet code (`sig` blocks, `T.cast`, `T::Set`, etc.) is left unchanged

## Test plan

* [ ] CI passes -- this is a comment-only change with no runtime behavior impact