### PR TITLE
Drop support for EOL Ruby 3.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,12 +41,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.2", "3.3", "3.4", "4.0","head"]
+        ruby: ["3.3", "3.4", "4.0","head"]
         rails: ["8.0", "current", "main"]
         rubygems: ["4.0.10"]
-        exclude:
-          - ruby: "3.2"
-            rails: "main"
         include:
           - rails: "main"
             experimental: true

--- a/tapioca.gemspec
+++ b/tapioca.gemspec
@@ -40,5 +40,5 @@ Gem::Specification.new do |spec|
   # https://github.com/ruby/rbs/pull/2601
   spec.add_dependency("tsort") # Until rbs supports Ruby 4.0 with tsort extracted to bundled gems
 
-  spec.required_ruby_version = ">= 3.2"
+  spec.required_ruby_version = ">= 3.3"
 end


### PR DESCRIPTION

### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
Also unblocks the `rbi` bump https://github.com/Shopify/tapioca/pull/2682
### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->

### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->

