### PR TITLE
Fix generic type validation for T::Props and composite members

### DIFF
--- a/lib/tapioca/runtime/generic_type_registry.rb
+++ b/lib/tapioca/runtime/generic_type_registry.rb
@@ -25,10 +25,9 @@ module Tapioca
 
       @type_variables = {}.compare_by_identity #: Hash[Module[top], Array[TypeVariableModule]]
 
-      # Subclasses `T::Types::Base`, not `T::Types::Simple`: `Simple` fast paths
-      # (e.g. `T::Props::Private::SetterFactory`) check `raw_type` directly, but our
-      # `raw_type` is the clone, so they reject instances of the underlying constant.
-      # `Base` routes all validation through the `valid?` override below.
+      # Subclasses `T::Types::Base` rather than `T::Types::Simple` so that all
+      # validation goes through the `valid?` override below. `Simple` fast paths
+      # check `raw_type` directly, which for us is the clone, not the underlying type.
       class GenericType < T::Types::Base
         #: Module[top]
         attr_reader :raw_type

--- a/lib/tapioca/runtime/generic_type_registry.rb
+++ b/lib/tapioca/runtime/generic_type_registry.rb
@@ -25,12 +25,10 @@ module Tapioca
 
       @type_variables = {}.compare_by_identity #: Hash[Module[top], Array[TypeVariableModule]]
 
-      # Subclasses `T::Types::Base` rather than `T::Types::Simple` on purpose. Our
-      # `raw_type` is the generic *clone*, not the underlying constant, so the
-      # `obj.is_a?(raw_type)` checks that `Simple` and its `is_a?(Simple)` fast paths
-      # (e.g. `T::Props::Private::SetterFactory`) perform against `raw_type` would
-      # reject instances of the underlying constant. `Base` routes all validation
-      # through our `valid?` override instead.
+      # Subclasses `T::Types::Base`, not `T::Types::Simple`: `Simple` fast paths
+      # (e.g. `T::Props::Private::SetterFactory`) check `raw_type` directly, but our
+      # `raw_type` is the clone, so they reject instances of the underlying constant.
+      # `Base` routes all validation through the `valid?` override below.
       class GenericType < T::Types::Base
         #: Module[top]
         attr_reader :raw_type
@@ -61,9 +59,7 @@ module Tapioca
           nil
         end
 
-        # We are not implementing a runtime type checker, so it is enough for
-        # covariance/contravariance checks to pass, matching the always-true `<=`
-        # we define on the generic clone in `create_generic_type`.
+        # Matches the always-true `<=` we define on the clone in `create_generic_type`.
         #: (T::Types::Base type) -> bool
         private def subtype_of_single?(type)
           true

--- a/lib/tapioca/runtime/generic_type_registry.rb
+++ b/lib/tapioca/runtime/generic_type_registry.rb
@@ -38,6 +38,15 @@ module Tapioca
         def valid?(obj)
           obj.is_a?(@underlying_type)
         end
+
+        # `T::Types::Base#recursively_valid?` checks the clone `raw_type` instead of
+        # routing through `valid?`, so delegate to keep composite (`T.all`, `T::Hash`)
+        # and `T::Props` member validation consistent with the `valid?` override above.
+        # @override
+        #: (untyped obj) -> bool
+        def recursively_valid?(obj)
+          valid?(obj)
+        end
       end
 
       class << self

--- a/lib/tapioca/runtime/generic_type_registry.rb
+++ b/lib/tapioca/runtime/generic_type_registry.rb
@@ -25,11 +25,21 @@ module Tapioca
 
       @type_variables = {}.compare_by_identity #: Hash[Module[top], Array[TypeVariableModule]]
 
-      class GenericType < T::Types::Simple
+      # Subclasses `T::Types::Base` rather than `T::Types::Simple` on purpose. Our
+      # `raw_type` is the generic *clone*, not the underlying constant, so the
+      # `obj.is_a?(raw_type)` checks that `Simple` and its `is_a?(Simple)` fast paths
+      # (e.g. `T::Props::Private::SetterFactory`) perform against `raw_type` would
+      # reject instances of the underlying constant. `Base` routes all validation
+      # through our `valid?` override instead.
+      class GenericType < T::Types::Base
+        #: Module[top]
+        attr_reader :raw_type
+
         #: (Module[top] raw_type, Module[top] underlying_type) -> void
         def initialize(raw_type, underlying_type)
-          super(raw_type)
+          super()
 
+          @raw_type = raw_type
           @underlying_type = underlying_type #: Module[top]
         end
 
@@ -39,13 +49,24 @@ module Tapioca
           obj.is_a?(@underlying_type)
         end
 
-        # `T::Types::Base#recursively_valid?` checks the clone `raw_type` instead of
-        # routing through `valid?`, so delegate to keep composite (`T.all`, `T::Hash`)
-        # and `T::Props` member validation consistent with the `valid?` override above.
         # @override
-        #: (untyped obj) -> bool
-        def recursively_valid?(obj)
-          valid?(obj)
+        #: -> String
+        def name
+          T.must(@raw_type.name)
+        end
+
+        # @override
+        #: -> nil
+        def build_type
+          nil
+        end
+
+        # We are not implementing a runtime type checker, so it is enough for
+        # covariance/contravariance checks to pass, matching the always-true `<=`
+        # we define on the generic clone in `create_generic_type`.
+        #: (T::Types::Base type) -> bool
+        private def subtype_of_single?(type)
+          true
         end
       end
 

