### PR TITLE
Include ActiveRecord::TestFixtures in the fixtures RBI

### DIFF
--- a/lib/tapioca/dsl/compilers/active_record_fixtures.rb
+++ b/lib/tapioca/dsl/compilers/active_record_fixtures.rb
@@ -37,10 +37,10 @@ module Tapioca
       # ~~~
       #
       # The `include` is generated because Rails mixes `ActiveRecord::TestFixtures` into
-      # `ActiveSupport::TestCase` from a `:active_support_test_case` load hook in `rails/test_help.rb`,
-      # which is only required from an app's `test_helper.rb` and therefore never runs during RBI
-      # generation. Without it, Sorbet does not see the class methods the module contributes via
-      # `mixes_in_class_methods`, such as `fixtures`.
+      # `ActiveSupport::TestCase` through the `:active_support_test_case` load hook in
+      # `rails/test_help.rb`. Since RBI generation does not load an app's test helper, this runtime
+      # include is not captured. Without it, Sorbet does not see the class methods the module
+      # contributes via `mixes_in_class_methods`, such as `fixtures`.
       #: [ConstantType = singleton(ActiveSupport::TestCase)]
       class ActiveRecordFixtures < Compiler
         MISSING = Object.new
@@ -53,8 +53,6 @@ module Tapioca
           else
             method_names_from_eager_fixture_loader
           end
-
-          return if method_names.empty?
 
           method_names.select! { |name| fixture_class_mapping_from_fixture_files[name] != MISSING }
 

--- a/lib/tapioca/dsl/compilers/active_record_fixtures.rb
+++ b/lib/tapioca/dsl/compilers/active_record_fixtures.rb
@@ -37,9 +37,10 @@ module Tapioca
       # ~~~
       #
       # The `include` is generated because Rails mixes `ActiveRecord::TestFixtures` into
-      # `ActiveSupport::TestCase` from the `active_record.test_fixtures` railtie initializer, which
-      # does not run during gem RBI generation. Without it, Sorbet does not see the class methods
-      # the module contributes via `mixes_in_class_methods`, such as `fixtures`.
+      # `ActiveSupport::TestCase` from a `:active_support_test_case` load hook in `rails/test_help.rb`,
+      # which is only required from an app's `test_helper.rb` and therefore never runs during RBI
+      # generation. Without it, Sorbet does not see the class methods the module contributes via
+      # `mixes_in_class_methods`, such as `fixtures`.
       #: [ConstantType = singleton(ActiveSupport::TestCase)]
       class ActiveRecordFixtures < Compiler
         MISSING = Object.new
@@ -53,8 +54,9 @@ module Tapioca
             method_names_from_eager_fixture_loader
           end
 
-          method_names.select! { |name| fixture_class_mapping_from_fixture_files[name] != MISSING }
           return if method_names.empty?
+
+          method_names.select! { |name| fixture_class_mapping_from_fixture_files[name] != MISSING }
 
           root.create_path(constant) do |mod|
             mod.create_include("ActiveRecord::TestFixtures")

--- a/lib/tapioca/dsl/compilers/active_record_fixtures.rb
+++ b/lib/tapioca/dsl/compilers/active_record_fixtures.rb
@@ -26,6 +26,8 @@ module Tapioca
       # # test_case.rbi
       # # typed: true
       # class ActiveSupport::TestCase
+      #   include ActiveRecord::TestFixtures
+      #
       #   sig { returns(T::Array[Post]) }                                                          #   No names: returns an Array of all fixtures
       #   sig { params(fixture_name: T.any(String, Symbol)).returns(Post) }                        #   One name: returns the requested fixture
       #   sig { params(fixture_name: T.any(String, Symbol), other_fixtures: T.any(String, Symbol)) # Many names: returns an Array of the requested fixtures
@@ -33,6 +35,11 @@ module Tapioca
       #   def posts(fixture_name = nil, *other_fixtures); end
       # end
       # ~~~
+      #
+      # The `include` is generated because Rails mixes `ActiveRecord::TestFixtures` into
+      # `ActiveSupport::TestCase` from the `active_record.test_fixtures` railtie initializer, which
+      # does not run during gem RBI generation. Without it, Sorbet does not see the class methods
+      # the module contributes via `mixes_in_class_methods`, such as `fixtures`.
       #: [ConstantType = singleton(ActiveSupport::TestCase)]
       class ActiveRecordFixtures < Compiler
         MISSING = Object.new
@@ -50,6 +57,8 @@ module Tapioca
           return if method_names.empty?
 
           root.create_path(constant) do |mod|
+            mod.create_include("ActiveRecord::TestFixtures")
+
             method_names.each do |name|
               create_fixture_method(mod, name.to_s)
             end

--- a/manual/compiler_activerecordfixtures.md
+++ b/manual/compiler_activerecordfixtures.md
@@ -29,6 +29,7 @@ end
 ~~~
 
 The `include` is generated because Rails mixes `ActiveRecord::TestFixtures` into
