### PR TITLE
Unpin sorbet upper bound constraint

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,7 +22,7 @@ PATH
       rbi (>= 0.3.7)
       require-hooks (>= 0.2.2)
       rubydex (>= 0.1.0.beta10)
-      sorbet-static-and-runtime (>= 0.6.12698, <= 0.6.13118)
+      sorbet-static-and-runtime (>= 0.6.12698)
       spoom (>= 1.7.9)
       thor (>= 1.2.0)
       tsort

--- a/tapioca.gemspec
+++ b/tapioca.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency("parallel", ">= 1.21.0")
   spec.add_dependency("require-hooks", ">= 0.2.2")
   spec.add_dependency("rubydex", ">= 0.1.0.beta10")
-  spec.add_dependency("sorbet-static-and-runtime", ">= 0.6.12698", "<= 0.6.13118")
+  spec.add_dependency("sorbet-static-and-runtime", ">= 0.6.12698")
   spec.add_dependency("thor", ">= 1.2.0")
 
   # Tapioca requires a specific minimum versions of RBI and Spoom


### PR DESCRIPTION
Unpin sorbet upper bound constraint. https://github.com/Shopify/tapioca/commit/11c4ab935658fe66caa7fe368e4fd40d12145178 introduced the pin as a temporary measure, but the issue has already been fixed upstream.