### PR TITLE
Fix initialize return type when sig uses .void.checked(:tests)

### DIFF
--- a/lib/tapioca/gem/listeners/sorbet_signatures.rb
+++ b/lib/tapioca/gem/listeners/sorbet_signatures.rb
@@ -16,7 +16,12 @@ module Tapioca
           signature = event.signature
           return unless signature
 
-          event.node.sigs << compile_signature(signature, event.parameters)
+          sig = compile_signature(signature, event.parameters)
+          # `initialize` must always return void. When a sig uses `.void.checked(:tests)`,
+          # Sorbet introspects the return type as `T.anything` outside of test mode, so we
+          # correct it here.
+          sig.return_type = "void" if event.node.name == "initialize"
+          event.node.sigs << sig
         end
 
         #: (untyped signature, Array[[Symbol, String]] parameters) -> RBI::Sig

--- a/spec/tapioca/gem/pipeline_spec.rb
+++ b/spec/tapioca/gem/pipeline_spec.rb
@@ -2225,6 +2225,28 @@ class Tapioca::Gem::PipelineSpec < Minitest::HooksSpec
       assert_equal(output, compile)
     end
 
+    it "compiles initialize with void sig using checked(:tests)" do
+      add_ruby_file("bar.rb", <<~RUBY)
+        class Bar
+          extend T::Sig
+
+          sig { params(x: Integer).void.checked(:tests) }
+          def initialize(x)
+            @x = x
+          end
+        end
+      RUBY
+
+      output = template(<<~RBI)
+        class Bar
+          sig { params(x: ::Integer).void }
+          def initialize(x); end
+        end
+      RBI
+
+      assert_equal(output, compile)
+    end
+
     it "understands redefined attr_accessor" do
       add_ruby_file("toto.rb", <<~RUBY)
         class Toto


### PR DESCRIPTION
### Motivation

When a Sorbet sig uses `.void.checked(:tests)`, the Sorbet runtime introspects the `return_type` as `T::Types::Anything` outside of test mode. Tapioca then serializes this as `returns(T.anything)` in the generated gem RBI, which is invalid — `initialize` must always return `void` in Sorbet.

This produces RBI files that fail the `Sorbet/InitializeShouldReturnVoid` RuboCop cop, causing pre-commit hook failures for anyone running `tapioca gems` on a codebase that uses `.void.checked(:tests)` on `initialize`.

Repro:
```ruby
class Foo
  extend T::Sig
  sig { params(x: Integer).void.checked(:tests) }
  def initialize(x); end
end

sig = T::Utils.signature_for_method(Foo.instance_method(:initialize))
sig.return_type.class #=> T::Types::Anything  (not T::Private::Types::Void)
sig.return_type.to_s  #=> "T.anything"
```

Note: `.void.checked(:tests)` causes `T.anything` to be introspected as the return type for *any* method with that sig pattern, not just `initialize`. However, only `initialize` produces a hard `srb tc` failure (Sorbet requires it to return void). There is no stable Sorbet API to distinguish "declared void, introspected as `T.anything`" for other methods, so the broader case is out of scope here.

### Implementation

In `SorbetSignatures#on_method`, after compiling the sig, unconditionally set `return_type` to `"void"` when the method is `initialize`. Since Sorbet requires `initialize` to always return void, this is always correct regardless of what the signature's return type introspects to.

### Tests

Added a spec case to `pipeline_spec.rb` covering an `initialize` method with `.void.checked(:tests)`, asserting the generated RBI emits `void`.