### PR TITLE
Use `rest_type`/`keyrest_type` for a Sorbet signature

### DIFF
--- a/lib/tapioca/dsl/compiler.rb
+++ b/lib/tapioca/dsl/compiler.rb
@@ -124,10 +124,12 @@ module Tapioca
         signature.kwarg_types.each { |_, kwarg_type| params << kwarg_type.to_s }
 
         # rest parameter type
-        params << signature.rest_type.to_s if signature.has_rest
+        rest_type = signature.rest_type
+        params << rest_type.to_s if rest_type
 
         # keyrest parameter type
-        params << signature.keyrest_type.to_s if signature.has_keyrest
+        keyrest_type = signature.keyrest_type
+        params << keyrest_type.to_s if keyrest_type
 
         # special case `.void` in a proc
         unless signature.block_name.nil?

--- a/lib/tapioca/gem/listeners/sorbet_signatures.rb
+++ b/lib/tapioca/gem/listeners/sorbet_signatures.rb
@@ -23,8 +23,10 @@ module Tapioca
         def compile_signature(signature, parameters)
           parameter_types = signature.arg_types.to_h #: Hash[Symbol, T::Types::Base]
           parameter_types.merge!(signature.kwarg_types)
-          parameter_types[signature.rest_name] = signature.rest_type if signature.has_rest
-          parameter_types[signature.keyrest_name] = signature.keyrest_type if signature.has_keyrest
+          rest_type = signature.rest_type
+          parameter_types[signature.rest_name] = rest_type if rest_type
+          keyrest_type = signature.keyrest_type
+          parameter_types[signature.keyrest_name] = keyrest_type if keyrest_type
           parameter_types[signature.block_name] = signature.block_type if signature.block_name
 
           sig = RBI::Sig.new


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
`sorbet-runtime` 0.6.13149 (sorbet/sorbet#10177) removed `@has_rest` and `@has_keyrest` from `T::Private::Methods::Signature`, since they were redundant with the `@rest_type`/`@keyrest_type` ivars (nil when absent).

### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
Update to pre-existing variables `rest_type`/`keyrest_type`, no Sorbet version bump is necessary.
### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->
Already tested