### PR TITLE
Fix Sorbet types for serialized + encrypted ActiveRecord columns

### DIFF
--- a/lib/tapioca/dsl/helpers/active_record_column_type_helper.rb
+++ b/lib/tapioca/dsl/helpers/active_record_column_type_helper.rb
@@ -123,9 +123,11 @@ module Tapioca
             # Reflect to see if `ActiveModel::Type::Value` is being used first.
             getter_type = Tapioca::Dsl::Helpers::ActiveModelTypeHelper.type_for(column_type)
 
-            # Fallback to String as `ActiveRecord::Encryption::EncryptedAttributeType` inherits from
-            # `ActiveRecord::Type::Text` which inherits from `ActiveModel::Type::String`.
-            return "::String" if getter_type == "T.untyped"
+            # Otherwise resolve the wrapped `cast_type` (e.g. a serialized column), which `encrypts`
+            # preserves. This naturally falls back to `::String` for plain encrypted string/text columns.
+            if getter_type == "T.untyped" && column_type.respond_to?(:cast_type)
+              return type_for_activerecord_value(column_type.cast_type, column_nullability:)
+            end
 
             as_non_nilable_if_persisted_and_not_nullable(getter_type, column_nullability:)
           when ActiveRecord::Type::String
@@ -237,7 +239,7 @@ module Tapioca
         #: (ActiveRecord::Type::Serialized column_type) -> String
         def serialized_column_type(column_type)
           case column_type.coder
-          when ActiveRecord::Coders::YAMLColumn
+          when ActiveRecord::Coders::ColumnSerializer
             case column_type.coder.object_class
             when Array.singleton_class
               "T::Array[T.untyped]"
@@ -253,8 +255,11 @@ module Tapioca
 
         #: (untyped column_type) -> bool
         def not_nilable_serialized_column?(column_type)
+          if defined?(ActiveRecord::Encryption) && ActiveRecord::Encryption::EncryptedAttributeType === column_type
+            column_type = column_type.cast_type
+          end
           return false unless column_type.is_a?(ActiveRecord::Type::Serialized)
-          return false unless column_type.coder.is_a?(ActiveRecord::Coders::YAMLColumn)
+          return false unless column_type.coder.is_a?(ActiveRecord::Coders::ColumnSerializer)
 
           [Array.singleton_class, Hash.singleton_class].include?(column_type.coder.object_class.singleton_class)
         end

--- a/spec/tapioca/dsl/compilers/active_record_columns_spec.rb
+++ b/spec/tapioca/dsl/compilers/active_record_columns_spec.rb
@@ -557,6 +557,7 @@ module Tapioca
                         t.text :serialized_column_custom
                         t.text :serialized_column_hash
                         t.text :serialized_column_json
+                        t.text :serialized_column_json_hash
                       end
                     end
                   end
@@ -567,6 +568,7 @@ module Tapioca
                     serialize :serialized_column_array, type: Array
                     serialize :serialized_column_hash, type: Hash
                     serialize :serialized_column_json, coder: JSON
+                    serialize :serialized_column_json_hash, type: Hash, coder: JSON
                     serialize :serialized_column_custom, coder: CustomCoder
                   end
                 RUBY
@@ -618,6 +620,66 @@ module Tapioca
                 expected = indented(<<~RBI, 4)
                   sig { returns(T.untyped) }
                   def serialized_column_json; end
