### PR TITLE
Pin json to < 3 temporarily

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,9 @@ group :development, :test do
   else
     rails_version = CURRENT_RAILS_VERSION if rails_version == "current"
     gem "rails", "~> #{rails_version}.0"
+
+    # Remove this constraint once Rails ships a version that supports JSON 3
+    gem "json", "< 3"
   end
 
   gem "sqlite3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -453,6 +453,7 @@ DEPENDENCIES
   graphql
   identity_cache
   irb
+  json (< 3)
   json_api_client!
   kramdown (~> 2.5)
   kredis


### PR DESCRIPTION
### Motivation

JSON v3.0.0 has some breaking changes. Those are already addressed in Rails main, but there's no release yet, which is making the Rails main build pass while the 8.0 [fails](https://github.com/Shopify/tapioca/actions/runs/34492142915/job/102921310151).

### Implementation

Let's pin the version temporarily until Rails releases a version supporting JSON >= 3.
