### PR TITLE
Fix double-wrapped array type for list arguments with a typed prepare method

### DIFF
--- a/lib/tapioca/dsl/helpers/graphql_type_helper.rb
+++ b/lib/tapioca/dsl/helpers/graphql_type_helper.rb
@@ -91,15 +91,20 @@ module Tapioca
             "T.untyped"
           end
 
+          prepared = false
           if prepare_method
             prepare_signature = Runtime::Reflection.signature_of(prepare_method)
             prepare_return_type = prepare_signature&.return_type
             if valid_return_type?(prepare_return_type)
               parsed_type = prepare_return_type&.to_s
+              prepared = true
             end
           end
 
-          if type.list?
+          # A `prepare` method receives (and returns) the argument's fully coerced value, list
+          # wrapper included, so its return type already accounts for `type.list?` and must not be
+          # wrapped again.
+          if type.list? && !prepared
             parsed_type = "T::Array[#{parsed_type}]"
           end
 

--- a/spec/tapioca/dsl/compilers/graphql_input_object_spec.rb
+++ b/spec/tapioca/dsl/compilers/graphql_input_object_spec.rb
@@ -111,6 +111,39 @@ module Tapioca
               assert_equal(expected, rbi_for(:CreateCommentInput))
             end
 
+            it "generates correct RBI for a list argument with a prepare method returning the same list type" do
+              add_ruby_file("create_comment_input.rb", <<~RUBY)
+                class CreateCommentInput < GraphQL::Schema::InputObject
+                  extend T::Sig
+
+                  class << self
+                    extend T::Sig
+                    sig { params(tags: T::Array[String], _context: T.untyped).returns(T::Array[String]) }
+                    def prepare_tags(tags, _context)
+                      tags.map(&:downcase)
+                    end
+                  end
+
+                  argument :tags, [String], "Tags for the comment", prepare: :prepare_tags, required: true
+
+                  def resolve(tags:)
+                    # ...
+                  end
+                end
+              RUBY
+
+              expected = <<~RBI
+                # typed: strong
+
+                class CreateCommentInput
+                  sig { returns(T::Array[::String]) }
+                  def tags; end
+                end
+              RBI
+
+              assert_equal(expected, rbi_for(:CreateCommentInput))
+            end
+
             it "doesn't fail when input object is anonymous" do
               add_ruby_file("create_comment_input.rb", <<~RUBY)
                 class CreateCommentInput < GraphQL::Schema::InputObject

--- a/spec/tapioca/dsl/compilers/graphql_mutation_spec.rb
+++ b/spec/tapioca/dsl/compilers/graphql_mutation_spec.rb
@@ -224,6 +224,77 @@ module Tapioca
               assert_equal(expected, rbi_for(:CreateComment))
             end
 
+            it "generates correct RBI for a list argument with a prepare method returning the same list type" do
+              add_ruby_file("create_comment.rb", <<~RUBY)
+                class CreateComment < GraphQL::Schema::Mutation
+                  extend T::Sig
+
+                  class << self
+                    extend T::Sig
+                    sig { params(tags: T::Array[String], _context: T.untyped).returns(T::Array[String]) }
+                    def prepare_tags(tags, _context)
+                      tags.map(&:downcase)
+                    end
+                  end
+
+                  argument :tags, [String], "Tags for the comment", prepare: :prepare_tags
+
+                  def resolve(tags:)
+                    # ...
+                  end
+                end
+              RUBY
+
+              expected = <<~RBI
+                # typed: strong
+
+                class CreateComment
+                  sig { params(tags: T::Array[::String]).returns(T.untyped) }
+                  def resolve(tags:); end
+                end
+              RBI
+
+              assert_equal(expected, rbi_for(:CreateComment))
+            end
+
+            it "generates correct RBI for a list argument with a prepare method that has no valid return type" do
+              add_ruby_file("create_comment.rb", <<~RUBY)
+                class CreateComment < GraphQL::Schema::Mutation
+                  extend T::Sig
+
+                  class << self
+                    extend T::Sig
+                    sig { params(tags: T::Array[String], _context: T.untyped).void }
+                    def prepare_tags_void(tags, _context)
+                      tags.map(&:downcase)
+                    end
+
+                    def prepare_tags_untyped(tags, _context)
+                      tags.map(&:downcase)
+                    end
+                  end
+
+                  argument :tags, [String], "Tags for the comment", prepare: :prepare_tags_void
+                  argument :other_tags, [String], "Other tags for the comment", prepare: :prepare_tags_untyped
+
+                  def resolve(tags:, other_tags:)
+                    # ...
+                  end
+                end
+              RUBY
+
+              expected = <<~RBI
+                # typed: strong
+
+                class CreateComment
+                  sig { params(tags: T::Array[::String], other_tags: T::Array[::String]).returns(T.untyped) }
+                  def resolve(tags:, other_tags:); end
+                end
+              RBI
+
+              assert_equal(expected, rbi_for(:CreateComment))
+            end
+
             it "generates correct RBI arguments with a prepare method on the argument class" do
               add_ruby_file("create_comment.rb", <<~RUBY)
                 class CommentInput < GraphQL::Schema::InputObject


