### PR TITLE
Use prism as the parser when creating sorbet/config

### DIFF
--- a/lib/tapioca/commands/configure.rb
+++ b/lib/tapioca/commands/configure.rb
@@ -38,6 +38,7 @@ module Tapioca
           .
           --ignore=tmp/
           --ignore=vendor/
+          --parser=prism
         CONTENT
       end
 

--- a/spec/tapioca/cli/configure_spec.rb
+++ b/spec/tapioca/cli/configure_spec.rb
@@ -31,6 +31,7 @@ module Tapioca
           .
           --ignore=tmp/
           --ignore=vendor/
+          --parser=prism
         CONFIG
 
         assert_project_file_equal("sorbet/tapioca/require.rb", <<~RB)


### PR DESCRIPTION
### Motivation

Change our generated `sorbet/config` to make Prism the default parser.