### PR TITLE
Skip ActiveSupport deprecation proxies when gathering DSL constants

### DIFF
--- a/lib/tapioca/dsl/compiler.rb
+++ b/lib/tapioca/dsl/compiler.rb
@@ -75,7 +75,19 @@ module Tapioca
             @@requested_constants.grep(Module)
           else
             ObjectSpace.each_object(Module).to_a
-          end.freeze #: Enumerable[Module[top]]?
+          end.reject { |mod| deprecated_constant_proxy?(mod) }.freeze #: Enumerable[Module[top]]?
+        end
+
+        # Rails 8.1+ wraps deprecated constants in DeprecatedConstantProxy, which
+        # undefines most instance methods and warns from method_missing. Inspecting
+        # those modules during DSL discovery (is_a?, singleton_class, etc.) emits
+        # deprecation warnings even though Tapioca is only enumerating ObjectSpace.
+        # class_of uses Kernel#class so we can recognize the proxy without warning.
+        #: (Module[top] mod) -> bool
+        def deprecated_constant_proxy?(mod)
+          proxy_class_name = name_of(class_of(mod))
+          proxy_class_name == "ActiveSupport::Deprecation::DeprecatedConstantProxy" ||
+            proxy_class_name == "ActiveSupport::DeprecatedConstantProxy"
         end
       end
 

--- a/lib/tapioca/dsl/compiler.rb
+++ b/lib/tapioca/dsl/compiler.rb
@@ -74,8 +74,8 @@ module Tapioca
           @all_modules ||= if @@requested_constants.any?
             @@requested_constants.grep(Module)
           else
-            ObjectSpace.each_object(Module).to_a
-          end.reject { |mod| deprecated_constant_proxy?(mod) }.freeze #: Enumerable[Module[top]]?
+            ObjectSpace.each_object(Module).reject { |mod| deprecated_constant_proxy?(mod) }.to_a
+          end.freeze #: Enumerable[Module[top]]?
         end
 
         # Rails 8.1+ wraps deprecated constants in DeprecatedConstantProxy, which

--- a/spec/tapioca/dsl/compilers/active_support_concern_spec.rb
+++ b/spec/tapioca/dsl/compilers/active_support_concern_spec.rb
@@ -22,12 +22,14 @@ module Tapioca
               ActiveSupport.deprecator.behavior = ->(message, *) { warnings << message.to_s }
 
               begin
-                constants = gathered_constants
+                proxy = ActiveSupport::Concurrency.const_get(:LoadInterlockAwareMonitor, false)
+                gathered_constants
+                all_modules = Tapioca::Dsl::Compilers::ActiveSupportConcern.send(:all_modules)
               ensure
                 ActiveSupport.deprecator.behavior = previous_behavior
               end
 
-              refute_includes(constants, "ActiveSupport::Concurrency::LoadInterlockAwareMonitor")
+              refute(all_modules.any? { |mod| Tapioca::Runtime::Reflection.are_equal?(mod, proxy) })
               assert_empty(warnings.grep(/LoadInterlockAwareMonitor/))
             end
 

--- a/spec/tapioca/dsl/compilers/active_support_concern_spec.rb
+++ b/spec/tapioca/dsl/compilers/active_support_concern_spec.rb
@@ -26,12 +26,10 @@ module Tapioca
                   ActiveSupport.deprecator,
                 )
                 # Name the proxy so discovery can trigger its warning.
-                self.class.const_set(:FakeDeprecatedConstant, proxy)
+                ActiveSupportConcernSpec.const_set(:FakeDeprecatedConstant, proxy)
                 gathered_constants
                 all_modules = Tapioca::Dsl::Compilers::ActiveSupportConcern.send(:all_modules)
               ensure
-                self.class.send(:remove_const, :FakeDeprecatedConstant) if # rubocop:disable RSpec/RemoveConst
-                  self.class.const_defined?(:FakeDeprecatedConstant, false)
                 ActiveSupport.deprecator.behavior = previous_behavior
               end
 

