### PR TITLE
Create parameter type list based on position instead of name

### DIFF
--- a/lib/tapioca/gem/listeners/sorbet_signatures.rb
+++ b/lib/tapioca/gem/listeners/sorbet_signatures.rb
@@ -21,18 +21,12 @@ module Tapioca
 
         #: (untyped signature, Array[[Symbol, String]] parameters) -> RBI::Sig
         def compile_signature(signature, parameters)
-          parameter_types = signature.arg_types.to_h #: Hash[Symbol, T::Types::Base]
-          parameter_types.merge!(signature.kwarg_types)
-          rest_type = signature.rest_type
-          parameter_types[signature.rest_name] = rest_type if rest_type
-          keyrest_type = signature.keyrest_type
-          parameter_types[signature.keyrest_name] = keyrest_type if keyrest_type
-          parameter_types[signature.block_name] = signature.block_type if signature.block_name
+          parameter_types = parameter_types_for(signature, parameters)
 
           sig = RBI::Sig.new
 
-          parameters.each do |_, name|
-            type = sanitize_signature_types(parameter_types[name.to_sym].to_s)
+          parameters.each_with_index do |(_, name), index|
+            type = sanitize_signature_types(parameter_types.fetch(index))
             @pipeline.push_symbol(type)
             sig << RBI::SigParam.new(name, type)
           end
@@ -42,7 +36,7 @@ module Tapioca
           sig.return_type = return_type
           @pipeline.push_symbol(return_type)
 
-          sig.type_params.concat(extract_type_parameters(parameter_types.values.map(&:to_s).append(return_type)))
+          sig.type_params.concat(extract_type_parameters([*parameter_types, return_type]))
 
           case signature.mode
           when "abstract"
@@ -59,6 +53,29 @@ module Tapioca
           sig.is_final = signature_final?(signature)
 
           sig
+        end
+
+        #: (untyped signature, Array[[Symbol, String]] parameters) -> Array[String]
+        def parameter_types_for(signature, parameters)
+          positional_types = signature.arg_types.map { |_name, type| type }
+          keyword_types = signature.kwarg_types.values
+
+          parameters.map do |kind, _name|
+            type = case kind
+            when :req, :opt
+              positional_types.shift
+            when :keyreq, :key
+              keyword_types.shift
+            when :rest
+              signature.rest_type
+            when :keyrest
+              signature.keyrest_type
+            when :block
+              signature.block_type
+            end
+
+            type ? type.to_s : "T.untyped"
+          end
         end
 
         #: (untyped signature) -> bool

--- a/spec/tapioca/gem/pipeline_spec.rb
+++ b/spec/tapioca/gem/pipeline_spec.rb
@@ -5012,5 +5012,90 @@ class Tapioca::Gem::PipelineSpec < Minitest::HooksSpec
 
       assert_equal(output, compile(include_doc: true))
     end
+
+    it "compiles signatures for methods with anonymous block parameters" do
+      add_ruby_file("foo.rb", <<~RUBY)
+        # typed: true
+
+        class Foo
+          #: (String path) { -> void } -> void
+          def anon_block(path, &); end
+        end
+      RUBY
+
+      output = template(<<~RBI)
+        class Foo
+          sig { params(path: ::String, _arg1: T.proc.void).void }
+          def anon_block(path, &_arg1); end
+        end
+      RBI
+
+      assert_equal(output, compile)
+    end
+
+    it "compiles signatures for methods with anonymous rest parameters" do
+      # Required to reproduce otherwise we raise
+      T::Configuration.sig_validation_error_handler = ->(*) {}
+
+      add_ruby_file("foo.rb", <<~RUBY)
+        # typed: true
+
+        class Foo
+          #: (String path, ?arena_stats: bool) -> void
+          def bar(path, **); end
+        end
+      RUBY
+
+      output = template(<<~RBI)
+        class Foo
+          sig { params(path: T.untyped, _arg1: T.untyped).returns(T.untyped) }
+          def bar(path, **_arg1); end
+        end
+      RBI
+
+      assert_equal(output, compile)
+    ensure
+      T::Configuration.instance_variable_set(:@sig_validation_error_handler, nil)
+    end
+
+    it "compiles signatures for methods mixing named and anonymous parameters" do
+      add_ruby_file("foo.rb", <<~RUBY)
+        # typed: true
+
+        class Foo
+          #: (Integer, *String, k: Symbol, **Float) { -> void } -> void
+          def all_anon(x, *, k:, **, &); end
+        end
+      RUBY
+
+      output = template(<<~RBI)
+        class Foo
+          sig { params(x: ::Integer, _arg1: ::String, k: ::Symbol, _arg3: ::Float, _arg4: T.proc.void).void }
+          def all_anon(x, *_arg1, k:, **_arg3, &_arg4); end
+        end
+      RBI
+
+      assert_equal(output, compile)
+    end
+
+    it "compiles post parameters" do
+      add_ruby_file("foo.rb", <<~RUBY)
+        # typed: true
+
+        class Foo
+          #: (Integer, String, Integer) -> void
+          def posts(a, *b, c); end
+        end
+      RUBY
+
+      output = template(<<~RBI)
+        class Foo
+          sig { params(a: ::Integer, b: ::String, c: ::Integer).void }
+          def posts(a, *b, c); end
+        end
+      RBI
+
+      assert_equal(output, compile)
+    end
   end
 end


### PR DESCRIPTION
### Motivation

I was testing out the latest Tapioca main and noticed that we are producing invalid syntax in RBIs for anonymous keyword rest or block parameters (see tests).

We are currently outputting this:

```ruby
# Note the missing type after the parameter name, which is a syntax error
sig { arg_1: }.void
def foo(**); end
```

### Implementation

The essence of the issue is that we create a hash of parameter types, which we lookup based on names. This only works if the parameter actually has a name.

The idea of the implementation is to rely on the fact that Sorbet errors if parameters are out of order and process them based on their position instead. This allows us to at least produce syntactically valid RBIs under the scenarios.

### Tests

Added tests.