--- a/spec/tapioca/runtime/generic_type_registry_spec.rb
+++ b/spec/tapioca/runtime/generic_type_registry_spec.rb
@@ -62,6 +62,19 @@ module Tapioca
             T.let(SampleGenericInterfaceImplementation.new, SampleGenericInterface[Object])
           end
 
+          it "recognizes underlying-type instances via recursively_valid? in composite/T::Props members (issue #2130)" do
+            struct_class = T.let(
+              Class.new(T::Struct) do
+                const :members, T::Hash[Symbol, SampleGenericInterface[Object]]
+              end,
+              T.untyped,
+            )
+
+            instance = struct_class.new(members: { key: SampleGenericInterfaceImplementation.new })
+
+            assert_instance_of(SampleGenericInterfaceImplementation, instance.members.fetch(:key))
+          end
+
           it "does not reuse generic instances for redefined constants with the same name" do
             first_constant, first_generic_type = register_reloadable_generic
 

--- a/spec/tapioca/runtime/generic_type_registry_spec.rb
+++ b/spec/tapioca/runtime/generic_type_registry_spec.rb
@@ -62,7 +62,7 @@ module Tapioca
             T.let(SampleGenericInterfaceImplementation.new, SampleGenericInterface[Object])
           end
 
-          it "recognizes underlying-type instances via recursively_valid? in composite/T::Props members (issue #2130)" do
+          it "recognizes underlying-type instances in a composite T::Props member (issue #2130)" do
             struct_class = T.let(
               Class.new(T::Struct) do
                 const :members, T::Hash[Symbol, SampleGenericInterface[Object]]
@@ -76,9 +76,7 @@ module Tapioca
           end
 
           it "recognizes underlying-type instances in a bare T::Props member (issue #2130)" do
-            # `T::Props::Private::SetterFactory` takes a `T::Types::Simple` fast path
-            # that reads `raw_type` directly and bypasses `valid?`/`recursively_valid?`.
-            # A bare generic member (not nested in a composite) exercises that path.
+            # A bare (non-composite) member exercises the `T::Types::Simple` setter fast path.
             struct_class = T.let(
               Class.new(T::Struct) do
                 const :member, SampleGenericInterface[Object]

--- a/spec/tapioca/runtime/generic_type_registry_spec.rb
+++ b/spec/tapioca/runtime/generic_type_registry_spec.rb
@@ -75,6 +75,22 @@ module Tapioca
             assert_instance_of(SampleGenericInterfaceImplementation, instance.members.fetch(:key))
           end
 
+          it "recognizes underlying-type instances in a bare T::Props member (issue #2130)" do
+            # `T::Props::Private::SetterFactory` takes a `T::Types::Simple` fast path
+            # that reads `raw_type` directly and bypasses `valid?`/`recursively_valid?`.
+            # A bare generic member (not nested in a composite) exercises that path.
+            struct_class = T.let(
+              Class.new(T::Struct) do
+                const :member, SampleGenericInterface[Object]
+              end,
+              T.untyped,
+            )
+
+            instance = struct_class.new(member: SampleGenericInterfaceImplementation.new)
+
+            assert_instance_of(SampleGenericInterfaceImplementation, instance.member)
+          end
+
           it "does not reuse generic instances for redefined constants with the same name" do
             first_constant, first_generic_type = register_reloadable_generic
 


### PR DESCRIPTION
### Motivation

Fixes #2130.

When a constant is typed with a Tapioca generic type (e.g. a generic interface `Foo[Bar]`) as a `T::Props`/`T::Struct` member, instantiating or setting that member raises a spurious `TypeError`, even though the value is an instance of the underlying constant. This happens whether the member is typed with the generic directly (`const :x, Foo[Bar]`) or nested inside a composite type (`T::Hash[..., Foo[Bar]]`, `T.all(Foo[Bar], ...)`), and it blocks `bin/tapioca dsl` from loading applications that use generic types in prop/struct members.

### Implementation

`GenericTypeRegistry::GenericType` overrides `valid?` to validate against the underlying constant (`@underlying_type`) instead of the generic *clone* it wraps as `raw_type`. Previously it subclassed `T::Types::Simple`, but `Simple` validates with `obj.is_a?(raw_type)` and `sorbet-runtime` has fast paths keyed on `is_a?(T::Types::Simple)` that read `raw_type` directly and bypass `valid?`/`recursively_valid?` entirely:

- `T::Props::Private::SetterFactory` uses `simple_non_nil_proc`/`simple_nilable_proc` for `Simple` types, checking `val.is_a?(raw_type)` inline. This is what a bare `const :x, Foo[Bar]` (or `T.nilable(Foo[Bar])`) member hits.
- `T.nilable` union construction takes a `SimplePairUnion` fast path for `Simple` members.

Because `raw_type` is the clone rather than the underlying constant, every one of these rejects a valid instance. Subclassing `T::Types::Base` instead removes all of those fast paths, so all validation routes through the `valid?` override. `Base` is more minimal than `Simple`, so the pieces it does not provide are added: `name`, `build_type`, and `subtype_of_single?` (which returns `true`, matching the always-true `<=` we already define on the clone in `create_generic_type`).

This complements #2657, which fixed the `T.let`/`T.cast` coercion path but did not cover the setter/composite validation paths.

### Tests

Added tests to `spec/tapioca/runtime/generic_type_registry_spec.rb` covering both a bare `T::Struct` member (`const :member, SampleGenericInterface[Object]`) and a composite member (`T::Hash[Symbol, SampleGenericInterface[Object]]`), each constructed with an implementation instance. Both fail with a `TypeError` before this change and pass after.
