### PR TITLE
Preserve anonymous parameters in generated RBIs

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,7 +19,7 @@ PATH
       bundler (>= 2.2.25)
       netrc (>= 0.11.0)
       parallel (>= 1.21.0)
-      rbi (>= 0.3.7)
+      rbi (>= 0.4.1)
       require-hooks (>= 0.2.2)
       rubydex (>= 0.1.0.beta10)
       sorbet-static-and-runtime (>= 0.6.12698)
@@ -307,7 +307,7 @@ GEM
       zeitwerk (~> 2.6)
     rainbow (3.1.1)
     rake (13.4.2)
-    rbi (0.4.0)
+    rbi (0.4.1)
       prism (~> 1.0)
       rbs (>= 4.0.1)
     rbs (4.1.0)
@@ -582,7 +582,7 @@ CHECKSUMS
   railties (8.1.3) sha256=913eb0e0cb520aac687ffd74916bd726d48fa21f47833c6292576ef6a286de22
   rainbow (3.1.1) sha256=039491aa3a89f42efa1d6dec2fc4e62ede96eb6acd95e52f1ad581182b79bc6a
   rake (13.4.2) sha256=cb825b2bd5f1f8e91ca37bddb4b9aaf345551b4731da62949be002fa89283701
-  rbi (0.4.0) sha256=cb54fe8ba39c113e7c8ce93b411d2681cf9c67d95c2da779906d61d6ecb902d3
+  rbi (0.4.1) sha256=66611ca331b0b47d98607a7afda12ab44e0a98297d5393d4b93b846b9786d44d
   rbs (4.1.0) sha256=8baba59008b0643b4ba2090e9b1d0149655b0bbd42eb2ffe42b1d0eb6923fd72
   rdoc (7.2.0) sha256=8650f76cd4009c3b54955eb5d7e3a075c60a57276766ebf36f9085e8c9f23192
   redis (5.4.0) sha256=798900d869418a9fc3977f916578375b45c38247a556b61d58cba6bb02f7d06b

--- a/lib/tapioca/dsl/compiler.rb
+++ b/lib/tapioca/dsl/compiler.rb
@@ -163,25 +163,27 @@ module Tapioca
         parameters.each_with_index.map do |(type, name), index|
           fallback_arg_name = "_arg#{index}"
 
-          name = name ? name.to_s : fallback_arg_name
-          name = fallback_arg_name unless valid_parameter_name?(name)
+          sig_name = name ? name.to_s : fallback_arg_name
+          is_anonymous_parameter = anonymous_parameter_name?(type, sig_name)
+          sig_name = fallback_arg_name unless is_anonymous_parameter || valid_parameter_name?(sig_name)
+          param_name = is_anonymous_parameter ? nil : sig_name
           method_type = T.must(method_types[index])
 
           case type
           when :req
-            create_param(name, type: method_type)
+            create_param(sig_name, type: method_type)
           when :opt
-            create_opt_param(name, type: method_type, default: "T.unsafe(nil)")
+            create_opt_param(sig_name, type: method_type, default: "T.unsafe(nil)")
           when :rest
-            create_rest_param(name, type: method_type)
+            create_rest_param(param_name, type: method_type)
           when :keyreq
-            create_kw_param(name, type: method_type)
+            create_kw_param(sig_name, type: method_type)
           when :key
-            create_kw_opt_param(name, type: method_type, default: "T.unsafe(nil)")
+            create_kw_opt_param(sig_name, type: method_type, default: "T.unsafe(nil)")
           when :keyrest
-            create_kw_rest_param(name, type: method_type)
+            create_kw_rest_param(param_name, type: method_type)
           when :block
-            create_block_param(name, type: method_type)
+            create_block_param(param_name, type: method_type)
           else
             raise "Unknown type `#{type}`."
           end

--- a/lib/tapioca/gem/listeners/methods.rb
+++ b/lib/tapioca/gem/listeners/methods.rb
@@ -126,10 +126,13 @@ module Tapioca
               end
             end
 
-            # Sanitize param names
-            name = fallback_arg_name unless valid_parameter_name?(name)
+            # Sanitize param names, except for anonymous splat, keyword splat,
+            # and block parameters. Ruby reflects those as `:*`, `:**`, and `:&`,
+            # and Sorbet signatures use the same names to store their types.
+            anonymous_parameter = anonymous_parameter_name?(type, name)
+            name = fallback_arg_name unless anonymous_parameter || valid_parameter_name?(name)
 
-            [type, name]
+            [type, name, anonymous_parameter]
           end
 
           rbi_method = RBI::Method.new(
@@ -138,26 +141,27 @@ module Tapioca
             visibility: visibility,
           )
 
-          sanitized_parameters.each do |type, name|
+          sanitized_parameters.each do |type, name, anonymous_parameter|
             case type
             when :req
               rbi_method << RBI::ReqParam.new(name)
             when :opt
               rbi_method << RBI::OptParam.new(name, "T.unsafe(nil)")
             when :rest
-              rbi_method << RBI::RestParam.new(name)
+              rbi_method << RBI::RestParam.new(anonymous_parameter ? nil : name)
             when :keyreq
               rbi_method << RBI::KwParam.new(name)
             when :key
               rbi_method << RBI::KwOptParam.new(name, "T.unsafe(nil)")
             when :keyrest
-              rbi_method << RBI::KwRestParam.new(name)
+              rbi_method << RBI::KwRestParam.new(anonymous_parameter ? nil : name)
             when :block
-              rbi_method << RBI::BlockParam.new(name)
+              rbi_method << RBI::BlockParam.new(anonymous_parameter ? nil : name)
             end
           end
 
-          @pipeline.push_method(symbol_name, constant, method, rbi_method, signature, sanitized_parameters)
+          parameters_for_signature = sanitized_parameters.map { |type, name, _anonymous_parameter| [type, name] }
+          @pipeline.push_method(symbol_name, constant, method, rbi_method, signature, parameters_for_signature)
           tree << rbi_method
         end
 
@@ -251,6 +255,20 @@ module Tapioca
         def same_source_location?(method, other_method)
           source_location = method.source_location
           !!source_location && source_location == other_method.source_location
