### PR TITLE
Normalize setter sig param names from exported gem RBIs

### DIFF
--- a/lib/tapioca/commands/abstract_gem.rb
+++ b/lib/tapioca/commands/abstract_gem.rb
@@ -283,10 +283,55 @@ module Tapioca
         end
 
         file.root = RBI::Rewriters::Merge.merge_trees(file.root, tree, keep: RBI::Rewriters::Merge::Keep::LEFT)
+        normalize_setter_sig_params(file.root)
       rescue RBI::ParseError => e
         say_error("\n\n  RBIs exported by `#{gem.name}` contain errors and can't be used:", :yellow)
         say_error("Cause: #{e.message} (#{e.location})")
       end
+
+      # After merging a gem's exported RBI (Keep::LEFT), setter sigs from the exported RBI may
+      # use a parameter name that differs from the runtime method def. For example, stripe names
+      # setter params `_expand` in its exported sigs, but its define_method-based attr_accessor
+      # override produces a runtime parameter named `value`. Sorbet rejects the resulting
+      # sig/def mismatch (error 5003), so we normalize every setter sig to match the method def.
+      #: (RBI::Tree tree) -> void
+      def normalize_setter_sig_params(tree)
+        SetterSigParamNormalizer.new.visit(tree)
+      end
+
+      # Visitor that normalizes setter sig param names to match the method def's param name.
+      class SetterSigParamNormalizer < RBI::Visitor
+        # @override
+        #: (RBI::Node? node) -> void
+        def visit(node)
+          if node.is_a?(RBI::Method) && node.name.end_with?("=")
+            normalize_setter(node)
+          end
+          visit_all(node.nodes) if node.is_a?(RBI::Tree)
+        end
+
+        private
+
+        #: (RBI::Method node) -> void
+        def normalize_setter(node)
+          return unless node.params.size == 1
+
+          method_param = node.params.first
+          return unless method_param.is_a?(RBI::ReqParam)
+
+          method_param_name = method_param.name
+          node.sigs.each do |sig|
+            sig_params = sig.params
+            next if sig_params.size != 1
+
+            sig_param = sig_params.fetch(0)
+            next if sig_param.name == method_param_name
+
+            sig_params[0] = RBI::SigParam.new(method_param_name, sig_param.type)
+          end
+        end
+      end
+      private_constant :SetterSigParamNormalizer
     end
   end
 end

--- a/spec/tapioca/cli/gem_spec.rb
+++ b/spec/tapioca/cli/gem_spec.rb
@@ -518,6 +518,40 @@ module Tapioca
           assert_success_status(result)
         end
 
+        it "must normalize setter sig param names from exported RBI to match the runtime method def" do
+          # Stripe (and other gems) override attr_accessor with define_method, which names
+          # the setter parameter `value` at runtime. Their exported RBI sigs use a different
+          # name (e.g. `_expand`). After the Keep::LEFT merge, the method def has `value` but
+          # the sig has `_expand`, which Sorbet rejects with error 5003.
+          foo = mock_gem("foo", "0.0.1") do
+            write!("lib/foo.rb", <<~RB)
+              class Foo
+                define_method(:expand=) { |value| @expand = value }
+                def expand; @expand; end
+              end
+            RB
+
+            write!("rbi/foo.rbi", <<~RBI)
+              class Foo
+                sig { params(_expand: T.nilable(T::Array[String])).returns(T.nilable(T::Array[String])) }
+                def expand=(_expand); end
+              end
+            RBI
+          end
+
+          @project.require_mock_gem(foo)
+          @project.bundle_install!
+
+          result = @project.tapioca("gem foo")
+
+          assert_success_status(result)
+          assert_project_file_includes(
+            "sorbet/rbi/gems/foo@0.0.1.rbi",
+            "  sig { params(value: T.nilable(T::Array[String])).returns(T.nilable(T::Array[String])) }\n" \
+            "  def expand=(value); end\n",
+          )
+        end
+
         it "must generate a gem RBI and resolves conflicts with exported gem RBIs by keeping the generated RBI" do
           foo = mock_gem("foo", "0.0.1") do
             write!("lib/foo.rb", FOO_RB)


### PR DESCRIPTION
### Motivation

Some gems (notably [stripe-ruby](https://github.com/stripe/stripe-ruby)) ship exported RBIs where setter sigs use the attribute name with a leading underscore (`_expand`, `_payment_intent`, etc.) as the parameter name. However, stripe overrides `attr_accessor` with `define_method("#{name}=") { |value| ... }`, so the runtime setter parameter is named `value`.

After tapioca's `Keep::LEFT` merge, the method def comes from runtime introspection (`value`) but the sig is pulled from the exported RBI (`_expand`). Sorbet rejects this sig/def mismatch with error 5003, producing type errors in codebases that depend on the stripe gem.

### Implementation

After `merge_trees`, the merged tree is walked by a new `SetterSigParamNormalizer` visitor. For each setter method (name ends with `=`) with a single `ReqParam`, any attached sig param whose name differs from the method def's param name is replaced with a new `SigParam` using the method def's param name. The type annotation from the exported RBI is preserved — only the parameter name is normalized.

`SetterSigParamNormalizer` is an `RBI::Visitor` subclass defined inside `Commands::AbstractGem` and marked `private_constant`.

### Tests

Added an integration test that creates a mock gem with a `define_method`-based setter (runtime parameter `value`) and a bundled RBI whose sig uses `_expand`, then asserts the generated RBI has `params(value: ...)` in the sig.
