### PR TITLE
Skip RBS rewrite when no markers are present

### DIFF
--- a/lib/tapioca/rbs/rewriter.rb
+++ b/lib/tapioca/rbs/rewriter.rb
@@ -62,6 +62,50 @@ end
 
 require "require-hooks/setup"
 
+module Tapioca
+  module RBS
+    module Rewriter
+      TYPED_FILE_PATTERN = /^\s*#\s*typed: (ignore|false|true|strict|strong|__STDLIB_INTERNAL)/
+      # Markers consumed by Spoom's RBS comment rewriter beyond `#:`/`#|`.
+      # Keep in sync with Spoom: missing markers skip rewrites; extra markers only add safe false positives.
+      RBS_ANNOTATION_MARKERS = [
+        "# @abstract",
+        "# @interface",
+        "# @sealed",
+        "# @final",
+        "# @requires_ancestor:",
+        "# @override",
+        "# @overridable",
+        "# @without_runtime",
+      ].freeze #: Array[String]
+      RBS_REWRITE_PATTERN = Regexp.union(["#:", "#|"] + RBS_ANNOTATION_MARKERS).freeze #: Regexp
+
+      class << self
+        #: (String source) -> bool
+        def typed_file?(source)
+          source.match?(TYPED_FILE_PATTERN)
+        end
+
+        #: (String source) -> bool
+        def possible_rbs_runtime_rewrite_syntax?(source)
+          source.match?(RBS_REWRITE_PATTERN)
+        end
+
+        #: (untyped path, String source) -> String?
+        def rewrite(path, source)
+          return unless typed_file?(source)
+          return source unless possible_rbs_runtime_rewrite_syntax?(source)
+
+          Spoom::Sorbet::Translate.rbs_comments_to_sorbet_sigs(source, file: path)
+        rescue Spoom::Sorbet::Translate::Error
+          # If we can't translate the RBS comments back into Sorbet's signatures, we just skip the file.
+          source
+        end
+      end
+    end
+  end
+end
+
 # We need to include `T::Sig` very early to make sure that the `sig` method is available since gems using RBS comments
 # are unlikely to include `T::Sig` in their own classes.
 Module.include(T::Sig)
@@ -71,11 +115,5 @@ RequireHooks.source_transform(patterns: ["**/*.rb"]) do |path, source|
   # The source is most likely nil since no `source_transform` hook was triggered before this one.
   source ||= File.read(path, encoding: "UTF-8")
 
-  # For performance reasons, we only rewrite files that use Sorbet.
-  if source =~ /^\s*#\s*typed: (ignore|false|true|strict|strong|__STDLIB_INTERNAL)/
-    Spoom::Sorbet::Translate.rbs_comments_to_sorbet_sigs(source, file: path)
-  end
-rescue Spoom::Sorbet::Translate::Error
-  # If we can't translate the RBS comments back into Sorbet's signatures, we just skip the file.
-  source
+  Tapioca::RBS::Rewriter.rewrite(path, source)
 end

