### PR TITLE
Temporarily constrain Sorbet version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,7 +22,7 @@ PATH
       rbi (>= 0.3.7)
       require-hooks (>= 0.2.2)
       rubydex (>= 0.1.0.beta10)
-      sorbet-static-and-runtime (>= 0.6.12698)
+      sorbet-static-and-runtime (>= 0.6.12698, <= 0.6.13096)
       spoom (>= 1.7.9)
       thor (>= 1.2.0)
       tsort

--- a/tapioca.gemspec
+++ b/tapioca.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency("parallel", ">= 1.21.0")
   spec.add_dependency("require-hooks", ">= 0.2.2")
   spec.add_dependency("rubydex", ">= 0.1.0.beta10")
-  spec.add_dependency("sorbet-static-and-runtime", ">= 0.6.12698")
+  spec.add_dependency("sorbet-static-and-runtime", ">= 0.6.12698", "<= 0.6.13096")
   spec.add_dependency("thor", ">= 1.2.0")
 
   # Tapioca requires a specific minimum versions of RBI and Spoom


### PR DESCRIPTION
### Motivation

Temporarily constrain the Sorbet version. It seems that one of the recent changes has an ordering bug when printing todo constants, which results in incorrect RBI generation (and is the reason why main CI is broken).

<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->