### PR TITLE
Cache RBS rewrites with bootsnap & add `dsl --only-bootsnap-rbs-cache`

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ Tapioca makes it easy to work with [Sorbet](https://sorbet.org) in your codebase
     * [Using DSL compiler options](#using-dsl-compiler-options)
     * [Writing custom DSL compilers](#writing-custom-dsl-compilers)
     * [Writing custom DSL extensions](#writing-custom-dsl-extensions)
+  * [Rewriting RBS comments to Sorbet signatures](#rewriting-rbs-comments-to-sorbet-signatures)
+    * [Caching rewrites with Bootsnap](#caching-rewrites-with-bootsnap)
+    * [Priming the cache from CI](#priming-the-cache-from-ci)
   * [RBI files for missing constants and methods](#rbi-files-for-missing-constants-and-methods)
   * [Configuration](#configuration)
 * [Editor Integration](#editor-integration)
@@ -837,6 +840,42 @@ end
 In order for DSL extensions to be discovered by Tapioca, they either needs to be placed inside the `sorbet/tapioca/extensions` directory of your application or be inside a `tapioca/dsl/extensions` folder on the load path.
 
 For more concrete and advanced examples, take a look at [Tapioca's default DSL extensions](https://github.com/Shopify/tapioca/tree/main/lib/tapioca/dsl/extensions).
+
+### Rewriting RBS comments to Sorbet signatures
+
+Tapioca translates [RBS comments](https://sorbet.org/docs/rbs-comments) into Sorbet `sig {}` blocks at file load time, so `sorbet-runtime` wraps the methods as if they had been written with native sigs. This is what lets the DSL command introspect signatures that were originally documented as RBS comments.
+
+The rewriting is automatic on every `tapioca` invocation: [`require-hooks`](https://github.com/Shopify/require-hooks) intercepts `.rb` loads and `Spoom::Sorbet::Translate.rbs_comments_to_sorbet_sigs` translates the source before Ruby compiles it to bytecode.
+
+#### Caching rewrites with Bootsnap
+
+`tapioca dsl` boots the app and eager-loads source files for introspection, so the rewrite runs across the whole codebase. On large applications this adds noticeable overhead. To cache the rewrite output across runs using [bootsnap](https://github.com/Shopify/bootsnap)'s iseq cache, you can set `TAPIOCA_RBS_CACHE=1`:
+
+```shell
+$ TAPIOCA_RBS_CACHE=1 bin/tapioca dsl
+```
+
+Tapioca configures Bootsnap's iseq cache against a dedicated directory (`tmp/cache/bootsnap-tapioca-rbs` by default; override with `TAPIOCA_BOOTSNAP_CACHE_DIR`). The first run is slower because every file is rewritten and the result is baked into the iseq cache; subsequent runs against the same directory skip the rewrite entirely.
+
+`Bootsnap.setup` mutates a process-wide singleton, and a second call would overwrite Tapioca's dedicated cache directory and start writing rewritten iseqs into the host's normal cache. Tapioca enforces this under `TAPIOCA_RBS_CACHE=1`: after its own setup runs, any subsequent `Bootsnap.setup` raises a clear error pointing at the fix. Gate your host's `Bootsnap.setup` on the same env var. Rails apps do this in `config/boot.rb`:
+
+```ruby
+# e.g. config/boot.rb
+require "bootsnap/setup" unless ENV["TAPIOCA_RBS_CACHE"] == "1"
+```
+
+#### Priming the cache from CI
+
+For CI pipelines that want to populate the cache once and have downstream jobs read from a warm copy, use `--only-bootsnap-rbs-cache`. This pattern lets you scope cache writes to a single job (the prime) so PR-side jobs read from it without uploading on every successful build:
+
+```shell
+# Prime: populate the cache.
+$ TAPIOCA_RBS_CACHE=1 bin/tapioca dsl --only-bootsnap-rbs-cache
+
+# Consumer: read from the populated cache.
+# BOOTSNAP_READONLY=1 prevents bootsnap from writing back to a read-only mount.
+$ TAPIOCA_RBS_CACHE=1 BOOTSNAP_READONLY=1 bin/tapioca dsl
+```
 
 ### RBI files for missing constants and methods
 

--- a/README.md
+++ b/README.md
@@ -489,33 +489,35 @@ Usage:
   tapioca dsl [constant...]
 
 Options:
-  --out, -o, [--outdir=directory]                                                                  # The output directory for generated DSL RBI files
-                                                                                                   # Default: sorbet/rbi/dsl
-             [--file-header], [--no-file-header], [--skip-file-header]                             # Add a "This file is generated" header on top of each generated RBI file
-                                                                                                   # Default: true
-             [--only=compiler [compiler ...]]                                                      # Only run supplied DSL compiler(s)
-             [--exclude=compiler [compiler ...]]                                                   # Exclude supplied DSL compiler(s)
-             [--verify], [--no-verify], [--skip-verify]                                            # Verifies RBIs are up-to-date
-                                                                                                   # Default: false
-  -q,        [--quiet], [--no-quiet], [--skip-quiet]                                               # Suppresses file creation output
-                                                                                                   # Default: false
-  -w,        [--workers=N]                                                                         # Number of parallel workers to use when generating RBIs (default: auto)
-             [--rbi-max-line-length=N]                                                             # Set the max line length of generated RBIs. Signatures longer than the max line length will be wrapped
-                                                                                                   # Default: 120
-  -e,        [--environment=ENVIRONMENT]                                                           # The Rack/Rails environment to use when generating RBIs
-                                                                                                   # Default: development
-  -l,        [--list-compilers], [--no-list-compilers], [--skip-list-compilers]                    # List all loaded compilers
-                                                                                                   # Default: false
-             [--app-root=APP_ROOT]                                                                 # The path to the Rails application
-                                                                                                   # Default: .
-             [--halt-upon-load-error], [--no-halt-upon-load-error], [--skip-halt-upon-load-error]  # Halt upon a load error while loading the Rails application
-                                                                                                   # Default: true
-             [--skip-constant=constant [constant ...]]                                             # Do not generate RBI definitions for the given application constant(s)
-             [--compiler-options=key:value]                                                        # Options to pass to the DSL compilers
-  -c,        [--config=<config file path>]                                                         # Path to the Tapioca configuration file
-                                                                                                   # Default: sorbet/tapioca/config.yml
-  -V,        [--verbose], [--no-verbose], [--skip-verbose]                                         # Verbose output for debugging purposes
-                                                                                                   # Default: false
+  --out, -o, [--outdir=directory]                                                                           # The output directory for generated DSL RBI files
+                                                                                                            # Default: sorbet/rbi/dsl
+             [--file-header], [--no-file-header], [--skip-file-header]                                      # Add a "This file is generated" header on top of each generated RBI file
+                                                                                                            # Default: true
+             [--only=compiler [compiler ...]]                                                               # Only run supplied DSL compiler(s)
+             [--exclude=compiler [compiler ...]]                                                            # Exclude supplied DSL compiler(s)
+             [--verify], [--no-verify], [--skip-verify]                                                     # Verifies RBIs are up-to-date
+                                                                                                            # Default: false
+             [--only-bootsnap-rbs-cache], [--no-only-bootsnap-rbs-cache], [--skip-only-bootsnap-rbs-cache]  # Only boot the application and load DSL extensions/compilers to populate the bootsnap iseq cache, then exit. Skips compiler execution and RBI generation. Mutually exclusive with --verify and --list-compilers.
+                                                                                                            # Default: false
+  -q,        [--quiet], [--no-quiet], [--skip-quiet]                                                        # Suppresses file creation output
+                                                                                                            # Default: false
+  -w,        [--workers=N]                                                                                  # Number of parallel workers to use when generating RBIs (default: auto)
+             [--rbi-max-line-length=N]                                                                      # Set the max line length of generated RBIs. Signatures longer than the max line length will be wrapped
+                                                                                                            # Default: 120
+  -e,        [--environment=ENVIRONMENT]                                                                    # The Rack/Rails environment to use when generating RBIs
+                                                                                                            # Default: development
+  -l,        [--list-compilers], [--no-list-compilers], [--skip-list-compilers]                             # List all loaded compilers
+                                                                                                            # Default: false
+             [--app-root=APP_ROOT]                                                                          # The path to the Rails application
+                                                                                                            # Default: .
+             [--halt-upon-load-error], [--no-halt-upon-load-error], [--skip-halt-upon-load-error]           # Halt upon a load error while loading the Rails application
+                                                                                                            # Default: true
+             [--skip-constant=constant [constant ...]]                                                      # Do not generate RBI definitions for the given application constant(s)
+             [--compiler-options=key:value]                                                                 # Options to pass to the DSL compilers
+  -c,        [--config=<config file path>]                                                                  # Path to the Tapioca configuration file
+                                                                                                            # Default: sorbet/tapioca/config.yml
+  -V,        [--verbose], [--no-verbose], [--skip-verbose]                                                  # Verbose output for debugging purposes
+                                                                                                            # Default: false
 
 Generate RBIs for dynamic methods
 ```
@@ -957,6 +959,7 @@ dsl:
   only: []
   exclude: []
   verify: false
+  only_bootsnap_rbs_cache: false
   quiet: false
   workers: 1
   rbi_max_line_length: 120

--- a/lib/tapioca/cli.rb
+++ b/lib/tapioca/cli.rb
@@ -103,6 +103,10 @@ module Tapioca
       type: :boolean,
       default: false,
       desc: "Verifies RBIs are up-to-date"
+    option :only_bootsnap_rbs_cache,
+      type: :boolean,
+      default: false,
+      desc: "Only boot the application and load DSL extensions/compilers to populate the bootsnap iseq cache, then exit. Skips compiler execution and RBI generation. Mutually exclusive with --verify and --list-compilers."
     option :quiet,
       aliases: ["-q"],
       type: :boolean,
@@ -146,6 +150,12 @@ module Tapioca
     def dsl(*constant_or_paths)
       set_environment(options)
 
+      if options[:only_bootsnap_rbs_cache] && (options[:verify] || options[:list_compilers])
+        conflicting = options[:verify] ? "--verify" : "--list-compilers"
+        raise MalformattedArgumentError,
+          "Options '--only-bootsnap-rbs-cache' and '#{conflicting}' are mutually exclusive"
+      end
+
       # Assume anything starting with a capital letter or colon is a class, otherwise a path
       constants, paths = constant_or_paths.partition { |c| c =~ /\A[A-Z:]/ }
 
@@ -173,7 +183,7 @@ module Tapioca
       elsif options[:list_compilers]
         Commands::DslCompilerList.new(**command_args)
       else
-        Commands::DslGenerate.new(**command_args)
+        Commands::DslGenerate.new(**command_args, only_bootsnap_rbs_cache: options[:only_bootsnap_rbs_cache])
       end
 
       command.run

--- a/lib/tapioca/commands/dsl_generate.rb
+++ b/lib/tapioca/commands/dsl_generate.rb
@@ -4,12 +4,23 @@
 module Tapioca
   module Commands
     class DslGenerate < AbstractDsl
+      #: (?only_bootsnap_rbs_cache: bool, **untyped) -> void
+      def initialize(only_bootsnap_rbs_cache: false, **kwargs)
+        @only_bootsnap_rbs_cache = only_bootsnap_rbs_cache
+        super(**T.unsafe(kwargs))
+      end
+
       private
 
       # @override
       #: -> void
       def execute
         load_application
+
+        if @only_bootsnap_rbs_cache
+          say("Bootsnap RBS cache populated, exiting before RBI generation.", :green)
+          return
+        end
 
         say("Compiling DSL RBI files...")
         say("")

--- a/lib/tapioca/rbs/rewriter.rb
+++ b/lib/tapioca/rbs/rewriter.rb
@@ -1,40 +1,38 @@
 # typed: strict
 # frozen_string_literal: true
 
-require "require-hooks/setup"
-
 # This code rewrites RBS comments back into Sorbet's signatures as the files are being loaded.
 # This will allow `sorbet-runtime` to wrap the methods as if they were originally written with the `sig{}` blocks.
 # This will in turn allow Tapioca to use this signatures to generate typed RBI files.
 
-begin
-  # When in a `bootsnap` environment, files are loaded from the cache and won't trigger the `source_transform` method.
-  # The `require-hooks` gem comes with a `bootsnap` mode that will disable the `bootsnap/compile_cache/iseq` caching.
-  # Sadly, we're way to early in the boot process to use it as bootsnap won't be loaded yet and the `require-hooks`
-  # setup won't pick it up.
-  #
-  # As a workaround, if we can preemptively require `bootsnap` and `bootsnap/compile_cache/iseq` we manually override
-  # the `load_iseq` method to disable the caching mechanism.
-  #
-  # This will make the Rails app load slower but allows us to trigger the RBS -> RBI source transform.
-  require "bootsnap"
-  require "bootsnap/compile_cache/iseq"
-
-  module Bootsnap
-    module CompileCache
-      module ISeq
-        module InstructionSequenceMixin
-          #: (String) -> RubyVM::InstructionSequence
-          def load_iseq(path)
-            super if defined?(super)
-          end
-        end
-      end
-    end
+# When TAPIOCA_RBS_CACHE=1, set up bootsnap with a dedicated cache directory
+# and load require-hooks so the RBS-rewritten iseqs get cached. Subsequent
+# runs read the rewritten iseq directly and skip the rewrite.
+#
+# The host app must also skip its own Bootsnap.setup under this flag,
+# otherwise it'll override our settings during Rails boot.
+if ENV["TAPIOCA_RBS_CACHE"] == "1"
+  begin
+    require "bootsnap"
+    # Respect BOOTSNAP_READONLY for consumers reading a pre-populated cache
+    # (e.g. a CI prime step).
+    readonly = !["0", "false", false].include?(ENV.fetch("BOOTSNAP_READONLY") { false })
+    Bootsnap.setup(
+      cache_dir: ENV.fetch("TAPIOCA_BOOTSNAP_CACHE_DIR", File.join(Dir.pwd, "tmp/cache/bootsnap-tapioca-rbs")),
+      development_mode: true,
+      load_path_cache: true,
+      compile_cache_iseq: true,
+      compile_cache_yaml: true,
+      readonly: readonly,
+      revalidation: true,
+    )
+    Bootsnap.log_stats!
+  rescue LoadError
+    # Bootsnap is not in the bundle, skip iseq caching.
   end
-rescue LoadError
-  # Bootsnap is not in the bundle, we don't need to do anything.
 end
+
+require "require-hooks/setup"
 
 # We need to include `T::Sig` very early to make sure that the `sig` method is available since gems using RBS comments
 # are unlikely to include `T::Sig` in their own classes.

--- a/lib/tapioca/rbs/rewriter.rb
+++ b/lib/tapioca/rbs/rewriter.rb
@@ -5,12 +5,39 @@
 # This will allow `sorbet-runtime` to wrap the methods as if they were originally written with the `sig{}` blocks.
 # This will in turn allow Tapioca to use this signatures to generate typed RBI files.
 
+module Tapioca
+  module RBS
+    class HostBootsnapSetupError < StandardError; end
+
+    # Raises when the host calls `Bootsnap.setup` after tapioca's setup. Host's call
+    # would overwrite tapioca's cache directory, so rewritten iseqs would end up in
+    # the host's regular cache.
+    module BootsnapGuard
+      extend T::Sig
+
+      sig { params(_kwargs: T.untyped).void }
+      def setup(**_kwargs)
+        Kernel.raise HostBootsnapSetupError, <<~MSG
+          Bootsnap.setup was called while TAPIOCA_RBS_CACHE=1 is set. Tapioca already
+          configured bootsnap with a dedicated cache directory; re-running setup
+          would overwrite that config and start writing rewritten iseqs into your
+          host's cache.
+
+          Gate your host's Bootsnap.setup on the env var, e.g. in config/boot.rb:
+
+            require "bootsnap/setup" unless ENV["TAPIOCA_RBS_CACHE"] == "1"
+        MSG
+      end
+    end
+  end
+end
+
 # When TAPIOCA_RBS_CACHE=1, set up bootsnap with a dedicated cache directory
 # and load require-hooks so the RBS-rewritten iseqs get cached. Subsequent
 # runs read the rewritten iseq directly and skip the rewrite.
 #
-# The host app must also skip its own Bootsnap.setup under this flag,
-# otherwise it'll override our settings during Rails boot.
+# After our setup, BootsnapGuard is prepended so the host application can't
+# replace our cache directory.
 if ENV["TAPIOCA_RBS_CACHE"] == "1"
   begin
     require "bootsnap"
@@ -27,6 +54,7 @@ if ENV["TAPIOCA_RBS_CACHE"] == "1"
       revalidation: true,
     )
     Bootsnap.log_stats!
+    Bootsnap.singleton_class.prepend(Tapioca::RBS::BootsnapGuard)
   rescue LoadError
     # Bootsnap is not in the bundle, skip iseq caching.
   end

--- a/sorbet/rbi/shims/bootsnap.rbi
+++ b/sorbet/rbi/shims/bootsnap.rbi
@@ -1,0 +1,9 @@
+# typed: true
+
+# Bootsnap is loaded conditionally in `lib/tapioca/rbs/rewriter.rb` when
+# `TAPIOCA_RBS_CACHE=1`. It isn't in the Gemfile, so this shim declares the
+# minimal surface used there.
+module Bootsnap
+  def self.setup(**); end
+  def self.log_stats!; end
+end

--- a/spec/helpers/mock_project.rb
+++ b/spec/helpers/mock_project.rb
@@ -97,8 +97,8 @@ module Tapioca
     end
 
     # Run a Tapioca `command` with `bundle exec` in this project context (unbundled env)
-    #: (String command, ?enforce_typechecking: bool, ?exclude: Array[String]) -> Spoom::ExecResult
-    def tapioca(command, enforce_typechecking: true, exclude: tapioca_dependencies)
+    #: (String command, ?enforce_typechecking: bool, ?exclude: Array[String], ?env: Hash[String, String]) -> Spoom::ExecResult
+    def tapioca(command, enforce_typechecking: true, exclude: tapioca_dependencies, env: {})
       exec_command = ["tapioca", command]
       if command.start_with?("gem")
         exec_command << "--workers=1" unless command.match?("--workers")
@@ -109,15 +109,15 @@ module Tapioca
         exec_command << "--workers=1" unless command.match?("--workers")
       end
 
-      env = {}
-      env["ENFORCE_TYPECHECKING"] = if enforce_typechecking
+      merged_env = env.dup
+      merged_env["ENFORCE_TYPECHECKING"] = if enforce_typechecking
         "1"
       else
         warn("Ignoring typechecking errors in CLI test")
         "0"
       end
 
-      bundle_exec(exec_command.join(" "), env)
+      bundle_exec(exec_command.join(" "), merged_env)
     end
 
     private

--- a/spec/tapioca/cli/dsl_spec.rb
+++ b/spec/tapioca/cli/dsl_spec.rb
@@ -60,6 +60,7 @@ module Tapioca
         before(:all) do
           @project.require_real_gem("smart_properties", "1.15.0")
           @project.require_real_gem("sidekiq", "6.2.1")
+          @project.require_real_gem("bootsnap", "1.18.4")
           @project.bundle_install!
           @gemfile = @project.read("Gemfile")
           @gemfile_lock = @project.read("Gemfile.lock")
@@ -677,6 +678,27 @@ module Tapioca
           assert_empty_stderr(result)
           refute_project_file_exist("sorbet/rbi/dsl/post.rbi")
           assert_success_status(result)
+        end
+
+        it "raises when the host calls Bootsnap.setup under TAPIOCA_RBS_CACHE=1" do
+          @project.write!("lib/post.rb", <<~RB)
+            require "bootsnap"
+            Bootsnap.setup(cache_dir: File.join(Dir.pwd, "tmp/cache/host-bootsnap"))
+            require "smart_properties"
+
+            class Post
+              include SmartProperties
+              property :title, accepts: String
+            end
+          RB
+
+          result = @project.tapioca("dsl Post", env: { "TAPIOCA_RBS_CACHE" => "1" })
+
+          assert_stderr_includes(
+            result,
+            "Bootsnap.setup was called while TAPIOCA_RBS_CACHE=1 is set",
+          )
+          refute_success_status(result)
         end
 
         it "generates RBI files without header" do

--- a/spec/tapioca/cli/dsl_spec.rb
+++ b/spec/tapioca/cli/dsl_spec.rb
@@ -658,6 +658,27 @@ module Tapioca
           assert_success_status(result)
         end
 
+        it "exits before RBI generation when --only-bootsnap-rbs-cache is set" do
+          @project.write!("lib/post.rb", <<~RB)
+            require "smart_properties"
+
+            class Post
+              include SmartProperties
+              property :title, accepts: String
+            end
+          RB
+
+          result = @project.tapioca("dsl --only-bootsnap-rbs-cache Post")
+
+          assert_stdout_includes(result, <<~OUT)
+            Bootsnap RBS cache populated, exiting before RBI generation.
+          OUT
+
+          assert_empty_stderr(result)
+          refute_project_file_exist("sorbet/rbi/dsl/post.rbi")
+          assert_success_status(result)
+        end
+
         it "generates RBI files without header" do
           @project.write!("lib/post.rb", <<~RB)
             require "smart_properties"
@@ -1946,6 +1967,26 @@ module Tapioca
 
           assert_empty_stderr(result)
           assert_success_status(result)
+        end
+
+        it "rejects --only-bootsnap-rbs-cache combined with --verify" do
+          result = @project.tapioca("dsl --verify --only-bootsnap-rbs-cache")
+
+          assert_stderr_includes(
+            result,
+            "Options '--only-bootsnap-rbs-cache' and '--verify' are mutually exclusive",
+          )
+          refute_success_status(result)
+        end
+
+        it "rejects --only-bootsnap-rbs-cache combined with --list-compilers" do
+          result = @project.tapioca("dsl --list-compilers --only-bootsnap-rbs-cache")
+
+          assert_stderr_includes(
+            result,
+            "Options '--only-bootsnap-rbs-cache' and '--list-compilers' are mutually exclusive",
+          )
+          refute_success_status(result)
         end
 
         it "advises of removed file(s) and returns exit status 1 when files are excluded" do


### PR DESCRIPTION
## Motivation

`tapioca dsl` rewrites RBS comments to Sorbet `sig {}` blocks on every loaded file via `require-hooks`. On Shopify's monolith this dominates wall time (locally ~16 min). Caching the post-rewrite bytecode in bootsnap drops it to ~4 min (4.2x).

## Implementation

- Opt-in via `TAPIOCA_RBS_CACHE=1`. The rewriter sets up bootsnap with a dedicated cache directory (default `tmp/cache/bootsnap-tapioca-rbs`, override via `TAPIOCA_BOOTSNAP_CACHE_DIR`) and forwards `BOOTSNAP_READONLY` to bootsnap's `readonly:` arg. After setup, `Tapioca::RBS::BootsnapGuard` is prepended on `Bootsnap.singleton_class` so the host's own `Bootsnap.setup` raises instead of silently clobbering the cache dir.

- `--only-bootsnap-rbs-cache` populates the cache and exits before any RBI work (CI prime/consumer pattern, mutually exclusive with `--verify`). `bootsnap` stays an optional runtime dep; a Sorbet shim covers the static surface.

## Tests

CLI tests in `spec/tapioca/cli/dsl_spec.rb` cover the flag's early-exit, the `--verify` mutex, and the guard's raise.