-`ActiveSupport::TestCase` from the `active_record.test_fixtures` railtie initializer, which
-does not run during gem RBI generation. Without it, Sorbet does not see the class methods
-the module contributes via `mixes_in_class_methods`, such as `fixtures`.
+`ActiveSupport::TestCase` from a `:active_support_test_case` load hook in `rails/test_help.rb`,
+which is only required from an app's `test_helper.rb` and therefore never runs during RBI
+generation. Without it, Sorbet does not see the class methods the module contributes via
+`mixes_in_class_methods`, such as `fixtures`.

--- a/manual/compiler_activerecordfixtures.md
+++ b/manual/compiler_activerecordfixtures.md
@@ -29,7 +29,7 @@ end
 ~~~
 
 The `include` is generated because Rails mixes `ActiveRecord::TestFixtures` into
-`ActiveSupport::TestCase` from a `:active_support_test_case` load hook in `rails/test_help.rb`,
-which is only required from an app's `test_helper.rb` and therefore never runs during RBI
-generation. Without it, Sorbet does not see the class methods the module contributes via
-`mixes_in_class_methods`, such as `fixtures`.
+`ActiveSupport::TestCase` through the `:active_support_test_case` load hook in
+`rails/test_help.rb`. Since RBI generation does not load an app's test helper, this runtime
+include is not captured. Without it, Sorbet does not see the class methods the module
+contributes via `mixes_in_class_methods`, such as `fixtures`.

--- a/manual/compiler_activerecordfixtures.md
+++ b/manual/compiler_activerecordfixtures.md
@@ -18,6 +18,8 @@ The generated RBI by this compiler will produce the following
 # test_case.rbi
 # typed: true
 class ActiveSupport::TestCase