--- a/spec/tapioca/dsl/compilers/active_support_concern_spec.rb
+++ b/spec/tapioca/dsl/compilers/active_support_concern_spec.rb
@@ -14,6 +14,23 @@ module Tapioca
           end
 
           describe "gather_constants" do
+            it "does not gather ActiveSupport deprecation proxies and does not warn" do
+              require "active_support/concurrency/load_interlock_aware_monitor"
+
+              warnings = []
+              previous_behavior = ActiveSupport.deprecator.behavior
+              ActiveSupport.deprecator.behavior = ->(message, *) { warnings << message.to_s }
+
+              begin
+                constants = gathered_constants
+              ensure
+                ActiveSupport.deprecator.behavior = previous_behavior
+              end
+
+              refute_includes(constants, "ActiveSupport::Concurrency::LoadInterlockAwareMonitor")
+              assert_empty(warnings.grep(/LoadInterlockAwareMonitor/))
+            end
+
             it "does not gather anonymous constants" do
               add_ruby_file("test_case.rb", <<~RUBY)
                 module TestCase

--- a/spec/tapioca/dsl/compilers/active_support_concern_spec.rb
+++ b/spec/tapioca/dsl/compilers/active_support_concern_spec.rb
@@ -30,7 +30,7 @@ module Tapioca
                 gathered_constants
                 all_modules = Tapioca::Dsl::Compilers::ActiveSupportConcern.send(:all_modules)
               ensure
-                self.class.send(:remove_const, :FakeDeprecatedConstant) if
+                self.class.send(:remove_const, :FakeDeprecatedConstant) if # rubocop:disable RSpec/RemoveConst
                   self.class.const_defined?(:FakeDeprecatedConstant, false)
                 ActiveSupport.deprecator.behavior = previous_behavior
               end

--- a/spec/tapioca/dsl/compilers/active_support_concern_spec.rb
+++ b/spec/tapioca/dsl/compilers/active_support_concern_spec.rb
@@ -15,22 +15,28 @@ module Tapioca
 
           describe "gather_constants" do
             it "does not gather ActiveSupport deprecation proxies and does not warn" do
-              require "active_support/concurrency/load_interlock_aware_monitor"
-
               warnings = []
               previous_behavior = ActiveSupport.deprecator.behavior
               ActiveSupport.deprecator.behavior = ->(message, *) { warnings << message.to_s }
 
               begin
-                proxy = ActiveSupport::Concurrency.const_get(:LoadInterlockAwareMonitor, false)
+                proxy = ActiveSupport::Deprecation::DeprecatedConstantProxy.new(
+                  "FakeDeprecatedConstant",
+                  "Module",
+                  ActiveSupport.deprecator,
+                )
+                # Name the proxy so discovery can trigger its warning.
+                self.class.const_set(:FakeDeprecatedConstant, proxy)
                 gathered_constants
                 all_modules = Tapioca::Dsl::Compilers::ActiveSupportConcern.send(:all_modules)
               ensure
+                self.class.send(:remove_const, :FakeDeprecatedConstant) if
+                  self.class.const_defined?(:FakeDeprecatedConstant, false)
                 ActiveSupport.deprecator.behavior = previous_behavior
               end
 
               refute(all_modules.any? { |mod| Tapioca::Runtime::Reflection.are_equal?(mod, proxy) })
-              assert_empty(warnings.grep(/LoadInterlockAwareMonitor/))
+              assert_empty(warnings.grep(/FakeDeprecatedConstant/))
             end
 
             it "does not gather anonymous constants" do


### PR DESCRIPTION
Fixes Shopify/tapioca#2463

Rails 8.1 replaced LoadInterlockAwareMonitor with a DeprecatedConstantProxy. DSL compilers walk every loaded module and call methods such as singleton_class on each one. Those calls go through method_missing on the proxy and print deprecation warnings even though Tapioca is only enumerating ObjectSpace.

This change drops DeprecatedConstantProxy modules from all_modules so every DSL compiler skips them. Kernel.class is used to recognize the proxy without triggering the warning.

The ActiveSupportConcern gather_constants spec covers the Rails 8.1 LoadInterlockAwareMonitor proxy.