### PR TITLE
Add 'breaking-change' label to required label list

### DIFF
--- a/bin/check_pr_labels
+++ b/bin/check_pr_labels
@@ -13,6 +13,7 @@ REQUIRED_LABELS = [
   "security",
   "sorbet",
   "dependencies",
+  "breaking-change",
 ].freeze
 
 arg = ARGV.first


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
We should allow PRs that are labelled `breaking-change`.