+        end
+
+        #: (Symbol type, String name) -> bool
+        def anonymous_parameter_name?(type, name)
+          case type
+          when :rest
+            name == "*"
+          when :keyrest
+            name == "**"
+          when :block
+            name == "&"
+          else
+            false
+          end
         end
 
         #: (Module[top] constant, String method_name) -> bool

--- a/lib/tapioca/gem/listeners/methods.rb
+++ b/lib/tapioca/gem/listeners/methods.rb
@@ -258,20 +258,6 @@ module Tapioca
           !!source_location && source_location == other_method.source_location
         end
 
-        #: (Symbol type, String name) -> bool
-        def anonymous_parameter_name?(type, name)
-          case type
-          when :rest
-            name == "*"
-          when :keyrest
-            name == "**"
-          when :block
-            name == "&"
-          else
-            false
-          end
-        end
-
         #: (Module[top] constant, String method_name) -> bool
         def struct_method?(constant, method_name)
           return false unless T::Props::ClassMethods === constant

--- a/lib/tapioca/gem/listeners/methods.rb
+++ b/lib/tapioca/gem/listeners/methods.rb
@@ -102,7 +102,7 @@ module Tapioca
           sanitized_parameters = parameters.each_with_index.map do |(type, name), index|
             fallback_arg_name = "_arg#{index}"
 
-            name = if name
+            sig_name = if name
               name.to_s
             else
               # For attr_writer methods, Sorbet signatures have the name
@@ -129,10 +129,11 @@ module Tapioca
             # Sanitize param names, except for anonymous splat, keyword splat,
             # and block parameters. Ruby reflects those as `:*`, `:**`, and `:&`,
             # and Sorbet signatures use the same names to store their types.
-            is_anonymous_parameter = anonymous_parameter_name?(type, name)
-            name = fallback_arg_name unless is_anonymous_parameter || valid_parameter_name?(name)
+            is_anonymous_parameter = anonymous_parameter_name?(type, sig_name)
+            sig_name = fallback_arg_name unless is_anonymous_parameter || valid_parameter_name?(sig_name)
+            param_name = is_anonymous_parameter ? nil : sig_name
 
-            [type, name, is_anonymous_parameter]
+            [type, param_name, sig_name]
           end
 
           rbi_method = RBI::Method.new(
@@ -141,26 +142,26 @@ module Tapioca
             visibility: visibility,
           )
 
-          sanitized_parameters.each do |type, name, is_anonymous_parameter|
+          sanitized_parameters.each do |type, param_name, _sig_name|
             case type
             when :req
-              rbi_method << RBI::ReqParam.new(name)
+              rbi_method << RBI::ReqParam.new(param_name)
             when :opt
-              rbi_method << RBI::OptParam.new(name, "T.unsafe(nil)")
+              rbi_method << RBI::OptParam.new(param_name, "T.unsafe(nil)")
             when :rest
-              rbi_method << RBI::RestParam.new(is_anonymous_parameter ? nil : name)
+              rbi_method << RBI::RestParam.new(param_name)
             when :keyreq
-              rbi_method << RBI::KwParam.new(name)
+              rbi_method << RBI::KwParam.new(param_name)
             when :key
-              rbi_method << RBI::KwOptParam.new(name, "T.unsafe(nil)")
+              rbi_method << RBI::KwOptParam.new(param_name, "T.unsafe(nil)")
             when :keyrest
-              rbi_method << RBI::KwRestParam.new(is_anonymous_parameter ? nil : name)
+              rbi_method << RBI::KwRestParam.new(param_name)
             when :block
-              rbi_method << RBI::BlockParam.new(is_anonymous_parameter ? nil : name)
+              rbi_method << RBI::BlockParam.new(param_name)
             end
           end
 
-          parameters_for_signature = sanitized_parameters.map { |type, name, _is_anonymous_parameter| [type, name] }
+          parameters_for_signature = sanitized_parameters.map { |type, _param_name, sig_name| [type, sig_name] }
           @pipeline.push_method(symbol_name, constant, method, rbi_method, signature, parameters_for_signature)
           tree << rbi_method
         end

--- a/lib/tapioca/gem/listeners/methods.rb
+++ b/lib/tapioca/gem/listeners/methods.rb
@@ -129,10 +129,10 @@ module Tapioca
             # Sanitize param names, except for anonymous splat, keyword splat,
             # and block parameters. Ruby reflects those as `:*`, `:**`, and `:&`,
             # and Sorbet signatures use the same names to store their types.
-            anonymous_parameter = anonymous_parameter_name?(type, name)
-            name = fallback_arg_name unless anonymous_parameter || valid_parameter_name?(name)
+            is_anonymous_parameter = anonymous_parameter_name?(type, name)
+            name = fallback_arg_name unless is_anonymous_parameter || valid_parameter_name?(name)
 
-            [type, name, anonymous_parameter]
+            [type, name, is_anonymous_parameter]
           end
 
           rbi_method = RBI::Method.new(
@@ -141,26 +141,26 @@ module Tapioca
             visibility: visibility,
           )
 
-          sanitized_parameters.each do |type, name, anonymous_parameter|
+          sanitized_parameters.each do |type, name, is_anonymous_parameter|
             case type
             when :req
               rbi_method << RBI::ReqParam.new(name)
             when :opt
               rbi_method << RBI::OptParam.new(name, "T.unsafe(nil)")
             when :rest
-              rbi_method << RBI::RestParam.new(anonymous_parameter ? nil : name)
+              rbi_method << RBI::RestParam.new(is_anonymous_parameter ? nil : name)
             when :keyreq
               rbi_method << RBI::KwParam.new(name)
             when :key
               rbi_method << RBI::KwOptParam.new(name, "T.unsafe(nil)")
             when :keyrest
-              rbi_method << RBI::KwRestParam.new(anonymous_parameter ? nil : name)
+              rbi_method << RBI::KwRestParam.new(is_anonymous_parameter ? nil : name)
             when :block
