### PR TITLE
Require Spoom 1.7.14

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,7 +23,7 @@ PATH
       require-hooks (>= 0.2.2)
       rubydex (>= 0.1.0.beta10)
       sorbet-static-and-runtime (>= 0.6.12698)
-      spoom (>= 1.7.9)
+      spoom (>= 1.7.14)
       thor (>= 1.2.0)
       tsort
 
@@ -379,7 +379,7 @@ GEM
     sorbet-static-and-runtime (0.6.13185)
       sorbet (= 0.6.13185)
       sorbet-runtime (= 0.6.13185)
-    spoom (1.7.13)
+    spoom (1.7.14)
       erubi (>= 1.10.0)
       prism (>= 0.28.0)
       rbi (>= 0.3.3)
@@ -612,7 +612,7 @@ CHECKSUMS
   sorbet-static (0.6.13185-universal-darwin) sha256=0ad9b2a781e41226453d237e4bb1f5f5b7669d147e4db03a887325f67cd08b07
   sorbet-static (0.6.13185-x86_64-linux) sha256=3e3bdc3d19667d4f6157d6a96b1bf3b65ca66e9de35d3ff5603c9805f04afb99
   sorbet-static-and-runtime (0.6.13185) sha256=255ce183fad55b70642f4c4994ff901703261a67af0cbc353dbbe0f305f53b9c
-  spoom (1.7.13) sha256=f82178f8a5db8ddf45fcd0d8cb4436e1969cd8f57abe4fc1d8d06ed083588454
+  spoom (1.7.14) sha256=48da4e39d9a63611aa0132a3656d7e75833fcccb6006d59f7fa879b98c8877c4
   sprockets (4.2.2) sha256=761e5a49f1c288704763f73139763564c845a8f856d52fba013458f8af1b59b1
   sqlite3 (2.9.0-aarch64-linux-gnu) sha256=cfe1e0216f46d7483839719bf827129151e6c680317b99d7b8fc1597a3e13473
   sqlite3 (2.9.0-aarch64-linux-musl) sha256=56a35cb2d70779afc2ac191baf2c2148242285ecfed72f9b021218c5c4917913

--- a/sorbet/rbi/gems/spoom@1.7.14.rbi
+++ b/sorbet/rbi/gems/spoom@1.7.14.rbi
@@ -3024,25 +3024,25 @@ class Spoom::LSP::Error::Diagnostics < ::Spoom::LSP::Error
   end
 end
 
-# pkg:gem/spoom#lib/spoom/sorbet/lsp/structures.rb:16
+# pkg:gem/spoom#lib/spoom/sorbet/lsp/structures.rb:74
 class Spoom::LSP::Hover < ::T::Struct
   include ::Spoom::LSP::PrintableSymbol
 
   const :contents, ::String
-  const :range, T.nilable(T::Range[T.untyped])
+  const :range, T.nilable(::Spoom::LSP::Range)
 
   # @override
   #
-  # pkg:gem/spoom#lib/spoom/sorbet/lsp/structures.rb:34
+  # pkg:gem/spoom#lib/spoom/sorbet/lsp/structures.rb:92
   sig { override.params(printer: ::Spoom::LSP::SymbolPrinter).void }
   def accept_printer(printer); end
 
-  # pkg:gem/spoom#lib/spoom/sorbet/lsp/structures.rb:40
+  # pkg:gem/spoom#lib/spoom/sorbet/lsp/structures.rb:98
   sig { returns(::String) }
   def to_s; end
 
   class << self
-    # pkg:gem/spoom#lib/spoom/sorbet/lsp/structures.rb:24
+    # pkg:gem/spoom#lib/spoom/sorbet/lsp/structures.rb:82
     sig { params(json: T::Hash[T.untyped, T.untyped]).returns(::Spoom::LSP::Hover) }
     def from_json(json); end
   end
@@ -3110,7 +3110,7 @@ class Spoom::LSP::Notification < ::Spoom::LSP::Message
   def params; end
 end
 