+  include ActiveRecord::TestFixtures
+
   sig { returns(T::Array[Post]) }                                                          #   No names: returns an Array of all fixtures
   sig { params(fixture_name: T.any(String, Symbol)).returns(Post) }                        #   One name: returns the requested fixture
   sig { params(fixture_name: T.any(String, Symbol), other_fixtures: T.any(String, Symbol)) # Many names: returns an Array of the requested fixtures
@@ -25,3 +27,8 @@ class ActiveSupport::TestCase
   def posts(fixture_name = nil, *other_fixtures); end
 end
 ~~~
+
+The `include` is generated because Rails mixes `ActiveRecord::TestFixtures` into
+`ActiveSupport::TestCase` from the `active_record.test_fixtures` railtie initializer, which
+does not run during gem RBI generation. Without it, Sorbet does not see the class methods
+the module contributes via `mixes_in_class_methods`, such as `fixtures`.

--- a/spec/tapioca/dsl/compilers/active_record_fixtures_spec.rb
+++ b/spec/tapioca/dsl/compilers/active_record_fixtures_spec.rb
@@ -79,6 +79,8 @@ module Tapioca
                 # typed: strong
 
                 class ActiveSupport::TestCase
+                  include ActiveRecord::TestFixtures
+
                   sig { returns(T::Array[Post]) }
                   sig { params(fixture_name: T.any(String, Symbol)).returns(Post) }
                   sig { params(fixture_name: T.any(String, Symbol), other_fixtures: T.any(String, Symbol)).returns(T::Array[Post]) }
@@ -107,6 +109,8 @@ module Tapioca
                 # typed: strong
 
                 class ActiveSupport::TestCase
+                  include ActiveRecord::TestFixtures
+
                   sig { returns(T::Array[Post]) }
                   sig { params(fixture_name: T.any(String, Symbol)).returns(Post) }
                   sig { params(fixture_name: T.any(String, Symbol), other_fixtures: T.any(String, Symbol)).returns(T::Array[Post]) }
@@ -146,6 +150,8 @@ module Tapioca
                 # typed: strong
 
                 class ActiveSupport::TestCase
+                  include ActiveRecord::TestFixtures
+
                   sig { returns(T::Array[Blog::Post]) }
                   sig { params(fixture_name: T.any(String, Symbol)).returns(Blog::Post) }
                   sig { params(fixture_name: T.any(String, Symbol), other_fixtures: T.any(String, Symbol)).returns(T::Array[Blog::Post]) }
@@ -181,6 +187,8 @@ module Tapioca
                 # typed: strong
 
                 class ActiveSupport::TestCase
+                  include ActiveRecord::TestFixtures
+
                   sig { returns(T::Array[Post]) }
                   sig { params(fixture_name: T.any(String, Symbol)).returns(Post) }
                   sig { params(fixture_name: T.any(String, Symbol), other_fixtures: T.any(String, Symbol)).returns(T::Array[Post]) }
@@ -204,6 +212,8 @@ module Tapioca
                 # typed: strong
 
                 class ActiveSupport::TestCase
+                  include ActiveRecord::TestFixtures
+
                   sig { returns(T::Array[T.untyped]) }
                   sig { params(fixture_name: T.any(String, Symbol)).returns(T.untyped) }
                   sig { params(fixture_name: T.any(String, Symbol), other_fixtures: T.any(String, Symbol)).returns(T::Array[T.untyped]) }

--- a/spec/tapioca/dsl/compilers/active_record_fixtures_spec.rb
+++ b/spec/tapioca/dsl/compilers/active_record_fixtures_spec.rb
@@ -47,12 +47,42 @@ module Tapioca
               assert_equal(["ActiveSupport::TestCase"], gathered_constants)
             end
 
-            it "does nothing if there are no fixtures" do
+            it "makes fixture class methods available when there are no fixtures" do
               expected = <<~RBI
                 # typed: strong
+
+                class ActiveSupport::TestCase
+                  include ActiveRecord::TestFixtures
+                end
               RBI
 
-              assert_equal(expected, rbi_for("ActiveSupport::TestCase"))
+              generated_rbi = rbi_for("ActiveSupport::TestCase")
+              dependencies_rbi = add_content_file("dependencies.rbi", <<~RBI)
+                # typed: true
+
+                module ActiveRecord::TestFixtures
+                  mixes_in_class_methods ::ActiveRecord::TestFixtures::ClassMethods
+                end
+
+                module ActiveRecord::TestFixtures::ClassMethods
+                  def fixtures(*fixture_set_names); end
+                end
+
+                class ActiveSupport::TestCase; end
+              RBI
+              generated_rbi_file = add_content_file("generated.rbi", generated_rbi)
+              test_file = add_content_file("test_case.rb", <<~RUBY)
+                # typed: true
+
+                class PostTest < ActiveSupport::TestCase
+                  fixtures :all
+                end
+              RUBY
+
+              result = context.sorbet("--no-config", dependencies_rbi, generated_rbi_file, test_file)
+
+              assert(result.status, result.err)
+              assert_equal(expected, generated_rbi)
             end
 
             it "ignores fixtures that do not have an associated model" do
@@ -242,7 +272,7 @@ module Tapioca
               assert_equal(expected, rbi_for("ActiveSupport::TestCase"))
             end
 
-            it "generates no methods for file fixtures" do
+            it "generates only the include for file fixtures" do
               add_content_file("test/fixtures/files/posts.yml", <<~YAML)
                 super_post:
                   title: An incredible Ruby post
@@ -253,6 +283,10 @@ module Tapioca
 
               expected = <<~RBI
                 # typed: strong
+
+                class ActiveSupport::TestCase
+                  include ActiveRecord::TestFixtures
+                end
               RBI
 
               assert_equal(expected, rbi_for("ActiveSupport::TestCase"))

--- a/spec/tapioca/dsl/compilers/active_record_fixtures_spec.rb
+++ b/spec/tapioca/dsl/compilers/active_record_fixtures_spec.rb
@@ -91,6 +91,24 @@ module Tapioca
               assert_equal(expected, rbi_for("ActiveSupport::TestCase"))
             end
 
+            it "generates only the include if no fixture has an associated model" do
+              add_content_file("test/fixtures/serialized_data.yml", <<~YAML)
+                ---
+                field1: 123
+                name: Hello
+              YAML
+
+              expected = <<~RBI
+                # typed: strong
+
+                class ActiveSupport::TestCase
+                  include ActiveRecord::TestFixtures
+                end
+              RBI
+
+              assert_equal(expected, rbi_for("ActiveSupport::TestCase"))
+            end
+
             it "generates methods for fixtures" do
               add_content_file("test/fixtures/posts.yml", <<~YAML)
                 super_post:


### PR DESCRIPTION
### Motivation

Rails mixes `ActiveRecord::TestFixtures` into `ActiveSupport::TestCase` from the [`:active_support_test_case` load hook in `rails/test_help.rb`](https://github.com/rails/rails/blob/main/railties/lib/rails/test_help.rb). That file is required from an app's `test_helper.rb`, so the hook never runs during RBI generation, the include never makes it into the gem RBI, and Sorbet doesn't see the class methods the module contributes through `mixes_in_class_methods` — most visibly `fixtures`:

```ruby
class PostTest < ActiveSupport::TestCase
  fixtures :all # Method `fixtures` does not exist on `T.class_of(PostTest)` (7003)
end
```

Today every Rails app using fixtures shims this by hand (a `sorbet/rbi/shims` entry, or a local DSL compiler that emits nothing but the include). `ActiveRecordFixtures` already targets `ActiveSupport::TestCase` and already knows Rails is loaded, so it's the natural place to make the include explicit.

### Implementation

One line in `decorate` — `mod.create_include("ActiveRecord::TestFixtures")` — inside the existing `create_path`.

The early return now sits above the `select!` that drops fixture sets whose model constant can't be resolved, so the two cases it used to conflate are separated: an app with no fixture files at all still generates no RBI, while an app that has fixture files but no matching models gets an RBI with just the include (it writes `fixtures :all` too).

### Tests

`spec/tapioca/dsl/compilers/active_record_fixtures_spec.rb` updated for the extra line, plus a new case for fixtures with no associated model at all; the whole file passes. `bin/typecheck` and `rubocop` are clean, and `manual/` is regenerated via `bin/docs`.