-              rbi_method << RBI::BlockParam.new(anonymous_parameter ? nil : name)
+              rbi_method << RBI::BlockParam.new(is_anonymous_parameter ? nil : name)
             end
           end
 
-          parameters_for_signature = sanitized_parameters.map { |type, name, _anonymous_parameter| [type, name] }
+          parameters_for_signature = sanitized_parameters.map { |type, name, _is_anonymous_parameter| [type, name] }
           @pipeline.push_method(symbol_name, constant, method, rbi_method, signature, parameters_for_signature)
           tree << rbi_method
         end

--- a/lib/tapioca/helpers/rbi_helper.rb
+++ b/lib/tapioca/helpers/rbi_helper.rb
@@ -37,7 +37,7 @@ module Tapioca
       create_typed_param(RBI::OptParam.new(name, default), type)
     end
 
-    #: (String name, type: String) -> RBI::TypedParam
+    #: (String? name, type: String) -> RBI::TypedParam
     def create_rest_param(name, type:)
       create_typed_param(RBI::RestParam.new(name), type)
     end
@@ -52,12 +52,12 @@ module Tapioca
       create_typed_param(RBI::KwOptParam.new(name, default), type)
     end
 
-    #: (String name, type: String) -> RBI::TypedParam
+    #: (String? name, type: String) -> RBI::TypedParam
     def create_kw_rest_param(name, type:)
       create_typed_param(RBI::KwRestParam.new(name), type)
     end
 
-    #: (String name, type: String) -> RBI::TypedParam
+    #: (String? name, type: String) -> RBI::TypedParam
     def create_block_param(name, type:)
       create_typed_param(RBI::BlockParam.new(name), type)
     end

--- a/lib/tapioca/helpers/rbi_helper.rb
+++ b/lib/tapioca/helpers/rbi_helper.rb
@@ -110,5 +110,19 @@ module Tapioca
     def valid_parameter_name?(name)
       Prism.parse_success?("def sentinel_method_name(#{name}:); end")
     end
+
+    #: (Symbol type, String name) -> bool
+    def anonymous_parameter_name?(type, name)
+      case type
+      when :rest
+        name == "*"
+      when :keyrest
+        name == "**"
+      when :block
+        name == "&"
+      else
+        false
+      end
+    end
   end
 end

--- a/lib/tapioca/helpers/sorbet_helper.rb
+++ b/lib/tapioca/helpers/sorbet_helper.rb
@@ -24,7 +24,7 @@ module Tapioca
 
     #: (String, rbi_mode: bool) { (String stderr) -> void } -> void
     def sorbet_syntax_check!(source, rbi_mode:, &on_failure)
-      quoted_source = "\"#{source}\""
+      quoted_source = source.shellescape
 
       result = if rbi_mode
         # --e-rbi cannot be used on its own, so we pass a dummy value like `-e ""`

--- a/lib/tapioca/rbi_ext/model.rb
+++ b/lib/tapioca/rbi_ext/model.rb
@@ -76,11 +76,10 @@ module RBI
       if !block || !parameters.empty? || return_type
         # If there is no block, and the params and return type have not been supplied, then
         # we create a single signature with the given parameters and return type
-        params = parameters.map { |param| RBI::SigParam.new(param.param.name.to_s, param.type) }
         return_type ||= "T.untyped"
         type_params = Tapioca::RBIHelper.extract_type_parameters(parameters.map(&:type).append(return_type))
 
-        sig = RBI::Sig.new(params: params, return_type: return_type, type_params: type_params)
+        sig = RBI::Sig.new(params: parameters.map(&:to_sig_param), return_type: return_type, type_params: type_params)
         sigs << sig
       end
 
@@ -117,5 +116,20 @@ module RBI
   class TypedParam < T::Struct
     const :param, RBI::Param
     const :type, String
+
+    #: -> RBI::SigParam
+    def to_sig_param
+      name = case param
+      when RestParam
+        param.anonymous? ? "*".inspect : param.name.to_s
+      when KwRestParam
+        param.anonymous? ? "**".inspect : param.name.to_s
+      when BlockParam
+        param.anonymous? ? "&".inspect : param.name.to_s
+      else
+        param.name.to_s
+      end
+      RBI::SigParam.new(name, type)
+    end
   end
 end

--- a/sorbet/rbi/gems/rbi@0.4.1.rbi
+++ b/sorbet/rbi/gems/rbi@0.4.1.rbi
@@ -533,11 +533,11 @@ class RBI::File
   end
   def print(out: T.unsafe(nil), indent: T.unsafe(nil), print_locs: T.unsafe(nil), max_line_length: T.unsafe(nil)); end
 
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:1236
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:1246
   sig { params(out: T.any(::IO, ::StringIO), indent: ::Integer, print_locs: T::Boolean).void }
   def rbs_print(out: T.unsafe(nil), indent: T.unsafe(nil), print_locs: T.unsafe(nil)); end
 
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:1242
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:1252
   sig { params(indent: ::Integer, print_locs: T::Boolean).returns(::String) }
   def rbs_string(indent: T.unsafe(nil), print_locs: T.unsafe(nil)); end
 
