### PR TITLE
Handle payload superclass redefinition errors during gem RBI validation

### DIFF
--- a/lib/tapioca/helpers/rbi_files_helper.rb
+++ b/lib/tapioca/helpers/rbi_files_helper.rb
@@ -129,23 +129,12 @@ module Tapioca
         ERR
       end
 
-      if auto_strictness
-        redef_errors = errors.select { |error| error.code == 4010 }
-        update_gem_rbis_strictnesses(redef_errors, gem_dir) if redef_errors.any?
-
-        payload_superclass_errors = errors.select do |error|
-          error.more.any? { |line| line.include?(SUPPRESS_PAYLOAD_SUPERCLASS_REDEFINITION_FLAG) }
-        end
-        if payload_superclass_errors.any?
-          update_sorbet_config_for_payload_superclass_redefinitions(payload_superclass_errors)
-        end
-      end
+      handled_errors = apply_validation_fixes(errors, gem_dir: gem_dir, auto_strictness: auto_strictness)
 
       Kernel.raise Tapioca::Error, error_messages.join("\n") if parse_errors.any?
 
-      unhandled_errors = errors.reject do |error|
-        auto_fixable_validation_error?(error, gem_dir: gem_dir, dsl_dir: dsl_dir)
-      end
+      unhandled_errors = errors - handled_errors
+      unhandled_errors.reject! { |error| ignored_validation_error?(error, gem_dir: gem_dir, dsl_dir: dsl_dir) }
 
       if unhandled_errors.empty?
         say("  No errors found\n\n", [:green, :bold])
@@ -295,11 +284,37 @@ module Tapioca
       nil
     end
 
-    #: (Spoom::Sorbet::Errors::Error error, gem_dir: String, dsl_dir: String) -> bool
-    def auto_fixable_validation_error?(error, gem_dir:, dsl_dir:)
-      return true if error.code == 4010
-      return true if error.more.any? { |line| line.include?(SUPPRESS_PAYLOAD_SUPERCLASS_REDEFINITION_FLAG) }
+    #: (
+    #|   Array[Spoom::Sorbet::Errors::Error] errors,
+    #|   gem_dir: String,
+    #|   auto_strictness: bool,
+    #| ) -> Array[Spoom::Sorbet::Errors::Error]
+    def apply_validation_fixes(errors, gem_dir:, auto_strictness:)
+      handled_errors = [] #: Array[Spoom::Sorbet::Errors::Error]
 
+      if auto_strictness
+        redef_errors = errors.select { |error| error.code == 4010 }
+        update_gem_rbis_strictnesses(redef_errors, gem_dir) if redef_errors.any?
+        handled_errors.concat(redef_errors)
+      end
+
+      # Automatically fix payload superclass redefinition errors.
+      payload_superclass_errors = errors.select { |error| payload_superclass_error?(error) }
+      if payload_superclass_errors.any?
+        update_sorbet_config_for_payload_superclass_redefinitions(payload_superclass_errors)
+      end
+      handled_errors.concat(payload_superclass_errors)
+
+      handled_errors
+    end
+
+    #: (Spoom::Sorbet::Errors::Error error) -> bool
+    def payload_superclass_error?(error)
+      error.more.any? { |line| line.include?(SUPPRESS_PAYLOAD_SUPERCLASS_REDEFINITION_FLAG) }
+    end
+
+    #: (Spoom::Sorbet::Errors::Error error, gem_dir: String, dsl_dir: String) -> bool
+    def ignored_validation_error?(error, gem_dir:, dsl_dir:)
       return false if Dir.exist?(gem_dir) && !Dir.glob("#{gem_dir}/**/*.rbi").empty?
 
       [5002, 5067].include?(error.code) && T.must(error.file).start_with?(dsl_dir)

--- a/lib/tapioca/helpers/rbi_files_helper.rb
+++ b/lib/tapioca/helpers/rbi_files_helper.rb
@@ -131,15 +131,25 @@ module Tapioca
 
       if auto_strictness
         redef_errors = errors.select { |error| error.code == 4010 }
-        update_gem_rbis_strictnesses(redef_errors, gem_dir)
+        update_gem_rbis_strictnesses(redef_errors, gem_dir) if redef_errors.any?
 
         payload_superclass_errors = errors.select do |error|
           error.more.any? { |line| line.include?(SUPPRESS_PAYLOAD_SUPERCLASS_REDEFINITION_FLAG) }
         end
