### PR TITLE
Skip RBS rewrite for files without RBS comments

### DIFF
--- a/lib/tapioca/rbs/rewriter.rb
+++ b/lib/tapioca/rbs/rewriter.rb
@@ -36,6 +36,21 @@ rescue LoadError
   # Bootsnap is not in the bundle, we don't need to do anything.
 end
 
+module Tapioca
+  module RBS
+    module Rewriter
+      TYPED_SIGIL_PATTERN = /^\s*#\s*typed: (ignore|false|true|strict|strong|__STDLIB_INTERNAL)/
+
+      class << self
+        #: (String source) -> bool
+        def rewrite?(source)
+          source.match?(TYPED_SIGIL_PATTERN) && (source.include?("#:") || source.include?("#|"))
+        end
+      end
+    end
+  end
+end
+
 # We need to include `T::Sig` very early to make sure that the `sig` method is available since gems using RBS comments
 # are unlikely to include `T::Sig` in their own classes.
 Module.include(T::Sig)
@@ -45,8 +60,8 @@ RequireHooks.source_transform(patterns: ["**/*.rb"]) do |path, source|
   # The source is most likely nil since no `source_transform` hook was triggered before this one.
   source ||= File.read(path, encoding: "UTF-8")
 
-  # For performance reasons, we only rewrite files that use Sorbet.
-  if source =~ /^\s*#\s*typed: (ignore|false|true|strict|strong|__STDLIB_INTERNAL)/
+  # For performance reasons, we only rewrite typed files that contain RBS comments.
+  if Tapioca::RBS::Rewriter.rewrite?(source)
     Spoom::Sorbet::Translate.rbs_comments_to_sorbet_sigs(source, file: path)
   end
 rescue Spoom::Sorbet::Translate::Error

--- a/spec/tapioca/rbs/rewriter_spec.rb
+++ b/spec/tapioca/rbs/rewriter_spec.rb
@@ -1,0 +1,68 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Tapioca
+  module RBS
+    class RewriterSpec < Minitest::Spec
+      def described_class
+        Tapioca::RBS::Rewriter
+      end
+
+      describe Tapioca::RBS::Rewriter do
+        it "rewrites typed files with RBS signature comments" do
+          source = <<~RUBY
+            # typed: strict
+
+            #: (String) -> Integer
+            def parse(value)
+              value.to_i
+            end
+          RUBY
+
+          assert(described_class.rewrite?(source))
+        end
+
+        it "rewrites typed files with multiline RBS comments" do
+          source = <<~RUBY
+            # typed: strict
+
+            #| (String,
+            #|  Integer) -> String
+            def format(value, count)
+              value * count
+            end
+          RUBY
+
+          assert(described_class.rewrite?(source))
+        end
+
+        it "skips typed files without RBS comments" do
+          source = <<~RUBY
+            # typed: strict
+
+            def parse(value)
+              value.to_i
+            end
+          RUBY
+
+          refute(described_class.rewrite?(source))
+        end
+
+        it "skips files with RBS-looking comments but without a typed sigil" do
+          source = <<~RUBY
+            # frozen_string_literal: true
+
+            #: (String) -> Integer
+            def parse(value)
+              value.to_i
+            end
+          RUBY
+
+          refute(described_class.rewrite?(source))
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What

Skip RBS source rewriting for typed Ruby files that do not contain RBS comment markers.

Tapioca's RBS rewriter currently calls `Spoom::Sorbet::Translate.rbs_comments_to_sorbet_sigs` for every file with a `# typed:` sigil. This adds a cheap prefilter so translation only runs when the source also contains `#:` or `#|`, the markers used by RBS comments.

## Why

The RBS rewriter runs while application files are being loaded. In large applications, many typed files do not contain RBS comments, so calling the translator for each of them is unnecessary work.

This keeps the existing behavior for files that can contain RBS comments while avoiding translation attempts for files that cannot produce RBS-derived runtime signatures.

## Safety

This should be behavior-preserving:

- Files with `# typed:` and RBS comment markers still go through the existing translator.
- Files without RBS comment markers have no RBS comments for the translator to rewrite.
- False positives are acceptable because they preserve the old path for that file.

This does not change the broader Bootsnap/source-transform behavior; it only avoids unnecessary translator calls after source has been read.

## Validation

Ran:

```bash
bundle exec ruby -I spec spec/tapioca/rbs/rewriter_spec.rb
bundle exec rubocop lib/tapioca/rbs/rewriter.rb spec/tapioca/rbs/rewriter_spec.rb
```

Both passed locally.

## Follow-up

This is a conservative first step. A larger optimization would be to avoid disabling/bypassing Bootsnap for files that do not require RBS rewriting, while preserving byte-identical generated RBI output.