@@ -1293,7 +1293,7 @@ class RBI::Node
   end
   def print(out: T.unsafe(nil), indent: T.unsafe(nil), print_locs: T.unsafe(nil), max_line_length: T.unsafe(nil)); end
 
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:1251
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:1261
   sig do
     params(
       out: T.any(::IO, ::StringIO),
@@ -1304,7 +1304,7 @@ class RBI::Node
   end
   def rbs_print(out: T.unsafe(nil), indent: T.unsafe(nil), print_locs: T.unsafe(nil), positional_names: T.unsafe(nil)); end
 
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:1257
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:1267
   sig { params(indent: ::Integer, print_locs: T::Boolean, positional_names: T::Boolean).returns(::String) }
   def rbs_string(indent: T.unsafe(nil), print_locs: T.unsafe(nil), positional_names: T.unsafe(nil)); end
 
@@ -2391,7 +2391,7 @@ class RBI::RBSPrinter < ::RBI::Visitor
   sig { params(node: ::RBI::Method, sig: ::RBI::Sig).void }
   def print_method_sig_inline(node, sig); end
 
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:488
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:491
   sig { params(node: ::RBI::Method, sig: ::RBI::Sig).void }
   def print_method_sig_multiline(node, sig); end
 
@@ -2421,7 +2421,7 @@ class RBI::RBSPrinter < ::RBI::Visitor
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:690
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:693
   sig { override.params(node: ::RBI::Arg).void }
   def visit_arg(node); end
 
@@ -2455,7 +2455,7 @@ class RBI::RBSPrinter < ::RBI::Visitor
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:622
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:625
   sig { override.params(node: ::RBI::BlockParam).void }
   def visit_block_param(node); end
 
@@ -2473,7 +2473,7 @@ class RBI::RBSPrinter < ::RBI::Visitor
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:826
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:829
   sig { override.params(node: ::RBI::ConflictTree).void }
   def visit_conflict_tree(node); end
 
@@ -2485,7 +2485,7 @@ class RBI::RBSPrinter < ::RBI::Visitor
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:634
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:637
   sig { override.params(node: ::RBI::Extend).void }
   def visit_extend(node); end
 
@@ -2497,43 +2497,43 @@ class RBI::RBSPrinter < ::RBI::Visitor
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:799
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:802
   sig { override.params(node: ::RBI::Group).void }
   def visit_group(node); end
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:787
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:790
   sig { override.params(node: ::RBI::Helper).void }
   def visit_helper(node); end
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:628
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:631
   sig { override.params(node: ::RBI::Include).void }
   def visit_include(node); end
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:696
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:699
   sig { override.params(node: ::RBI::KwArg).void }
   def visit_kw_arg(node); end
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:609
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:612
   sig { override.params(node: ::RBI::KwOptParam).void }
   def visit_kw_opt_param(node); end
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:603
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:606
   sig { override.params(node: ::RBI::KwParam).void }
   def visit_kw_param(node); end
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:615
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:618
   sig { override.params(node: ::RBI::KwRestParam).void }
   def visit_kw_rest_param(node); end
 
@@ -2545,11 +2545,11 @@ class RBI::RBSPrinter < ::RBI::Visitor
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:793
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:796
   sig { override.params(node: ::RBI::MixesInClassMethods).void }
   def visit_mixes_in_class_methods(node); end
 
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:639
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:642
   sig { params(node: ::RBI::Mixin).void }
   def visit_mixin(node); end
 
@@ -2561,43 +2561,43 @@ class RBI::RBSPrinter < ::RBI::Visitor
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:583
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:589
   sig { override.params(node: ::RBI::OptParam).void }
   def visit_opt_param(node); end
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:669
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:672
   sig { override.params(node: ::RBI::Private).void }
   def visit_private(node); end
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:663
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:666
   sig { override.params(node: ::RBI::Protected).void }
   def visit_protected(node); end
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:657
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:660
   sig { override.params(node: ::RBI::Public).void }
   def visit_public(node); end
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:573
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:579
   sig { override.params(node: ::RBI::ReqParam).void }
   def visit_req_param(node); end
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:820
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:823
   sig { override.params(node: ::RBI::RequiresAncestor).void }
   def visit_requires_ancestor(node); end
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:593
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:599
   sig { override.params(node: ::RBI::RestParam).void }
   def visit_rest_param(node); end
 
@@ -2611,7 +2611,7 @@ class RBI::RBSPrinter < ::RBI::Visitor
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:836
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:839
   sig { override.params(node: ::RBI::ScopeConflict).void }
   def visit_scope_conflict(node); end
 
@@ -2621,15 +2621,15 @@ class RBI::RBSPrinter < ::RBI::Visitor
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:684
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:687
   sig { override.params(node: ::RBI::Send).void }
   def visit_send(node); end
 
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:554
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:560
   sig { params(node: ::RBI::Sig).void }
   def visit_sig(node); end
 
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:567
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:573
   sig { params(node: ::RBI::SigParam).void }
   def visit_sig_param(node); end
 
@@ -2647,19 +2647,19 @@ class RBI::RBSPrinter < ::RBI::Visitor
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:753
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:756
   sig { override.params(node: ::RBI::TEnum).void }
   def visit_tenum(node); end
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:759
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:762
   sig { override.params(node: ::RBI::TEnumBlock).void }
   def visit_tenum_block(node); end
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:765
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:768
   sig { override.params(node: ::RBI::TEnumValue).void }
   def visit_tenum_value(node); end
 
@@ -2671,41 +2671,41 @@ class RBI::RBSPrinter < ::RBI::Visitor
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:702
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:705
   sig { override.params(node: ::RBI::TStruct).void }
   def visit_tstruct(node); end
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:737
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:740
   sig { override.params(node: ::RBI::TStructConst).void }
   def visit_tstruct_const(node); end
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:745
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:748
   sig { override.params(node: ::RBI::TStructProp).void }
   def visit_tstruct_prop(node); end
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:781
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:784
   sig { override.params(node: ::RBI::TypeMember).void }
   def visit_type_member(node); end
 
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:674
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:677
   sig { params(node: ::RBI::Visibility).void }
   def visit_visibility(node); end
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:806
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:809
   sig { override.params(node: ::RBI::VisibilityGroup).void }
   def visit_visibility_group(node); end
 
   private
 
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:929
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:939
   sig { params(node: ::RBI::Node).returns(T::Boolean) }
   def oneline?(node); end
 
@@ -2713,31 +2713,31 @@ class RBI::RBSPrinter < ::RBI::Visitor
   #
   # Returns `nil` is the string is not a `T.let`.
   #
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:963
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:973
   sig { params(code: T.nilable(::String)).returns(T.nilable(::String)) }
   def parse_t_let(code); end
 
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:951
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:961
   sig { params(type: T.any(::RBI::Type, ::String)).returns(::RBI::Type) }
   def parse_type(type); end
 
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:852
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:855
   sig { params(node: ::RBI::Node).void }
   def print_blank_line_before(node); end
 
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:871
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:874
   sig { params(node: ::RBI::Node).void }
   def print_loc(node); end
 
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:913
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:923
   sig { params(node: ::RBI::Param, last: T::Boolean).void }
   def print_param_comment_leading_space(node, last:); end
 
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:877
-  sig { params(node: ::RBI::Method, param: ::RBI::SigParam).void }
-  def print_sig_param(node, param); end
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:880
+  sig { params(sig_param: ::RBI::SigParam, method_param: ::RBI::Param).void }
+  def print_sig_param(sig_param, method_param); end
 
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:921
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:931
   sig { params(node: ::RBI::SigParam, last: T::Boolean).void }
   def print_sig_param_comment_leading_space(node, last:); end
 end
@@ -4175,23 +4175,23 @@ end
 class RBI::Type
   abstract!
 
-  # pkg:gem/rbi#lib/rbi/type.rb:993
+  # pkg:gem/rbi#lib/rbi/type.rb:1000
   sig { void }
   def initialize; end
 
   # @abstract
   #
-  # pkg:gem/rbi#lib/rbi/type.rb:1064
+  # pkg:gem/rbi#lib/rbi/type.rb:1071
   sig { abstract.params(other: ::BasicObject).returns(T::Boolean) }
   def ==(other); end
 
-  # pkg:gem/rbi#lib/rbi/type.rb:1067
+  # pkg:gem/rbi#lib/rbi/type.rb:1074
   sig { params(other: ::BasicObject).returns(T::Boolean) }
   def eql?(other); end
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/type.rb:1073
+  # pkg:gem/rbi#lib/rbi/type.rb:1080
   sig { override.returns(::Integer) }
   def hash; end
 
@@ -4205,13 +4205,13 @@ class RBI::Type
   # type.nilable.nilable.to_rbi # => "::T.nilable(String)"
   # ```
   #
-  # pkg:gem/rbi#lib/rbi/type.rb:1007
+  # pkg:gem/rbi#lib/rbi/type.rb:1014
   sig { returns(::RBI::Type) }
   def nilable; end
 
   # Returns whether the type is nilable.
   #
-  # pkg:gem/rbi#lib/rbi/type.rb:1034
+  # pkg:gem/rbi#lib/rbi/type.rb:1041
   sig { returns(T::Boolean) }
   def nilable?; end
 
@@ -4226,7 +4226,7 @@ class RBI::Type
   # type.non_nilable.non_nilable.to_rbi # => "String"
   # ```
   #
-  # pkg:gem/rbi#lib/rbi/type.rb:1022
+  # pkg:gem/rbi#lib/rbi/type.rb:1029
   sig { returns(::RBI::Type) }
   def non_nilable; end
 
@@ -4240,11 +4240,11 @@ class RBI::Type
   #
   # @abstract
   #
-  # pkg:gem/rbi#lib/rbi/type.rb:1048
+  # pkg:gem/rbi#lib/rbi/type.rb:1055
   sig { abstract.returns(::RBI::Type) }
   def normalize; end
 
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:1266
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:1276
   sig { returns(::String) }
   def rbs_string; end
 
@@ -4258,19 +4258,19 @@ class RBI::Type
   #
   # @abstract
   #
-  # pkg:gem/rbi#lib/rbi/type.rb:1060
+  # pkg:gem/rbi#lib/rbi/type.rb:1067
   sig { abstract.returns(::RBI::Type) }
   def simplify; end
 
   # @abstract
   #
-  # pkg:gem/rbi#lib/rbi/type.rb:1079
+  # pkg:gem/rbi#lib/rbi/type.rb:1086
   sig { abstract.returns(::String) }
   def to_rbi; end
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/type.rb:1083
+  # pkg:gem/rbi#lib/rbi/type.rb:1090
   sig { override.returns(::String) }
   def to_s; end
 
@@ -4280,7 +4280,7 @@ class RBI::Type
     # Note that this method transforms types such as `T.all(String, String)` into `String`, so
     # it may return something other than a `All`.
     #
-    # pkg:gem/rbi#lib/rbi/type.rb:929
+    # pkg:gem/rbi#lib/rbi/type.rb:936
     sig { params(type1: ::RBI::Type, type2: ::RBI::Type, types: ::RBI::Type).returns(::RBI::Type) }
     def all(type1, type2, *types); end
 
@@ -4289,37 +4289,37 @@ class RBI::Type
     # Note that this method transforms types such as `T.any(String, NilClass)` into `T.nilable(String)`, so
     # it may return something other than a `Any`.
     #
-    # pkg:gem/rbi#lib/rbi/type.rb:938
+    # pkg:gem/rbi#lib/rbi/type.rb:945
     sig { params(type1: ::RBI::Type, type2: ::RBI::Type, types: ::RBI::Type).returns(::RBI::Type) }
     def any(type1, type2, *types); end
 
     # Builds a type that represents `T.anything`.
     #
-    # pkg:gem/rbi#lib/rbi/type.rb:854
+    # pkg:gem/rbi#lib/rbi/type.rb:861
     sig { returns(::RBI::Type::Anything) }
     def anything; end
 
     # Builds a type that represents `T.attached_class`.
     #
-    # pkg:gem/rbi#lib/rbi/type.rb:860
+    # pkg:gem/rbi#lib/rbi/type.rb:867
     sig { returns(::RBI::Type::AttachedClass) }
     def attached_class; end
 
     # Builds a type that represents `T::Boolean`.
     #
-    # pkg:gem/rbi#lib/rbi/type.rb:866
+    # pkg:gem/rbi#lib/rbi/type.rb:873
     sig { returns(::RBI::Type::Boolean) }
     def boolean; end
 
     # Builds a type that represents the singleton class of another type like `T.class_of(Foo)`.
     #
-    # pkg:gem/rbi#lib/rbi/type.rb:910
+    # pkg:gem/rbi#lib/rbi/type.rb:917
     sig { params(type: ::RBI::Type::Simple, type_parameter: T.nilable(::RBI::Type)).returns(::RBI::Type::ClassOf) }
     def class_of(type, type_parameter = T.unsafe(nil)); end
 
     # Builds a type that represents a generic type like `T::Array[String]` or `T::Hash[Symbol, Integer]`.
     #
-    # pkg:gem/rbi#lib/rbi/type.rb:946
+    # pkg:gem/rbi#lib/rbi/type.rb:953
     sig { params(name: ::String, params: T.any(::RBI::Type, T::Array[::RBI::Type])).returns(::RBI::Type::Generic) }
     def generic(name, *params); end
 
@@ -4328,13 +4328,13 @@ class RBI::Type
     # Note that this method transforms types such as `T.nilable(T.untyped)` into `T.untyped`, so
     # it may return something other than a `RBI::Type::Nilable`.
     #
-    # pkg:gem/rbi#lib/rbi/type.rb:919
+    # pkg:gem/rbi#lib/rbi/type.rb:926
     sig { params(type: ::RBI::Type).returns(::RBI::Type) }
     def nilable(type); end
 
     # Builds a type that represents `T.noreturn`.
     #
-    # pkg:gem/rbi#lib/rbi/type.rb:872
+    # pkg:gem/rbi#lib/rbi/type.rb:879
     sig { returns(::RBI::Type::NoReturn) }
     def noreturn; end
 
@@ -4348,19 +4348,19 @@ class RBI::Type
 
     # Builds a type that represents a proc type like `T.proc.void`.
     #
-    # pkg:gem/rbi#lib/rbi/type.rb:980
+    # pkg:gem/rbi#lib/rbi/type.rb:987
     sig { returns(::RBI::Type::Proc) }
     def proc; end
 
     # Builds a type that represents `T.self_type`.
     #
-    # pkg:gem/rbi#lib/rbi/type.rb:878
+    # pkg:gem/rbi#lib/rbi/type.rb:885
     sig { returns(::RBI::Type::SelfType) }
     def self_type; end
 
     # Builds a type that represents a shape type like `{name: String, age: Integer}`.
     #
-    # pkg:gem/rbi#lib/rbi/type.rb:972
+    # pkg:gem/rbi#lib/rbi/type.rb:979
     sig { params(types: T::Hash[T.any(::String, ::Symbol), ::RBI::Type]).returns(::RBI::Type::Shape) }
     def shape(types = T.unsafe(nil)); end
 
@@ -4368,49 +4368,49 @@ class RBI::Type
     #
     # It raises a `NameError` if the name is not a valid Ruby class identifier.
     #
-    # pkg:gem/rbi#lib/rbi/type.rb:843
+    # pkg:gem/rbi#lib/rbi/type.rb:850
     sig { params(name: ::String).returns(::RBI::Type::Simple) }
     def simple(name); end
 
     # Builds a type that represents the class of another type like `T::Class[Foo]`.
     #
-    # pkg:gem/rbi#lib/rbi/type.rb:898
+    # pkg:gem/rbi#lib/rbi/type.rb:905
     sig { params(type: ::RBI::Type).returns(::RBI::Type::Class) }
     def t_class(type); end
 
     # Builds a type that represents the module of another type like `T::Module[Foo]`.
     #
-    # pkg:gem/rbi#lib/rbi/type.rb:904
+    # pkg:gem/rbi#lib/rbi/type.rb:911
     sig { params(type: ::RBI::Type).returns(::RBI::Type::Module) }
     def t_module(type); end
 
     # Builds a type that represents a tuple type like `[String, Integer]`.
     #
-    # pkg:gem/rbi#lib/rbi/type.rb:966
+    # pkg:gem/rbi#lib/rbi/type.rb:973
     sig { params(types: T.any(::RBI::Type, T::Array[::RBI::Type])).returns(::RBI::Type::Tuple) }
     def tuple(*types); end
 
     # Builds a type that represents a type alias like `MyTypeAlias`.
     #
-    # pkg:gem/rbi#lib/rbi/type.rb:958
+    # pkg:gem/rbi#lib/rbi/type.rb:965
     sig { params(name: ::String, aliased_type: ::RBI::Type).returns(::RBI::Type::TypeAlias) }
     def type_alias(name, aliased_type); end
 
     # Builds a type that represents a type parameter like `T.type_parameter(:U)`.
     #
-    # pkg:gem/rbi#lib/rbi/type.rb:952
+    # pkg:gem/rbi#lib/rbi/type.rb:959
     sig { params(name: ::Symbol).returns(::RBI::Type::TypeParameter) }
     def type_parameter(name); end
 
     # Builds a type that represents `T.untyped`.
     #
-    # pkg:gem/rbi#lib/rbi/type.rb:884
+    # pkg:gem/rbi#lib/rbi/type.rb:891
     sig { returns(::RBI::Type::Untyped) }
     def untyped; end
 
     # Builds a type that represents `void`.
     #
-    # pkg:gem/rbi#lib/rbi/type.rb:890
+    # pkg:gem/rbi#lib/rbi/type.rb:897
     sig { returns(::RBI::Type::Void) }
     def void; end
 
@@ -4480,7 +4480,7 @@ class RBI::Type
     sig { params(node: T.nilable(::Prism::Node)).returns(T::Boolean) }
     def t_type_alias?(node); end
 
-    # pkg:gem/rbi#lib/rbi/type.rb:987
+    # pkg:gem/rbi#lib/rbi/type.rb:994
     sig { params(name: ::String).returns(T::Boolean) }
     def valid_identifier?(name); end
   end
@@ -4872,61 +4872,61 @@ end
 
 # A proc type like `T.proc.void`.
 #
-# pkg:gem/rbi#lib/rbi/type.rb:743
+# pkg:gem/rbi#lib/rbi/type.rb:750
 class RBI::Type::Proc < ::RBI::Type
-  # pkg:gem/rbi#lib/rbi/type.rb:754
+  # pkg:gem/rbi#lib/rbi/type.rb:761
   sig { void }
   def initialize; end
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/type.rb:763
+  # pkg:gem/rbi#lib/rbi/type.rb:770
   sig { override.params(other: ::BasicObject).returns(T::Boolean) }
   def ==(other); end
 
-  # pkg:gem/rbi#lib/rbi/type.rb:791
+  # pkg:gem/rbi#lib/rbi/type.rb:798
   sig { params(type: T.untyped).returns(T.self_type) }
   def bind(type); end
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/type.rb:823
+  # pkg:gem/rbi#lib/rbi/type.rb:830
   sig { override.returns(::RBI::Type) }
   def normalize; end
 
-  # pkg:gem/rbi#lib/rbi/type.rb:773
+  # pkg:gem/rbi#lib/rbi/type.rb:780
   sig { params(params: ::RBI::Type).returns(T.self_type) }
   def params(**params); end
 
-  # pkg:gem/rbi#lib/rbi/type.rb:751
+  # pkg:gem/rbi#lib/rbi/type.rb:758
   sig { returns(T.nilable(::RBI::Type)) }
   def proc_bind; end
 
-  # pkg:gem/rbi#lib/rbi/type.rb:745
+  # pkg:gem/rbi#lib/rbi/type.rb:752
   sig { returns(T::Hash[::Symbol, ::RBI::Type]) }
   def proc_params; end
 
-  # pkg:gem/rbi#lib/rbi/type.rb:748
+  # pkg:gem/rbi#lib/rbi/type.rb:755
   sig { returns(::RBI::Type) }
   def proc_returns; end
 
-  # pkg:gem/rbi#lib/rbi/type.rb:779
+  # pkg:gem/rbi#lib/rbi/type.rb:786
   sig { params(type: T.untyped).returns(T.self_type) }
   def returns(type); end
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/type.rb:829
+  # pkg:gem/rbi#lib/rbi/type.rb:836
   sig { override.returns(::RBI::Type) }
   def simplify; end
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/type.rb:798
+  # pkg:gem/rbi#lib/rbi/type.rb:805
   sig { override.returns(::String) }
   def to_rbi; end
 
-  # pkg:gem/rbi#lib/rbi/type.rb:785
+  # pkg:gem/rbi#lib/rbi/type.rb:792
   sig { returns(T.self_type) }
   def void; end
 end
@@ -4976,13 +4976,13 @@ class RBI::Type::Shape < ::RBI::Type
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/type.rb:729
+  # pkg:gem/rbi#lib/rbi/type.rb:736
   sig { override.returns(::RBI::Type) }
   def normalize; end
 
   # @override
   #
-  # pkg:gem/rbi#lib/rbi/type.rb:735
+  # pkg:gem/rbi#lib/rbi/type.rb:742
   sig { override.returns(::RBI::Type) }
   def simplify; end
 
@@ -5337,99 +5337,99 @@ class RBI::TypeMember < ::RBI::NodeWithComments
   def value; end
 end
 
-# pkg:gem/rbi#lib/rbi/rbs_printer.rb:984
+# pkg:gem/rbi#lib/rbi/rbs_printer.rb:994
 class RBI::TypePrinter
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:989
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:999
   sig { params(max_line_length: T.nilable(::Integer)).void }
   def initialize(max_line_length: T.unsafe(nil)); end
 
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:986
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:996
   sig { returns(::String) }
   def string; end
 
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:995
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:1005
   sig { params(node: ::RBI::Type).void }
   def visit(node); end
 
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:1117
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:1127
   sig { params(type: ::RBI::Type::All).void }
   def visit_all(type); end
 
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:1127
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:1137
   sig { params(type: ::RBI::Type::Any).void }
   def visit_any(type); end
 
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:1062
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:1072
   sig { params(type: ::RBI::Type::Anything).void }
   def visit_anything(type); end
 
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:1087
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:1097
   sig { params(type: ::RBI::Type::AttachedClass).void }
   def visit_attached_class(type); end
 
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:1046
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:1056
   sig { params(type: ::RBI::Type::Boolean).void }
   def visit_boolean(type); end
 
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:1194
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:1204
   sig { params(type: ::RBI::Type::Class).void }
   def visit_class(type); end
 
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:1105
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:1115
   sig { params(type: ::RBI::Type::ClassOf).void }
   def visit_class_of(type); end
 
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:1051
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:1061
   sig { params(type: ::RBI::Type::Generic).void }
   def visit_generic(type); end
 
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:1201
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:1211
   sig { params(type: ::RBI::Type::Module).void }
   def visit_module(type); end
 
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:1092
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:1102
   sig { params(type: ::RBI::Type::Nilable).void }
   def visit_nilable(type); end
 
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:1072
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:1082
   sig { params(type: ::RBI::Type::NoReturn).void }
   def visit_no_return(type); end
 
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:1167
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:1177
   sig { params(type: ::RBI::Type::Proc).void }
   def visit_proc(type); end
 
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:1082
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:1092
   sig { params(type: ::RBI::Type::SelfType).void }
   def visit_self_type(type); end
 
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:1147
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:1157
   sig { params(type: ::RBI::Type::Shape).void }
   def visit_shape(type); end
 
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:1041
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:1051
   sig { params(type: ::RBI::Type::Simple).void }
   def visit_simple(type); end
 
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:1137
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:1147
   sig { params(type: ::RBI::Type::Tuple).void }
   def visit_tuple(type); end
 
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:1189
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:1199
   sig { params(type: ::RBI::Type::TypeParameter).void }
   def visit_type_parameter(type); end
 
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:1077
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:1087
   sig { params(type: ::RBI::Type::Untyped).void }
   def visit_untyped(type); end
 
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:1067
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:1077
   sig { params(type: ::RBI::Type::Void).void }
   def visit_void(type); end
 
   private
 
-  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:1210
+  # pkg:gem/rbi#lib/rbi/rbs_printer.rb:1220
   sig { params(type_name: ::String).returns(::String) }
   def translate_t_type(type_name); end
 end

--- a/spec/tapioca/dsl/compiler_spec.rb
+++ b/spec/tapioca/dsl/compiler_spec.rb
@@ -149,6 +149,25 @@ module Tapioca
           assert_equal(expected, rbi_for(:Post))
         end
 
+        it "compiles a class with anonymous splat, keyword splat, and block parameters" do
+          add_ruby_file("post.rb", <<~RUBY)
+            class Post
+              def foo(*, **, &); end
+            end
+          RUBY
+
+          expected = <<~RBI
+            # typed: strong
+
+            class Post
+              sig { params("*": T.untyped, "**": T.untyped, "&": T.untyped).returns(T.untyped) }
+              def foo(*, **, &); end
+            end
+          RBI
+
+          assert_equal(expected, rbi_for(:Post))
+        end
+
         it "compiles a class that overrides caller_locations" do
           add_ruby_file("post.rb", <<~RUBY)
             class Post

--- a/spec/tapioca/dsl/compilers/action_mailer_spec.rb
+++ b/spec/tapioca/dsl/compilers/action_mailer_spec.rb
@@ -134,11 +134,11 @@ module Tapioca
 
                 class NotifierMailer
                   class << self
-                    sig { params(_arg0: T.untyped, _arg1: T.untyped, _arg2: T.untyped).returns(::ActionMailer::MessageDelivery) }
-                    def notify_admin(*_arg0, **_arg1, &_arg2); end
+                    sig { params("*": T.untyped, "**": T.untyped, "&": T.untyped).returns(::ActionMailer::MessageDelivery) }
+                    def notify_admin(*, **, &); end
 
-                    sig { params(_arg0: T.untyped, _arg1: T.untyped, _arg2: T.untyped).returns(::ActionMailer::MessageDelivery) }
-                    def notify_customer(*_arg0, **_arg1, &_arg2); end
+                    sig { params("*": T.untyped, "**": T.untyped, "&": T.untyped).returns(::ActionMailer::MessageDelivery) }
+                    def notify_customer(*, **, &); end
                   end
                 end
               RBI

--- a/spec/tapioca/gem/pipeline_spec.rb
+++ b/spec/tapioca/gem/pipeline_spec.rb
@@ -2081,7 +2081,7 @@ class Tapioca::Gem::PipelineSpec < Minitest::HooksSpec
       assert_equal(output, compile)
     end
 
-    it "renames unnamed splats" do
+    it "keeps unnamed splats" do
       add_ruby_file("toto.rb", <<~RUBY)
         class Toto
           def toto(a, *, **)
@@ -2091,7 +2091,7 @@ class Tapioca::Gem::PipelineSpec < Minitest::HooksSpec
 
       output = template(<<~RBI)
         class Toto
-          def toto(a, *_arg1, **_arg2); end
+          def toto(a, *, **); end
         end
       RBI
 
@@ -2995,11 +2995,11 @@ class Tapioca::Gem::PipelineSpec < Minitest::HooksSpec
       output = template(<<~RBI)
         <% if ruby_version(">= 3.1") %>
         class Foo
-          def foo(*_arg0, **_arg1, &_arg2); end
+          def foo(*, **, &); end
         end
         <% else %>
         class Foo
-          def foo(*_arg0, &_arg1); end
+          def foo(*, &); end
         end
         <% end %>
       RBI
@@ -4015,7 +4015,7 @@ class Tapioca::Gem::PipelineSpec < Minitest::HooksSpec
       output = template(<<~RBI)
         class Foo
         <% if ruby_version(">= 3.1") %>
-          def bar(*args, **_arg1, &blk); end
+          def bar(*args, **, &blk); end
         <% else %>
           def bar(*args, &blk); end
         <% end %>
@@ -4024,7 +4024,7 @@ class Tapioca::Gem::PipelineSpec < Minitest::HooksSpec
           def baz(a); end
 
         <% if ruby_version(">= 3.1") %>
-          def foo(*args, **_arg1, &blk); end
+          def foo(*args, **, &blk); end
         <% else %>
           def foo(*args, &blk); end
         <% end %>
@@ -4793,6 +4793,26 @@ class Tapioca::Gem::PipelineSpec < Minitest::HooksSpec
             sig { void }
             def qux; end
           end
+        end
+      RBI
+
+      assert_equal(output, compile)
+    end
+
+    it "compiles RBS signature for a method with anonymous splat, keyword splat, and block parameters" do
+      add_ruby_file("foo.rb", <<~RUBY)
+        # typed: strict
+
+        class Foo
+          #: (*Integer, **String) { -> void } -> void
+          def foo(*, **, &); end
+        end
+      RUBY
+
+      output = template(<<~RBI)
+        class Foo
+          sig { params("*": ::Integer, "**": ::String, "&": T.proc.void).void }
+          def foo(*, **, &); end
         end
       RBI
 

--- a/tapioca.gemspec
+++ b/tapioca.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
 
   # Tapioca requires a specific minimum versions of RBI and Spoom
   # to ensure that the RBS comments are translated correctly.
-  spec.add_dependency("rbi", ">= 0.3.7")
+  spec.add_dependency("rbi", ">= 0.4.1")
   spec.add_dependency("spoom", ">= 1.7.16")
   # We need this to be ported to the RBS 4.0 branch before we can remove this dependency:
   # https://github.com/ruby/rbs/pull/2601


### PR DESCRIPTION
Ruby reflects anonymous splat, keyword splat, and block parameters using pseudo-names:

```ruby
def foo(*, **, &); end

method(:foo).parameters
# => [[:rest, :*], [:keyrest, :**], [:block, :&]]
```

Tapioca was treating those names as invalid parameter names and replacing them with fallback names like `_arg0`, `_arg1`, and `_arg2`. That caused two issues:

* Methods were generated with named parameters instead of preserving the original anonymous syntax.
* RBS-translated signatures could lose parameter types because Sorbet keeps the signature types under the original names: `"*"`, `"**"`, and `"&"`.

For example, this could generate invalid RBI like:

```ruby
sig { params(_arg0: , _arg1: , _arg2: ).void }
def foo(*_arg0, **_arg1, &_arg2); end
```

This change preserves anonymous parameter names for signature lookup, while rendering them as anonymous RBI parameters:

```ruby
sig { params("*": ::Integer, "**": ::String, "&": T.proc.void).void }
def foo(*, **, &); end
```

It also bumps the minimum `rbi` dependency to `0.4.1`, since older versions don’t support anonymous `RestParam`, `KwRestParam`, and `BlockParam` nodes represented with `nil` names.