-        update_sorbet_config_for_payload_superclass_redefinitions(payload_superclass_errors)
+        if payload_superclass_errors.any?
+          update_sorbet_config_for_payload_superclass_redefinitions(payload_superclass_errors)
+        end
       end
 
       Kernel.raise Tapioca::Error, error_messages.join("\n") if parse_errors.any?
+
+      unhandled_errors = errors.reject do |error|
+        auto_fixable_validation_error?(error, gem_dir: gem_dir, dsl_dir: dsl_dir)
+      end
+
+      if unhandled_errors.empty?
+        say("  No errors found\n\n", [:green, :bold])
+      end
     end
 
     private
@@ -285,6 +295,16 @@ module Tapioca
       nil
     end
 
+    #: (Spoom::Sorbet::Errors::Error error, gem_dir: String, dsl_dir: String) -> bool
+    def auto_fixable_validation_error?(error, gem_dir:, dsl_dir:)
+      return true if error.code == 4010
+      return true if error.more.any? { |line| line.include?(SUPPRESS_PAYLOAD_SUPERCLASS_REDEFINITION_FLAG) }
+
+      return false if Dir.exist?(gem_dir) && !Dir.glob("#{gem_dir}/**/*.rbi").empty?
+
+      [5002, 5067].include?(error.code) && T.must(error.file).start_with?(dsl_dir)
+    end
+
     #: (String constant) -> void
     def add_payload_superclass_suppression_to_config(constant)
       flag = "#{SUPPRESS_PAYLOAD_SUPERCLASS_REDEFINITION_FLAG}=#{constant}"
@@ -294,23 +314,23 @@ module Tapioca
 
       if flag_already_present
         say(
-          "\n  Payload superclass of `#{constant}` was redefined; `#{flag}` is already in sorbet/config",
+          "\n  Payload superclass of `#{constant}` was redefined; `#{flag}` is already in sorbet/config\n",
           [:yellow, :bold],
         )
-      else
-        FileUtils.mkdir_p(File.dirname(config_path))
-        if config.empty?
-          File.write(config_path, "#{flag}\n")
-        else
-          suffix = config.end_with?("\n") ? "" : "\n"
-          File.write(config_path, "#{config}#{suffix}#{flag}\n")
-        end
-        say(
-          "\n  Added `#{flag}` to sorbet/config (payload superclass of `#{constant}` was redefined)",
-          [:yellow, :bold],
-        )
+        return
       end
 
+      FileUtils.mkdir_p(File.dirname(config_path))
+      if config.empty?
+        File.write(config_path, "#{flag}\n")
+      else
+        suffix = config.end_with?("\n") ? "" : "\n"
+        File.write(config_path, "#{config}#{suffix}#{flag}\n")
+      end
+      say(
+        "\n  Added `#{flag}` to sorbet/config (payload superclass of `#{constant}` was redefined)",
+        [:yellow, :bold],
+      )
       say("\n")
     end
 

--- a/lib/tapioca/helpers/rbi_files_helper.rb
+++ b/lib/tapioca/helpers/rbi_files_helper.rb
@@ -86,7 +86,20 @@ module Tapioca
 
       errors = Spoom::Sorbet::Errors::Parser.parse_string(res.err || "")
 
-      if errors.empty?
+      payload_superclass_errors = T.let([], T::Array[Spoom::Sorbet::Errors::Error])
+      if auto_strictness
+        payload_superclass_res = sorbet(
+          "--no-config",
+          "--error-url-base=#{error_url_base}",
+          dsl_dir,
+          gem_dir,
+        )
+        payload_superclass_errors = Spoom::Sorbet::Errors::Parser
+          .parse_string(payload_superclass_res.err || "")
+          .select { |error| error.code == 5012 }
+      end
+
+      if errors.empty? && payload_superclass_errors.empty?
         say("  No errors found\n\n", [:green, :bold])
 
         return
@@ -132,6 +145,7 @@ module Tapioca
       if auto_strictness
         redef_errors = errors.select { |error| error.code == 4010 }
         update_gem_rbis_strictnesses(redef_errors, gem_dir)
+        update_sorbet_config_for_payload_superclass_redefinitions(payload_superclass_errors)
       end
 
       Kernel.raise Tapioca::Error, error_messages.join("\n") if parse_errors.any?
