### PR TITLE
Handle all annotation source request failures

### DIFF
--- a/lib/tapioca/commands/annotations.rb
+++ b/lib/tapioca/commands/annotations.rb
@@ -187,7 +187,7 @@ module Tapioca
           say_http_error(path, repo_uri, message: response.class)
           nil
         end
-      rescue SocketError, Errno::ECONNREFUSED => e
+      rescue => e
         say_http_error(path, repo_uri, message: e.message)
         nil
       end


### PR DESCRIPTION
### Motivation
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
Ran into this issue in this CI run: https://github.com/Shopify/tapioca/actions/runs/30581510365/job/91002633500?pr=2669#step:6:151
### Implementation
<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
Treat any error while fetching an HTTP annotation source as an unavailable source. I briefly looked into exception classes that can be raised and there were too many, I think the risk of calling `say_http_error` with a non network related exception in this function is low so I went with this approach instead of adding more exception classes.
### Tests
<!-- We hope you added tests as part of your changes, just state that you have. If you haven't, state why. -->

