### PR TITLE
Warn when `--only-bootsnap-rbs-cache` runs without `TAPIOCA_RBS_CACHE=1`

### DIFF
--- a/lib/tapioca/commands/dsl_generate.rb
+++ b/lib/tapioca/commands/dsl_generate.rb
@@ -18,7 +18,11 @@ module Tapioca
         load_application
 
         if @only_bootsnap_rbs_cache
-          say("Bootsnap RBS cache populated, exiting before RBI generation.", :green)
+          if ENV["TAPIOCA_RBS_CACHE"] == "1"
+            say("Bootsnap RBS cache populated, exiting before RBI generation.", :green)
+          else
+            say_error("Warning: --only-bootsnap-rbs-cache requires TAPIOCA_RBS_CACHE=1 to populate the cache", :yellow)
+          end
           return
         end
 

--- a/spec/tapioca/cli/dsl_spec.rb
+++ b/spec/tapioca/cli/dsl_spec.rb
@@ -669,13 +669,34 @@ module Tapioca
             end
           RB
 
-          result = @project.tapioca("dsl --only-bootsnap-rbs-cache Post")
+          result = @project.tapioca("dsl --only-bootsnap-rbs-cache Post", env: { "TAPIOCA_RBS_CACHE" => "1" })
 
           assert_stdout_includes(result, <<~OUT)
             Bootsnap RBS cache populated, exiting before RBI generation.
           OUT
 
-          assert_empty_stderr(result)
+          assert_stderr_includes(result, "bootsnap miss:")
+          refute_project_file_exist("sorbet/rbi/dsl/post.rbi")
+          assert_success_status(result)
+        end
+
+        it "warns when --only-bootsnap-rbs-cache is set without TAPIOCA_RBS_CACHE=1" do
+          @project.write!("lib/post.rb", <<~RB)
+            require "smart_properties"
+
+            class Post
+              include SmartProperties
+              property :title, accepts: String
+            end
+          RB
+
+          result = @project.tapioca("dsl --only-bootsnap-rbs-cache Post")
+
+          assert_stderr_includes(
+            result,
+            "Warning: --only-bootsnap-rbs-cache requires TAPIOCA_RBS_CACHE=1 to populate the cache",
+          )
+          refute_includes(result.out, "Bootsnap RBS cache populated")
           refute_project_file_exist("sorbet/rbi/dsl/post.rbi")
           assert_success_status(result)
         end


### PR DESCRIPTION
## Summary

- Addresses [PR #2617 review comment](https://github.com/Shopify/tapioca/pull/2617#discussion_r3209320189) from @Morriar.
- Without `TAPIOCA_RBS_CACHE=1` set, `bootsnap/setup` isn't required at boot and no RBS cache gets populated. Previously `tapioca dsl --only-bootsnap-rbs-cache` would still print "Bootsnap RBS cache populated", misleading users into thinking it had done useful work.
- Now emits a warning to stderr in that case so the misuse is visible.

## Test plan

- [x] New spec: `warns when --only-bootsnap-rbs-cache is set without TAPIOCA_RBS_CACHE=1`
- [x] Existing happy-path spec updated to set `TAPIOCA_RBS_CACHE=1` and assert bootsnap stats appear on stderr (confirming bootsnap actually ran)