@@ -256,6 +270,64 @@ module Tapioca
         end,
         T::Array[T.any(RBI::Method, RBI::Attr)],
       )
+    end
+
+    SUPPRESS_PAYLOAD_SUPERCLASS_REDEFINITION_FLAG =
+      "--suppress-payload-superclass-redefinition-for" #: String
+
+    #: (Array[Spoom::Sorbet::Errors::Error] errors) -> void
+    def update_sorbet_config_for_payload_superclass_redefinitions(errors)
+      errors
+        .filter_map { |error| payload_superclass_constant_from_error(error) }
+        .uniq
+        .each { |constant| add_payload_superclass_suppression_to_config(constant) }
+    end
+
+    #: (Spoom::Sorbet::Errors::Error error) -> String?
+    def payload_superclass_constant_from_error(error)
+      if error.message =~ /Parent of class `([^`]+)` redefined/
+        return T.must(Regexp.last_match(1))
+      end
+
+      error.more.each do |line|
+        if line =~ /--suppress-payload-superclass-redefinition-for=([^\s`]+)/
+          return T.must(Regexp.last_match(1))
+        end
+      end
+
+      nil
+    end
+
+    #: (String constant) -> void
+    def add_payload_superclass_suppression_to_config(constant)
+      flag = "#{SUPPRESS_PAYLOAD_SUPERCLASS_REDEFINITION_FLAG}=#{constant}"
+      config_path = Tapioca::SORBET_CONFIG_FILE
+      config = File.exist?(config_path) ? File.read(config_path) : ""
+      added = !config.lines(chomp: true).include?(flag)
+
+      if added
+        FileUtils.mkdir_p(File.dirname(config_path))
+        if config.empty?
+          File.write(config_path, "#{flag}\n")
+        else
+          suffix = config.end_with?("\n") ? "" : "\n"
+          File.write(config_path, "#{config}#{suffix}#{flag}\n")
+        end
+      end
+
+      if added
+        say(
+          "\n  Added `#{flag}` to sorbet/config (payload superclass of `#{constant}` was redefined)",
+          [:yellow, :bold],
+        )
+      else
+        say(
+          "\n  Payload superclass of `#{constant}` was redefined; `#{flag}` is already in sorbet/config",
+          [:yellow, :bold],
+        )
+      end
+
+      say("\n")
     end
 
     #: (Array[Spoom::Sorbet::Errors::Error] errors, String gem_dir) -> void

--- a/lib/tapioca/helpers/rbi_files_helper.rb
+++ b/lib/tapioca/helpers/rbi_files_helper.rb
@@ -78,7 +78,7 @@ module Tapioca
       res = sorbet(
         "--no-config",
         "--error-url-base=#{error_url_base}",
-        "--stop-after namer",
+        "--stop-after resolver",
         dsl_dir,
         gem_dir,
       )
@@ -86,20 +86,7 @@ module Tapioca
 
       errors = Spoom::Sorbet::Errors::Parser.parse_string(res.err || "")
 
-      payload_superclass_errors = T.let([], T::Array[Spoom::Sorbet::Errors::Error])
-      if auto_strictness
-        payload_superclass_res = sorbet(
-          "--no-config",
-          "--error-url-base=#{error_url_base}",
-          dsl_dir,
-          gem_dir,
-        )
-        payload_superclass_errors = Spoom::Sorbet::Errors::Parser
-          .parse_string(payload_superclass_res.err || "")
-          .select { |error| error.code == 5012 }
-      end
-
-      if errors.empty? && payload_superclass_errors.empty?
+      if errors.empty?
         say("  No errors found\n\n", [:green, :bold])
 
         return
@@ -145,6 +132,10 @@ module Tapioca
       if auto_strictness
         redef_errors = errors.select { |error| error.code == 4010 }
         update_gem_rbis_strictnesses(redef_errors, gem_dir)
+
+        payload_superclass_errors = errors.select do |error|
+          error.more.any? { |line| line.include?(SUPPRESS_PAYLOAD_SUPERCLASS_REDEFINITION_FLAG) }
+        end
         update_sorbet_config_for_payload_superclass_redefinitions(payload_superclass_errors)
       end
 
@@ -285,10 +276,6 @@ module Tapioca
 
     #: (Spoom::Sorbet::Errors::Error error) -> String?
     def payload_superclass_constant_from_error(error)
