### PR TITLE
Bootstrap gem symbols from Rubydex graph

### DIFF
--- a/lib/tapioca/gem/pipeline.rb
+++ b/lib/tapioca/gem/pipeline.rb
@@ -32,7 +32,7 @@ module Tapioca
 
         @payload_symbols = Static::SymbolLoader.payload_symbols #: Set[String]
         gem_graph = Static::SymbolLoader.graph_from_paths(@gem.files) #: Rubydex::Graph
-        gem_symbols = gem_graph.declarations.map(&:name).to_set
+        gem_symbols = Static::SymbolLoader.symbols_from_graph(gem_graph)
         engine_symbols = Static::SymbolLoader.engine_symbols(@gem)
         @bootstrap_symbols = gem_symbols.union(engine_symbols) #: Set[String]
 

--- a/lib/tapioca/gem/pipeline.rb
+++ b/lib/tapioca/gem/pipeline.rb
@@ -31,8 +31,10 @@ module Tapioca
         @events = [] #: Array[Gem::Event]
 
         @payload_symbols = Static::SymbolLoader.payload_symbols #: Set[String]
-        @bootstrap_symbols = load_bootstrap_symbols(@gem) #: Set[String]
-        gem_graph = Static::SymbolLoader.graph_from_paths(@gem.files) if include_doc
+        gem_graph = Static::SymbolLoader.graph_from_paths(@gem.files) #: Rubydex::Graph
+        gem_symbols = gem_graph.declarations.map(&:name).to_set
+        engine_symbols = Static::SymbolLoader.engine_symbols(@gem)
+        @bootstrap_symbols = gem_symbols.union(engine_symbols) #: Set[String]
 
         @bootstrap_symbols.each { |symbol| push_symbol(symbol) }
 
@@ -190,14 +192,6 @@ module Tapioca
       end
 
       private
-
-      #: (Gemfile::GemSpec gem) -> Set[String]
-      def load_bootstrap_symbols(gem)
-        engine_symbols = Static::SymbolLoader.engine_symbols(gem)
-        gem_symbols = Static::SymbolLoader.gem_symbols(gem)
-
-        gem_symbols.union(engine_symbols)
-      end
 
       # Events handling
 

--- a/lib/tapioca/static/symbol_loader.rb
+++ b/lib/tapioca/static/symbol_loader.rb
@@ -27,11 +27,6 @@ module Tapioca
         end
 
         #: (Gemfile::GemSpec gem) -> Set[String]
-        def gem_symbols(gem)
-          symbols_from_paths(gem.files)
-        end
-
-        #: (Gemfile::GemSpec gem) -> Set[String]
         def engine_symbols(gem)
           gem_engine = engines.find do |engine|
             gem.full_gem_path == engine.config.root.to_s
@@ -51,7 +46,8 @@ module Tapioca
             Pathname.glob("#{load_path}/**/*.rb")
           end
 
-          symbols_from_paths(paths)
+          engine_graph = graph_from_paths(paths)
+          engine_graph.declarations.map(&:name).to_set
         rescue
           Set.new
         end

--- a/lib/tapioca/static/symbol_loader.rb
+++ b/lib/tapioca/static/symbol_loader.rb
@@ -26,6 +26,28 @@ module Tapioca
           graph
         end
 
+        #: (Rubydex::Graph graph) -> Set[String]
+        def symbols_from_graph(graph)
+          graph.declarations.filter_map do |decl|
+            next unless decl.is_a?(Rubydex::Namespace) ||
+              decl.is_a?(Rubydex::Constant) ||
+              decl.is_a?(Rubydex::ConstantAlias) ||
+              decl.is_a?(Rubydex::Todo)
+
+            # Declarations added by `graph.resolve` only have `rubydex:built-in` definitions.
+            # We exclude those unless the namespace has method or constant members defined in
+            # source files, which indicates a class reopening (e.g. `class Object; def Nokogiri(); end`).
+            if decl.definitions.any? && decl.definitions.all? { |defn| defn.location.uri == "rubydex:built-in" }
+              next unless decl.is_a?(Rubydex::Namespace) && decl.members.any? do |m|
+                (m.is_a?(Rubydex::Method) || m.is_a?(Rubydex::Constant) || m.is_a?(Rubydex::ConstantAlias)) &&
+                  m.definitions.any?
+              end
+            end
+
+            decl.name
+          end.to_set
+        end
+
         #: (Gemfile::GemSpec gem) -> Set[String]
         def engine_symbols(gem)
           gem_engine = engines.find do |engine|
@@ -47,7 +69,7 @@ module Tapioca
           end
 
           engine_graph = graph_from_paths(paths)
-          engine_graph.declarations.map(&:name).to_set
+          symbols_from_graph(engine_graph)
         rescue
           Set.new
         end


### PR DESCRIPTION
## Summary

Extracted from #2524. Instead of shelling out to Sorbet to get the symbol table for a gem's files, we use the Rubydex graph which is already available and faster. The engine symbols path also switches to Rubydex for consistency.

* Replace Sorbet's symbol table (`symbols_from_paths`) with Rubydex graph for bootstrapping gem symbols in the pipeline
* The gem graph is now always built (not conditional on `include_doc`), and reused for both symbol bootstrapping and documentation
* Remove `gem_symbols` from `SymbolLoader` and `load_bootstrap_symbols` from `Pipeline` since Rubydex handles both cases