+                RBI
+                assert_includes(output, expected)
+
+                expected = indented(<<~RBI, 4)
+                  sig { params(value: T.nilable(T::Hash[T.untyped, T.untyped])).returns(T.nilable(T::Hash[T.untyped, T.untyped])) }
+                  def serialized_column_json_hash=(value); end
+                RBI
+                assert_includes(output, expected)
+
+                expected = indented(<<~RBI, 4)
+                  sig { returns(T::Hash[T.untyped, T.untyped]) }
+                  def serialized_column_json_hash; end
+                RBI
+                assert_includes(output, expected)
+              end
+
+              it "generates correct types for serialized columns that are also encrypted" do
+                add_ruby_file("schema.rb", <<~RUBY)
+                  ActiveRecord::Migration.suppress_messages do
+                    ActiveRecord::Schema.define do
+                      create_table :posts do |t|
+                        t.text :secret_array
+                        t.text :secret_hash
+                      end
+                    end
+                  end
+                RUBY
+
+                add_ruby_file("post.rb", <<~RUBY)
+                  class Post < ActiveRecord::Base
+                    serialize :secret_array, type: Array, coder: JSON
+                    serialize :secret_hash, type: Hash, coder: JSON
+                    encrypts :secret_array
+                    encrypts :secret_hash
+                  end
+                RUBY
+
+                output = rbi_for(:Post)
+
+                expected = indented(<<~RBI, 4)
+                  sig { params(value: T.nilable(T::Array[T.untyped])).returns(T.nilable(T::Array[T.untyped])) }
+                  def secret_array=(value); end
+                RBI
+                assert_includes(output, expected)
+
+                expected = indented(<<~RBI, 4)
+                  sig { returns(T::Array[T.untyped]) }
+                  def secret_array; end
+                RBI
+                assert_includes(output, expected)
+
+                expected = indented(<<~RBI, 4)
+                  sig { params(value: T.nilable(T::Hash[T.untyped, T.untyped])).returns(T.nilable(T::Hash[T.untyped, T.untyped])) }
+                  def secret_hash=(value); end
+                RBI
+                assert_includes(output, expected)
+
+                expected = indented(<<~RBI, 4)
+                  sig { returns(T::Hash[T.untyped, T.untyped]) }
+                  def secret_hash; end
                 RBI
                 assert_includes(output, expected)
               end


### PR DESCRIPTION
## Summary

When an ActiveRecord column is both `serialize`d and `encrypts`ed:

```ruby
class MyModel < ApplicationRecord
  serialize :secret_hash, type: Hash, coder: JSON
  encrypts :secret_hash
end
```

the `ActiveRecordColumns` DSL compiler generated `::String` accessors instead of `T::Hash[T.untyped, T.untyped]`, leaking the encrypted-at-rest DB representation rather than the Ruby type users work with.

Two gaps combined to cause this (in `lib/tapioca/dsl/helpers/active_record_column_type_helper.rb`):

1. **Encryption branch never reached the serialized handling.** `encrypts` wraps the prior type in `ActiveRecord::Encryption::EncryptedAttributeType`, whose `cast_type` is the underlying `ActiveRecord::Type::Serialized`. The encryption branch reflected only on the outer type and hardcoded a `::String` fallback, ignoring `cast_type`. It now recurses into `cast_type` when reflection is inconclusive — routing serialized columns through the existing serialized handler while still resolving to `::String` for plain encrypted string/text columns.

2. **`serialized_column_type` only recognized the YAML coder.** A `type: Hash, coder: JSON` declaration produces an `ActiveRecord::Coders::ColumnSerializer` coder (which carries `object_class == Hash`), not a `YAMLColumn`. The coder match was generalized to `ColumnSerializer` (the superclass of `YAMLColumn`), so `type:` declarations made with non-YAML coders are honored — both with and without `encrypts`. Bare `coder: JSON` (no `type:`) still resolves to `T.untyped`.

`not_nilable_serialized_column?` now also unwraps the encryption layer so nullable encrypted-serialized columns get the same non-nilable getter as their non-encrypted counterparts.

Closes #2631.

## Test plan

- [x] `bin/test spec/tapioca/dsl/compilers/active_record_columns_spec.rb` — 27 tests pass, including a new "serialized columns that are also encrypted" test (Hash + Array variants) and an extended non-encrypted `type: Hash, coder: JSON` assertion
- [x] `bin/typecheck` — no errors
- [x] `bundle exec rubocop` on changed files — no offenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)