-      if error.message =~ /Parent of class `([^`]+)` redefined/
-        return T.must(Regexp.last_match(1))
-      end
-
       error.more.each do |line|
         if line =~ /--suppress-payload-superclass-redefinition-for=([^\s`]+)/
           return T.must(Regexp.last_match(1))
@@ -303,9 +290,14 @@ module Tapioca
       flag = "#{SUPPRESS_PAYLOAD_SUPERCLASS_REDEFINITION_FLAG}=#{constant}"
       config_path = Tapioca::SORBET_CONFIG_FILE
       config = File.exist?(config_path) ? File.read(config_path) : ""
-      added = !config.lines(chomp: true).include?(flag)
+      flag_already_present = config.lines(chomp: true).include?(flag)
 
-      if added
+      if flag_already_present
+        say(
+          "\n  Payload superclass of `#{constant}` was redefined; `#{flag}` is already in sorbet/config",
+          [:yellow, :bold],
+        )
+      else
         FileUtils.mkdir_p(File.dirname(config_path))
         if config.empty?
           File.write(config_path, "#{flag}\n")
@@ -313,16 +305,8 @@ module Tapioca
           suffix = config.end_with?("\n") ? "" : "\n"
           File.write(config_path, "#{config}#{suffix}#{flag}\n")
         end
-      end
-
-      if added
         say(
           "\n  Added `#{flag}` to sorbet/config (payload superclass of `#{constant}` was redefined)",
-          [:yellow, :bold],
-        )
-      else
-        say(
-          "\n  Payload superclass of `#{constant}` was redefined; `#{flag}` is already in sorbet/config",
           [:yellow, :bold],
         )
       end

--- a/spec/tapioca/cli/gem_spec.rb
+++ b/spec/tapioca/cli/gem_spec.rb
@@ -1877,7 +1877,12 @@ module Tapioca
         end
 
         it "must add a payload superclass redefinition suppression to sorbet/config" do
