### PR TITLE
Remove `NilClass` parameters from AR fixture methods

### DIFF
--- a/lib/tapioca/dsl/compilers/active_record_fixtures.rb
+++ b/lib/tapioca/dsl/compilers/active_record_fixtures.rb
@@ -26,10 +26,10 @@ module Tapioca
       # # test_case.rbi
       # # typed: true
       # class ActiveSupport::TestCase
-      #   sig { params(fixture_name: NilClass, other_fixtures: NilClass).returns(T::Array[Post]) }
-      #   sig { params(fixture_name: T.any(String, Symbol), other_fixtures: NilClass).returns(Post) }
-      #   sig { params(fixture_name: T.any(String, Symbol), other_fixtures: T.any(String, Symbol))
-      #           .returns(T::Array[Post]) }
+      #   sig { returns(T::Array[Post]) }                                                          #   No names: returns an Array of all fixtures
+      #   sig { params(fixture_name: T.any(String, Symbol)).returns(Post) }                        #   One name: returns the requested fixture
+      #   sig { params(fixture_name: T.any(String, Symbol), other_fixtures: T.any(String, Symbol)) # Many names: returns an Array of the requested fixtures
+      #   .returns(T::Array[Post]) }
       #   def posts(fixture_name = nil, *other_fixtures); end
       # end
       # ~~~
@@ -110,19 +110,16 @@ module Tapioca
             node.add_opt_param("fixture_name", "nil")
             node.add_rest_param("other_fixtures")
 
-            node.add_sig do |sig|
-              sig.add_param("fixture_name", "NilClass")
-              sig.add_param("other_fixtures", "NilClass")
+            node.add_sig do |sig| # No-parameter overload: returns an Array of all fixtures
               sig.return_type = "T::Array[#{return_type}]"
             end
 
-            node.add_sig do |sig|
+            node.add_sig do |sig| # One parameter overload: returns the requested fixture
               sig.add_param("fixture_name", "T.any(String, Symbol)")
-              sig.add_param("other_fixtures", "NilClass")
               sig.return_type = return_type
             end
 
-            node.add_sig do |sig|
+            node.add_sig do |sig| # Multi-parameter overload: returns an Array of the requested fixtures
               sig.add_param("fixture_name", "T.any(String, Symbol)")
               sig.add_param("other_fixtures", "T.any(String, Symbol)")
               sig.return_type = "T::Array[#{return_type}]"

--- a/manual/compiler_activerecordfixtures.md
+++ b/manual/compiler_activerecordfixtures.md
@@ -18,10 +18,10 @@ The generated RBI by this compiler will produce the following
 # test_case.rbi
 # typed: true
 class ActiveSupport::TestCase
-  sig { params(fixture_name: NilClass, other_fixtures: NilClass).returns(T::Array[Post]) }
-  sig { params(fixture_name: T.any(String, Symbol), other_fixtures: NilClass).returns(Post) }
-  sig { params(fixture_name: T.any(String, Symbol), other_fixtures: T.any(String, Symbol))
-          .returns(T::Array[Post]) }
+  sig { returns(T::Array[Post]) }                                                          #   No names: returns an Array of all fixtures
+  sig { params(fixture_name: T.any(String, Symbol)).returns(Post) }                        #   One name: returns the requested fixture
+  sig { params(fixture_name: T.any(String, Symbol), other_fixtures: T.any(String, Symbol)) # Many names: returns an Array of the requested fixtures
+  .returns(T::Array[Post]) }
   def posts(fixture_name = nil, *other_fixtures); end
 end
 ~~~

--- a/spec/tapioca/dsl/compilers/active_record_fixtures_spec.rb
+++ b/spec/tapioca/dsl/compilers/active_record_fixtures_spec.rb
@@ -79,8 +79,8 @@ module Tapioca
                 # typed: strong
 
                 class ActiveSupport::TestCase
-                  sig { params(fixture_name: NilClass, other_fixtures: NilClass).returns(T::Array[Post]) }
-                  sig { params(fixture_name: T.any(String, Symbol), other_fixtures: NilClass).returns(Post) }
+                  sig { returns(T::Array[Post]) }
+                  sig { params(fixture_name: T.any(String, Symbol)).returns(Post) }
                   sig { params(fixture_name: T.any(String, Symbol), other_fixtures: T.any(String, Symbol)).returns(T::Array[Post]) }
                   def posts(fixture_name = nil, *other_fixtures); end
                 end
