### PR TITLE
Use Rubydex graph for constants_from_requested_paths

### DIFF
--- a/lib/tapioca/commands/abstract_dsl.rb
+++ b/lib/tapioca/commands/abstract_dsl.rb
@@ -359,7 +359,9 @@ module Tapioca
       #: -> Array[String]
       def constants_from_requested_paths
         @constants_from_requested_paths ||=
-          Static::SymbolLoader.symbols_from_paths(@requested_paths).to_a #: Array[String]?
+          Static::SymbolLoader.symbols_from_graph(
+            Static::SymbolLoader.graph_from_paths(@requested_paths),
+          ).to_a #: Array[String]?
       end
     end
   end

--- a/lib/tapioca/static/symbol_loader.rb
+++ b/lib/tapioca/static/symbol_loader.rb
@@ -74,22 +74,6 @@ module Tapioca
           Set.new
         end
 
-        #: (Array[Pathname] paths) -> Set[String]
-        def symbols_from_paths(paths)
-          return Set.new if paths.empty?
-
-          output = Tempfile.create("sorbet") do |file|
-            file.write(Array(paths).join("\n"))
-            file.flush
-
-            symbol_table_json_from("@#{file.path.shellescape}")
-          end
-
-          return Set.new if output.empty?
-
-          SymbolTableParser.parse_json(output)
-        end
-
         private
 
         # @without_runtime


### PR DESCRIPTION
## Summary

Extracted from #2524. Instead of shelling out to Sorbet to get the symbol table for requested paths, we use the Rubydex graph which is already available and faster.

* Replace `symbols_from_paths` (Sorbet shell-out) with `graph_from_paths` (Rubydex) in `constants_from_requested_paths`
* Remove the now-unused `symbols_from_paths` method from `SymbolLoader`