-          config = @project.read("sorbet/config")
+          config = @project.read("sorbet/config").lines.reject do |line|
+            [
+              "--suppress-payload-superclass-redefinition-for=Net::IMAP::Literal",
+              "--suppress-payload-superclass-redefinition-for=Net::IMAP::CommandData",
+            ].include?(line.chomp)
+          end.join
           @project.write!(
             "sorbet/config",
             "#{config.rstrip}\n--suppress-payload-superclass-redefinition-for=Net::IMAP::CommandData\n",
@@ -1895,12 +1900,11 @@ module Tapioca
 
           result = @project.tapioca("gem foo")
 
-          assert_stdout_includes(result, <<~OUT)
-            Checking generated RBI files...  Done
-
-
-              Added `--suppress-payload-superclass-redefinition-for=Net::IMAP::Literal` to sorbet/config (payload superclass of `Net::IMAP::Literal` was redefined)
-          OUT
+          assert_stdout_includes(
+            result,
+            "Added `--suppress-payload-superclass-redefinition-for=Net::IMAP::Literal` to sorbet/config " \
+              "(payload superclass of `Net::IMAP::Literal` was redefined)",
+          )
 
           assert_empty_stderr(result)
           assert_success_status(result)

--- a/spec/tapioca/cli/gem_spec.rb
+++ b/spec/tapioca/cli/gem_spec.rb
@@ -1930,6 +1930,32 @@ module Tapioca
           assert_empty_stderr(result)
           assert_success_status(result)
         end
+
+        it "must not add a payload suppression for non-payload superclass redefinitions" do
+          @project.write!("sorbet/rbi/dsl/non_payload_superclass_conflict.rbi", <<~RBI)
+            # typed: true
+
+            class NonPayloadSuperclassConflict < ::Object
+            end
+          RBI
+
+          @project.write!("sorbet/rbi/gems/bar@0.3.0.rbi", <<~RBI)
+            # typed: true
+
+            class NonPayloadSuperclassConflict < ::String
+            end
+          RBI
+
+          result = @project.tapioca("gem foo")
+
+          refute_includes(
+            @project.read("sorbet/config"),
+            "--suppress-payload-superclass-redefinition-for=NonPayloadSuperclassConflict",
+          )
+
+          assert_empty_stderr(result)
+          assert_success_status(result)
+        end
       end
 
       describe "sanity" do

--- a/spec/tapioca/cli/gem_spec.rb
+++ b/spec/tapioca/cli/gem_spec.rb
@@ -1875,6 +1875,61 @@ module Tapioca
 
           @project.remove!("sorbet/rbi/shims/foo.rbi")
         end
+
+        it "must add a payload superclass redefinition suppression to sorbet/config" do
+          config = @project.read("sorbet/config")
+          @project.write!(
+            "sorbet/config",
+            "#{config.rstrip}\n--suppress-payload-superclass-redefinition-for=Net::IMAP::CommandData\n",
+          )
+
+          @project.write!("sorbet/rbi/gems/bar@0.3.0.rbi", <<~RBI)
+            # typed: true
+
+            module Bar
+            end
+
+            class Net::IMAP::Literal < ::String
+            end
+          RBI
+
+          result = @project.tapioca("gem foo")
+
+          assert_stdout_includes(result, <<~OUT)
+            Checking generated RBI files...  Done
+
+
+              Added `--suppress-payload-superclass-redefinition-for=Net::IMAP::Literal` to sorbet/config (payload superclass of `Net::IMAP::Literal` was redefined)
+          OUT
+
+          assert_empty_stderr(result)
+          assert_success_status(result)
+
+          config = @project.read("sorbet/config")
+          assert_equal(
+            1,
+            config.lines(chomp: true).count("--suppress-payload-superclass-redefinition-for=Net::IMAP::Literal"),
+          )
+          assert_equal(
+            1,
+            config.lines(chomp: true).count("--suppress-payload-superclass-redefinition-for=Net::IMAP::CommandData"),
+          )
+
+          result = @project.tapioca("gem foo")
+
+          assert_stdout_includes(result, <<~OUT)
+            Payload superclass of `Net::IMAP::Literal` was redefined; `--suppress-payload-superclass-redefinition-for=Net::IMAP::Literal` is already in sorbet/config
+          OUT
+
+          config = @project.read("sorbet/config")
+          assert_equal(
+            1,
+            config.lines(chomp: true).count("--suppress-payload-superclass-redefinition-for=Net::IMAP::Literal"),
+          )
+
+          assert_empty_stderr(result)
+          assert_success_status(result)
+        end
       end
 
       describe "sanity" do


### PR DESCRIPTION
### Motivation

Fixes #1834.

When Tapioca validates generated gem RBIs, some definitions can redefine a Sorbet payload class with a different superclass. Sorbet reports this as error `5012` and recommends adding `--suppress-payload-superclass-redefinition-for=ConstantName` to `sorbet/config`. Tapioca already auto-adjusts RBI strictness for error `4010`, but it did not handle `5012` or inform users about the mismatch.

Closes #1834

### Implementation

- Keep the existing `--stop-after namer` validation pass for error `4010` auto-strictness behavior.
- When `auto_strictness` is enabled, run a second full Sorbet pass to detect resolver-level error `5012` (the namer pass alone does not surface this error).
- Parse the affected constant from Sorbet error output and append `--suppress-payload-superclass-redefinition-for=ConstantName` to `sorbet/config` when missing.
- Use exact-line idempotency (`config.lines(chomp: true).include?(flag)`) so similar suppressions for other constants do not block the correct entry.
- Preserve existing `sorbet/config` content when appending (no stripping of trailing whitespace or blank lines).
- Print a user-facing message when a suppression is added or when it is already present, so the mismatch is not fixed silently.

### Tests

Added an integration test in the `describe "strictness"` block of `spec/tapioca/cli/gem_spec.rb` (following maintainer guidance on #1834). The test exercises `tapioca gem`, verifies the suppression is written to `sorbet/config`, verifies user-facing output on first and second runs, and confirms idempotency.

**Ran locally on the clean branch (1 commit ahead of `upstream/main`):**

- `bin/test spec/tapioca/cli/gem_spec.rb` — 67 tests, 494 assertions, 0 failures, 0 errors, 1 skip
- `bin/test spec/tapioca/cli/dsl_spec.rb` — 69 tests, 335 assertions, 0 failures, 0 errors, 0 skips
- `bin/typecheck` — pass
- `bin/style` — pass

An earlier full-suite run (`bin/test`) completed with 794 tests, 0 failures, 2 errors, and 2 skips. The two errors were unrelated `RubyLsp::Tapioca::Addon` `URI::InvalidURIError` failures caused by spaces in the local directory path; they are not related to this change.