### PR DESCRIPTION
## Motivation

`Tapioca::Dsl::Compilers::GraphqlMutation` (and `GraphqlInputObject`, which shares the same `GraphqlTypeHelper.type_for` helper) generate an incorrect, doubly-nested array type for a list-typed GraphQL argument whose `prepare:` method has a Sorbet sig.

Given:

```ruby
class CreateComment < GraphQL::Schema::Mutation
  extend T::Sig

  class << self
    extend T::Sig
    sig { params(tags: T::Array[String], _context: T.untyped).returns(T::Array[String]) }
    def prepare_tags(tags, _context)
      tags.map(&:downcase)
    end
  end

  argument :tags, [String], "Tags for the comment", prepare: :prepare_tags

  def resolve(tags:)
    # ...
  end
end
```

Tapioca currently generates:

```ruby
sig { params(tags: T::Array[T::Array[::String]]).returns(T.untyped) }
```

instead of the correct:

```ruby
sig { params(tags: T::Array[::String]).returns(T.untyped) }
```

## Root cause

In `GraphqlTypeHelper#type_for`, when a `prepare_method` has a valid sig, its return type unconditionally replaces `parsed_type`:

```ruby
if prepare_method
  ...
  if valid_return_type?(prepare_return_type)
    parsed_type = prepare_return_type&.to_s
  end
end

if type.list?
  parsed_type = "T::Array[#{parsed_type}]"
end
```

A GraphQL `prepare` method receives (and returns) the argument's fully coerced value — including the list wrapper, when the argument type is a list. So when a prepare method's sig return type is used as `parsed_type`, it already reflects the full (possibly list) shape of the final value. The subsequent `if type.list?` block wraps it in `T::Array[...]` again, double-nesting it.

This bug forces users to strip Sorbet sigs from otherwise well-typed `prepare` methods just to get a correct RBI, which was the workaround applied in the wild that led me to find this (see [Gusto/zenpayroll#356117](https://github.com/Gusto/zenpayroll/pull/356117)).

## Fix

Track whether `parsed_type` came from a `prepare_method`'s return type, and skip the extra list-wrap in that case, since the prepare method's return type is already final.

## Test plan

- Added regression tests to `graphql_mutation_spec.rb`:
  - a list argument with a `prepare:` method whose sig returns the same list type (exercises the double-wrap bug directly)
  - a list argument with a `prepare:` method that has no valid return type (void/untyped), confirming the existing fallback list-wrap behavior is untouched by the fix
- Added a regression test to `graphql_input_object_spec.rb` for a list argument with a `prepare:` method whose sig returns the same list type, since `GraphqlInputObject` shares the same `GraphqlTypeHelper.type_for` code path but previously had no `prepare:` coverage
- Ran the full `graphql_mutation_spec.rb` and `graphql_input_object_spec.rb` suites — all pass (24 tests, 74 assertions)
- Verified against the real-world case that surfaced this (a GraphQL mutation argument with a list-typed input object argument and a `prepare:` method with a matching `T::Array[...]` return sig) — regenerated RBI now produces `T::Array[X]` instead of `T::Array[T::Array[X]]`, and downstream `srb tc` passes.