-# pkg:gem/spoom#lib/spoom/sorbet/lsp/structures.rb:45
+# pkg:gem/spoom#lib/spoom/sorbet/lsp/structures.rb:16
 class Spoom::LSP::Position < ::T::Struct
   include ::Spoom::LSP::PrintableSymbol
 
@@ -3119,16 +3119,16 @@ class Spoom::LSP::Position < ::T::Struct
 
   # @override
   #
-  # pkg:gem/spoom#lib/spoom/sorbet/lsp/structures.rb:63
+  # pkg:gem/spoom#lib/spoom/sorbet/lsp/structures.rb:34
   sig { override.params(printer: ::Spoom::LSP::SymbolPrinter).void }
   def accept_printer(printer); end
 
-  # pkg:gem/spoom#lib/spoom/sorbet/lsp/structures.rb:68
+  # pkg:gem/spoom#lib/spoom/sorbet/lsp/structures.rb:39
   sig { returns(::String) }
   def to_s; end
 
   class << self
-    # pkg:gem/spoom#lib/spoom/sorbet/lsp/structures.rb:53
+    # pkg:gem/spoom#lib/spoom/sorbet/lsp/structures.rb:24
     sig { params(json: T::Hash[T.untyped, T.untyped]).returns(::Spoom::LSP::Position) }
     def from_json(json); end
   end
@@ -3147,7 +3147,7 @@ module Spoom::LSP::PrintableSymbol
   def accept_printer(printer); end
 end
 
-# pkg:gem/spoom#lib/spoom/sorbet/lsp/structures.rb:73
+# pkg:gem/spoom#lib/spoom/sorbet/lsp/structures.rb:44
 class Spoom::LSP::Range < ::T::Struct
   include ::Spoom::LSP::PrintableSymbol
 
@@ -3156,16 +3156,16 @@ class Spoom::LSP::Range < ::T::Struct
 
   # @override
   #
-  # pkg:gem/spoom#lib/spoom/sorbet/lsp/structures.rb:91
+  # pkg:gem/spoom#lib/spoom/sorbet/lsp/structures.rb:62
   sig { override.params(printer: ::Spoom::LSP::SymbolPrinter).void }
   def accept_printer(printer); end
 
-  # pkg:gem/spoom#lib/spoom/sorbet/lsp/structures.rb:98
+  # pkg:gem/spoom#lib/spoom/sorbet/lsp/structures.rb:69
   sig { returns(::String) }
   def to_s; end
 
   class << self
-    # pkg:gem/spoom#lib/spoom/sorbet/lsp/structures.rb:81
+    # pkg:gem/spoom#lib/spoom/sorbet/lsp/structures.rb:52
     sig { params(json: T::Hash[T.untyped, T.untyped]).returns(::Spoom::LSP::Range) }
     def from_json(json); end
   end

--- a/tapioca.gemspec
+++ b/tapioca.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
   # Tapioca requires a specific minimum versions of RBI and Spoom
   # to ensure that the RBS comments are translated correctly.
   spec.add_dependency("rbi", ">= 0.3.7")
-  spec.add_dependency("spoom", ">= 1.7.9")
+  spec.add_dependency("spoom", ">= 1.7.14")
   # We need this to be ported to the RBS 4.0 branch before we can remove this dependency:
   # https://github.com/ruby/rbs/pull/2601
   spec.add_dependency("tsort") # Until rbs supports Ruby 4.0 with tsort extracted to bundled gems


### PR DESCRIPTION
This bumps Tapioca's Spoom lower bound to `>= 1.7.14` and updates the checked-in lockfile to resolve `spoom 1.7.14`.

`spoom 1.7.13` can crash at load time with newer `sorbet-runtime` versions while Tapioca is requiring Spoom from `lib/tapioca/internal.rb`. The failure happens before Tapioca's RBS rewriter code is loaded, which is why it showed up as unrelated CI noise on #2616.

Spoom 1.7.14 includes Shopify/spoom#911, which fixes the `Spoom::LSP::Hover` forward reference to `Range` that triggered the Sorbet runtime `Invalid value for type constraint ... Got a NilClass` crash. Requiring this version prevents Bundler from selecting the broken `spoom 1.7.13` + newer Sorbet runtime combination in lockless/temp-Gemfile installs.