--- a/spec/tapioca/rbs/rewriter_spec.rb
+++ b/spec/tapioca/rbs/rewriter_spec.rb
@@ -1,0 +1,156 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Tapioca
+  module RBS
+    class RewriterSpec < Minitest::Spec
+      describe ".typed_file?" do
+        it "returns true for supported typed sigils" do
+          [
+            "# typed: ignore",
+            "# typed: false",
+            "# typed: true",
+            "# typed: strict",
+            "# typed: strong",
+            "# typed: __STDLIB_INTERNAL",
+          ].each do |sigil|
+            assert(Tapioca::RBS::Rewriter.typed_file?(sigil))
+          end
+        end
+
+        it "returns false when the file is not typed" do
+          refute(Tapioca::RBS::Rewriter.typed_file?("class Foo; end"))
+        end
+      end
+
+      describe ".rewrite" do
+        it "does not call the translator for typed files without RBS runtime rewrite syntax" do
+          source = <<~RUBY
+            # typed: true
+
+            class Foo
+              def foo; end
+            end
+          RUBY
+
+          Spoom::Sorbet::Translate.stub(:rbs_comments_to_sorbet_sigs, ->(*) { flunk("translator should not run") }) do
+            assert_equal(source, Tapioca::RBS::Rewriter.rewrite("foo.rb", source))
+          end
+        end
+
+        it "returns nil for untyped files" do
+          assert_nil(Tapioca::RBS::Rewriter.rewrite("foo.rb", "class Foo; end"))
+        end
+
+        it "calls the translator for typed files with RBS runtime rewrite syntax" do
+          source = <<~RUBY
+            # typed: true
+
+            class Foo
+              #: -> String
+              def foo; end
+            end
+          RUBY
+
+          Spoom::Sorbet::Translate.stub(:rbs_comments_to_sorbet_sigs, ->(rewritten_source, file:) {
+            assert_equal(source, rewritten_source)
+            assert_equal("foo.rb", file)
+            "translated"
+          }) do
+            assert_equal("translated", Tapioca::RBS::Rewriter.rewrite("foo.rb", source))
+          end
+        end
+
+        it "returns the original source when translation fails" do
+          source = <<~RUBY
+            # typed: true
+
+            class Foo
+              #: invalid
+              def foo; end
+            end
+          RUBY
+
+          Spoom::Sorbet::Translate.stub(:rbs_comments_to_sorbet_sigs, ->(*) {
+            raise Spoom::Sorbet::Translate::Error, "invalid"
+          }) do
+            assert_equal(source, Tapioca::RBS::Rewriter.rewrite("foo.rb", source))
+          end
+        end
+      end
+
+      describe ".possible_rbs_runtime_rewrite_syntax?" do
+        it "returns true for RBS signature comments" do
+          assert(Tapioca::RBS::Rewriter.possible_rbs_runtime_rewrite_syntax?(<<~RUBY))
+            # typed: true
+
+            class Foo
+              #: -> String
+              def foo; end
+            end
+          RUBY
+        end
+
+        it "returns true for multiline RBS signature continuation comments" do
+          assert(Tapioca::RBS::Rewriter.possible_rbs_runtime_rewrite_syntax?(<<~RUBY))
+            # typed: true
+
+            class Foo
+              #: -> Array[
+              #| String
+              #| ]
+              def foo; end
+            end
+          RUBY
+        end
+
+        it "returns true for supported RBS annotations" do
+          Tapioca::RBS::Rewriter::RBS_ANNOTATION_MARKERS.each do |marker|
+            assert(Tapioca::RBS::Rewriter.possible_rbs_runtime_rewrite_syntax?(<<~RUBY), marker)
+              # typed: true
+
+              #{marker}
+              class Foo; end
+            RUBY
+          end
+        end
+
+        it "returns true for supported override annotations with options" do
+          [
+            "# @override(allow_incompatible: true)",
+            "# @override(allow_incompatible: :visibility)",
+          ].each do |marker|
+            assert(Tapioca::RBS::Rewriter.possible_rbs_runtime_rewrite_syntax?(<<~RUBY), marker)
+              # typed: true
+
+              #{marker}
+              def foo; end
+            RUBY
+          end
+        end
+
+        it "returns false for typed files without RBS runtime rewrite syntax" do
+          refute(Tapioca::RBS::Rewriter.possible_rbs_runtime_rewrite_syntax?(<<~RUBY))
+            # typed: true
+
+            class Foo
+              def foo; end
+            end
+          RUBY
+        end
+
+        it "returns false for unrelated YARD tags" do
+          refute(Tapioca::RBS::Rewriter.possible_rbs_runtime_rewrite_syntax?(<<~RUBY))
+            # typed: true
+
+            # @param value [String]
+            # @return [String]
+            def foo(value); end
+          RUBY
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Avoid running Spoom's RBS-to-Sorbet-sig translator for typed Ruby files that cannot contain runtime-rewriteable RBS syntax.

Tapioca currently calls `Spoom::Sorbet::Translate.rbs_comments_to_sorbet_sigs` for every typed Ruby file loaded through the RBS rewriter. A large portion of typed files in Core do not contain RBS signatures or supported RBS annotations, so the translator often parses source only to return it unchanged.

This keeps the existing `typed:` gate and adds a conservative marker gate. Translation now runs only when source contains one of:

- `#:`
- `#|`
- `# @abstract`
- `# @interface`
- `# @sealed`
- `# @final`
- `# @requires_ancestor:`
- `# @override`
- `# @overridable`
- `# @without_runtime`

False positives are safe because they still use the existing translator. False negatives would be unsafe, so the annotation list is intentionally aligned with Spoom's currently supported runtime-rewrite annotations.