@@ -107,8 +107,8 @@ module Tapioca
                 # typed: strong
 
                 class ActiveSupport::TestCase
-                  sig { params(fixture_name: NilClass, other_fixtures: NilClass).returns(T::Array[Post]) }
-                  sig { params(fixture_name: T.any(String, Symbol), other_fixtures: NilClass).returns(Post) }
+                  sig { returns(T::Array[Post]) }
+                  sig { params(fixture_name: T.any(String, Symbol)).returns(Post) }
                   sig { params(fixture_name: T.any(String, Symbol), other_fixtures: T.any(String, Symbol)).returns(T::Array[Post]) }
                   def posts(fixture_name = nil, *other_fixtures); end
                 end
@@ -146,13 +146,13 @@ module Tapioca
                 # typed: strong
 
                 class ActiveSupport::TestCase
-                  sig { params(fixture_name: NilClass, other_fixtures: NilClass).returns(T::Array[Blog::Post]) }
-                  sig { params(fixture_name: T.any(String, Symbol), other_fixtures: NilClass).returns(Blog::Post) }
+                  sig { returns(T::Array[Blog::Post]) }
+                  sig { params(fixture_name: T.any(String, Symbol)).returns(Blog::Post) }
                   sig { params(fixture_name: T.any(String, Symbol), other_fixtures: T.any(String, Symbol)).returns(T::Array[Blog::Post]) }
                   def blog_posts(fixture_name = nil, *other_fixtures); end
 
-                  sig { params(fixture_name: NilClass, other_fixtures: NilClass).returns(T::Array[User]) }
-                  sig { params(fixture_name: T.any(String, Symbol), other_fixtures: NilClass).returns(User) }
+                  sig { returns(T::Array[User]) }
+                  sig { params(fixture_name: T.any(String, Symbol)).returns(User) }
                   sig { params(fixture_name: T.any(String, Symbol), other_fixtures: T.any(String, Symbol)).returns(T::Array[User]) }
                   def users(fixture_name = nil, *other_fixtures); end
                 end
@@ -181,8 +181,8 @@ module Tapioca
                 # typed: strong
 
                 class ActiveSupport::TestCase
-                  sig { params(fixture_name: NilClass, other_fixtures: NilClass).returns(T::Array[Post]) }
-                  sig { params(fixture_name: T.any(String, Symbol), other_fixtures: NilClass).returns(Post) }
+                  sig { returns(T::Array[Post]) }
+                  sig { params(fixture_name: T.any(String, Symbol)).returns(Post) }
                   sig { params(fixture_name: T.any(String, Symbol), other_fixtures: T.any(String, Symbol)).returns(T::Array[Post]) }
                   def posts_with_other_names(fixture_name = nil, *other_fixtures); end
                 end
@@ -204,8 +204,8 @@ module Tapioca
                 # typed: strong
 
                 class ActiveSupport::TestCase
-                  sig { params(fixture_name: NilClass, other_fixtures: NilClass).returns(T::Array[T.untyped]) }
-                  sig { params(fixture_name: T.any(String, Symbol), other_fixtures: NilClass).returns(T.untyped) }
+                  sig { returns(T::Array[T.untyped]) }
+                  sig { params(fixture_name: T.any(String, Symbol)).returns(T.untyped) }
                   sig { params(fixture_name: T.any(String, Symbol), other_fixtures: T.any(String, Symbol)).returns(T::Array[T.untyped]) }
                   def posts(fixture_name = nil, *other_fixtures); end
                 end


### PR DESCRIPTION
### Motivation

Fixture methods have 3 overloads to describe the different ways they can be called. Their current shape incorrectly allows to nils to be passed, like:

```ruby
users(nil)
users(:alice, nil)
users(:alice, nil, nil)
```

This PR fixes these annotations to not allow such `nil`s, which has the pleasant side-effect of making them much simpler.

See also #1871, #1895

### Implementation

Uses the same approach I used to describe [`Module#private`](https://github.com/Shopify/sorbet/blob/2ad6c31376029ba05cd96a35454fc824d1225e5c/rbi/core/module.rbi#L1374-L1378) (https://github.com/sorbet/sorbet/pull/10239).

### Tests

Updated.

Validated against Shopify Core. Type-checking fails, but for a great reason: there's a few of new errors like:

> `T.cast` is useless because `Foo` is already a subtype of `Foo`